### PR TITLE
chore(migrations): canonicalize legacy DailyLog.Date and User.LastPer…

### DIFF
--- a/internal/db/migrations_bootstrap_test.go
+++ b/internal/db/migrations_bootstrap_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/glebarez/sqlite"
 	"github.com/ovumcy/ovumcy-web/internal/models"
@@ -41,6 +42,119 @@ func TestOpenSQLiteUpgradesLegacyInitSchema(t *testing.T) {
 
 	assertMigratedLegacyUserDefaults(t, database)
 	assertMigratedLegacyDailyLogDefaults(t, database)
+	assertMigratedLegacyDailyLogDateCanonicalized(t, database)
+}
+
+// TestMigration019CanonicalizesNonUTCDateFields locks the on-disk
+// rewrite contract of migration 019: legacy rows whose stored date or
+// last_period_start carries a non-UTC offset (because they were written
+// before the DailyLog BeforeSave hook landed) must be rewritten to
+// canonical UTC-midnight TEXT form. The migration is idempotent — a row
+// already in canonical form is left at the same value.
+func TestMigration019CanonicalizesNonUTCDateFields(t *testing.T) {
+	databasePath := filepath.Join(t.TempDir(), "ovumcy-019.db")
+	database := openSQLiteForMigrationBootstrapTest(t, databasePath)
+
+	if err := database.Exec(
+		`INSERT INTO users (email, password_hash, role, last_period_start, created_at)
+		 VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)`,
+		"non-canonical@example.com",
+		"test-hash",
+		"owner",
+		"2026-02-15 00:00:00-05:00",
+	).Error; err != nil {
+		t.Fatalf("insert non-canonical user: %v", err)
+	}
+
+	var nonCanonicalUser struct {
+		ID uint `gorm:"column:id"`
+	}
+	if err := database.Raw(
+		`SELECT id FROM users WHERE email = ?`, "non-canonical@example.com",
+	).Scan(&nonCanonicalUser).Error; err != nil {
+		t.Fatalf("load non-canonical user id: %v", err)
+	}
+
+	if err := database.Exec(
+		`INSERT INTO daily_logs (user_id, date, is_period, flow, symptom_ids, notes, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+		nonCanonicalUser.ID,
+		"2026-02-20 00:00:00+09:00",
+		true,
+		"medium",
+		"[]",
+		"non-canonical-log",
+	).Error; err != nil {
+		t.Fatalf("insert non-canonical daily log: %v", err)
+	}
+
+	if err := database.Exec(
+		`INSERT INTO daily_logs (user_id, date, is_period, flow, symptom_ids, notes, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+		nonCanonicalUser.ID,
+		"2026-02-21 00:00:00+00:00",
+		false,
+		"none",
+		"[]",
+		"already-canonical-log",
+	).Error; err != nil {
+		t.Fatalf("insert already-canonical daily log: %v", err)
+	}
+
+	if err := database.Exec(
+		`DELETE FROM schema_migrations WHERE version = ?`, "019",
+	).Error; err != nil {
+		t.Fatalf("delete migration 019 record: %v", err)
+	}
+
+	sqlDB, err := database.DB()
+	if err != nil {
+		t.Fatalf("get sql db handle: %v", err)
+	}
+	if err := sqlDB.Close(); err != nil {
+		t.Fatalf("close sql db: %v", err)
+	}
+
+	reopened := openSQLiteForMigrationBootstrapTest(t, databasePath)
+
+	assertStoredDateEqualsUTCMidnight(t, reopened,
+		`SELECT last_period_start FROM users WHERE email = ?`,
+		"non-canonical@example.com",
+		time.Date(2026, time.February, 15, 0, 0, 0, 0, time.UTC),
+	)
+
+	assertStoredDateEqualsUTCMidnight(t, reopened,
+		`SELECT date FROM daily_logs WHERE notes = ?`,
+		"non-canonical-log",
+		time.Date(2026, time.February, 20, 0, 0, 0, 0, time.UTC),
+	)
+
+	assertStoredDateEqualsUTCMidnight(t, reopened,
+		`SELECT date FROM daily_logs WHERE notes = ?`,
+		"already-canonical-log",
+		time.Date(2026, time.February, 21, 0, 0, 0, 0, time.UTC),
+	)
+}
+
+// assertStoredDateEqualsUTCMidnight reads the column the query selects
+// and asserts the value, parsed by the glebarez driver into time.Time,
+// equals the expected UTC-midnight instant. This is format-agnostic
+// (the driver reformats DATE columns on read, so byte-equal comparisons
+// are unreliable) but instant-strict — a non-UTC offset row resolves to
+// a different instant than the canonical UTC-midnight target.
+func assertStoredDateEqualsUTCMidnight(t *testing.T, database *gorm.DB, query string, arg any, expected time.Time) {
+	t.Helper()
+
+	var stored time.Time
+	if err := database.Raw(query, arg).Row().Scan(&stored); err != nil {
+		t.Fatalf("scan stored date for %v: %v", arg, err)
+	}
+	if !stored.Equal(expected) {
+		t.Fatalf("expected stored date %s for %v, got %s", expected.Format(time.RFC3339), arg, stored.Format(time.RFC3339))
+	}
+	if stored.Hour() != 0 || stored.Minute() != 0 || stored.Second() != 0 {
+		t.Fatalf("expected midnight time-of-day for %v, got %s", arg, stored.Format(time.RFC3339Nano))
+	}
 }
 
 func assertMigratedLegacyUserDefaults(t *testing.T, database *gorm.DB) {
@@ -180,6 +294,13 @@ func assertMigratedLegacyDailyLogDefaults(t *testing.T, database *gorm.DB) {
 	if migratedLog.SymptomIDs == nil || strings.TrimSpace(*migratedLog.SymptomIDs) != "[1,2]" {
 		t.Fatalf("expected migrated symptom_ids to remain [1,2], got %v", migratedLog.SymptomIDs)
 	}
+}
+
+func assertMigratedLegacyDailyLogDateCanonicalized(t *testing.T, database *gorm.DB) {
+	t.Helper()
+
+	expected := time.Date(2026, time.January, 10, 0, 0, 0, 0, time.UTC)
+	assertStoredDateEqualsUTCMidnight(t, database, `SELECT date FROM daily_logs WHERE notes = ?`, "legacy-log", expected)
 }
 
 func assertOIDCLogoutStateSchemaReconciled(t *testing.T, database *gorm.DB) {

--- a/migrations/019_canonicalize_date_fields_utc.sql
+++ b/migrations/019_canonicalize_date_fields_utc.sql
@@ -1,0 +1,29 @@
+-- Canonicalize date-only stored values to UTC-midnight to match the
+-- on-disk shape produced by the DailyLog BeforeSave hook.
+--
+-- glebarez/sqlite stores DATE columns as TEXT. Legacy rows from before
+-- the BeforeSave hook may carry a non-UTC offset that reflects the
+-- request locale at write time, or be bare YYYY-MM-DD strings inserted
+-- via raw SQL. Read-side services.CalendarDay already handles mixed
+-- shapes correctly, so the application is unaffected by mixed storage.
+-- This migration aligns the on-disk shape so future range queries do
+-- not need to defend against legacy variants.
+--
+-- The rewrite extracts the YYYY-MM-DD prefix that all glebarez DATE
+-- serializations share and rebuilds it at UTC-midnight. The user
+-- intended calendar day is preserved across all source offsets because
+-- a row stored as `2026-02-10 00:00:00-05:00` represents calendar day
+-- 2026-02-10 in the writing locale, and the prefix slice returns the
+-- same `2026-02-10` regardless of the offset suffix.
+--
+-- Idempotent: applied to an already-canonical value, the prefix slice
+-- returns the same calendar day and the suffix is the same canonical
+-- string.
+
+UPDATE daily_logs
+SET date = substr(date, 1, 10) || ' 00:00:00+00:00'
+WHERE date IS NOT NULL;
+
+UPDATE users
+SET last_period_start = substr(last_period_start, 1, 10) || ' 00:00:00+00:00'
+WHERE last_period_start IS NOT NULL;

--- a/migrations/postgres/019_canonicalize_date_fields_utc.sql
+++ b/migrations/postgres/019_canonicalize_date_fields_utc.sql
@@ -1,0 +1,8 @@
+-- PostgreSQL DATE columns store calendar days without offset metadata,
+-- so existing rows are already canonical and there is nothing to
+-- rewrite on this storage path. This file is recorded for version
+-- parity with the sqlite migration that canonicalizes glebarez TEXT
+-- DATE values whose legacy offsets may have reflected the request
+-- locale at write time.
+
+SELECT 1;


### PR DESCRIPTION
…iodStart on disk

Follow-up to #49. The Go-side write-path fix already keeps newly written rows canonical, but legacy rows in glebarez/sqlite TEXT storage may still carry the request-locale offset they were written with before the DailyLog BeforeSave hook landed. Read-side services.CalendarDay handles mixed shapes correctly, so this is hygiene rather than a user-visible fix.

- migrations/019_canonicalize_date_fields_utc.sql rewrites every daily_logs.date and users.last_period_start to `YYYY-MM-DD 00:00:00+00:00`. The rewrite extracts the calendar-day prefix that all glebarez DATE serializations share, so the user-intended calendar day is preserved across all source offsets (a row stored as `2026-02-10 00:00:00-05:00` represents calendar day 2026-02-10 in the writing locale; the prefix slice returns the same `2026-02-10` regardless of the offset suffix). Idempotent.
- migrations/postgres/019_canonicalize_date_fields_utc.sql is a documented no-op (`SELECT 1`) since PostgreSQL DATE columns store calendar days without offset metadata. The file exists for version parity with the sqlite migration.
- migrations_bootstrap_test.go covers two paths:
  - assertMigratedLegacyDailyLogDateCanonicalized verifies the legacy seed's bare-date row is rewritten to UTC-midnight after a full bootstrap.
  - TestMigration019CanonicalizesNonUTCDateFields seeds a fresh DB with non-canonical rows on both daily_logs.date and users.last_period_start, rolls back migration 019 in schema_migrations, reopens the DB so the runner re-applies 019 only, and verifies the rewritten instants. The third row (already-canonical) confirms idempotency.

Both assertions compare via time.Time.Equal because the glebarez driver reformats DATE columns on read; instant equality is format-agnostic but still detects a missed offset rewrite.