### PR TITLE
fix(time): canonicalize DailyLog.Date and User.LastPeriodStart to UTC…

### DIFF
--- a/internal/api/day_upsert_canonicalization_regression_test.go
+++ b/internal/api/day_upsert_canonicalization_regression_test.go
@@ -1,0 +1,111 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/ovumcy/ovumcy-web/internal/models"
+)
+
+// TestUpsertDayCanonicalizesStoredDateToUTCMidnightForRequestTimezone is the
+// HTTP-level lock for issue #49. A POST /api/days/{ISODate} arriving with
+// a non-UTC request timezone (X-Ovumcy-Timezone header + ovumcy_tz cookie
+// pair) must persist DailyLog.Date as UTC-midnight on disk. The same
+// calendar day, fetched via GET in the same locale, must round-trip back
+// through DayRange and find the row. Without the BeforeSave hook +
+// DayRange UTC bounds, the upsert succeeds but a follow-up DELETE/UPSERT
+// cycle would miss the row in UTC-minus zones, producing a unique-index
+// conflict.
+func TestUpsertDayCanonicalizesStoredDateToUTCMidnightForRequestTimezone(t *testing.T) {
+	cases := []struct {
+		name         string
+		timezoneName string
+		email        string
+	}{
+		{name: "America/Toronto UTC-5", timezoneName: "America/Toronto", email: "upsert-canonical-toronto@example.com"},
+		{name: "Asia/Tokyo UTC+9", timezoneName: "Asia/Tokyo", email: "upsert-canonical-tokyo@example.com"},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			location, err := time.LoadLocation(tt.timezoneName)
+			if err != nil {
+				t.Skipf("zoneinfo for %s unavailable: %v", tt.timezoneName, err)
+			}
+
+			app, database, _ := newOnboardingTestAppWithLocation(t, time.UTC)
+			user := createOnboardingTestUser(t, database, tt.email, "StrongPass1", true)
+			authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
+
+			payload := map[string]any{
+				"is_period":   true,
+				"flow":        models.FlowMedium,
+				"symptom_ids": []uint{},
+				"notes":       "",
+			}
+			body, err := json.Marshal(payload)
+			if err != nil {
+				t.Fatalf("marshal payload: %v", err)
+			}
+
+			postedDayRaw := "2026-02-10"
+			request := httptest.NewRequest(http.MethodPost, "/api/days/"+postedDayRaw, bytes.NewReader(body))
+			request.Header.Set("Content-Type", fiber.MIMEApplicationJSON)
+			request.Header.Set("Cookie", joinCookieHeader(authCookie, timezoneCookieName+"="+location.String()))
+			request.Header.Set(timezoneHeaderName, location.String())
+
+			response, err := app.Test(request, -1)
+			if err != nil {
+				t.Fatalf("upsert request failed: %v", err)
+			}
+			defer response.Body.Close()
+			if response.StatusCode != http.StatusOK {
+				t.Fatalf("expected upsert status 200, got %d", response.StatusCode)
+			}
+
+			var rawDate string
+			if err := database.Raw("SELECT date FROM daily_logs WHERE user_id = ? ORDER BY date ASC LIMIT 1", user.ID).Row().Scan(&rawDate); err != nil {
+				t.Fatalf("raw SELECT date: %v", err)
+			}
+			if !strings.HasPrefix(rawDate, postedDayRaw) {
+				t.Fatalf("expected on-disk date prefix %q, got %q (calendar day must reflect the request locale day)", postedDayRaw, rawDate)
+			}
+			if strings.Contains(rawDate, "-05:") || strings.Contains(rawDate, "+09:") {
+				t.Fatalf("expected canonical UTC offset on disk, got non-UTC offset in %q", rawDate)
+			}
+
+			roundTripRequest := httptest.NewRequest(http.MethodGet, "/api/days/"+postedDayRaw, nil)
+			roundTripRequest.Header.Set("Cookie", joinCookieHeader(authCookie, timezoneCookieName+"="+location.String()))
+			roundTripRequest.Header.Set(timezoneHeaderName, location.String())
+
+			roundTripResponse, err := app.Test(roundTripRequest, -1)
+			if err != nil {
+				t.Fatalf("round-trip GET failed: %v", err)
+			}
+			defer roundTripResponse.Body.Close()
+			if roundTripResponse.StatusCode != http.StatusOK {
+				t.Fatalf("expected round-trip status 200, got %d", roundTripResponse.StatusCode)
+			}
+
+			var loaded models.DailyLog
+			if err := json.NewDecoder(roundTripResponse.Body).Decode(&loaded); err != nil {
+				t.Fatalf("decode round-trip body: %v", err)
+			}
+			if !loaded.IsPeriod {
+				t.Fatalf("expected round-trip entry to retain is_period=true; DayRange bounds may be drifting past the canonical row in %s", tt.timezoneName)
+			}
+			if loaded.Flow != models.FlowMedium {
+				t.Fatalf("expected flow %q, got %q", models.FlowMedium, loaded.Flow)
+			}
+			if loaded.Date.Format("2006-01-02") != postedDayRaw {
+				t.Fatalf("expected calendar day %s preserved through round-trip, got %s", postedDayRaw, loaded.Date.Format("2006-01-02"))
+			}
+		})
+	}
+}

