### PR TITLE
test: cover TOTP rate-limit, cookie round-trip, login RequiresTOTP br…

### DIFF
--- a/internal/api/auth_login_totp_required_regression_test.go
+++ b/internal/api/auth_login_totp_required_regression_test.go
@@ -1,0 +1,71 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// TestLogin_TOTPEnabledUser_IssuesPendingCookieAndRedirectsTo2FAChallenge
+// covers the RequiresTOTP branch of the login handler: when valid credentials
+// are submitted by a user with TOTP enabled, the response must redirect to
+// the 2FA challenge page, set the sealed pending cookie carrying the user's
+// ID and the submitted rememberMe flag, and must NOT issue an auth session
+// cookie before the second factor is verified.
+func TestLogin_TOTPEnabledUser_IssuesPendingCookieAndRedirectsTo2FAChallenge(t *testing.T) {
+	app, database := newOnboardingTestApp(t)
+	user := createOnboardingTestUser(t, database, "totp-login@example.com", "StrongPass1", true)
+	secretKey := []byte("test-secret-key")
+	setupTOTPForUser(t, database, user.ID, secretKey)
+
+	form := url.Values{
+		"email":       {user.Email},
+		"password":    {"StrongPass1"},
+		"remember_me": {"1"},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := app.Test(req, -1)
+	if err != nil {
+		t.Fatalf("POST /api/auth/login: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303", resp.StatusCode)
+	}
+	if loc := resp.Header.Get("Location"); loc != "/auth/2fa" {
+		t.Errorf("Location = %q, want /auth/2fa", loc)
+	}
+
+	if c := responseCookie(resp.Cookies(), authCookieName); c != nil && c.Value != "" {
+		t.Error("auth cookie must not be issued before TOTP verification succeeds")
+	}
+
+	pendingCookie := responseCookie(resp.Cookies(), totpPendingCookieName)
+	if pendingCookie == nil || pendingCookie.Value == "" {
+		t.Fatalf("expected Set-Cookie %q with non-empty value", totpPendingCookieName)
+	}
+
+	codec, err := newSecureCookieCodec(secretKey)
+	if err != nil {
+		t.Fatalf("newSecureCookieCodec: %v", err)
+	}
+	decoded, err := codec.open(totpPendingCookieName, pendingCookie.Value)
+	if err != nil {
+		t.Fatalf("open pending cookie: %v", err)
+	}
+	var payload totpPendingCookiePayload
+	if err := json.Unmarshal(decoded, &payload); err != nil {
+		t.Fatalf("unmarshal pending payload: %v", err)
+	}
+	if payload.UserID != user.ID {
+		t.Errorf("pending cookie user_id = %d, want %d", payload.UserID, user.ID)
+	}
+	if !payload.RememberMe {
+		t.Error("pending cookie remember_me = false, want true (submitted with form)")
+	}
+}

--- a/internal/api/totp_cookies_test.go
+++ b/internal/api/totp_cookies_test.go
@@ -1,0 +1,275 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+// --- helpers for cookie tests ---
+
+// newTOTPCookieTestApp returns a *fiber.App and a *Handler wired to use the
+// given secret key. Two routes are registered: /seal-pending and /parse-pending
+// (and the same pair for setup) — they thinly wrap the cookie helpers under
+// test so the tests can drive the seal/parse flow through real HTTP.
+func newTOTPCookieTestApp(t *testing.T, secretKey []byte) (*fiber.App, *Handler) {
+	t.Helper()
+	handler := &Handler{secretKey: secretKey, cookieSecure: false}
+	app := fiber.New()
+	app.Get("/seal-pending", func(c *fiber.Ctx) error {
+		userID := uint(c.QueryInt("user_id", 0))
+		remember := c.QueryBool("remember_me", false)
+		if err := handler.setTOTPPendingCookie(c, userID, remember); err != nil {
+			return c.Status(fiber.StatusInternalServerError).SendString(err.Error())
+		}
+		return c.SendStatus(fiber.StatusOK)
+	})
+	app.Get("/parse-pending", func(c *fiber.Ctx) error {
+		uid, remember, err := handler.parseTOTPPendingCookie(c)
+		if err != nil {
+			return c.Status(fiber.StatusBadRequest).SendString(err.Error())
+		}
+		return c.JSON(fiber.Map{"user_id": uid, "remember_me": remember})
+	})
+	app.Get("/seal-setup", func(c *fiber.Ctx) error {
+		raw := c.Query("raw_secret", "")
+		if err := handler.setTOTPSetupCookie(c, raw); err != nil {
+			return c.Status(fiber.StatusInternalServerError).SendString(err.Error())
+		}
+		return c.SendStatus(fiber.StatusOK)
+	})
+	app.Get("/parse-setup", func(c *fiber.Ctx) error {
+		raw, err := handler.parseTOTPSetupCookie(c)
+		if err != nil {
+			return c.Status(fiber.StatusBadRequest).SendString(err.Error())
+		}
+		return c.JSON(fiber.Map{"raw_secret": raw})
+	})
+	return app, handler
+}
+
+func captureCookieValue(t *testing.T, resp *http.Response, name string) string {
+	t.Helper()
+	c := responseCookie(resp.Cookies(), name)
+	if c == nil || c.Value == "" {
+		t.Fatalf("expected Set-Cookie %q with non-empty value", name)
+	}
+	return c.Value
+}
+
+func sealExpiredPayload(t *testing.T, secretKey []byte, purpose string, payload any) string {
+	t.Helper()
+	serialized, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	codec, err := newSecureCookieCodec(secretKey)
+	if err != nil {
+		t.Fatalf("newSecureCookieCodec: %v", err)
+	}
+	sealed, err := codec.seal(purpose, serialized)
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	return sealed
+}
+
+// --- TOTP pending cookie ---
+
+func TestTOTPPendingCookie_RoundTrip(t *testing.T) {
+	app, _ := newTOTPCookieTestApp(t, []byte("test-secret-key"))
+
+	sealReq := httptest.NewRequest(http.MethodGet, "/seal-pending?user_id=42&remember_me=true", nil)
+	sealResp, err := app.Test(sealReq, -1)
+	if err != nil {
+		t.Fatalf("GET /seal-pending: %v", err)
+	}
+	defer sealResp.Body.Close()
+	if sealResp.StatusCode != http.StatusOK {
+		t.Fatalf("seal status = %d, want 200", sealResp.StatusCode)
+	}
+	cookieValue := captureCookieValue(t, sealResp, totpPendingCookieName)
+
+	parseReq := httptest.NewRequest(http.MethodGet, "/parse-pending", nil)
+	parseReq.Header.Set("Cookie", totpPendingCookieName+"="+cookieValue)
+	parseResp, err := app.Test(parseReq, -1)
+	if err != nil {
+		t.Fatalf("GET /parse-pending: %v", err)
+	}
+	defer parseResp.Body.Close()
+	if parseResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(parseResp.Body)
+		t.Fatalf("parse status = %d, body = %q", parseResp.StatusCode, body)
+	}
+
+	var got struct {
+		UserID     uint `json:"user_id"`
+		RememberMe bool `json:"remember_me"`
+	}
+	if err := json.NewDecoder(parseResp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode parse response: %v", err)
+	}
+	if got.UserID != 42 {
+		t.Errorf("user_id = %d, want 42", got.UserID)
+	}
+	if !got.RememberMe {
+		t.Error("remember_me = false, want true")
+	}
+}
+
+func TestTOTPPendingCookie_ExpiredPayload_ParseError(t *testing.T) {
+	secretKey := []byte("test-secret-key")
+	app, _ := newTOTPCookieTestApp(t, secretKey)
+
+	sealed := sealExpiredPayload(t, secretKey, totpPendingCookieName, totpPendingCookiePayload{
+		UserID:    1,
+		ExpiresAt: time.Now().Add(-1 * time.Minute),
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/parse-pending", nil)
+	req.Header.Set("Cookie", totpPendingCookieName+"="+sealed)
+	resp, err := app.Test(req, -1)
+	if err != nil {
+		t.Fatalf("GET /parse-pending: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "expired") {
+		t.Errorf("error %q, want to contain %q", string(body), "expired")
+	}
+}
+
+func TestTOTPPendingCookie_WrongSigningKey_ParseError(t *testing.T) {
+	sealedSecret := []byte("seal-key-original")
+	openSecret := []byte("open-key-different")
+
+	sealApp, _ := newTOTPCookieTestApp(t, sealedSecret)
+	sealReq := httptest.NewRequest(http.MethodGet, "/seal-pending?user_id=7", nil)
+	sealResp, err := sealApp.Test(sealReq, -1)
+	if err != nil {
+		t.Fatalf("GET /seal-pending: %v", err)
+	}
+	defer sealResp.Body.Close()
+	cookieValue := captureCookieValue(t, sealResp, totpPendingCookieName)
+
+	openApp, _ := newTOTPCookieTestApp(t, openSecret)
+	parseReq := httptest.NewRequest(http.MethodGet, "/parse-pending", nil)
+	parseReq.Header.Set("Cookie", totpPendingCookieName+"="+cookieValue)
+	parseResp, err := openApp.Test(parseReq, -1)
+	if err != nil {
+		t.Fatalf("GET /parse-pending: %v", err)
+	}
+	defer parseResp.Body.Close()
+	if parseResp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", parseResp.StatusCode)
+	}
+	body, _ := io.ReadAll(parseResp.Body)
+	if !strings.Contains(string(body), "invalid") {
+		t.Errorf("error %q, want to contain %q", string(body), "invalid")
+	}
+}
+
+// --- TOTP setup cookie ---
+
+func TestTOTPSetupCookie_RoundTrip(t *testing.T) {
+	app, _ := newTOTPCookieTestApp(t, []byte("test-secret-key"))
+
+	const rawSecret = "JBSWY3DPEHPK3PXP"
+
+	sealReq := httptest.NewRequest(http.MethodGet, "/seal-setup?raw_secret="+rawSecret, nil)
+	sealResp, err := app.Test(sealReq, -1)
+	if err != nil {
+		t.Fatalf("GET /seal-setup: %v", err)
+	}
+	defer sealResp.Body.Close()
+	if sealResp.StatusCode != http.StatusOK {
+		t.Fatalf("seal status = %d, want 200", sealResp.StatusCode)
+	}
+	cookieValue := captureCookieValue(t, sealResp, totpSetupCookieName)
+
+	parseReq := httptest.NewRequest(http.MethodGet, "/parse-setup", nil)
+	parseReq.Header.Set("Cookie", totpSetupCookieName+"="+cookieValue)
+	parseResp, err := app.Test(parseReq, -1)
+	if err != nil {
+		t.Fatalf("GET /parse-setup: %v", err)
+	}
+	defer parseResp.Body.Close()
+	if parseResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(parseResp.Body)
+		t.Fatalf("parse status = %d, body = %q", parseResp.StatusCode, body)
+	}
+
+	var got struct {
+		RawSecret string `json:"raw_secret"`
+	}
+	if err := json.NewDecoder(parseResp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode parse response: %v", err)
+	}
+	if got.RawSecret != rawSecret {
+		t.Errorf("raw_secret = %q, want %q", got.RawSecret, rawSecret)
+	}
+}
+
+func TestTOTPSetupCookie_ExpiredPayload_ParseError(t *testing.T) {
+	secretKey := []byte("test-secret-key")
+	app, _ := newTOTPCookieTestApp(t, secretKey)
+
+	sealed := sealExpiredPayload(t, secretKey, totpSetupCookieName, totpSetupCookiePayload{
+		RawSecret: "JBSWY3DPEHPK3PXP",
+		ExpiresAt: time.Now().Add(-1 * time.Minute),
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/parse-setup", nil)
+	req.Header.Set("Cookie", totpSetupCookieName+"="+sealed)
+	resp, err := app.Test(req, -1)
+	if err != nil {
+		t.Fatalf("GET /parse-setup: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "expired") {
+		t.Errorf("error %q, want to contain %q", string(body), "expired")
+	}
+}
+
+func TestTOTPSetupCookie_WrongSigningKey_ParseError(t *testing.T) {
+	sealedSecret := []byte("seal-key-original")
+	openSecret := []byte("open-key-different")
+
+	sealApp, _ := newTOTPCookieTestApp(t, sealedSecret)
+	sealReq := httptest.NewRequest(http.MethodGet, "/seal-setup?raw_secret=JBSWY3DPEHPK3PXP", nil)
+	sealResp, err := sealApp.Test(sealReq, -1)
+	if err != nil {
+		t.Fatalf("GET /seal-setup: %v", err)
+	}
+	defer sealResp.Body.Close()
+	cookieValue := captureCookieValue(t, sealResp, totpSetupCookieName)
+
+	openApp, _ := newTOTPCookieTestApp(t, openSecret)
+	parseReq := httptest.NewRequest(http.MethodGet, "/parse-setup", nil)
+	parseReq.Header.Set("Cookie", totpSetupCookieName+"="+cookieValue)
+	parseResp, err := openApp.Test(parseReq, -1)
+	if err != nil {
+		t.Fatalf("GET /parse-setup: %v", err)
+	}
+	defer parseResp.Body.Close()
+	if parseResp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", parseResp.StatusCode)
+	}
+	body, _ := io.ReadAll(parseResp.Body)
+	if !strings.Contains(string(body), "invalid") {
+		t.Errorf("error %q, want to contain %q", string(body), "invalid")
+	}
+}

--- a/internal/services/totp_service_test.go
+++ b/internal/services/totp_service_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -242,5 +243,174 @@ func TestTOTPService_EnableTOTP_RepoError(t *testing.T) {
 	err := svc.EnableTOTP(1, "JBSWY3DPEHPK3PXP")
 	if err == nil {
 		t.Fatal("EnableTOTP() should propagate repo error")
+	}
+}
+
+// --- rate-limit: verification (CheckRateLimit / RecordFailure / ResetAttempts) ---
+
+func TestTOTPService_CheckRateLimit_BelowLimit_ReturnsNil(t *testing.T) {
+	repo := &stubTOTPUserRepo{}
+	secretKey := []byte("test-secret-key-32-bytes-padding!")
+	svc := NewTOTPService(repo, secretKey, nil)
+	now := time.Now()
+
+	for i := 0; i < DefaultTOTPAttemptsLimit-1; i++ {
+		svc.RecordFailure(secretKey, "1.2.3.4", 1, now)
+	}
+
+	if err := svc.CheckRateLimit(secretKey, "1.2.3.4", 1, now); err != nil {
+		t.Errorf("CheckRateLimit() after %d failures = %v, want nil", DefaultTOTPAttemptsLimit-1, err)
+	}
+}
+
+func TestTOTPService_CheckRateLimit_AtLimit_ReturnsErrTOTPRateLimited(t *testing.T) {
+	repo := &stubTOTPUserRepo{}
+	secretKey := []byte("test-secret-key-32-bytes-padding!")
+	svc := NewTOTPService(repo, secretKey, nil)
+	now := time.Now()
+
+	for i := 0; i < DefaultTOTPAttemptsLimit; i++ {
+		svc.RecordFailure(secretKey, "1.2.3.4", 1, now)
+	}
+
+	err := svc.CheckRateLimit(secretKey, "1.2.3.4", 1, now)
+	if !errors.Is(err, ErrTOTPRateLimited) {
+		t.Errorf("CheckRateLimit() after %d failures = %v, want ErrTOTPRateLimited", DefaultTOTPAttemptsLimit, err)
+	}
+}
+
+func TestTOTPService_ResetAttempts_ClearsLimit(t *testing.T) {
+	repo := &stubTOTPUserRepo{}
+	secretKey := []byte("test-secret-key-32-bytes-padding!")
+	svc := NewTOTPService(repo, secretKey, nil)
+	now := time.Now()
+
+	for i := 0; i < DefaultTOTPAttemptsLimit; i++ {
+		svc.RecordFailure(secretKey, "1.2.3.4", 1, now)
+	}
+	if err := svc.CheckRateLimit(secretKey, "1.2.3.4", 1, now); !errors.Is(err, ErrTOTPRateLimited) {
+		t.Fatalf("precondition: limiter not tripped after %d failures, err=%v", DefaultTOTPAttemptsLimit, err)
+	}
+
+	svc.ResetAttempts(secretKey, "1.2.3.4", 1)
+
+	if err := svc.CheckRateLimit(secretKey, "1.2.3.4", 1, now); err != nil {
+		t.Errorf("CheckRateLimit() after ResetAttempts = %v, want nil", err)
+	}
+}
+
+// TestTOTPService_CheckRateLimit_IdentityIsolation verifies that failures
+// recorded for one user do not trip the limiter for another user from a
+// different client. Both the client bucket and the HMAC'd identity bucket
+// must be independent.
+func TestTOTPService_CheckRateLimit_IdentityIsolation(t *testing.T) {
+	repo := &stubTOTPUserRepo{}
+	secretKey := []byte("test-secret-key-32-bytes-padding!")
+	svc := NewTOTPService(repo, secretKey, nil)
+	now := time.Now()
+
+	for i := 0; i < DefaultTOTPAttemptsLimit; i++ {
+		svc.RecordFailure(secretKey, "client-A", 1, now)
+	}
+
+	if err := svc.CheckRateLimit(secretKey, "client-A", 1, now); !errors.Is(err, ErrTOTPRateLimited) {
+		t.Fatalf("user 1 from client-A should be limited, got %v", err)
+	}
+	if err := svc.CheckRateLimit(secretKey, "client-B", 2, now); err != nil {
+		t.Errorf("user 2 from client-B should not be limited (HMAC'd identity bucket independent), got %v", err)
+	}
+}
+
+// TestTOTPService_CheckRateLimit_ClientIPIsolation verifies that failures
+// recorded from one client IP do not trip the limiter for another client IP
+// when the user identity also differs.
+func TestTOTPService_CheckRateLimit_ClientIPIsolation(t *testing.T) {
+	repo := &stubTOTPUserRepo{}
+	secretKey := []byte("test-secret-key-32-bytes-padding!")
+	svc := NewTOTPService(repo, secretKey, nil)
+	now := time.Now()
+
+	for i := 0; i < DefaultTOTPAttemptsLimit; i++ {
+		svc.RecordFailure(secretKey, "1.1.1.1", 100, now)
+	}
+
+	if err := svc.CheckRateLimit(secretKey, "1.1.1.1", 100, now); !errors.Is(err, ErrTOTPRateLimited) {
+		t.Fatalf("client 1.1.1.1 should be limited, got %v", err)
+	}
+	if err := svc.CheckRateLimit(secretKey, "2.2.2.2", 200, now); err != nil {
+		t.Errorf("client 2.2.2.2 should not be limited, got %v", err)
+	}
+}
+
+// --- rate-limit: disable (CheckDisableRateLimit / RecordDisableFailure / ResetDisableAttempts) ---
+
+func TestTOTPService_CheckDisableRateLimit_BelowLimit_ReturnsNil(t *testing.T) {
+	repo := &stubTOTPUserRepo{}
+	secretKey := []byte("test-secret-key-32-bytes-padding!")
+	svc := NewTOTPService(repo, secretKey, nil)
+	now := time.Now()
+
+	for i := 0; i < DefaultTOTPDisableAttemptsLimit-1; i++ {
+		svc.RecordDisableFailure(secretKey, "1.2.3.4", 1, now)
+	}
+
+	if err := svc.CheckDisableRateLimit(secretKey, "1.2.3.4", 1, now); err != nil {
+		t.Errorf("CheckDisableRateLimit() after %d failures = %v, want nil", DefaultTOTPDisableAttemptsLimit-1, err)
+	}
+}
+
+func TestTOTPService_CheckDisableRateLimit_AtLimit_ReturnsErrTOTPDisableRateLimited(t *testing.T) {
+	repo := &stubTOTPUserRepo{}
+	secretKey := []byte("test-secret-key-32-bytes-padding!")
+	svc := NewTOTPService(repo, secretKey, nil)
+	now := time.Now()
+
+	for i := 0; i < DefaultTOTPDisableAttemptsLimit; i++ {
+		svc.RecordDisableFailure(secretKey, "1.2.3.4", 1, now)
+	}
+
+	err := svc.CheckDisableRateLimit(secretKey, "1.2.3.4", 1, now)
+	if !errors.Is(err, ErrTOTPDisableRateLimited) {
+		t.Errorf("CheckDisableRateLimit() after %d failures = %v, want ErrTOTPDisableRateLimited", DefaultTOTPDisableAttemptsLimit, err)
+	}
+}
+
+func TestTOTPService_ResetDisableAttempts_ClearsLimit(t *testing.T) {
+	repo := &stubTOTPUserRepo{}
+	secretKey := []byte("test-secret-key-32-bytes-padding!")
+	svc := NewTOTPService(repo, secretKey, nil)
+	now := time.Now()
+
+	for i := 0; i < DefaultTOTPDisableAttemptsLimit; i++ {
+		svc.RecordDisableFailure(secretKey, "1.2.3.4", 1, now)
+	}
+	if err := svc.CheckDisableRateLimit(secretKey, "1.2.3.4", 1, now); !errors.Is(err, ErrTOTPDisableRateLimited) {
+		t.Fatalf("precondition: disable limiter not tripped after %d failures, err=%v", DefaultTOTPDisableAttemptsLimit, err)
+	}
+
+	svc.ResetDisableAttempts(secretKey, "1.2.3.4", 1)
+
+	if err := svc.CheckDisableRateLimit(secretKey, "1.2.3.4", 1, now); err != nil {
+		t.Errorf("CheckDisableRateLimit() after ResetDisableAttempts = %v, want nil", err)
+	}
+}
+
+// TestTOTPService_DisableAndVerifyLimitsAreIndependent verifies that the
+// "totp" and "totp.disable" scopes use separate buckets — exhausting the
+// disable limit must not trip the verification limit and vice versa.
+func TestTOTPService_DisableAndVerifyLimitsAreIndependent(t *testing.T) {
+	repo := &stubTOTPUserRepo{}
+	secretKey := []byte("test-secret-key-32-bytes-padding!")
+	svc := NewTOTPService(repo, secretKey, nil)
+	now := time.Now()
+
+	for i := 0; i < DefaultTOTPDisableAttemptsLimit; i++ {
+		svc.RecordDisableFailure(secretKey, "1.2.3.4", 1, now)
+	}
+	if err := svc.CheckDisableRateLimit(secretKey, "1.2.3.4", 1, now); !errors.Is(err, ErrTOTPDisableRateLimited) {
+		t.Fatalf("precondition: disable limiter not tripped, err=%v", err)
+	}
+	if err := svc.CheckRateLimit(secretKey, "1.2.3.4", 1, now); err != nil {
+		t.Errorf("verify limiter must be independent of disable limiter, got %v", err)
 	}
 }


### PR DESCRIPTION
…anch

Coverage-only follow-up to #51. No production code changes.

- internal/services/totp_service_test.go: rate-limit triple (below-limit / at-limit / reset) for both verify and disable scopes, identity isolation, client-IP isolation, and that the two scopes' buckets are independent.
- internal/api/totp_cookies_test.go: round-trip + expired payload
  + wrong signing key for both pending and setup cookies.
- internal/api/auth_login_totp_required_regression_test.go: login with TOTP-enabled user redirects to /auth/2fa, sets the sealed pending cookie carrying user ID + rememberMe, and does not issue an auth session cookie before the second factor.