### PR TITLE
fix(e2e): anchor BUG-01 onboarding test dates inside a single month

### DIFF
--- a/e2e/bugs.spec.ts
+++ b/e2e/bugs.spec.ts
@@ -297,7 +297,18 @@ test.describe('Bug regressions', () => {
       await continueFromRecoveryCode(page);
       await expect(page).toHaveURL(/\/onboarding(?:\?.*)?$/);
 
-      const onboardingDate = shiftISODate(await browserLocalISODate(page), -3);
+      // Pin onboardingDate to the 5th of a stable month so the +0..+4 window walked
+      // below stays inside one calendar month — otherwise the loop crosses a month
+      // boundary on early-month days and the rendered ?month=YYYY-MM grid has no
+      // buttons for the spillover days. Falls back to the 5th of the prior month
+      // when today's day-of-month is < 5 so the date stays in the past (onboarding
+      // step1 rejects future dates).
+      const todayISO = await browserLocalISODate(page);
+      const [todayYear, todayMonth, todayDay] = todayISO.split('-').map((part) => Number(part));
+      const monthAnchor =
+        todayDay >= 5 ? new Date(todayYear, todayMonth - 1, 5) : new Date(todayYear, todayMonth - 2, 5);
+      const onboardingDate = `${monthAnchor.getFullYear()}-${String(monthAnchor.getMonth() + 1).padStart(2, '0')}-05`;
+
       await fillDateField(page.locator('#last-period-start'), onboardingDate);
       await page.locator('form[hx-post="/onboarding/step1"] button[type="submit"]').click();
       await expect(page.locator('form[hx-post="/onboarding/step2"]')).toBeVisible();


### PR DESCRIPTION
## Summary
- Pin the onboarding date in BUG-01 `onboarding with auto period fill disabled` to the 5th of a stable month (current month if today.day >= 5, otherwise prior month) so the +0..+4 day window the test asserts on always stays inside one calendar month.
- Fixes the time-dependent CI failure observed on PR #51 where, on early-month days, the calendar URL `?month=YYYY-MM` was pinned to the start month while the loop walked into the next month, producing `element(s) not found` for the spillover `button[data-day]` locators.

## Why this date
- Onboarding step1 rejects future dates and dates older than ~60 days (`internal/api/onboarding_step1_validation_test.go`). The 5th-of-stable-month anchor stays in `[today - 30, today]`, well inside that window.
- Same idea as the `time.Now()`-relative refactor applied to `internal/api/stats_rich_insights_regression_test.go` in commit ac58147.

## Test plan
- [ ] `npm run e2e:fast -- e2e/bugs.spec.ts` (CI default)
- [ ] Re-run the spec with the system clock set to a 1st-of-month date to confirm the month-boundary case is fixed
- [ ] Re-run with the system clock on the 5th to confirm the today.day == 5 boundary still passes the onboarding step1 "no future dates" validator