--- a/internal/models/daily_log.go
+++ b/internal/models/daily_log.go
@@ -47,5 +47,9 @@ func (logEntry *DailyLog) BeforeSave(*gorm.DB) error {
 	if logEntry.CycleFactorKeys == nil {
 		logEntry.CycleFactorKeys = []string{}
 	}
+	if !logEntry.Date.IsZero() {
+		year, month, day := logEntry.Date.Date()
+		logEntry.Date = time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+	}
 	return nil
 }

--- a/internal/services/day_canonicalization_regression_test.go
+++ b/internal/services/day_canonicalization_regression_test.go
@@ -1,0 +1,87 @@
+package services
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+)
+
+// TestDayServiceUpsertCanonicalizesDateToUTCMidnight is the regression lock
+// for issue #49. After the BeforeSave hook + DayRange fix, every newly
+// written DailyLog.Date must persist as UTC-midnight on disk regardless of
+// the request location, and the same round-trip via FetchLogByDate must
+// find the row from the local-calendar-day perspective. Without the
+// DayRange UTC bounds, the FetchLogByDate query in UTC-minus zones drifts
+// past the row and returns no match (the failure mode flagged in the
+// issue: 8 tests broke when only the BeforeSave hook landed).
+func TestDayServiceUpsertCanonicalizesDateToUTCMidnight(t *testing.T) {
+	toronto, err := time.LoadLocation("America/Toronto")
+	if err != nil {
+		t.Skipf("zoneinfo for America/Toronto unavailable: %v", err)
+	}
+	tokyo, err := time.LoadLocation("Asia/Tokyo")
+	if err != nil {
+		t.Skipf("zoneinfo for Asia/Tokyo unavailable: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		location *time.Location
+		email    string
+	}{
+		{name: "America/Toronto UTC-5", location: toronto, email: "canonicalize-toronto@example.com"},
+		{name: "Asia/Tokyo UTC+9", location: tokyo, email: "canonicalize-tokyo@example.com"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service, database := newDayServiceIntegration(t)
+			user := createDayServiceTestUser(t, database, tt.email)
+
+			localCalendarDay := time.Date(2026, time.February, 10, 0, 0, 0, 0, tt.location)
+			now := localCalendarDay.Add(8 * time.Hour)
+
+			if _, err := service.UpsertDayEntryWithAutoFillAt(user.ID, localCalendarDay, DayEntryInput{
+				IsPeriod:      true,
+				Flow:          models.FlowMedium,
+				Mood:          0,
+				SexActivity:   models.SexActivityNone,
+				CervicalMucus: models.CervicalMucusNone,
+			}, now, tt.location); err != nil {
+				t.Fatalf("UpsertDayEntryWithAutoFillAt: %v", err)
+			}
+
+			var rawDate string
+			if err := database.Raw("SELECT date FROM daily_logs WHERE user_id = ? ORDER BY date ASC LIMIT 1", user.ID).Row().Scan(&rawDate); err != nil {
+				t.Fatalf("raw SELECT date: %v", err)
+			}
+			if !strings.HasPrefix(rawDate, "2026-02-10") {
+				t.Fatalf("expected on-disk date to begin with local calendar day 2026-02-10, got %q", rawDate)
+			}
+			if strings.Contains(rawDate, "+") || strings.Contains(rawDate, "-05:") || strings.Contains(rawDate, "+09:") {
+				if !strings.Contains(rawDate, "+00:00") && !strings.Contains(rawDate, "Z") {
+					t.Fatalf("expected on-disk offset to be UTC (+00:00 or Z), got %q", rawDate)
+				}
+			}
+
+			entry, err := service.FetchLogByDate(user.ID, localCalendarDay, tt.location)
+			if err != nil {
+				t.Fatalf("FetchLogByDate after canonicalized write: %v", err)
+			}
+			if !entry.IsPeriod {
+				t.Fatalf("expected upserted period entry to be found via local-day round-trip, got is_period=false (DayRange bounds drifted past UTC-midnight row)")
+			}
+			if entry.Flow != models.FlowMedium {
+				t.Fatalf("expected flow %q, got %q", models.FlowMedium, entry.Flow)
+			}
+			if entry.Date.Format("2006-01-02") != "2026-02-10" {
+				t.Fatalf("expected loaded entry to carry calendar day 2026-02-10, got %s", entry.Date.Format("2006-01-02"))
+			}
+			if entry.Date.Hour() != 0 || entry.Date.Minute() != 0 {
+				t.Fatalf("expected loaded entry at midnight, got %s", entry.Date.Format(time.RFC3339Nano))
+			}
+		})
+	}
+}

--- a/internal/services/day_utils.go
+++ b/internal/services/day_utils.go
@@ -57,8 +57,17 @@ func CalendarDayKey(value time.Time) string {
 	return fmt.Sprintf("%04d-%02d-%02d", year, month, day)
 }
 
+// DayRange returns the [start, end) bounds for the local calendar day of
+// `value` in `location`, expressed as UTC-midnight instants. The local
+// calendar day is computed via DateAtLocation; the resulting y/m/d is then
+// rebuilt at UTC-midnight so the bounds match the on-disk shape produced
+// by DailyLog.BeforeSave (which canonicalizes Date to UTC-midnight). This
+// keeps DELETE/UPSERT range queries aligned with stored rows regardless
+// of the request timezone offset.
 func DayRange(value time.Time, location *time.Location) (time.Time, time.Time) {
-	start := DateAtLocation(value, location)
+	localMidnight := DateAtLocation(value, location)
+	year, month, day := localMidnight.Date()
+	start := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
 	return start, start.AddDate(0, 0, 1)
 }
 

--- a/internal/services/day_utils_test.go
+++ b/internal/services/day_utils_test.go
@@ -54,20 +54,62 @@ func TestDayHasData(t *testing.T) {
 	}
 }
 
-func TestDayRangeNormalizesToLocationMidnight(t *testing.T) {
-	location, err := time.LoadLocation("Europe/Moscow")
+func TestDayRangeReturnsUTCBoundsForLocalCalendarDay(t *testing.T) {
+	moscow, err := time.LoadLocation("Europe/Moscow")
 	if err != nil {
-		t.Fatalf("load location: %v", err)
+		t.Fatalf("load Europe/Moscow: %v", err)
+	}
+	toronto, err := time.LoadLocation("America/Toronto")
+	if err != nil {
+		t.Fatalf("load America/Toronto: %v", err)
 	}
 
-	raw := time.Date(2026, 2, 1, 19, 35, 10, 0, time.UTC)
-	start, end := DayRange(raw, location)
-
-	if start.Hour() != 0 || start.Minute() != 0 || start.Second() != 0 {
-		t.Fatalf("expected midnight start, got %s", start.Format(time.RFC3339))
+	tests := []struct {
+		name        string
+		input       time.Time
+		location    *time.Location
+		wantDateKey string
+	}{
+		{
+			name:        "Moscow UTC+3 instant in local 2026-02-01",
+			input:       time.Date(2026, time.February, 1, 19, 35, 10, 0, time.UTC),
+			location:    moscow,
+			wantDateKey: "2026-02-01",
+		},
+		{
+			name:        "Toronto UTC-5 instant past UTC midnight is local 2026-02-09",
+			input:       time.Date(2026, time.February, 10, 2, 0, 0, 0, time.UTC),
+			location:    toronto,
+			wantDateKey: "2026-02-09",
+		},
+		{
+			name:        "Toronto UTC-5 morning instant is local 2026-02-10",
+			input:       time.Date(2026, time.February, 10, 14, 0, 0, 0, time.UTC),
+			location:    toronto,
+			wantDateKey: "2026-02-10",
+		},
 	}
-	if !end.Equal(start.AddDate(0, 0, 1)) {
-		t.Fatalf("expected next day end, got %s", end.Format(time.RFC3339))
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			start, end := DayRange(tt.input, tt.location)
+
+			if start.Location() != time.UTC {
+				t.Fatalf("expected UTC start, got %s", start.Location())
+			}
+			if end.Location() != time.UTC {
+				t.Fatalf("expected UTC end, got %s", end.Location())
+			}
+			if start.Hour() != 0 || start.Minute() != 0 || start.Second() != 0 || start.Nanosecond() != 0 {
+				t.Fatalf("expected UTC-midnight start, got %s", start.Format(time.RFC3339Nano))
+			}
+			if got := start.Format("2006-01-02"); got != tt.wantDateKey {
+				t.Fatalf("expected local calendar day %s rebuilt at UTC, got %s", tt.wantDateKey, got)
+			}
+			if got := end.Sub(start); got != 24*time.Hour {
+				t.Fatalf("expected 24h range, got %s", got)
+			}
+		})
 	}
 }
 

--- a/internal/services/onboarding_policy_test.go
+++ b/internal/services/onboarding_policy_test.go
@@ -114,6 +114,51 @@ func TestValidateAndParseStep1StartDate(t *testing.T) {
 	if parsed.Format("2006-01-02") != "2026-04-10" {
 		t.Fatalf("expected parsed date 2026-04-10, got %s", parsed.Format("2006-01-02"))
 	}
+	if parsed.Location() != time.UTC {
+		t.Fatalf("expected canonical UTC location, got %s", parsed.Location())
+	}
+	if parsed.Hour() != 0 || parsed.Minute() != 0 || parsed.Second() != 0 || parsed.Nanosecond() != 0 {
+		t.Fatalf("expected UTC-midnight, got %s", parsed.Format(time.RFC3339Nano))
+	}
+}
+
+func TestValidateAndParseStep1StartDateCanonicalizesAcrossLocations(t *testing.T) {
+	tokyo, err := time.LoadLocation("Asia/Tokyo")
+	if err != nil {
+		t.Fatalf("load Asia/Tokyo: %v", err)
+	}
+	toronto, err := time.LoadLocation("America/Toronto")
+	if err != nil {
+		t.Fatalf("load America/Toronto: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		location *time.Location
+	}{
+		{name: "UTC+9 Tokyo", location: tokyo},
+		{name: "UTC-5 Toronto", location: toronto},
+	}
+
+	service := NewOnboardingService(nil)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			now := time.Date(2026, time.April, 15, 10, 0, 0, 0, tt.location)
+			parsed, err := service.ValidateAndParseStep1StartDate("2026-04-10", now, tt.location)
+			if err != nil {
+				t.Fatalf("expected valid step1 date, got %v", err)
+			}
+			if parsed.Location() != time.UTC {
+				t.Fatalf("expected canonical UTC location regardless of input location, got %s", parsed.Location())
+			}
+			if parsed.Format("2006-01-02") != "2026-04-10" {
+				t.Fatalf("expected calendar day 2026-04-10 preserved, got %s", parsed.Format("2006-01-02"))
+			}
+			if parsed.Hour() != 0 || parsed.Minute() != 0 {
+				t.Fatalf("expected UTC-midnight, got %s", parsed.Format(time.RFC3339Nano))
+			}
+		})
+	}
 }
 
 func TestResolveCycleAndPeriodDefaults(t *testing.T) {

--- a/internal/services/onboarding_service.go
+++ b/internal/services/onboarding_service.go
@@ -64,7 +64,7 @@ func (service *OnboardingService) ValidateAndParseStep1StartDate(raw string, now
 	if err := service.ValidateStep1StartDate(parsed, now, location); err != nil {
 		return time.Time{}, err
 	}
-	return parsed, nil
+	return time.Date(parsed.Year(), parsed.Month(), parsed.Day(), 0, 0, 0, 0, time.UTC), nil
 }
 
 func (service *OnboardingService) SaveStep2(userID uint, cycleLength int, periodLength int, autoPeriodFill bool, irregularCycle bool, ageGroup string, usageGoal string) (int, int, error) {
@@ -106,7 +106,7 @@ func (service *OnboardingService) CompleteOnboardingForUser(userID uint, locatio
 		return time.Time{}, ErrOnboardingStepsRequired
 	}
 
-	startDay := CalendarDay(*current.LastPeriodStart, location)
+	startDay := CalendarDay(*current.LastPeriodStart, time.UTC)
 	_, periodLength := SanitizeOnboardingCycleAndPeriod(current.CycleLength, current.PeriodLength)
 	if err := service.users.CompleteOnboarding(userID, startDay, periodLength, current.AutoPeriodFill); err != nil {
 		return time.Time{}, err

--- a/internal/services/onboarding_service_test.go
+++ b/internal/services/onboarding_service_test.go
@@ -91,4 +91,13 @@ func TestCompleteOnboardingForUserNormalizesDateAndPeriod(t *testing.T) {
 	if startDay.Hour() != 0 || startDay.Minute() != 0 {
 		t.Fatalf("expected normalized start day, got %s", startDay.Format(time.RFC3339))
 	}
+	if startDay.Location() != time.UTC {
+		t.Fatalf("expected start day at UTC so user_repository.CompleteOnboarding iterates UTC-midnight bounds, got %s", startDay.Location())
+	}
+	if !repo.completeStartDay.Equal(startDay) {
+		t.Fatalf("expected repo to receive same canonical start day, got repo=%s service=%s", repo.completeStartDay.Format(time.RFC3339), startDay.Format(time.RFC3339))
+	}
+	if repo.completeStartDay.Format("2006-01-02") != "2026-02-10" {
+		t.Fatalf("expected calendar day 2026-02-10 preserved, got %s", repo.completeStartDay.Format("2006-01-02"))
+	}
 }

--- a/internal/services/settings_cycle_policy.go
+++ b/internal/services/settings_cycle_policy.go
@@ -67,14 +67,14 @@ func (service *SettingsService) ValidateCycleSettings(input CycleSettingsValidat
 	if err != nil {
 		return CycleSettingsUpdate{}, ErrSettingsCycleStartDateInvalid
 	}
-	parsedDay = DateAtLocation(parsedDay, location)
 
 	minCycleStart, today := SettingsCycleStartDateBounds(now, location)
 	if parsedDay.Before(minCycleStart) || parsedDay.After(today) {
 		return CycleSettingsUpdate{}, ErrSettingsCycleStartDateInvalid
 	}
 
-	update.LastPeriodStart = &parsedDay
+	canonical := time.Date(parsedDay.Year(), parsedDay.Month(), parsedDay.Day(), 0, 0, 0, 0, time.UTC)
+	update.LastPeriodStart = &canonical
 	return update, nil
 }
 

--- a/internal/services/settings_service_cycle_test.go
+++ b/internal/services/settings_service_cycle_test.go
@@ -89,6 +89,12 @@ func TestValidateCycleSettingsBuildsUpdate(t *testing.T) {
 	if update.LastPeriodStart == nil || update.LastPeriodStart.Format("2006-01-02") != "2026-02-10" {
 		t.Fatalf("expected normalized last_period_start 2026-02-10, got %#v", update.LastPeriodStart)
 	}
+	if update.LastPeriodStart.Location() != time.UTC {
+		t.Fatalf("expected canonical UTC location, got %s", update.LastPeriodStart.Location())
+	}
+	if update.LastPeriodStart.Hour() != 0 || update.LastPeriodStart.Minute() != 0 {
+		t.Fatalf("expected UTC-midnight, got %s", update.LastPeriodStart.Format(time.RFC3339Nano))
+	}
 
 	cleared, err := service.ValidateCycleSettings(CycleSettingsValidationInput{
 		CycleLength:        28,
@@ -102,6 +108,80 @@ func TestValidateCycleSettingsBuildsUpdate(t *testing.T) {
 	}
 	if cleared.LastPeriodStart != nil {
 		t.Fatalf("expected nil last_period_start, got %#v", cleared.LastPeriodStart)
+	}
+}
+
+func TestValidateCycleSettingsCanonicalizesLastPeriodStartAcrossLocations(t *testing.T) {
+	tokyo, err := time.LoadLocation("Asia/Tokyo")
+	if err != nil {
+		t.Fatalf("load Asia/Tokyo: %v", err)
+	}
+	toronto, err := time.LoadLocation("America/Toronto")
+	if err != nil {
+		t.Fatalf("load America/Toronto: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		location *time.Location
+	}{
+		{name: "UTC+9 Tokyo", location: tokyo},
+		{name: "UTC-5 Toronto", location: toronto},
+	}
+
+	service := NewSettingsService(nil)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			now := time.Date(2026, time.February, 15, 12, 0, 0, 0, tt.location)
+
+			update, err := service.ValidateCycleSettings(CycleSettingsValidationInput{
+				CycleLength:        28,
+				PeriodLength:       6,
+				LastPeriodStartSet: true,
+				LastPeriodStartRaw: "2026-02-10",
+			}, now, tt.location)
+			if err != nil {
+				t.Fatalf("expected valid date, got %v", err)
+			}
+			if update.LastPeriodStart == nil {
+				t.Fatal("expected non-nil last_period_start")
+			}
+			if update.LastPeriodStart.Location() != time.UTC {
+				t.Fatalf("expected canonical UTC location regardless of input location, got %s", update.LastPeriodStart.Location())
+			}
+			if update.LastPeriodStart.Format("2006-01-02") != "2026-02-10" {
+				t.Fatalf("expected calendar day 2026-02-10 preserved, got %s", update.LastPeriodStart.Format("2006-01-02"))
+			}
+			if update.LastPeriodStart.Hour() != 0 || update.LastPeriodStart.Minute() != 0 {
+				t.Fatalf("expected UTC-midnight, got %s", update.LastPeriodStart.Format(time.RFC3339Nano))
+			}
+		})
+	}
+}
+
+func TestValidateCycleSettingsAcceptsLocalTodayInPositiveOffset(t *testing.T) {
+	tokyo, err := time.LoadLocation("Asia/Tokyo")
+	if err != nil {
+		t.Fatalf("load Asia/Tokyo: %v", err)
+	}
+
+	service := NewSettingsService(nil)
+	now := time.Date(2026, time.February, 15, 12, 0, 0, 0, tokyo)
+
+	update, err := service.ValidateCycleSettings(CycleSettingsValidationInput{
+		CycleLength:        28,
+		PeriodLength:       6,
+		LastPeriodStartSet: true,
+		LastPeriodStartRaw: "2026-02-15",
+	}, now, tokyo)
+	if err != nil {
+		t.Fatalf("expected today (UTC+9) to pass bounds check, got %v", err)
+	}
+	if update.LastPeriodStart == nil || update.LastPeriodStart.Format("2006-01-02") != "2026-02-15" {
+		t.Fatalf("expected today canonicalized to 2026-02-15 UTC, got %#v", update.LastPeriodStart)
+	}
+	if update.LastPeriodStart.Location() != time.UTC {
+		t.Fatalf("expected UTC location, got %s", update.LastPeriodStart.Location())
 	}
 }
 


### PR DESCRIPTION
…-midnight on write (#49)

Closes #49.

Coupled write-side normalization that was deferred during the issue #48 fix.

- DayRange now returns UTC-bounded [start, start+24h) over the local calendar day, so range queries match the canonical on-disk shape produced by the BeforeSave hook.
- DailyLog.BeforeSave normalizes Date to UTC-midnight by stripping any timezone offset from the calendar components. Inline (no models -> services import).
- settings_cycle_policy.ValidateCycleSettings keeps the bounds comparison in the request locale (so 'today' in UTC+ zones is not rejected as future) and canonicalizes to UTC only at assignment.
- onboarding_service.ValidateAndParseStep1StartDate validates in the request locale, then returns the canonical UTC-midnight value. CompleteOnboardingForUser switches from CalendarDay(value, location) to CalendarDay(value, time.UTC) so user_repository.CompleteOnboarding iterates UTC-midnight bounds when it builds its own day-by-day range WHERE clause (the one DB range query that bypasses DayRange).

Service-level regression test
(services/day_canonicalization_regression_test.go) locks the on-disk shape via raw SELECT for both America/Toronto (UTC-5) and Asia/Tokyo (UTC+9) and confirms the round-trip via FetchLogByDate.

HTTP-level regression test
(api/day_upsert_canonicalization_regression_test.go) covers the full transport -> service -> DB flow, sending both X-Ovumcy-Timezone header and ovumcy_tz cookie on each request to keep full-page and HTMX paths in one consistent timezone context.

The optional SQL migration to canonicalize existing rows with non-UTC offsets in glebarez/sqlite storage is deferred to a follow-up PR. Read-side CalendarDay already handles the mixed-offset rows on disk, so the deferral has no user-visible impact.