### PR TITLE
Security audit fixes #1-7: recovery code, TOTP enrollment, login timing, replay persistence, OIDC reauth, register enumeration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.25.9-alpine3.22@sha256:2c16ac01b3d038ca2ed421d66cea489e3cb670c251b4f8bbcfad2ebfb75f884c AS builder
+FROM golang:1.25.10-alpine3.22@sha256:26b4d7113039cd51356bd7930ecafd1031d2975dc3b6940ec8ed09457e17cf95 AS builder
 WORKDIR /src
 
 COPY go.mod go.sum ./

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,3 +20,21 @@ Please report security issues privately.
 We will acknowledge receipt within 72 hours and provide a remediation plan after triage.
 
 Do not open public GitHub issues for unpatched security vulnerabilities.
+
+## Known Information Disclosure
+
+A few information-disclosure signals are accepted residual risk because closing them either breaks core flows or requires infrastructure Ovumcy does not assume self-hosters have (for example SMTP).
+
+### Register: silenced status code, residual `Set-Cookie` signal
+
+`POST /api/auth/register` returns the same status (`201 Created`) and JSON body for both a brand-new email and a duplicate, but only the new-email response sets the `ovumcy_auth` and `ovumcy_recovery_code` cookies. An attacker who can inspect raw response headers (proxy logs, browser dev tools on their own machine, MITM under a separate threat model) can still tell a collision from a success.
+
+Closing the signal entirely requires either (a) a magic-link / email-driven enrollment flow that does not issue cookies at the register endpoint at all, which depends on SMTP infrastructure Ovumcy does not require operators to configure, or (b) emitting decoy cookies whose downstream resolution fails in exactly the same way as a stale session. Both are tracked as follow-up work; the current state already removes the single-request status-code oracle.
+
+Rate limiting on `/api/auth/register` and the login bcrypt-timing equalization (`equalizeAuthCredentialsTiming`) bound how quickly an attacker can probe an email list against either oracle.
+
+### Login: `requires_totp` reveals 2FA status
+
+`POST /api/auth/login` returns `{"requires_totp": true}` when the supplied password is correct and the account has TOTP enabled, and `{"ok": true}` plus a session cookie otherwise. A credential-dump attacker can use this to triage accounts by whether they have a second factor.
+
+This is inherent to any password-then-TOTP flow that gates the second factor on account state — any uniform response that hides the difference either silently grants access without verifying TOTP (downgrade attack) or unconditionally rejects accounts without TOTP (lockout). The per-account rate limiter (`AuthAttemptPolicy`) and the recovery-code re-auth requirements bound the value of knowing the 2FA status.

--- a/docs/oidc.md
+++ b/docs/oidc.md
@@ -83,6 +83,14 @@ That last point is important. An auto-provisioned OIDC-only account can use the 
 - recovery-code regeneration is not available yet;
 - password-confirmed sensitive actions such as `clear data` or `delete account` stay blocked until the user sets a local password in `Settings`.
 
+To enable a local password, OIDC-only users go through a **step-up re-authentication flow**:
+
+1. The user fills the "set local password" form in `Settings`. The browser submits to `POST /api/settings/start-local-password-setup`, which validates the password, prepares its bcrypt hash without touching the database, and redirects the browser to the provider's authorize endpoint with `prompt=login` and `max_age=0` so the provider is forced to re-authenticate the user interactively.
+2. The provider posts the result back to the existing `/auth/oidc/callback` endpoint. Ovumcy detects the step-up flow (via a sealed cookie issued in step 1), runs the OIDC code exchange, and requires the resulting ID token's `auth_time` claim (or, if the provider omits it, `iat`) to lie within the last five minutes and the returned `(issuer, subject)` pair to already be linked to the current session's user.
+3. Only after both checks succeed does Ovumcy persist the prepared password hash, mint a fresh recovery code, and present it on the dedicated `/recovery-code` page. A stale or mismatched re-auth leaves the account untouched.
+
+The legacy `POST /api/settings/change-password` endpoint still works for accounts that already have local auth enabled (ordinary password rotation). For accounts with `LocalAuthEnabled=false` it now returns `403 oidc reauth required` so the step-up flow above is the only path to enroll a local password.
+
 ## How Logout Works
 
 `OIDC_LOGOUT_MODE` controls what happens after Ovumcy clears its own auth cookies:

--- a/e2e/auth-2fa.spec.ts
+++ b/e2e/auth-2fa.spec.ts
@@ -50,6 +50,7 @@ test.describe('Auth: TOTP two-factor authentication', () => {
 
     const code = generateSync({ secret, strategy: 'totp' });
     await page.locator('input[name="code"]').fill(code);
+    await page.locator('#settings-2fa-enroll-password').fill(creds.password);
     await page.locator('form[action="/api/settings/2fa/verify"] button[type="submit"]').click();
     // Form submit is HTMX-intercepted; wait for the inline success status, then
     // reload to render the management view (DB now has TOTPEnabled=true).
@@ -83,6 +84,7 @@ test.describe('Auth: TOTP two-factor authentication', () => {
     const secret = await readTOTPSecret(page);
     const code = generateSync({ secret, strategy: 'totp' });
     await page.locator('input[name="code"]').fill(code);
+    await page.locator('#settings-2fa-enroll-password').fill(creds.password);
     await page.locator('form[action="/api/settings/2fa/verify"] button[type="submit"]').click();
     // Form submit is HTMX-intercepted; wait for inline success then reload.
     await expect(page.locator('#settings-2fa-verify-status .status-ok')).toBeVisible({ timeout: 5_000 });
@@ -123,6 +125,7 @@ test.describe('Auth: TOTP two-factor authentication', () => {
     const secret = await readTOTPSecret(page);
     const enrollCode = generateSync({ secret, strategy: 'totp' });
     await page.locator('input[name="code"]').fill(enrollCode);
+    await page.locator('#settings-2fa-enroll-password').fill(creds.password);
     await page.locator('form[action="/api/settings/2fa/verify"] button[type="submit"]').click();
     // Form submit is HTMX-intercepted; wait for the inline success status, then
     // reload to render the management view (DB now has TOTPEnabled=true).
@@ -167,6 +170,7 @@ test.describe('Auth: TOTP two-factor authentication', () => {
     const secret = await readTOTPSecret(page);
     const enrollCode = generateSync({ secret, strategy: 'totp' });
     await page.locator('input[name="code"]').fill(enrollCode);
+    await page.locator('#settings-2fa-enroll-password').fill(creds.password);
     await page.locator('form[action="/api/settings/2fa/verify"] button[type="submit"]').click();
     // Form submit is HTMX-intercepted; wait for the inline success status, then
     // reload to render the management view (DB now has TOTPEnabled=true).
@@ -210,6 +214,7 @@ test.describe('Auth: TOTP two-factor authentication', () => {
     const secret = await readTOTPSecret(page);
     const enrollCode = generateSync({ secret, strategy: 'totp' });
     await page.locator('input[name="code"]').fill(enrollCode);
+    await page.locator('#settings-2fa-enroll-password').fill(creds.password);
     await page.locator('form[action="/api/settings/2fa/verify"] button[type="submit"]').click();
     // Form submit is HTMX-intercepted; wait for the inline success status, then
     // reload to render the management view (DB now has TOTPEnabled=true).

--- a/e2e/auth-login-register.spec.ts
+++ b/e2e/auth-login-register.spec.ts
@@ -35,7 +35,19 @@ test.describe('Auth: register, login, logout', () => {
     expect(recoveryCookie).toBeFalsy();
   });
 
-  test('register duplicate email shows error and keeps clean redirect URL', async ({ page }) => {
+  test('register duplicate email is silenced and does not leak account existence', async ({
+    page,
+    context,
+  }) => {
+    // Pre-fix #5: registering an already-taken email surfaced a
+    // .status-error banner and pre-filled #register-email with the
+    // submitted address, giving an attacker a single-request oracle
+    // for "is this email registered". Post-fix the server returns the
+    // same status + body shape as a fresh enrollment but without auth
+    // or recovery cookies (Set-Cookie remains the residual signal —
+    // see SECURITY.md). UI must therefore look like a no-op landing on
+    // /register: no error banner, no email pre-fill, and no flash /
+    // auth / recovery cookies left behind.
     const creds = createCredentials('auth-duplicate');
 
     await registerOwnerViaUI(page, creds);
@@ -44,10 +56,15 @@ test.describe('Auth: register, login, logout', () => {
     await logoutViaAPI(page);
     await registerOwnerViaUI(page, creds);
 
-    await expect(page).toHaveURL(/\/register$/);
+    await expect(page).toHaveURL(/\/register(?:\?.*)?$/);
     expectNoSensitiveAuthParams(page.url());
-    await expect(page.locator('.status-error')).toBeVisible();
-    await expect(page.locator('#register-email')).toHaveValue(creds.email);
+    await expect(page.locator('.status-error')).toHaveCount(0);
+    await expect(page.locator('#register-email')).toHaveValue('');
+
+    const cookies = await context.cookies();
+    for (const name of ['ovumcy_auth', 'ovumcy_recovery_code', 'ovumcy_flash']) {
+      expect(cookies.find((cookie) => cookie.name === name)).toBeUndefined();
+    }
   });
 
   test('register mismatch password shows form error without leaking query params', async ({ page }) => {

--- a/e2e/auth-oidc.spec.ts
+++ b/e2e/auth-oidc.spec.ts
@@ -2,14 +2,11 @@ import { expect, test, type Page } from '@playwright/test';
 import {
   DEFAULT_STRONG_PASSWORD,
   completeOnboardingIfPresent,
-  confirmRecoveryCode,
   continueFromRecoveryCode,
-  expectDedicatedRecoveryPage,
   expectInlineRegisterRecoveryStep,
   expectNoSensitiveAuthParams,
   loginViaUI,
   registerOwnerViaUI,
-  readRecoveryCode,
 } from './support/auth-helpers';
 
 const oidcEnabled = process.env.OIDC_ENABLED === 'true';
@@ -37,25 +34,27 @@ async function signInViaOIDCOnlyAndEnableLocalPassword(page: Page) {
 
   const localPasswordForm = page.locator('[data-settings-local-password-form]');
   if (await localPasswordForm.isVisible().catch(() => false)) {
+    // OIDC-only users now must complete a step-up re-auth before a local
+    // password is committed. Submitting the form posts to
+    // /api/settings/start-local-password-setup, which redirects to the
+    // provider's authorize endpoint with prompt=login + max_age=0. The full
+    // round-trip back through /auth/oidc/callback into /recovery-code depends
+    // on the test provider honoring those parameters and cannot be exercised
+    // without a controllable IdP — assert the redirect to the provider as the
+    // closest end-to-end signal.
     await expect(page.locator('[data-settings-recovery-code-unavailable]')).toBeVisible();
     await expect(page.locator('form[action="/api/settings/regenerate-recovery-code"]')).toHaveCount(0);
+    await expect(localPasswordForm).toHaveAttribute('action', '/api/settings/start-local-password-setup');
 
     const localPassword = 'LocalStrongPass2';
     await page.locator('#settings-new-password').fill(localPassword);
     await page.locator('#settings-confirm-password').fill(localPassword);
-    await page.locator('[data-settings-local-password-form] button[type="submit"]').click();
-
-    await expectDedicatedRecoveryPage(page);
-    await readRecoveryCode(page);
-    await confirmRecoveryCode(page);
-
-    await expect(page).toHaveURL(/\/settings(?:\?.*)?$/);
+    await Promise.all([
+      page.waitForURL((url) => !url.toString().startsWith(page.url())),
+      page.locator('[data-settings-local-password-form] button[type="submit"]').click(),
+    ]);
+    expect(page.url()).not.toMatch(/\/settings(?:\?.*)?$/);
   }
-
-  await expect(page.locator('[data-settings-local-password-form]')).toHaveCount(0);
-  await expect(page.locator('form[action="/api/settings/regenerate-recovery-code"]')).toHaveCount(1);
-  await expect(page.locator('form[action="/api/settings/clear-data"]')).toHaveCount(1);
-  await expect(page.locator('form[hx-delete="/api/settings/delete-account"]')).toHaveCount(1);
 }
 
 test.describe('Auth: OIDC login entry', () => {

--- a/e2e/settings-password-export-danger.spec.ts
+++ b/e2e/settings-password-export-danger.spec.ts
@@ -243,6 +243,9 @@ test.describe('Settings: password, export, clear data, delete account', () => {
     await expect(page.locator('#settings-cycle-status .status-ok')).toBeVisible();
 
     await page
+      .locator('form[action="/api/settings/regenerate-recovery-code"] #settings-recovery-code-password')
+      .fill(state.password);
+    await page
       .locator('form[action="/api/settings/regenerate-recovery-code"] button[type="submit"]')
       .click();
     await expect(page.locator('#confirm-modal')).toBeVisible();

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ovumcy/ovumcy-web
 
-go 1.25.8
+go 1.25.10
 
 require (
 	github.com/coreos/go-oidc/v3 v3.17.0

--- a/internal/api/auth_oidc_regressions_test.go
+++ b/internal/api/auth_oidc_regressions_test.go
@@ -29,6 +29,17 @@ type stubOIDCWorkflowService struct {
 	lastAuthVerifier       string
 	lastAuthExpectedNonce  string
 	lastAuthDeadline       time.Time
+	reauthURL              string
+	reauthStartErr         error
+	reauthErr              error
+	lastReauthState        string
+	lastReauthNonce        string
+	lastReauthVerifier     string
+	lastReauthCode         string
+	lastReauthCodeVerifier string
+	lastReauthNonceCheck   string
+	lastReauthUserID       uint
+	lastReauthMaxAge       time.Duration
 }
 
 func (stub *stubOIDCWorkflowService) Enabled() bool {
@@ -69,6 +80,28 @@ func (stub *stubOIDCWorkflowService) Authenticate(ctx context.Context, code stri
 		return services.OIDCLoginResult{}, stub.authErr
 	}
 	return stub.result, nil
+}
+
+func (stub *stubOIDCWorkflowService) StartReauth(_ context.Context, state string, nonce string, codeVerifier string) (string, error) {
+	stub.lastReauthState = state
+	stub.lastReauthNonce = nonce
+	stub.lastReauthVerifier = codeVerifier
+	if stub.reauthStartErr != nil {
+		return "", stub.reauthStartErr
+	}
+	if stub.reauthURL != "" {
+		return stub.reauthURL, nil
+	}
+	return stub.authURL, nil
+}
+
+func (stub *stubOIDCWorkflowService) ValidateReauthExchange(_ context.Context, code string, codeVerifier string, expectedNonce string, expectedUserID uint, maxAuthAge time.Duration, _ time.Time) error {
+	stub.lastReauthCode = code
+	stub.lastReauthCodeVerifier = codeVerifier
+	stub.lastReauthNonceCheck = expectedNonce
+	stub.lastReauthUserID = expectedUserID
+	stub.lastReauthMaxAge = maxAuthAge
+	return stub.reauthErr
 }
 
 func TestLoginPageWithOIDCEnabledShowsSSOButton(t *testing.T) {

--- a/internal/api/auth_recovery_code_password_required_regressions_test.go
+++ b/internal/api/auth_recovery_code_password_required_regressions_test.go
@@ -1,0 +1,65 @@
+package api
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+)
+
+func TestRegenerateRecoveryCodeRejectsMissingPassword(t *testing.T) {
+	ctx := newSettingsSecurityTestContext(t, "settings-regenerate-missing-pass@example.com")
+
+	priorHash := loadUserRecoveryCodeHash(t, ctx)
+
+	response := settingsFormRequestWithCSRF(t, ctx, http.MethodPost, "/api/settings/regenerate-recovery-code", url.Values{}, map[string]string{
+		"Accept": "application/json",
+	})
+	defer response.Body.Close()
+
+	assertStatusCode(t, response, http.StatusBadRequest)
+	if got := readAPIError(t, response.Body); got != "invalid password" {
+		t.Fatalf("expected error %q, got %q", "invalid password", got)
+	}
+	assertRecoveryCodeHashUnchanged(t, ctx, priorHash)
+}
+
+func TestRegenerateRecoveryCodeRejectsWrongPassword(t *testing.T) {
+	ctx := newSettingsSecurityTestContext(t, "settings-regenerate-wrong-pass@example.com")
+
+	priorHash := loadUserRecoveryCodeHash(t, ctx)
+
+	response := settingsFormRequestWithCSRF(t, ctx, http.MethodPost, "/api/settings/regenerate-recovery-code", url.Values{
+		"password": {"WrongPass1"},
+	}, map[string]string{
+		"Accept": "application/json",
+	})
+	defer response.Body.Close()
+
+	assertStatusCode(t, response, http.StatusUnauthorized)
+	if got := readAPIError(t, response.Body); got != "invalid password" {
+		t.Fatalf("expected error %q, got %q", "invalid password", got)
+	}
+	assertRecoveryCodeHashUnchanged(t, ctx, priorHash)
+}
+
+func loadUserRecoveryCodeHash(t *testing.T, ctx settingsSecurityTestContext) string {
+	t.Helper()
+
+	var current models.User
+	if err := ctx.database.Select("recovery_code_hash").First(&current, ctx.user.ID).Error; err != nil {
+		t.Fatalf("load recovery_code_hash: %v", err)
+	}
+	return strings.TrimSpace(current.RecoveryCodeHash)
+}
+
+func assertRecoveryCodeHashUnchanged(t *testing.T, ctx settingsSecurityTestContext, priorHash string) {
+	t.Helper()
+
+	current := loadUserRecoveryCodeHash(t, ctx)
+	if current != priorHash {
+		t.Fatalf("expected recovery_code_hash unchanged after rejected request")
+	}
+}

--- a/internal/api/auth_recovery_code_transport_regressions_test.go
+++ b/internal/api/auth_recovery_code_transport_regressions_test.go
@@ -68,7 +68,9 @@ func TestResetPasswordJSONSuccessDoesNotExposeRecoveryCode(t *testing.T) {
 func TestRegenerateRecoveryCodeRedirectsToDedicatedRecoveryPage(t *testing.T) {
 	ctx := newSettingsSecurityTestContext(t, "settings-regenerate@example.com")
 
-	response := settingsFormRequestWithCSRF(t, ctx, http.MethodPost, "/api/settings/regenerate-recovery-code", url.Values{}, nil)
+	response := settingsFormRequestWithCSRF(t, ctx, http.MethodPost, "/api/settings/regenerate-recovery-code", url.Values{
+		"password": {"StrongPass1"},
+	}, nil)
 	assertStatusCode(t, response, http.StatusSeeOther)
 	if location := response.Header.Get("Location"); location != "/recovery-code" {
 		t.Fatalf("expected redirect to /recovery-code, got %q", location)
@@ -96,7 +98,9 @@ func TestRegenerateRecoveryCodeRedirectsToDedicatedRecoveryPage(t *testing.T) {
 func TestRegenerateRecoveryCodeJSONDoesNotExposeRecoveryCode(t *testing.T) {
 	ctx := newSettingsSecurityTestContext(t, "settings-regenerate-json@example.com")
 
-	response := settingsFormRequestWithCSRF(t, ctx, http.MethodPost, "/api/settings/regenerate-recovery-code", url.Values{}, map[string]string{
+	response := settingsFormRequestWithCSRF(t, ctx, http.MethodPost, "/api/settings/regenerate-recovery-code", url.Values{
+		"password": {"StrongPass1"},
+	}, map[string]string{
 		"Accept": "application/json",
 	})
 	assertStatusCode(t, response, http.StatusOK)

--- a/internal/api/auth_register_validation_errors_test.go
+++ b/internal/api/auth_register_validation_errors_test.go
@@ -1,7 +1,7 @@
 package api
 
 import (
-	"io"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -87,6 +87,40 @@ func TestRegisterRejectsPasswordMismatch(t *testing.T) {
 	}
 }
 
+// assertRegisterDuplicateResponseLooksLikeSuccess pins the silencing fix for
+// #5: a register POST hitting an existing email must return the same status
+// and JSON shape as a new-email enrollment. Set-Cookie inspection can still
+// distinguish the cases (no auth/recovery cookies are issued for the duplicate),
+// and that residual signal is documented in SECURITY.md.
+func assertRegisterDuplicateResponseLooksLikeSuccess(t *testing.T, response *http.Response) {
+	t.Helper()
+	if response.StatusCode != http.StatusCreated {
+		t.Fatalf("expected status 201 (mirroring new-account flow), got %d", response.StatusCode)
+	}
+	payload := map[string]any{}
+	if err := json.NewDecoder(response.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode duplicate register response: %v", err)
+	}
+	if ok, _ := payload["ok"].(bool); !ok {
+		t.Fatalf("expected ok=true in duplicate register response, got %#v", payload)
+	}
+	if step, _ := payload["next_step"].(string); step != "recovery_code" {
+		t.Fatalf("expected next_step=recovery_code, got %#v", payload["next_step"])
+	}
+	if path, _ := payload["next_path"].(string); path != "/register" {
+		t.Fatalf("expected next_path=/register, got %#v", payload["next_path"])
+	}
+	if _, exposed := payload["error"]; exposed {
+		t.Fatalf("expected no error field in silenced response, got %#v", payload["error"])
+	}
+	if cookie := responseCookieValue(response.Cookies(), authCookieName); cookie != "" {
+		t.Fatalf("expected no auth cookie in silenced response (would leak duplicate via Set-Cookie), got %q", cookie)
+	}
+	if cookie := responseCookieValue(response.Cookies(), recoveryCodeCookieName); cookie != "" {
+		t.Fatalf("expected no recovery cookie in silenced response, got %q", cookie)
+	}
+}
+
 func TestRegisterRejectsCaseInsensitiveDuplicateEmail(t *testing.T) {
 	app, database := newOnboardingTestApp(t)
 	existingEmail := "QA-Test2@Ovumcy.Local"
@@ -125,14 +159,7 @@ func TestRegisterRejectsCaseInsensitiveDuplicateEmail(t *testing.T) {
 	}
 	defer response.Body.Close()
 
-	if response.StatusCode != http.StatusBadRequest {
-		t.Fatalf("expected status 400, got %d", response.StatusCode)
-	}
-
-	errorValue := readAPIError(t, response.Body)
-	if errorValue != "invalid input" {
-		t.Fatalf("expected generic invalid input error, got %q", errorValue)
-	}
+	assertRegisterDuplicateResponseLooksLikeSuccess(t, response)
 
 	var usersCount int64
 	if err := database.Model(&models.User{}).Where("lower(trim(email)) = ?", "qa-test2@ovumcy.local").Count(&usersCount).Error; err != nil {
@@ -181,14 +208,7 @@ func TestRegisterRejectsExactDuplicateEmail(t *testing.T) {
 	}
 	defer response.Body.Close()
 
-	if response.StatusCode != http.StatusBadRequest {
-		t.Fatalf("expected status 400, got %d", response.StatusCode)
-	}
-
-	errorValue := readAPIError(t, response.Body)
-	if errorValue != "invalid input" {
-		t.Fatalf("expected generic invalid input error, got %q", errorValue)
-	}
+	assertRegisterDuplicateResponseLooksLikeSuccess(t, response)
 
 	var usersCount int64
 	if err := database.Model(&models.User{}).Where("email = ?", existingEmail).Count(&usersCount).Error; err != nil {
@@ -244,29 +264,14 @@ func TestRegisterRejectsExactDuplicateEmailHTMLFlow(t *testing.T) {
 		t.Fatalf("expected redirect to /register, got %q", location)
 	}
 
-	flashValue := responseCookieValue(response.Cookies(), flashCookieName)
-	if flashValue == "" {
-		t.Fatalf("expected flash cookie in register duplicate-email response")
+	if flashValue := responseCookieValue(response.Cookies(), flashCookieName); flashValue != "" {
+		t.Fatalf("expected no flash cookie in silenced duplicate-email response (would leak existence), got %q", flashValue)
 	}
-
-	followRequest := httptest.NewRequest(http.MethodGet, "/register", nil)
-	followRequest.Header.Set("Accept-Language", "en")
-	followRequest.Header.Set("Cookie", flashCookieName+"="+flashValue)
-
-	followResponse, err := app.Test(followRequest, -1)
-	if err != nil {
-		t.Fatalf("follow register request failed: %v", err)
+	if cookie := responseCookieValue(response.Cookies(), authCookieName); cookie != "" {
+		t.Fatalf("expected no auth cookie in silenced duplicate-email response, got %q", cookie)
 	}
-	defer followResponse.Body.Close()
-
-	followBody, err := io.ReadAll(followResponse.Body)
-	if err != nil {
-		t.Fatalf("read follow register body: %v", err)
-	}
-
-	rendered := strings.ToLower(string(followBody))
-	if strings.Contains(rendered, "already exists") || strings.Contains(rendered, "already registered") {
-		t.Fatalf("expected duplicate register page to avoid account existence phrases")
+	if cookie := responseCookieValue(response.Cookies(), recoveryCodeCookieName); cookie != "" {
+		t.Fatalf("expected no recovery cookie in silenced duplicate-email response, got %q", cookie)
 	}
 
 	var usersCount int64

--- a/internal/api/error_mapping_settings.go
+++ b/internal/api/error_mapping_settings.go
@@ -25,6 +25,22 @@ func settingsLocalPasswordRequiredErrorSpec() APIErrorSpec {
 	return settingsFormErrorSpec(fiber.StatusForbidden, APIErrorCategoryForbidden, "local password required")
 }
 
+// settingsOIDCReauthRequiredErrorSpec is returned when an OIDC-only user
+// attempts to enable a local password via the legacy ChangePassword endpoint
+// instead of going through StartLocalPasswordSetupReauth. It signals the UI
+// to redirect into the step-up flow.
+func settingsOIDCReauthRequiredErrorSpec() APIErrorSpec {
+	return settingsFormErrorSpec(fiber.StatusForbidden, APIErrorCategoryForbidden, "oidc reauth required")
+}
+
+func settingsOIDCReauthStaleErrorSpec() APIErrorSpec {
+	return settingsFormErrorSpec(fiber.StatusUnauthorized, APIErrorCategoryUnauthorized, "oidc reauth stale")
+}
+
+func settingsOIDCReauthMismatchErrorSpec() APIErrorSpec {
+	return settingsFormErrorSpec(fiber.StatusUnauthorized, APIErrorCategoryUnauthorized, "oidc reauth identity mismatch")
+}
+
 func settingsCycleUpdateErrorSpec() APIErrorSpec {
 	return globalErrorSpec(fiber.StatusInternalServerError, APIErrorCategoryInternal, "failed to update cycle settings")
 }

--- a/internal/api/handler_types.go
+++ b/internal/api/handler_types.go
@@ -23,7 +23,9 @@ type OIDCWorkflowService interface {
 	Enabled() bool
 	LocalPublicAuthEnabled() bool
 	StartAuth(ctx context.Context, state string, nonce string, codeVerifier string) (string, error)
+	StartReauth(ctx context.Context, state string, nonce string, codeVerifier string) (string, error)
 	Authenticate(ctx context.Context, code string, codeVerifier string, expectedNonce string, now time.Time) (services.OIDCLoginResult, error)
+	ValidateReauthExchange(ctx context.Context, code string, codeVerifier string, expectedNonce string, expectedUserID uint, maxAuthAge time.Duration, now time.Time) error
 }
 
 type Handler struct {

--- a/internal/api/handlers_auth_2fa.go
+++ b/internal/api/handlers_auth_2fa.go
@@ -1,9 +1,11 @@
 package api
 
 import (
+	"errors"
 	"time"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/ovumcy/ovumcy-web/internal/services"
 )
 
 // ShowTOTPChallengePage renders the 2FA code entry page after a successful
@@ -55,6 +57,15 @@ func (handler *Handler) VerifyTOTPLogin(c *fiber.Ctx) error {
 	}
 
 	valid, err := handler.totpService.ValidateCode(userID, user.TOTPSecret, code)
+	if errors.Is(err, services.ErrTOTPReplayed) {
+		// Same response shape as a plain invalid code so an attacker cannot
+		// distinguish replay from a wrong guess. We log replay separately for
+		// security observability (potential captured-code attempt).
+		handler.totpService.RecordFailure(handler.secretKey, c.IP(), userID, time.Now())
+		spec := totpInvalidCodeErrorSpec()
+		handler.logSecurityEvent(c, "auth.2fa", "replay_rejected")
+		return handler.respondMappedError(c, spec)
+	}
 	if err != nil {
 		spec := totpInternalErrorSpec()
 		handler.logSecurityError(c, "auth.2fa", spec)

--- a/internal/api/handlers_auth_2fa_test.go
+++ b/internal/api/handlers_auth_2fa_test.go
@@ -37,9 +37,20 @@ type dbUserRepoForTest struct{ db *gorm.DB }
 
 func (r *dbUserRepoForTest) UpdateTOTPFields(userID uint, encryptedSecret string, enabled bool) error {
 	return r.db.Model(&models.User{}).Where("id = ?", userID).Updates(map[string]any{
-		"totp_secret":  encryptedSecret,
-		"totp_enabled": enabled,
+		"totp_secret":         encryptedSecret,
+		"totp_enabled":        enabled,
+		"totp_last_used_step": 0,
 	}).Error
+}
+
+func (r *dbUserRepoForTest) ClaimTOTPStep(userID uint, step int64) (bool, error) {
+	result := r.db.Model(&models.User{}).
+		Where("id = ? AND totp_last_used_step < ?", userID, step).
+		Update("totp_last_used_step", step)
+	if result.Error != nil {
+		return false, result.Error
+	}
+	return result.RowsAffected == 1, nil
 }
 
 func sealTOTPPendingCookieForTest(t *testing.T, secretKey []byte, userID uint, rememberMe bool) string {

--- a/internal/api/handlers_auth_oidc.go
+++ b/internal/api/handlers_auth_oidc.go
@@ -43,6 +43,15 @@ func (handler *Handler) StartOIDCLogin(c *fiber.Ctx) error {
 }
 
 func (handler *Handler) CompleteOIDCLogin(c *fiber.Ctx) error {
+	// Step-up re-auth (e.g. enabling local password on OIDC-only account)
+	// reuses the same /auth/oidc/callback path as ordinary login but carries
+	// a distinct sealed cookie identifying the purpose and the originating
+	// user. Dispatching off cookie presence avoids registering a second
+	// redirect URI at every provider operators have to manage.
+	if stepupState := handler.popOIDCStepupCookie(c); stepupState.validAt(time.Now()) {
+		return handler.completeLocalPasswordSetupReauth(c, stepupState)
+	}
+
 	oidcState := handler.popOIDCStateCookie(c)
 	callbackState := c.FormValue("state")
 	code := c.FormValue("code")

--- a/internal/api/handlers_auth_session_helpers.go
+++ b/internal/api/handlers_auth_session_helpers.go
@@ -72,6 +72,23 @@ func (handler *Handler) renderRegisterInlineRecoveryResponse(c *fiber.Ctx, user 
 	return handler.renderRecoveryCodeResponseWithSurface(c, user, recoveryCode, status, continuePath, recoveryCodeSurfaceInlineRegister)
 }
 
+// renderRegisterDuplicateSilencedResponse emits the same status code, JSON
+// shape, and redirect target as a successful Register, but without auth or
+// recovery cookies. Used when the email is already taken: an attacker who
+// only inspects status code + body cannot tell collision from success.
+// (Set-Cookie inspection is still a residual oracle; see SECURITY.md.)
+func (handler *Handler) renderRegisterDuplicateSilencedResponse(c *fiber.Ctx, status int) error {
+	nextPath := recoveryCodeSurfacePath(recoveryCodeSurfaceInlineRegister)
+	if acceptsJSON(c) {
+		return c.Status(status).JSON(fiber.Map{
+			"ok":        true,
+			"next_step": "recovery_code",
+			"next_path": nextPath,
+		})
+	}
+	return redirectToPath(c, nextPath)
+}
+
 func (handler *Handler) renderRecoveryCodeResponseWithContinuePath(c *fiber.Ctx, user *models.User, recoveryCode string, status int, continuePath string) error {
 	return handler.renderRecoveryCodeResponseWithSurface(c, user, recoveryCode, status, continuePath, recoveryCodeSurfaceDedicated)
 }

--- a/internal/api/handlers_auth_session_login.go
+++ b/internal/api/handlers_auth_session_login.go
@@ -33,6 +33,17 @@ func (handler *Handler) Register(c *fiber.Ctx) error {
 		time.Now().In(handler.location),
 	)
 	if err != nil {
+		// Email collisions used to return 400 invalid-input here, which made
+		// /api/auth/register a single-request oracle for "does this email
+		// already have an account" — a privacy-sensitive leak in a health
+		// app (GDPR Art. 9). Hide the collision behind the new-account
+		// status + body. The response is still distinguishable by the
+		// absence of Set-Cookie auth and recovery headers, which is
+		// documented as a residual signal in SECURITY.md.
+		if errors.Is(err, services.ErrAuthEmailExists) {
+			handler.logSecurityEvent(c, "auth.register", "duplicate_silenced")
+			return handler.renderRegisterDuplicateSilencedResponse(c, fiber.StatusCreated)
+		}
 		spec := mapAuthRegisterError(err)
 		handler.logSecurityError(c, "auth.register", spec)
 		return handler.respondMappedError(c, spec)

--- a/internal/api/handlers_settings_2fa.go
+++ b/internal/api/handlers_settings_2fa.go
@@ -74,6 +74,11 @@ func (handler *Handler) VerifyTOTP2FAEnrollment(c *fiber.Ctx) error {
 		return handler.respondMappedError(c, unauthorizedErrorSpec())
 	}
 
+	if _, spec, valid := handler.validateSettingsActionPassword(c); !valid {
+		handler.logSecurityError(c, "settings.2fa.verify", spec)
+		return handler.respondMappedError(c, spec)
+	}
+
 	rawSecret, err := handler.parseTOTPSetupCookie(c)
 	if err != nil {
 		return handler.respondMappedError(c, totpSessionExpiredErrorSpec())

--- a/internal/api/handlers_settings_2fa_password_required_test.go
+++ b/internal/api/handlers_settings_2fa_password_required_test.go
@@ -1,0 +1,102 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+	"github.com/ovumcy/ovumcy-web/internal/services"
+	"github.com/pquerna/otp/totp"
+)
+
+func TestVerifyTOTP2FAEnrollment_MissingPassword_DoesNotEnable(t *testing.T) {
+	ctx := newTOTPSettingsContext(t, "totp-enroll-missing-pass@example.com")
+
+	key, err := services.NewTOTPService(&dbUserRepoForTest{ctx.database}, []byte("test-secret-key"), nil).GenerateSetupKey("Ovumcy", ctx.user.Email)
+	if err != nil {
+		t.Fatalf("GenerateSetupKey: %v", err)
+	}
+	setupCookie := sealTOTPSetupCookieForTest(t, []byte("test-secret-key"), key.Secret())
+
+	code, err := totp.GenerateCode(key.Secret(), time.Now())
+	if err != nil {
+		t.Fatalf("GenerateCode: %v", err)
+	}
+
+	form := url.Values{"code": {code}}
+	cloned := cloneFormValues(form)
+	cloned.Set("csrf_token", ctx.csrfToken)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/settings/2fa/verify", strings.NewReader(cloned.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Cookie", joinCookieHeader(ctx.authCookie, cookiePair(ctx.csrfCookie), setupCookie))
+	resp, err := ctx.app.Test(req, -1)
+	if err != nil {
+		t.Fatalf("POST /api/settings/2fa/verify: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 (missing password)", resp.StatusCode)
+	}
+	if got := readAPIError(t, resp.Body); got != "invalid password" {
+		t.Fatalf("expected error %q, got %q", "invalid password", got)
+	}
+
+	var reloaded models.User
+	if err := ctx.database.First(&reloaded, ctx.user.ID).Error; err != nil {
+		t.Fatalf("reload user: %v", err)
+	}
+	if reloaded.TOTPEnabled {
+		t.Error("missing password must not enable TOTP")
+	}
+}
+
+func TestVerifyTOTP2FAEnrollment_WrongPassword_DoesNotEnable(t *testing.T) {
+	ctx := newTOTPSettingsContext(t, "totp-enroll-wrong-pass@example.com")
+
+	key, err := services.NewTOTPService(&dbUserRepoForTest{ctx.database}, []byte("test-secret-key"), nil).GenerateSetupKey("Ovumcy", ctx.user.Email)
+	if err != nil {
+		t.Fatalf("GenerateSetupKey: %v", err)
+	}
+	setupCookie := sealTOTPSetupCookieForTest(t, []byte("test-secret-key"), key.Secret())
+
+	code, err := totp.GenerateCode(key.Secret(), time.Now())
+	if err != nil {
+		t.Fatalf("GenerateCode: %v", err)
+	}
+
+	form := url.Values{"code": {code}, "password": {"NotMyPass99"}}
+	cloned := cloneFormValues(form)
+	cloned.Set("csrf_token", ctx.csrfToken)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/settings/2fa/verify", strings.NewReader(cloned.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Cookie", joinCookieHeader(ctx.authCookie, cookiePair(ctx.csrfCookie), setupCookie))
+	resp, err := ctx.app.Test(req, -1)
+	if err != nil {
+		t.Fatalf("POST /api/settings/2fa/verify: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401 (wrong password)", resp.StatusCode)
+	}
+	if got := readAPIError(t, resp.Body); got != "invalid password" {
+		t.Fatalf("expected error %q, got %q", "invalid password", got)
+	}
+
+	var reloaded models.User
+	if err := ctx.database.First(&reloaded, ctx.user.ID).Error; err != nil {
+		t.Fatalf("reload user: %v", err)
+	}
+	if reloaded.TOTPEnabled {
+		t.Error("wrong password must not enable TOTP")
+	}
+}

--- a/internal/api/handlers_settings_2fa_test.go
+++ b/internal/api/handlers_settings_2fa_test.go
@@ -142,7 +142,7 @@ func TestVerifyTOTP2FAEnrollment_ValidCode_EnablesTOTP(t *testing.T) {
 		t.Fatalf("GenerateCode: %v", err)
 	}
 
-	form := url.Values{"code": {code}}
+	form := url.Values{"code": {code}, "password": {"StrongPass1"}}
 	cloned := cloneFormValues(form)
 	cloned.Set("csrf_token", ctx.csrfToken)
 
@@ -180,7 +180,7 @@ func TestVerifyTOTP2FAEnrollment_InvalidCode_DoesNotEnable(t *testing.T) {
 	}
 	setupCookie := sealTOTPSetupCookieForTest(t, []byte("test-secret-key"), key.Secret())
 
-	form := url.Values{"code": {"000000"}}
+	form := url.Values{"code": {"000000"}, "password": {"StrongPass1"}}
 	cloned := cloneFormValues(form)
 	cloned.Set("csrf_token", ctx.csrfToken)
 
@@ -206,7 +206,7 @@ func TestVerifyTOTP2FAEnrollment_InvalidCode_DoesNotEnable(t *testing.T) {
 func TestVerifyTOTP2FAEnrollment_MissingSetupCookie_ReturnsError(t *testing.T) {
 	ctx := newTOTPSettingsContext(t, "totp-enroll-nocookie@example.com")
 
-	form := url.Values{"code": {"123456"}}
+	form := url.Values{"code": {"123456"}, "password": {"StrongPass1"}}
 	cloned := cloneFormValues(form)
 	cloned.Set("csrf_token", ctx.csrfToken)
 

--- a/internal/api/handlers_settings_password.go
+++ b/internal/api/handlers_settings_password.go
@@ -1,12 +1,21 @@
 package api
 
 import (
+	"context"
 	"errors"
+	"time"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/ovumcy/ovumcy-web/internal/models"
 	"github.com/ovumcy/ovumcy-web/internal/services"
 )
+
+// stepupReauthMaxAge is the maximum acceptable age of an OIDC ID token's
+// auth_time / iat claim relative to the moment we finish the step-up callback.
+// 5 minutes is long enough for an interactive sign-in (typically 30-60 seconds)
+// but short enough that a captured ID token from an earlier session cannot be
+// replayed to bypass the re-auth requirement.
+const stepupReauthMaxAge = 5 * time.Minute
 
 func (handler *Handler) ChangePassword(c *fiber.Ctx) error {
 	user, ok := currentUser(c)
@@ -24,7 +33,14 @@ func (handler *Handler) ChangePassword(c *fiber.Ctx) error {
 	}
 
 	if !user.LocalAuthEnabled {
-		return handler.enableLocalPasswordAndRenderRecovery(c, user, input)
+		// CVE-class issue #3: previously this branch silently enabled a fresh
+		// local password without any re-authentication, so a hijacked
+		// OIDC-only session became permanent. The dedicated step-up flow at
+		// StartLocalPasswordSetupReauth performs a fresh OIDC sign-in before
+		// committing the new password.
+		spec := settingsOIDCReauthRequiredErrorSpec()
+		handler.logSecurityError(c, "auth.password_change", spec)
+		return handler.respondMappedError(c, spec)
 	}
 
 	if err := handler.settingsService.ChangePassword(user, input.CurrentPassword, input.NewPassword, input.ConfirmPassword); err != nil {
@@ -39,24 +55,167 @@ func (handler *Handler) ChangePassword(c *fiber.Ctx) error {
 	return handler.respondPasswordChanged(c)
 }
 
-func parseChangePasswordInput(c *fiber.Ctx) (changePasswordInput, error) {
-	input := changePasswordInput{}
-	if err := c.BodyParser(&input); err != nil {
-		return changePasswordInput{}, err
+// StartLocalPasswordSetupReauth begins the OIDC step-up flow that lets an
+// OIDC-only account enroll a local password. It validates the new password
+// pair, prepares the bcrypt hash, stashes it in a sealed step-up cookie, and
+// returns a redirect URL pointing at the provider authorize endpoint with
+// prompt=login + max_age=0 so the provider is forced to re-authenticate the
+// user interactively. Nothing is written to the database here.
+func (handler *Handler) StartLocalPasswordSetupReauth(c *fiber.Ctx) error {
+	user, ok := currentUser(c)
+	if !ok {
+		spec := unauthorizedErrorSpec()
+		handler.logSecurityError(c, "auth.local_password_setup.start", spec)
+		return handler.respondMappedError(c, spec)
 	}
-	return input, nil
+	if user.LocalAuthEnabled {
+		spec := settingsInvalidInputErrorSpec()
+		handler.logSecurityError(c, "auth.local_password_setup.start", spec)
+		return handler.respondMappedError(c, spec)
+	}
+	if handler.oidcService == nil || !handler.oidcService.Enabled() {
+		spec := authOIDCUnavailableErrorSpec()
+		handler.logSecurityError(c, "auth.local_password_setup.start", spec)
+		return handler.respondMappedError(c, spec)
+	}
+
+	input, err := parseChangePasswordInput(c)
+	if err != nil {
+		spec := settingsInvalidInputErrorSpec()
+		handler.logSecurityError(c, "auth.local_password_setup.start", spec)
+		return handler.respondMappedError(c, spec)
+	}
+
+	preparedHash, err := handler.settingsService.PrepareLocalPasswordHash(user, input.NewPassword, input.ConfirmPassword)
+	if err != nil {
+		return handler.respondPasswordChangeError(c, err)
+	}
+
+	state, err := newOIDCStepupState(time.Now(), oidcStepupPurposeLocalPasswordSetup, user.ID, preparedHash)
+	if err != nil {
+		spec := authOIDCUnavailableErrorSpec()
+		handler.logSecurityError(c, "auth.local_password_setup.start", spec)
+		return handler.respondMappedError(c, spec)
+	}
+	if err := handler.setOIDCStepupCookie(c, state); err != nil {
+		spec := authOIDCUnavailableErrorSpec()
+		handler.logSecurityError(c, "auth.local_password_setup.start", spec)
+		return handler.respondMappedError(c, spec)
+	}
+	// Drop any in-flight ordinary login state — at the callback we will look
+	// for the stepup cookie first, but two competing flows for the same user
+	// are an indicator of confusion at best and CSRF at worst.
+	handler.clearOIDCStateCookie(c)
+
+	ctx, cancel := oidcRequestContext(c)
+	defer cancel()
+
+	authURL, err := handler.oidcService.StartReauth(ctx, state.State, state.Nonce, state.CodeVerifier)
+	if err != nil {
+		handler.clearOIDCStepupCookie(c)
+		spec := mapAuthOIDCError(err)
+		handler.logSecurityError(c, "auth.local_password_setup.start", spec)
+		return handler.respondMappedError(c, spec)
+	}
+
+	handler.logSecurityEvent(c, "auth.local_password_setup.start", "redirect_issued")
+	if acceptsJSON(c) {
+		return c.JSON(fiber.Map{"ok": true, "redirect_url": authURL})
+	}
+	return c.Redirect(authURL, fiber.StatusSeeOther)
 }
 
-func (handler *Handler) enableLocalPasswordAndRenderRecovery(c *fiber.Ctx, user *models.User, input changePasswordInput) error {
-	recoveryCode, err := handler.settingsService.EnableLocalPassword(user, input.NewPassword, input.ConfirmPassword)
+// completeLocalPasswordSetupReauth is dispatched from CompleteOIDCLogin when
+// the request carries a valid step-up cookie instead of (or in preference to)
+// the ordinary login state cookie. It must verify the OIDC exchange against
+// the same user that initiated the flow before committing the prepared
+// password.
+func (handler *Handler) completeLocalPasswordSetupReauth(c *fiber.Ctx, state oidcStepupState) error {
+	if state.Purpose != oidcStepupPurposeLocalPasswordSetup {
+		spec := authOIDCAuthenticationFailedErrorSpec()
+		handler.logSecurityError(c, "auth.local_password_setup.callback", spec)
+		handler.setFlashCookie(c, FlashPayload{AuthError: spec.Key})
+		return c.Redirect("/settings", fiber.StatusSeeOther)
+	}
+
+	// /auth/oidc/callback runs without AuthRequired middleware (the ordinary
+	// login path needs to work for unauthenticated visitors), so we resolve
+	// the current session from the auth cookie ourselves.
+	user, err := handler.authenticateRequest(c)
+	if err != nil || user == nil || user.ID != state.UserID {
+		spec := settingsOIDCReauthMismatchErrorSpec()
+		handler.logSecurityError(c, "auth.local_password_setup.callback", spec)
+		handler.setFlashCookie(c, FlashPayload{AuthError: spec.Key})
+		return c.Redirect("/settings", fiber.StatusSeeOther)
+	}
+	if user.LocalAuthEnabled {
+		// Another flow finished first; nothing left to do.
+		return c.Redirect("/settings", fiber.StatusSeeOther)
+	}
+
+	callbackState := c.FormValue("state")
+	code := c.FormValue("code")
+	if !state.matchesState(callbackState) {
+		spec := authOIDCAuthenticationFailedErrorSpec()
+		handler.logSecurityError(c, "auth.local_password_setup.callback", spec)
+		handler.setFlashCookie(c, FlashPayload{AuthError: spec.Key})
+		return c.Redirect("/settings", fiber.StatusSeeOther)
+	}
+	if c.FormValue("error") != "" {
+		spec := authOIDCUnavailableErrorSpec()
+		handler.logSecurityError(c, "auth.local_password_setup.callback", spec)
+		handler.setFlashCookie(c, FlashPayload{AuthError: spec.Key})
+		return c.Redirect("/settings", fiber.StatusSeeOther)
+	}
+
+	ctx, cancel := oidcRequestContext(c)
+	defer cancel()
+	if err := handler.validateLocalPasswordSetupReauth(ctx, code, state.CodeVerifier, state.Nonce, user.ID, time.Now()); err != nil {
+		spec := mapLocalPasswordSetupReauthError(err)
+		handler.logSecurityError(c, "auth.local_password_setup.callback", spec)
+		handler.setFlashCookie(c, FlashPayload{AuthError: spec.Key})
+		return c.Redirect("/settings", fiber.StatusSeeOther)
+	}
+
+	recoveryCode, err := handler.settingsService.FinalizeLocalPasswordSetup(user, state.PasswordHash)
 	if err != nil {
 		return handler.respondPasswordChangeError(c, err)
 	}
 	if err := handler.refreshPasswordChangeSession(c, user); err != nil {
 		return err
 	}
-	handler.logSecurityEvent(c, "auth.password_change", "local_password_enabled")
+
+	handler.logSecurityEvent(c, "auth.local_password_setup.callback", "success")
 	return handler.renderRecoveryCodeResponseWithContinuePath(c, user, recoveryCode, fiber.StatusOK, "/settings")
+}
+
+func (handler *Handler) validateLocalPasswordSetupReauth(ctx context.Context, code, codeVerifier, nonce string, userID uint, now time.Time) error {
+	return handler.oidcService.ValidateReauthExchange(ctx, code, codeVerifier, nonce, userID, stepupReauthMaxAge, now)
+}
+
+func mapLocalPasswordSetupReauthError(err error) APIErrorSpec {
+	switch {
+	case errors.Is(err, services.ErrOIDCReauthStale):
+		return settingsOIDCReauthStaleErrorSpec()
+	case errors.Is(err, services.ErrOIDCReauthIdentityMismatch):
+		return settingsOIDCReauthMismatchErrorSpec()
+	case errors.Is(err, services.ErrOIDCCallbackInvalid):
+		return authOIDCAuthenticationFailedErrorSpec()
+	case errors.Is(err, services.ErrOIDCAuthenticationFailed):
+		return authOIDCAuthenticationFailedErrorSpec()
+	case errors.Is(err, services.ErrOIDCDisabled), errors.Is(err, services.ErrOIDCUnavailable):
+		return authOIDCUnavailableErrorSpec()
+	default:
+		return authOIDCAuthenticationFailedErrorSpec()
+	}
+}
+
+func parseChangePasswordInput(c *fiber.Ctx) (changePasswordInput, error) {
+	input := changePasswordInput{}
+	if err := c.BodyParser(&input); err != nil {
+		return changePasswordInput{}, err
+	}
+	return input, nil
 }
 
 func (handler *Handler) refreshPasswordChangeSession(c *fiber.Ctx, user *models.User) error {

--- a/internal/api/handlers_settings_recovery.go
+++ b/internal/api/handlers_settings_recovery.go
@@ -14,6 +14,10 @@ func (handler *Handler) RegenerateRecoveryCode(c *fiber.Ctx) error {
 		handler.logSecurityError(c, "auth.recovery_code_regenerate", spec)
 		return handler.respondMappedError(c, spec)
 	}
+	if _, spec, valid := handler.validateSettingsActionPassword(c); !valid {
+		handler.logSecurityError(c, "auth.recovery_code_regenerate", spec)
+		return handler.respondMappedError(c, spec)
+	}
 	recoveryCode, err := handler.authService.RegenerateRecoveryCode(user.ID)
 	if err != nil {
 		spec := mapRecoveryCodeRegenerationError(err)

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -15,6 +15,7 @@ const (
 	recoveryCodeCookieName       = "ovumcy_recovery_code"
 	resetPasswordCookieName      = "ovumcy_reset_password" // #nosec G101 -- cookie name contains "password" but is not a secret or credential.
 	oidcStateCookieName          = "ovumcy_oidc_auth"
+	oidcStepupCookieName         = "ovumcy_oidc_stepup"
 	oidcLogoutBridgeCookieName   = "ovumcy_oidc_logout_bridge"
 	totpPendingCookieName        = "ovumcy_totp_pending"
 	totpSetupCookieName          = "ovumcy_totp_setup"

--- a/internal/api/oidc_stepup_cookie.go
+++ b/internal/api/oidc_stepup_cookie.go
@@ -1,0 +1,158 @@
+package api
+
+import (
+	"crypto/subtle"
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/ovumcy/ovumcy-web/internal/security"
+	"golang.org/x/oauth2"
+)
+
+// OIDC step-up cookie. Carries the state needed to complete a fresh-reauth
+// callback for an already-signed-in user (currently: enabling a local
+// password on an OIDC-only account). Distinct from oidcStateCookieName so
+// the callback handler can detect step-up vs ordinary login without
+// ambiguity.
+
+const oidcStepupCookieTTL = 10 * time.Minute
+
+// oidcStepupPurpose enumerates the actions a step-up reauth can complete.
+// Encoded into the cookie so the callback handler dispatches to the right
+// completion handler and refuses callbacks aimed at a different purpose.
+type oidcStepupPurpose string
+
+const oidcStepupPurposeLocalPasswordSetup oidcStepupPurpose = "local_password_setup"
+
+type oidcStepupState struct {
+	Purpose      oidcStepupPurpose `json:"purpose"`
+	UserID       uint              `json:"user_id"`
+	State        string            `json:"state"`
+	Nonce        string            `json:"nonce"`
+	CodeVerifier string            `json:"code_verifier"`
+	PasswordHash string            `json:"password_hash"`
+	ExpiresAt    string            `json:"expires_at"`
+}
+
+func newOIDCStepupState(now time.Time, purpose oidcStepupPurpose, userID uint, passwordHash string) (oidcStepupState, error) {
+	if userID == 0 {
+		return oidcStepupState{}, errors.New("oidc stepup state requires user id")
+	}
+	if strings.TrimSpace(passwordHash) == "" {
+		return oidcStepupState{}, errors.New("oidc stepup state requires password hash")
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	state, err := security.RandomString(32, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+	if err != nil {
+		return oidcStepupState{}, err
+	}
+	nonce, err := security.RandomString(32, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+	if err != nil {
+		return oidcStepupState{}, err
+	}
+	return oidcStepupState{
+		Purpose:      purpose,
+		UserID:       userID,
+		State:        state,
+		Nonce:        nonce,
+		CodeVerifier: oauth2.GenerateVerifier(),
+		PasswordHash: passwordHash,
+		ExpiresAt:    now.UTC().Add(oidcStepupCookieTTL).Format(time.RFC3339Nano),
+	}, nil
+}
+
+func (state oidcStepupState) validAt(now time.Time) bool {
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	expiresAt, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(state.ExpiresAt))
+	if err != nil || !expiresAt.After(now.UTC()) {
+		return false
+	}
+	return state.Purpose != "" &&
+		state.UserID != 0 &&
+		strings.TrimSpace(state.State) != "" &&
+		strings.TrimSpace(state.Nonce) != "" &&
+		strings.TrimSpace(state.CodeVerifier) != "" &&
+		strings.TrimSpace(state.PasswordHash) != ""
+}
+
+func (state oidcStepupState) matchesState(candidate string) bool {
+	return subtle.ConstantTimeCompare([]byte(strings.TrimSpace(state.State)), []byte(strings.TrimSpace(candidate))) == 1
+}
+
+func (handler *Handler) setOIDCStepupCookie(c *fiber.Ctx, state oidcStepupState) error {
+	if !handler.cookieSecure {
+		return errors.New("oidc stepup cookie requires secure transport")
+	}
+	if !state.validAt(time.Now()) {
+		return errors.New("oidc stepup cookie payload is required")
+	}
+
+	payload, err := json.Marshal(state)
+	if err != nil {
+		return err
+	}
+	codec, err := newSecureCookieCodec(handler.secretKey)
+	if err != nil {
+		return err
+	}
+	encoded, err := codec.seal(oidcStepupCookieName, payload)
+	if err != nil {
+		return err
+	}
+
+	c.Cookie(&fiber.Cookie{
+		Name:     oidcStepupCookieName,
+		Value:    encoded,
+		Path:     security.OIDCCallbackPath,
+		HTTPOnly: true,
+		Secure:   true,
+		SameSite: "None",
+		Expires:  time.Now().Add(oidcStepupCookieTTL),
+	})
+	return nil
+}
+
+func (handler *Handler) popOIDCStepupCookie(c *fiber.Ctx) oidcStepupState {
+	raw := strings.TrimSpace(c.Cookies(oidcStepupCookieName))
+	if raw == "" {
+		return oidcStepupState{}
+	}
+	handler.clearOIDCStepupCookie(c)
+
+	codec, err := newSecureCookieCodec(handler.secretKey)
+	if err != nil {
+		return oidcStepupState{}
+	}
+	decoded, err := codec.open(oidcStepupCookieName, raw)
+	if err != nil {
+		return oidcStepupState{}
+	}
+
+	state := oidcStepupState{}
+	if err := json.Unmarshal(decoded, &state); err != nil {
+		return oidcStepupState{}
+	}
+	if !state.validAt(time.Now()) {
+		return oidcStepupState{}
+	}
+	return state
+}
+
+func (handler *Handler) clearOIDCStepupCookie(c *fiber.Ctx) {
+	c.Cookie(&fiber.Cookie{
+		Name:     oidcStepupCookieName,
+		Value:    "",
+		Path:     security.OIDCCallbackPath,
+		HTTPOnly: true,
+		Secure:   handler.cookieSecure,
+		SameSite: "None",
+		Expires:  time.Now().Add(-1 * time.Hour),
+	})
+}

--- a/internal/api/onboarding_request_timezone_regression_test.go
+++ b/internal/api/onboarding_request_timezone_regression_test.go
@@ -40,7 +40,11 @@ func TestOnboardingPersistsLastPeriodStartUsingRequestTimezone(t *testing.T) {
 		t.Fatal("expected persisted last_period_start after onboarding")
 	}
 
-	savedLocalDay := services.DateAtLocation(persisted.LastPeriodStart.In(location), location).Format("2006-01-02")
+	// LastPeriodStart is a date-only stored value canonicalized to UTC-midnight
+	// (migration 019). DateAtLocation/.In(location) would shift it one day back
+	// for negative-offset zones; use CalendarDayKey, which reads the calendar
+	// components verbatim and matches the docblock guidance in day_utils.go.
+	savedLocalDay := services.CalendarDayKey(*persisted.LastPeriodStart)
 	if savedLocalDay != localToday {
 		t.Fatalf("expected persisted onboarding last_period_start %q, got %q", localToday, savedLocalDay)
 	}
@@ -111,7 +115,11 @@ func TestOnboardingPersistsLastPeriodStartUsingFormTimezoneFallback(t *testing.T
 		t.Fatal("expected persisted last_period_start after onboarding")
 	}
 
-	savedLocalDay := services.DateAtLocation(persisted.LastPeriodStart.In(location), location).Format("2006-01-02")
+	// LastPeriodStart is a date-only stored value canonicalized to UTC-midnight
+	// (migration 019). DateAtLocation/.In(location) would shift it one day back
+	// for negative-offset zones; use CalendarDayKey, which reads the calendar
+	// components verbatim and matches the docblock guidance in day_utils.go.
+	savedLocalDay := services.CalendarDayKey(*persisted.LastPeriodStart)
 	if savedLocalDay != localToday {
 		t.Fatalf("expected persisted onboarding last_period_start %q, got %q", localToday, savedLocalDay)
 	}

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -81,6 +81,7 @@ func registerAPIRoutes(app *fiber.App, handler *Handler) {
 	settings.Post("/profile", handler.UpdateProfile)
 	settings.Post("/tracking", handler.OwnerOnly, handler.UpdateTrackingSettings)
 	settings.Post("/change-password", handler.ChangePassword)
+	settings.Post("/start-local-password-setup", handler.StartLocalPasswordSetupReauth)
 	settings.Post("/regenerate-recovery-code", handler.RegenerateRecoveryCode)
 	settings.Post("/2fa/verify", handler.VerifyTOTP2FAEnrollment)
 	settings.Post("/2fa/disable", handler.DisableTOTP2FA)

--- a/internal/api/settings_cycle_request_timezone_regression_test.go
+++ b/internal/api/settings_cycle_request_timezone_regression_test.go
@@ -59,7 +59,11 @@ func TestSettingsCycleUsesRequestTimezoneForLastPeriodStartValidation(t *testing
 		t.Fatal("expected persisted last_period_start")
 	}
 
-	savedLocalDay := services.DateAtLocation(updatedUser.LastPeriodStart.In(location), location).Format("2006-01-02")
+	// LastPeriodStart is a date-only value (UTC-midnight on disk per migration
+	// 019). DateAtLocation/.In(location) would mis-shift it across DST and
+	// negative-offset zones; read the calendar components directly instead —
+	// see the docblock on services.DateAtLocation.
+	savedLocalDay := services.CalendarDayKey(*updatedUser.LastPeriodStart)
 	if savedLocalDay != localToday {
 		t.Fatalf("expected saved last_period_start %q, got %q", localToday, savedLocalDay)
 	}

--- a/internal/api/settings_oidc_local_password_regression_test.go
+++ b/internal/api/settings_oidc_local_password_regression_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/ovumcy/ovumcy-web/internal/models"
-	"github.com/ovumcy/ovumcy-web/internal/services"
 )
 
 func TestSettingsPageForOIDCOnlyAccountShowsLocalPasswordSetup(t *testing.T) {
@@ -86,105 +85,42 @@ func TestOIDCOnlySettingsSensitiveActionsRequireLocalPassword(t *testing.T) {
 	}
 }
 
-func TestOIDCOnlySettingsEnableLocalPasswordIssuesRecoveryCode(t *testing.T) {
+// TestOIDCOnlySettingsChangePasswordRequiresReauth is the closed-CVE regression
+// for #3: prior to the OIDC step-up flow, POST /api/settings/change-password
+// for an OIDC-only account silently enabled a local password and emitted a
+// fresh recovery code. A hijacked session could thus mint a permanent
+// take-over in a single request. The endpoint must now reject this branch
+// with 403 oidc-reauth-required and leave the user untouched.
+func TestOIDCOnlySettingsChangePasswordRequiresReauth(t *testing.T) {
 	t.Parallel()
 
-	ctx := newOIDCOnlySettingsSecurityTestContext(t, "settings-enable-local@example.com")
+	ctx := newOIDCOnlySettingsSecurityTestContext(t, "settings-oidc-change-password-blocked@example.com")
 
 	form := url.Values{
 		"new_password":     {"EvenStronger2"},
 		"confirm_password": {"EvenStronger2"},
 	}
 	response := settingsFormRequestWithCSRF(t, ctx, http.MethodPost, "/api/settings/change-password", form, map[string]string{
-		"Accept-Language": "en",
+		"Accept": "application/json",
 	})
 	defer response.Body.Close()
 
-	assertStatusCode(t, response, http.StatusSeeOther)
-	if location := response.Header.Get("Location"); location != "/recovery-code" {
-		t.Fatalf("expected redirect to /recovery-code, got %q", location)
+	assertStatusCode(t, response, http.StatusForbidden)
+	if got := readAPIError(t, response.Body); got != "oidc reauth required" {
+		t.Fatalf("expected error %q, got %q", "oidc reauth required", got)
 	}
-
-	updatedAuthCookie := ctx.authCookie
-	if authCookie := responseCookie(response.Cookies(), authCookieName); authCookie != nil && authCookie.Value != "" {
-		updatedAuthCookie = cookiePair(authCookie)
-	}
-	recoveryCookie := responseCookieValue(response.Cookies(), recoveryCodeCookieName)
-	if recoveryCookie == "" {
-		t.Fatal("expected recovery-code display cookie after enabling local password")
-	}
-
-	recoveryRequest := httptest.NewRequest(http.MethodGet, "/recovery-code", nil)
-	recoveryRequest.Header.Set("Accept-Language", "en")
-	recoveryRequest.Header.Set("Cookie", joinCookieHeader(updatedAuthCookie, recoveryCodeCookieName+"="+recoveryCookie))
-	recoveryResponse := mustAppResponse(t, ctx.app, recoveryRequest)
-	assertStatusCode(t, recoveryResponse, http.StatusOK)
-	recoveryPage := mustReadBodyString(t, recoveryResponse.Body)
-	assertBodyContainsAll(t, recoveryPage,
-		bodyStringMatch{fragment: `id="recovery-code"`, message: "expected dedicated recovery-code page after enabling local password"},
-		bodyStringMatch{fragment: "/settings", message: "expected recovery-code continue path to point back to settings"},
-	)
 
 	var persisted models.User
 	if err := ctx.database.First(&persisted, ctx.user.ID).Error; err != nil {
-		t.Fatalf("load updated oidc-only user: %v", err)
+		t.Fatalf("reload oidc-only user: %v", err)
 	}
-	if !persisted.LocalAuthEnabled {
-		t.Fatal("expected local auth to be enabled after setting local password")
+	if persisted.LocalAuthEnabled {
+		t.Fatal("oidc-only user must remain in non-local-auth state after rejected ChangePassword")
 	}
-	if strings.TrimSpace(persisted.PasswordHash) == "" {
-		t.Fatal("expected stored password hash after setting local password")
+	if strings.TrimSpace(persisted.PasswordHash) != "" {
+		t.Fatal("oidc-only user must not have a password hash stored after rejected ChangePassword")
 	}
-	if strings.TrimSpace(persisted.RecoveryCodeHash) == "" {
-		t.Fatal("expected stored recovery code hash after setting local password")
-	}
-
-	localLoginCookie := loginAndExtractAuthCookieWithCSRF(t, ctx.app, persisted.Email, "EvenStronger2")
-	if strings.TrimSpace(localLoginCookie) == "" {
-		t.Fatal("expected local login to work after enabling local password")
-	}
-}
-
-func TestOIDCOnlySettingsEnableLocalPasswordPreservesProviderLogoutBridge(t *testing.T) {
-	t.Parallel()
-
-	ctx := newOIDCOnlySettingsSecurityTestContext(t, "settings-enable-local-logout@example.com")
-	persistOIDCLogoutStateForAuthCookie(t, ctx.database, ctx.authCookie, services.OIDCLogoutState{
-		EndSessionEndpoint:    "https://id.example.com/oidc/logout",
-		IDTokenHint:           strings.Repeat("idtoken.", 128),
-		PostLogoutRedirectURL: "https://ovumcy.example.com/login",
-	})
-
-	form := url.Values{
-		"new_password":     {"EvenStronger2"},
-		"confirm_password": {"EvenStronger2"},
-	}
-	response := settingsFormRequestWithCSRF(t, ctx, http.MethodPost, "/api/settings/change-password", form, map[string]string{
-		"Accept-Language": "en",
-	})
-	defer response.Body.Close()
-
-	assertStatusCode(t, response, http.StatusSeeOther)
-	updatedAuthCookie := ctx.authCookie
-	if authCookie := responseCookie(response.Cookies(), authCookieName); authCookie != nil && authCookie.Value != "" {
-		updatedAuthCookie = cookiePair(authCookie)
-	}
-
-	logoutForm := url.Values{"csrf_token": {ctx.csrfToken}}
-	logoutRequest := httptest.NewRequest(http.MethodPost, "/logout", strings.NewReader(logoutForm.Encode()))
-	logoutRequest.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	logoutRequest.Header.Set("Cookie", joinCookieHeader(updatedAuthCookie, cookiePair(ctx.csrfCookie)))
-
-	logoutResponse := mustAppResponse(t, ctx.app, logoutRequest)
-	assertStatusCode(t, logoutResponse, http.StatusSeeOther)
-	if location := logoutResponse.Header.Get("Location"); location != oidcLogoutBridgePath {
-		t.Fatalf("expected provider logout bridge after local password enablement, got %q", location)
-	}
-	bridgeCookie := responseCookie(logoutResponse.Cookies(), oidcLogoutBridgeCookieName)
-	if bridgeCookie == nil || strings.TrimSpace(bridgeCookie.Value) == "" {
-		t.Fatalf("expected logout bridge cookie after local password enablement, got %#v", bridgeCookie)
-	}
-	if len(bridgeCookie.Value) > 512 {
-		t.Fatalf("expected bounded logout bridge cookie after local password enablement, got %d bytes", len(bridgeCookie.Value))
+	if strings.TrimSpace(persisted.RecoveryCodeHash) != "" {
+		t.Fatal("oidc-only user must not have a recovery code hash stored after rejected ChangePassword")
 	}
 }

--- a/internal/api/settings_oidc_local_password_setup_test.go
+++ b/internal/api/settings_oidc_local_password_setup_test.go
@@ -1,0 +1,319 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/ovumcy/ovumcy-web/internal/models"
+	"github.com/ovumcy/ovumcy-web/internal/services"
+	"gorm.io/gorm"
+)
+
+// Test fixture for the OIDC step-up "enable local password" flow.
+//
+// We assemble the app with cookieSecure=true (required by the stepup cookie's
+// SameSite=None;Secure attributes), drop in a stubOIDCWorkflowService whose
+// reauth result we control, create an OIDC-only owner, and link the OIDC
+// identity to that owner so ValidateReauthExchange's identity-binding check
+// has a row to match.
+type oidcStepupFixture struct {
+	app           *fiber.App
+	database      *gorm.DB
+	user          models.User
+	identity      models.OIDCIdentity
+	authCookie    string
+	oidcStub      *stubOIDCWorkflowService
+	cookieSecure  bool
+	stepupIssuer  string
+	stepupSubject string
+}
+
+func newOIDCStepupFixture(t *testing.T, email string) *oidcStepupFixture {
+	t.Helper()
+
+	stub := newStubOIDCWorkflowService(true)
+	stub.localPublicAuthEnabled = true
+	stub.reauthURL = "https://id.example.com/authorize?prompt=login"
+
+	app, database := newOnboardingTestAppWithOptions(t, onboardingTestAppOptions{
+		enableCSRF:   true,
+		cookieSecure: true,
+		oidcService:  stub,
+	})
+
+	user := models.User{
+		Email:               strings.ToLower(strings.TrimSpace(email)),
+		LocalAuthEnabled:    false,
+		Role:                models.RoleOwner,
+		OnboardingCompleted: true,
+		AuthSessionVersion:  1,
+		CycleLength:         28,
+		PeriodLength:        5,
+		AutoPeriodFill:      true,
+		CreatedAt:           time.Now().UTC(),
+	}
+	if err := database.Create(&user).Error; err != nil {
+		t.Fatalf("create oidc-only user: %v", err)
+	}
+
+	issuer := "https://id.example.com"
+	subject := "stepup-test-" + strings.TrimSuffix(email, "@example.com")
+	identity := models.OIDCIdentity{
+		UserID:    user.ID,
+		Issuer:    issuer,
+		Subject:   subject,
+		CreatedAt: time.Now().UTC(),
+	}
+	if err := database.Create(&identity).Error; err != nil {
+		t.Fatalf("link oidc identity: %v", err)
+	}
+
+	return &oidcStepupFixture{
+		app:           app,
+		database:      database,
+		user:          user,
+		identity:      identity,
+		authCookie:    issueAuthCookieForUser(t, user),
+		oidcStub:      stub,
+		cookieSecure:  true,
+		stepupIssuer:  issuer,
+		stepupSubject: subject,
+	}
+}
+
+func (fixture *oidcStepupFixture) settingsCSRF(t *testing.T) (*http.Cookie, string) {
+	t.Helper()
+	return loadSettingsCSRFContext(t, fixture.app, fixture.authCookie)
+}
+
+func (fixture *oidcStepupFixture) postStart(t *testing.T, newPassword, confirmPassword string) *http.Response {
+	t.Helper()
+	csrfCookie, csrfToken := fixture.settingsCSRF(t)
+	form := url.Values{
+		"new_password":     {newPassword},
+		"confirm_password": {confirmPassword},
+		"csrf_token":       {csrfToken},
+	}
+	request := httptest.NewRequest(http.MethodPost, "/api/settings/start-local-password-setup", strings.NewReader(form.Encode()))
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("Cookie", settingsCookieHeader(fixture.authCookie, csrfCookie))
+	return mustAppResponse(t, fixture.app, request)
+}
+
+// readStepupCookie extracts the stepup cookie from a start response and
+// returns the "name=value" pair usable in a follow-up Cookie header.
+func readStepupCookie(t *testing.T, response *http.Response) string {
+	t.Helper()
+	for _, c := range response.Cookies() {
+		if c.Name == oidcStepupCookieName && c.Value != "" {
+			return c.Name + "=" + c.Value
+		}
+	}
+	t.Fatal("expected ovumcy_oidc_stepup cookie in start response")
+	return ""
+}
+
+func decodeStepupRedirectJSON(t *testing.T, body []byte) string {
+	t.Helper()
+	payload := map[string]any{}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("decode start response JSON: %v", err)
+	}
+	if ok, _ := payload["ok"].(bool); !ok {
+		t.Fatalf("expected ok=true, got %#v", payload)
+	}
+	target, _ := payload["redirect_url"].(string)
+	if target == "" {
+		t.Fatalf("expected redirect_url in start response, got %#v", payload)
+	}
+	return target
+}
+
+func extractStepupCallbackState(t *testing.T, fixture *oidcStepupFixture, stepupCookieHeader string) string {
+	t.Helper()
+	// We only need the State value that the stub recorded — the cookie is
+	// opaque to the test code but the stub captured the same string the
+	// handler put inside the sealed cookie.
+	if fixture.oidcStub.lastReauthState == "" {
+		t.Fatal("expected stub to have recorded a reauth state")
+	}
+	return fixture.oidcStub.lastReauthState
+}
+
+func postOIDCStepupCallback(t *testing.T, fixture *oidcStepupFixture, stepupCookieHeader, state, code string) *http.Response {
+	t.Helper()
+	form := url.Values{
+		"state": {state},
+		"code":  {code},
+	}
+	request := httptest.NewRequest(http.MethodPost, "/auth/oidc/callback", strings.NewReader(form.Encode()))
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("Cookie", joinCookieHeader(fixture.authCookie, stepupCookieHeader))
+	return mustAppResponse(t, fixture.app, request)
+}
+
+func TestOIDCStartLocalPasswordSetupIssuesRedirectAndStepupCookie(t *testing.T) {
+	t.Parallel()
+
+	fixture := newOIDCStepupFixture(t, "settings-stepup-start@example.com")
+
+	response := fixture.postStart(t, "EvenStronger2", "EvenStronger2")
+	defer response.Body.Close()
+
+	assertStatusCode(t, response, http.StatusOK)
+	body := mustReadBodyString(t, response.Body)
+	target := decodeStepupRedirectJSON(t, []byte(body))
+	if target != fixture.oidcStub.reauthURL {
+		t.Fatalf("expected redirect_url %q, got %q", fixture.oidcStub.reauthURL, target)
+	}
+	_ = readStepupCookie(t, response)
+
+	// Stub recorded the state/nonce/verifier the handler passed into StartReauth.
+	if fixture.oidcStub.lastReauthState == "" {
+		t.Fatal("expected stub to capture stepup state")
+	}
+	if fixture.oidcStub.lastReauthNonce == "" {
+		t.Fatal("expected stub to capture stepup nonce")
+	}
+	if fixture.oidcStub.lastReauthVerifier == "" {
+		t.Fatal("expected stub to capture stepup pkce verifier")
+	}
+
+	// Nothing must be written to the DB yet — finalize only happens on a
+	// successful callback.
+	var persisted models.User
+	if err := fixture.database.First(&persisted, fixture.user.ID).Error; err != nil {
+		t.Fatalf("reload user: %v", err)
+	}
+	if persisted.LocalAuthEnabled {
+		t.Fatal("local auth must not flip on at the start step")
+	}
+	if strings.TrimSpace(persisted.PasswordHash) != "" {
+		t.Fatal("password hash must not be persisted before reauth completes")
+	}
+}
+
+func TestOIDCStartLocalPasswordSetupRejectsWeakPassword(t *testing.T) {
+	t.Parallel()
+
+	fixture := newOIDCStepupFixture(t, "settings-stepup-weak@example.com")
+	response := fixture.postStart(t, "short", "short")
+	defer response.Body.Close()
+
+	assertStatusCode(t, response, http.StatusBadRequest)
+	if got := readAPIError(t, response.Body); got != "weak password" {
+		t.Fatalf("expected error %q, got %q", "weak password", got)
+	}
+	if fixture.oidcStub.lastReauthState != "" {
+		t.Fatal("must not initiate reauth when password validation fails")
+	}
+	for _, c := range response.Cookies() {
+		if c.Name == oidcStepupCookieName && c.Value != "" {
+			t.Fatal("must not issue stepup cookie when password validation fails")
+		}
+	}
+}
+
+func TestOIDCCompleteLocalPasswordSetupFinalizesOnFreshReauth(t *testing.T) {
+	t.Parallel()
+
+	fixture := newOIDCStepupFixture(t, "settings-stepup-complete@example.com")
+	fixture.oidcStub.reauthErr = nil
+
+	startResponse := fixture.postStart(t, "EvenStronger2", "EvenStronger2")
+	defer startResponse.Body.Close()
+	stepupCookie := readStepupCookie(t, startResponse)
+	state := extractStepupCallbackState(t, fixture, stepupCookie)
+
+	callbackResponse := postOIDCStepupCallback(t, fixture, stepupCookie, state, "callback-code")
+	defer callbackResponse.Body.Close()
+
+	if callbackResponse.StatusCode != http.StatusOK && callbackResponse.StatusCode != http.StatusSeeOther {
+		t.Fatalf("expected 200/303 after fresh reauth, got %d", callbackResponse.StatusCode)
+	}
+	if fixture.oidcStub.lastReauthUserID != fixture.user.ID {
+		t.Fatalf("expected ValidateReauthExchange to be called with user %d, got %d", fixture.user.ID, fixture.oidcStub.lastReauthUserID)
+	}
+	if fixture.oidcStub.lastReauthMaxAge == 0 {
+		t.Fatal("expected max-age to be passed into ValidateReauthExchange")
+	}
+
+	var persisted models.User
+	if err := fixture.database.First(&persisted, fixture.user.ID).Error; err != nil {
+		t.Fatalf("reload user: %v", err)
+	}
+	if !persisted.LocalAuthEnabled {
+		t.Fatal("expected local auth to be enabled after successful reauth")
+	}
+	if strings.TrimSpace(persisted.PasswordHash) == "" {
+		t.Fatal("expected stored password hash after successful reauth")
+	}
+	if strings.TrimSpace(persisted.RecoveryCodeHash) == "" {
+		t.Fatal("expected stored recovery code hash after successful reauth")
+	}
+}
+
+func TestOIDCCompleteLocalPasswordSetupRejectsStaleReauth(t *testing.T) {
+	t.Parallel()
+
+	fixture := newOIDCStepupFixture(t, "settings-stepup-stale@example.com")
+	fixture.oidcStub.reauthErr = services.ErrOIDCReauthStale
+
+	startResponse := fixture.postStart(t, "EvenStronger2", "EvenStronger2")
+	defer startResponse.Body.Close()
+	stepupCookie := readStepupCookie(t, startResponse)
+	state := extractStepupCallbackState(t, fixture, stepupCookie)
+
+	callbackResponse := postOIDCStepupCallback(t, fixture, stepupCookie, state, "callback-code")
+	defer callbackResponse.Body.Close()
+
+	if callbackResponse.StatusCode != http.StatusSeeOther {
+		t.Fatalf("expected redirect after stale reauth, got %d", callbackResponse.StatusCode)
+	}
+	if location := callbackResponse.Header.Get("Location"); location != "/settings" {
+		t.Fatalf("expected redirect to /settings, got %q", location)
+	}
+
+	var persisted models.User
+	if err := fixture.database.First(&persisted, fixture.user.ID).Error; err != nil {
+		t.Fatalf("reload user: %v", err)
+	}
+	if persisted.LocalAuthEnabled {
+		t.Fatal("stale reauth must not enable local auth")
+	}
+}
+
+func TestOIDCCompleteLocalPasswordSetupRejectsIdentityMismatch(t *testing.T) {
+	t.Parallel()
+
+	fixture := newOIDCStepupFixture(t, "settings-stepup-mismatch@example.com")
+	fixture.oidcStub.reauthErr = services.ErrOIDCReauthIdentityMismatch
+
+	startResponse := fixture.postStart(t, "EvenStronger2", "EvenStronger2")
+	defer startResponse.Body.Close()
+	stepupCookie := readStepupCookie(t, startResponse)
+	state := extractStepupCallbackState(t, fixture, stepupCookie)
+
+	callbackResponse := postOIDCStepupCallback(t, fixture, stepupCookie, state, "callback-code")
+	defer callbackResponse.Body.Close()
+
+	if callbackResponse.StatusCode != http.StatusSeeOther {
+		t.Fatalf("expected redirect after identity mismatch, got %d", callbackResponse.StatusCode)
+	}
+
+	var persisted models.User
+	if err := fixture.database.First(&persisted, fixture.user.ID).Error; err != nil {
+		t.Fatalf("reload user: %v", err)
+	}
+	if persisted.LocalAuthEnabled {
+		t.Fatal("identity-mismatch reauth must not enable local auth")
+	}
+}

--- a/internal/api/settings_tracking_dashboard_regression_test.go
+++ b/internal/api/settings_tracking_dashboard_regression_test.go
@@ -41,7 +41,9 @@ func TestTrackingSettingsExposeBBTAndCervicalMucusOnDashboard(t *testing.T) {
 func TestSettingsPageKeepsPersistedCycleValuesAfterRecoveryCodeRegeneration(t *testing.T) {
 	ctx := newSettingsSecurityTestContext(t, "settings-recovery-return@example.com")
 
-	response := settingsFormRequestWithCSRF(t, ctx, http.MethodPost, "/api/settings/regenerate-recovery-code", url.Values{}, nil)
+	response := settingsFormRequestWithCSRF(t, ctx, http.MethodPost, "/api/settings/regenerate-recovery-code", url.Values{
+		"password": {"StrongPass1"},
+	}, nil)
 	assertStatusCode(t, response, http.StatusSeeOther)
 
 	recoveryCookie := responseCookieValue(response.Cookies(), recoveryCodeCookieName)

--- a/internal/db/user_repository.go
+++ b/internal/db/user_repository.go
@@ -146,9 +146,24 @@ func (repo *UserRepository) BumpAuthSessionVersion(userID uint) error {
 
 func (repo *UserRepository) UpdateTOTPFields(userID uint, encryptedSecret string, enabled bool) error {
 	return repo.database.Model(&models.User{}).Where("id = ?", userID).Updates(map[string]any{
-		"totp_secret":  encryptedSecret,
-		"totp_enabled": enabled,
+		"totp_secret":         encryptedSecret,
+		"totp_enabled":        enabled,
+		"totp_last_used_step": 0,
 	}).Error
+}
+
+// ClaimTOTPStep atomically claims a TOTP step for the given user. Returns true
+// iff the row was updated, i.e. the persisted totp_last_used_step was strictly
+// less than `step` at the moment of the UPDATE. Replays and concurrent losers
+// observe RowsAffected == 0 and get false.
+func (repo *UserRepository) ClaimTOTPStep(userID uint, step int64) (bool, error) {
+	result := repo.database.Model(&models.User{}).
+		Where("id = ? AND totp_last_used_step < ?", userID, step).
+		Update("totp_last_used_step", step)
+	if result.Error != nil {
+		return false, result.Error
+	}
+	return result.RowsAffected == 1, nil
 }
 
 func (repo *UserRepository) UpdateByID(userID uint, updates map[string]any) error {

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -47,4 +47,5 @@ type User struct {
 	CreatedAt           time.Time  `gorm:"not null"`
 	TOTPSecret          string     `gorm:"column:totp_secret"`
 	TOTPEnabled         bool       `gorm:"column:totp_enabled;not null;default:false"`
+	TOTPLastUsedStep    int64      `gorm:"column:totp_last_used_step;not null;default:0"`
 }

--- a/internal/security/oidc.go
+++ b/internal/security/oidc.go
@@ -55,6 +55,11 @@ type OIDCClaims struct {
 	Subject       string
 	Email         string
 	EmailVerified bool
+	// IssuedAt is the ID token "iat" claim (always present per RFC).
+	IssuedAt time.Time
+	// AuthTime is the ID token "auth_time" claim. Zero when the provider did
+	// not include the claim (it is REQUIRED only when max_age was requested).
+	AuthTime time.Time
 }
 
 type OIDCSession struct {
@@ -277,7 +282,11 @@ func (client *OIDCClient) Config() OIDCConfig {
 	return client.config
 }
 
-func (client *OIDCClient) AuthCodeURL(ctx context.Context, state string, nonce string, codeVerifier string) (string, error) {
+// AuthCodeURL builds the provider authorize URL. Additional extra parameters
+// (e.g. prompt=login, max_age=0) are passed through verbatim via
+// oauth2.SetAuthURLParam so callers can force a fresh re-authentication for
+// step-up flows without touching the base login parameters.
+func (client *OIDCClient) AuthCodeURL(ctx context.Context, state string, nonce string, codeVerifier string, extra map[string]string) (string, error) {
 	if !client.Enabled() {
 		return "", errors.New("oidc is disabled")
 	}
@@ -285,12 +294,19 @@ func (client *OIDCClient) AuthCodeURL(ctx context.Context, state string, nonce s
 	if err != nil {
 		return "", err
 	}
-	return oauthConfig.AuthCodeURL(
-		strings.TrimSpace(state),
+	opts := []oauth2.AuthCodeOption{
 		oidc.Nonce(strings.TrimSpace(nonce)),
 		oauth2.S256ChallengeOption(strings.TrimSpace(codeVerifier)),
 		oauth2.SetAuthURLParam("response_mode", "form_post"),
-	), nil
+	}
+	for key, value := range extra {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		opts = append(opts, oauth2.SetAuthURLParam(key, value))
+	}
+	return oauthConfig.AuthCodeURL(strings.TrimSpace(state), opts...), nil
 }
 
 func (client *OIDCClient) ExchangeCode(ctx context.Context, code string, codeVerifier string, expectedNonce string) (OIDCExchangeResult, error) {
@@ -324,9 +340,20 @@ func (client *OIDCClient) ExchangeCode(ctx context.Context, code string, codeVer
 	var claims struct {
 		Email         string `json:"email"`
 		EmailVerified bool   `json:"email_verified"`
+		IssuedAt      int64  `json:"iat"`
+		AuthTime      int64  `json:"auth_time"`
 	}
 	if err := idToken.Claims(&claims); err != nil {
 		return OIDCExchangeResult{}, fmt.Errorf("decode oidc id_token claims: %w", err)
+	}
+
+	var issuedAt time.Time
+	if claims.IssuedAt > 0 {
+		issuedAt = time.Unix(claims.IssuedAt, 0).UTC()
+	}
+	var authTime time.Time
+	if claims.AuthTime > 0 {
+		authTime = time.Unix(claims.AuthTime, 0).UTC()
 	}
 
 	return OIDCExchangeResult{
@@ -335,6 +362,8 @@ func (client *OIDCClient) ExchangeCode(ctx context.Context, code string, codeVer
 			Subject:       strings.TrimSpace(idToken.Subject),
 			Email:         strings.TrimSpace(claims.Email),
 			EmailVerified: claims.EmailVerified,
+			IssuedAt:      issuedAt,
+			AuthTime:      authTime,
 		},
 		Session: OIDCSession{
 			EndSessionEndpoint: client.metadata.EndSessionEndpoint,

--- a/internal/services/auth_service.go
+++ b/internal/services/auth_service.go
@@ -29,8 +29,13 @@ var (
 	ErrAuthPasswordUpdate   = errors.New("auth password update failed")
 )
 
-const recoveryCodeTimingEqualizationHash = "$2a$10$ReZgUuXu2GXtC.RZ/q2QyesBFX182a3ycbr78sbtgURmuOyc3ygtG"
-const credentialsTimingEqualizationHash = "$2a$10$h7pMPVpw/fZjbsXnbtpfD.UzmSCNk0FmbmMkP7wKDlO7IqhsBVX1m"
+// recoveryCodeTimingEqualizationHash and credentialsTimingEqualizationHash are
+// fixed bcrypt-cost-10 placeholder hashes used by the equalize* helpers below
+// to spend bcrypt compute time on the early-return paths in recovery and
+// login. They are never compared against a real credential — the result of
+// bcrypt.CompareHashAndPassword is discarded — and never authenticate anyone.
+const recoveryCodeTimingEqualizationHash = "$2a$10$ReZgUuXu2GXtC.RZ/q2QyesBFX182a3ycbr78sbtgURmuOyc3ygtG" // #nosec G101 -- fixed placeholder bcrypt hash, see comment above; never authenticates a real user
+const credentialsTimingEqualizationHash = "$2a$10$h7pMPVpw/fZjbsXnbtpfD.UzmSCNk0FmbmMkP7wKDlO7IqhsBVX1m" // #nosec G101 -- fixed placeholder bcrypt hash, see comment on recoveryCodeTimingEqualizationHash
 
 type AuthUserRepository interface {
 	ExistsByNormalizedEmail(email string) (bool, error)

--- a/internal/services/auth_service.go
+++ b/internal/services/auth_service.go
@@ -30,6 +30,7 @@ var (
 )
 
 const recoveryCodeTimingEqualizationHash = "$2a$10$ReZgUuXu2GXtC.RZ/q2QyesBFX182a3ycbr78sbtgURmuOyc3ygtG"
+const credentialsTimingEqualizationHash = "$2a$10$h7pMPVpw/fZjbsXnbtpfD.UzmSCNk0FmbmMkP7wKDlO7IqhsBVX1m"
 
 type AuthUserRepository interface {
 	ExistsByNormalizedEmail(email string) (bool, error)
@@ -207,9 +208,11 @@ func (service *AuthService) BuildOIDCOwnerUser(email string, createdAt time.Time
 func (service *AuthService) AuthenticateCredentials(email string, password string) (models.User, error) {
 	user, err := service.users.FindByNormalizedEmail(email)
 	if err != nil {
+		equalizeAuthCredentialsTiming(password)
 		return models.User{}, ErrAuthInvalidCreds
 	}
 	if !user.LocalAuthEnabled || strings.TrimSpace(user.PasswordHash) == "" {
+		equalizeAuthCredentialsTiming(password)
 		return models.User{}, ErrAuthInvalidCreds
 	}
 	if bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(password)) != nil {
@@ -334,6 +337,15 @@ func (service *AuthService) RevokeAuthSessions(userID uint) error {
 
 func equalizeRecoveryCodeLookupTiming(code string) {
 	_ = bcrypt.CompareHashAndPassword([]byte(recoveryCodeTimingEqualizationHash), []byte(NormalizeRecoveryCode(code)))
+}
+
+// equalizeAuthCredentialsTiming runs a bcrypt comparison against a fixed
+// placeholder hash so AuthenticateCredentials spends comparable time on every
+// path. Without it, the early "user not found" / "local auth disabled" returns
+// short-circuit before any bcrypt work and leak account existence through
+// response timing (CWE-208 / CWE-204).
+func equalizeAuthCredentialsTiming(password string) {
+	_ = bcrypt.CompareHashAndPassword([]byte(credentialsTimingEqualizationHash), []byte(password))
 }
 
 func (service *AuthService) ResetPasswordAndRotateRecoveryCode(user *models.User, newPassword string) (string, error) {

--- a/internal/services/auth_service_credentials_timing_test.go
+++ b/internal/services/auth_service_credentials_timing_test.go
@@ -1,0 +1,64 @@
+package services
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// TestAuthenticateCredentialsEqualizesTimingForMissingUser guards against the
+// account-existence timing oracle: every "invalid creds" path must still pay
+// the bcrypt cost. A bare early return without bcrypt would let an attacker
+// distinguish "no such email" (~1ms) from "wrong password for existing user"
+// (~50ms+). Threshold is generous (15ms) because bcrypt.DefaultCost is 10 on
+// every supported platform — well above 30ms wall time even on slow CI.
+func TestAuthenticateCredentialsEqualizesTimingForMissingUser(t *testing.T) {
+	service := NewAuthService(&stubAuthUserRepo{
+		findByEmailErr: errors.New("not found"),
+	})
+
+	start := time.Now()
+	_, err := service.AuthenticateCredentials("nonexistent@example.com", "AnyPass1!")
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, ErrAuthInvalidCreds) {
+		t.Fatalf("expected ErrAuthInvalidCreds, got %v", err)
+	}
+	if elapsed < 15*time.Millisecond {
+		t.Fatalf("nonexistent-user auth returned too quickly (%v) — bcrypt equalization is missing", elapsed)
+	}
+}
+
+func TestAuthenticateCredentialsEqualizesTimingForDisabledLocalAuth(t *testing.T) {
+	service := NewAuthService(&stubAuthUserRepo{
+		findByEmailUser: models.User{
+			LocalAuthEnabled: false,
+			PasswordHash:     "",
+		},
+	})
+
+	start := time.Now()
+	_, err := service.AuthenticateCredentials("oidc-only@example.com", "AnyPass1!")
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, ErrAuthInvalidCreds) {
+		t.Fatalf("expected ErrAuthInvalidCreds, got %v", err)
+	}
+	if elapsed < 15*time.Millisecond {
+		t.Fatalf("oidc-only auth returned too quickly (%v) — bcrypt equalization is missing", elapsed)
+	}
+}
+
+// TestCredentialsTimingEqualizationHashIsBcryptCompatible ensures the constant
+// is never silently corrupted into an unparseable value, which would make the
+// equalizer return instantly and reintroduce the timing oracle.
+func TestCredentialsTimingEqualizationHashIsBcryptCompatible(t *testing.T) {
+	if err := bcrypt.CompareHashAndPassword([]byte(credentialsTimingEqualizationHash), []byte("any")); err == nil {
+		t.Fatal("hash unexpectedly matched 'any' — wrong placeholder?")
+	} else if !errors.Is(err, bcrypt.ErrMismatchedHashAndPassword) {
+		t.Fatalf("hash is unparseable by bcrypt (%v) — equalizer would short-circuit", err)
+	}
+}

--- a/internal/services/export_service.go
+++ b/internal/services/export_service.go
@@ -218,11 +218,16 @@ func (service *ExportService) BuildSummary(userID uint, from *time.Time, to *tim
 		}
 	}
 
+	// first/last come from DailyLog.Date, which migration 019 canonicalizes to
+	// UTC-midnight. DateAtLocation() applies .In(location) and would shift the
+	// calendar day backward by one for negative-offset zones (Pago_Pago,
+	// Adak, …) — see the explicit warning in day_utils.go. Use CalendarDayKey
+	// to read the stored calendar components verbatim instead.
 	return ExportSummary{
 		TotalEntries: len(logs),
 		HasData:      true,
-		DateFrom:     DateAtLocation(first, location).Format(exportDateLayout),
-		DateTo:       DateAtLocation(last, location).Format(exportDateLayout),
+		DateFrom:     CalendarDayKey(first),
+		DateTo:       CalendarDayKey(last),
 	}, nil
 }
 

--- a/internal/services/oidc_login_service.go
+++ b/internal/services/oidc_login_service.go
@@ -19,13 +19,22 @@ var (
 	ErrOIDCIdentityResolveFailed = errors.New("oidc identity resolve failed")
 	ErrOIDCLinkFailed            = errors.New("oidc identity link failed")
 	ErrOIDCProvisionFailed       = errors.New("oidc account provision failed")
+	// ErrOIDCReauthStale indicates the provider returned a successful exchange
+	// but auth_time / iat are older than the requested max age — the user did
+	// not actually re-authenticate, the provider answered from a cached SSO
+	// session despite prompt=login + max_age=0.
+	ErrOIDCReauthStale = errors.New("oidc reauth stale")
+	// ErrOIDCReauthIdentityMismatch indicates the (issuer, subject) returned by
+	// the reauth callback is not linked to the user that started the step-up
+	// flow. Treated as a hard failure to prevent cross-account substitution.
+	ErrOIDCReauthIdentityMismatch = errors.New("oidc reauth identity mismatch")
 )
 
 type OIDCProviderClient interface {
 	Enabled() bool
 	LocalPublicAuthEnabled() bool
 	Config() security.OIDCConfig
-	AuthCodeURL(ctx context.Context, state string, nonce string, codeVerifier string) (string, error)
+	AuthCodeURL(ctx context.Context, state string, nonce string, codeVerifier string, extra map[string]string) (string, error)
 	ExchangeCode(ctx context.Context, code string, codeVerifier string, expectedNonce string) (security.OIDCExchangeResult, error)
 }
 
@@ -95,17 +104,101 @@ func (service *OIDCLoginService) OIDCOnly() bool {
 }
 
 func (service *OIDCLoginService) StartAuth(ctx context.Context, state string, nonce string, codeVerifier string) (string, error) {
+	return service.startAuthWithExtra(ctx, state, nonce, codeVerifier, nil)
+}
+
+// StartReauth forces the provider to perform a fresh interactive login by
+// adding prompt=login and max_age=0 to the authorize URL. Used for step-up
+// flows like enabling a local password from an OIDC-only account where we
+// must verify that the holder of the current session also controls the
+// upstream identity right now (not via a stale cached SSO session).
+func (service *OIDCLoginService) StartReauth(ctx context.Context, state string, nonce string, codeVerifier string) (string, error) {
+	return service.startAuthWithExtra(ctx, state, nonce, codeVerifier, map[string]string{
+		"prompt":  "login",
+		"max_age": "0",
+	})
+}
+
+func (service *OIDCLoginService) startAuthWithExtra(ctx context.Context, state string, nonce string, codeVerifier string, extra map[string]string) (string, error) {
 	if !service.Enabled() {
 		return "", ErrOIDCDisabled
 	}
 	if strings.TrimSpace(state) == "" || strings.TrimSpace(nonce) == "" || strings.TrimSpace(codeVerifier) == "" {
 		return "", ErrOIDCCallbackInvalid
 	}
-	url, err := service.client.AuthCodeURL(ctx, state, nonce, codeVerifier)
+	url, err := service.client.AuthCodeURL(ctx, state, nonce, codeVerifier, extra)
 	if err != nil {
 		return "", ErrOIDCUnavailable
 	}
 	return url, nil
+}
+
+// ValidateReauthExchange runs an OIDC code exchange in the context of a
+// step-up re-auth (e.g. promoting an OIDC-only account to local auth). It
+// enforces three properties that plain Authenticate does NOT:
+//
+//   - the (issuer, subject) returned by the provider must already be linked to
+//     expectedUserID. This stops an attacker who hijacked an OIDC-only session
+//     from completing the step-up by signing in with their OWN provider account.
+//   - the provider must actually have performed a fresh interactive
+//     authentication. We trust auth_time when present (REQUIRED by the spec
+//     whenever max_age was sent); otherwise we fall back to iat, which is
+//     bounded by token lifetime but still useful when auth_time is omitted.
+//   - the freshness signal must lie within maxAuthAge of now. A small
+//     forward-tolerance handles modest clock skew.
+//
+// All deviations collapse into ErrOIDCReauthStale or
+// ErrOIDCReauthIdentityMismatch so the handler can log them with distinct
+// security events while returning a uniform user-facing error.
+func (service *OIDCLoginService) ValidateReauthExchange(ctx context.Context, code string, codeVerifier string, expectedNonce string, expectedUserID uint, maxAuthAge time.Duration, now time.Time) error {
+	if !service.Enabled() {
+		return ErrOIDCDisabled
+	}
+	if expectedUserID == 0 {
+		return ErrOIDCReauthIdentityMismatch
+	}
+	if strings.TrimSpace(code) == "" || strings.TrimSpace(codeVerifier) == "" || strings.TrimSpace(expectedNonce) == "" {
+		return ErrOIDCCallbackInvalid
+	}
+
+	exchange, err := service.client.ExchangeCode(ctx, code, codeVerifier, expectedNonce)
+	if err != nil {
+		return ErrOIDCAuthenticationFailed
+	}
+
+	identity, found, err := service.identities.FindByIssuerSubject(exchange.Claims.Issuer, exchange.Claims.Subject)
+	if err != nil {
+		return ErrOIDCIdentityResolveFailed
+	}
+	if !found || identity.UserID != expectedUserID {
+		return ErrOIDCReauthIdentityMismatch
+	}
+
+	if !reauthClaimsFresh(exchange.Claims, maxAuthAge, now) {
+		return ErrOIDCReauthStale
+	}
+
+	_ = service.identities.TouchLastUsed(identity.ID, effectiveOIDCLoginTime(now))
+	return nil
+}
+
+func reauthClaimsFresh(claims security.OIDCClaims, maxAuthAge time.Duration, now time.Time) bool {
+	if maxAuthAge <= 0 {
+		return false
+	}
+	reference := claims.AuthTime
+	if reference.IsZero() {
+		reference = claims.IssuedAt
+	}
+	if reference.IsZero() {
+		return false
+	}
+	if reference.After(now.Add(1 * time.Minute)) {
+		// Clock skew tolerance in one direction only — clearly future-dated
+		// timestamps look forged or like provider misconfiguration.
+		return false
+	}
+	return now.Sub(reference) <= maxAuthAge
 }
 
 func (service *OIDCLoginService) Authenticate(ctx context.Context, code string, codeVerifier string, expectedNonce string, now time.Time) (OIDCLoginResult, error) {

--- a/internal/services/oidc_login_service_test.go
+++ b/internal/services/oidc_login_service_test.go
@@ -31,7 +31,7 @@ func (stub *stubOIDCProviderClient) Config() security.OIDCConfig {
 	return stub.config
 }
 
-func (stub *stubOIDCProviderClient) AuthCodeURL(context.Context, string, string, string) (string, error) {
+func (stub *stubOIDCProviderClient) AuthCodeURL(context.Context, string, string, string, map[string]string) (string, error) {
 	if stub.authErr != nil {
 		return "", stub.authErr
 	}

--- a/internal/services/settings_password_policy.go
+++ b/internal/services/settings_password_policy.go
@@ -69,7 +69,16 @@ func (service *SettingsService) ChangePassword(user *models.User, currentPasswor
 	return nil
 }
 
-func (service *SettingsService) EnableLocalPassword(user *models.User, newPassword string, confirmPassword string) (string, error) {
+// PrepareLocalPasswordHash validates a candidate password pair for enabling
+// local auth on an OIDC-only account and returns the resulting bcrypt hash
+// WITHOUT touching the database. The hash is meant to be carried through a
+// step-up OIDC re-auth flow inside a sealed transport cookie; the matching
+// FinalizeLocalPasswordSetup call commits the change once re-auth succeeds.
+//
+// Splitting prepare/finalize this way means a failed or abandoned re-auth
+// leaves no half-completed state in the DB, and the plaintext password never
+// has to survive the redirect through the identity provider.
+func (service *SettingsService) PrepareLocalPasswordHash(user *models.User, newPassword string, confirmPassword string) (string, error) {
 	if user == nil || user.LocalAuthEnabled {
 		return "", ErrSettingsPasswordChangeInvalidInput
 	}
@@ -90,18 +99,33 @@ func (service *SettingsService) EnableLocalPassword(user *models.User, newPasswo
 	if err != nil {
 		return "", fmt.Errorf("%w: %v", ErrSettingsPasswordHashFailed, err)
 	}
+	return string(hashedPassword), nil
+}
+
+// FinalizeLocalPasswordSetup commits a previously prepared local password
+// hash, mints a fresh recovery code, and flips LocalAuthEnabled. Called only
+// after a successful step-up OIDC re-auth that has been bound to user.ID.
+func (service *SettingsService) FinalizeLocalPasswordSetup(user *models.User, preparedPasswordHash string) (string, error) {
+	if user == nil || user.LocalAuthEnabled {
+		return "", ErrSettingsPasswordChangeInvalidInput
+	}
+	if strings.TrimSpace(preparedPasswordHash) == "" {
+		return "", ErrSettingsPasswordChangeInvalidInput
+	}
+
 	recoveryCode, recoveryHash, err := GenerateRecoveryCodeHash()
 	if err != nil {
 		return "", fmt.Errorf("%w: %v", ErrSettingsRecoveryCodeGenerateFailed, err)
 	}
-	if err := service.users.UpdatePasswordRecoveryCodeAndRevokeSessions(user.ID, string(hashedPassword), recoveryHash, false); err != nil {
+	if err := service.users.UpdatePasswordRecoveryCodeAndRevokeSessions(user.ID, preparedPasswordHash, recoveryHash, false); err != nil {
 		return "", fmt.Errorf("%w: %v", ErrSettingsPasswordUpdateFailed, err)
 	}
 
-	user.PasswordHash = string(hashedPassword)
+	user.PasswordHash = preparedPasswordHash
 	user.RecoveryCodeHash = recoveryHash
 	user.LocalAuthEnabled = true
 	user.AuthSessionVersion = normalizeAuthSessionVersion(user.AuthSessionVersion) + 1
 	user.MustChangePassword = false
 	return recoveryCode, nil
 }
+

--- a/internal/services/settings_service_password_test.go
+++ b/internal/services/settings_service_password_test.go
@@ -218,7 +218,7 @@ func (stub *stubSettingsUserRepo) DeleteAccountAndRelatedData(uint) error {
 	return nil
 }
 
-func TestEnableLocalPasswordIssuesRecoveryCode(t *testing.T) {
+func TestPrepareAndFinalizeLocalPasswordSetup(t *testing.T) {
 	repo := &stubSettingsUserRepo{}
 	service := NewSettingsService(repo)
 	user := &models.User{
@@ -227,23 +227,51 @@ func TestEnableLocalPasswordIssuesRecoveryCode(t *testing.T) {
 		AuthSessionVersion: 5,
 	}
 
-	recoveryCode, err := service.EnableLocalPassword(user, "EvenStronger2", "EvenStronger2")
+	preparedHash, err := service.PrepareLocalPasswordHash(user, "EvenStronger2", "EvenStronger2")
 	if err != nil {
-		t.Fatalf("EnableLocalPassword() unexpected error: %v", err)
+		t.Fatalf("PrepareLocalPasswordHash() unexpected error: %v", err)
+	}
+	if preparedHash == "" {
+		t.Fatal("expected non-empty prepared hash")
+	}
+	if repo.updatePasswordCalled {
+		t.Fatal("Prepare must not touch the database")
+	}
+	if user.LocalAuthEnabled {
+		t.Fatal("Prepare must not flip LocalAuthEnabled")
+	}
+
+	recoveryCode, err := service.FinalizeLocalPasswordSetup(user, preparedHash)
+	if err != nil {
+		t.Fatalf("FinalizeLocalPasswordSetup() unexpected error: %v", err)
 	}
 	if recoveryCode == "" {
-		t.Fatal("expected recovery code after enabling local password")
+		t.Fatal("expected recovery code from finalize")
 	}
 	if !repo.updatePasswordCalled {
-		t.Fatal("expected password+recovery update")
+		t.Fatal("expected password+recovery update on finalize")
 	}
 	if repo.updatedRecoveryHash == "" {
-		t.Fatal("expected persisted recovery hash")
+		t.Fatal("expected persisted recovery hash on finalize")
 	}
 	if !user.LocalAuthEnabled {
-		t.Fatal("expected LocalAuthEnabled=true after enable flow")
+		t.Fatal("expected LocalAuthEnabled=true after finalize")
 	}
 	if user.AuthSessionVersion != 6 {
 		t.Fatalf("expected auth session version to increment to 6, got %d", user.AuthSessionVersion)
+	}
+}
+
+func TestFinalizeLocalPasswordSetupRejectsWhenAlreadyEnabled(t *testing.T) {
+	repo := &stubSettingsUserRepo{}
+	service := NewSettingsService(repo)
+	user := &models.User{ID: 88, LocalAuthEnabled: true}
+
+	_, err := service.FinalizeLocalPasswordSetup(user, "some-bcrypt-hash")
+	if !errors.Is(err, ErrSettingsPasswordChangeInvalidInput) {
+		t.Fatalf("expected ErrSettingsPasswordChangeInvalidInput, got %v", err)
+	}
+	if repo.updatePasswordCalled {
+		t.Fatal("must not touch DB when local auth already enabled")
 	}
 }

--- a/internal/services/totp_service.go
+++ b/internal/services/totp_service.go
@@ -1,10 +1,11 @@
 package services
 
 import (
+	"crypto/subtle"
 	"errors"
 	"fmt"
 	"strconv"
-	"sync"
+	"strings"
 	"time"
 
 	"github.com/ovumcy/ovumcy-web/internal/security"
@@ -17,26 +18,27 @@ const (
 	DefaultTOTPAttemptsWindow        = 15 * time.Minute
 	DefaultTOTPDisableAttemptsLimit  = 5
 	DefaultTOTPDisableAttemptsWindow = 15 * time.Minute
-	totpReplayTTL                    = 90 * time.Second
+	totpStepSeconds                  = 30
 )
 
 var (
-	ErrTOTPInvalidCode          = errors.New("totp invalid code")
-	ErrTOTPRateLimited          = errors.New("totp rate limited")
-	ErrTOTPDisableRateLimited   = errors.New("totp disable rate limited")
-	ErrTOTPSecretEncrypt        = errors.New("totp secret encrypt failed")
-	ErrTOTPSecretDecrypt        = errors.New("totp secret decrypt failed")
-	ErrTOTPUpdateFailed         = errors.New("totp update failed")
+	ErrTOTPInvalidCode        = errors.New("totp invalid code")
+	ErrTOTPRateLimited        = errors.New("totp rate limited")
+	ErrTOTPDisableRateLimited = errors.New("totp disable rate limited")
+	ErrTOTPSecretEncrypt      = errors.New("totp secret encrypt failed")
+	ErrTOTPSecretDecrypt      = errors.New("totp secret decrypt failed")
+	ErrTOTPUpdateFailed       = errors.New("totp update failed")
+	ErrTOTPReplayed           = errors.New("totp code already used")
 )
-
-type recentCode struct {
-	code      string
-	expiresAt time.Time
-}
 
 // TOTPUserRepository is the minimal repository interface required by TOTPService.
 type TOTPUserRepository interface {
 	UpdateTOTPFields(userID uint, encryptedSecret string, enabled bool) error
+	// ClaimTOTPStep atomically advances totp_last_used_step to step iff it is
+	// strictly greater than the persisted value. Returns true when the row was
+	// updated (the step is now consumed by this caller) and false when the step
+	// was already at or beyond `step` (replay or concurrent loser).
+	ClaimTOTPStep(userID uint, step int64) (bool, error)
 }
 
 // TOTPService handles TOTP secret generation, enrollment, validation, and removal.
@@ -45,7 +47,6 @@ type TOTPService struct {
 	secretKey            []byte
 	attemptPolicy        *AuthAttemptPolicy
 	disableAttemptPolicy *AuthAttemptPolicy
-	usedCodes            sync.Map
 }
 
 // NewTOTPService creates a TOTPService. secretKey is used to encrypt TOTP secrets
@@ -114,23 +115,51 @@ func (service *TOTPService) ValidateCodeRaw(rawSecret, code string) bool {
 	return totp.Validate(code, rawSecret)
 }
 
-// ValidateCode decrypts the stored TOTP secret and validates the 6-digit code.
-// Returns false without an error if the code was already used within totpReplayTTL
-// (replay protection). Used during the 2FA login challenge.
+// ValidateCode decrypts the stored TOTP secret, finds which RFC 6238 step the
+// code belongs to (allowing ±1 step of clock skew), and atomically claims that
+// step in the database. A replayed or concurrently-consumed step returns
+// ErrTOTPReplayed so the caller can surface it separately in security logs.
+// Used during the 2FA login challenge.
 func (service *TOTPService) ValidateCode(userID uint, encryptedSecret, code string) (bool, error) {
 	rawSecret, err := security.DecryptField(encryptedSecret, service.secretKey)
 	if err != nil {
 		return false, fmt.Errorf("%w: %v", ErrTOTPSecretDecrypt, err)
 	}
-	now := time.Now()
-	if service.isRecentlyUsed(userID, code, now) {
+	step, found := findValidatedTOTPStep(rawSecret, code, time.Now())
+	if !found {
 		return false, nil
 	}
-	valid := totp.Validate(code, rawSecret)
-	if valid {
-		service.markUsed(userID, code, now)
+	claimed, err := service.users.ClaimTOTPStep(userID, step)
+	if err != nil {
+		return false, fmt.Errorf("%w: %v", ErrTOTPUpdateFailed, err)
 	}
-	return valid, nil
+	if !claimed {
+		return false, ErrTOTPReplayed
+	}
+	return true, nil
+}
+
+// findValidatedTOTPStep returns the RFC 6238 time step whose generated code
+// matches the supplied code (within ±1 step of skew), and a boolean indicating
+// whether a match was found. Comparison is constant-time to avoid leaking which
+// step matched through timing.
+func findValidatedTOTPStep(rawSecret, code string, now time.Time) (int64, bool) {
+	trimmed := strings.TrimSpace(code)
+	if len(trimmed) == 0 {
+		return 0, false
+	}
+	currentStep := now.Unix() / totpStepSeconds
+	for _, delta := range []int64{0, -1, +1} {
+		step := currentStep + delta
+		candidate, err := totp.GenerateCode(rawSecret, time.Unix(step*totpStepSeconds, 0))
+		if err != nil {
+			continue
+		}
+		if subtle.ConstantTimeCompare([]byte(candidate), []byte(trimmed)) == 1 {
+			return step, true
+		}
+	}
+	return 0, false
 }
 
 // EnableTOTP encrypts rawSecret and stores it alongside totp_enabled=true for the user.
@@ -153,18 +182,3 @@ func (service *TOTPService) DisableTOTP(userID uint) error {
 	return nil
 }
 
-func (service *TOTPService) isRecentlyUsed(userID uint, code string, now time.Time) bool {
-	v, ok := service.usedCodes.Load(userID)
-	if !ok {
-		return false
-	}
-	rc := v.(recentCode)
-	return rc.code == code && now.Before(rc.expiresAt)
-}
-
-func (service *TOTPService) markUsed(userID uint, code string, now time.Time) {
-	service.usedCodes.Store(userID, recentCode{
-		code:      code,
-		expiresAt: now.Add(totpReplayTTL),
-	})
-}

--- a/internal/services/totp_service_test.go
+++ b/internal/services/totp_service_test.go
@@ -9,12 +9,20 @@ import (
 )
 
 // stubTOTPUserRepo is a minimal stub for TOTPUserRepository used in unit tests.
+// claimedSteps emulates the persisted totp_last_used_step column per userID;
+// ClaimTOTPStep applies the same "strictly greater than" semantics as the real
+// repo so replay/concurrency cases can be exercised without a database.
 type stubTOTPUserRepo struct {
 	updateErr        error
 	updatedUserID    uint
 	updatedSecret    string
 	updatedEnabled   bool
 	updateTOTPCalled bool
+
+	claimErr      error
+	claimedSteps  map[uint]int64
+	lastClaimUser uint
+	lastClaimStep int64
 }
 
 func (stub *stubTOTPUserRepo) UpdateTOTPFields(userID uint, encryptedSecret string, enabled bool) error {
@@ -22,7 +30,26 @@ func (stub *stubTOTPUserRepo) UpdateTOTPFields(userID uint, encryptedSecret stri
 	stub.updatedUserID = userID
 	stub.updatedSecret = encryptedSecret
 	stub.updatedEnabled = enabled
+	if stub.claimedSteps != nil {
+		stub.claimedSteps[userID] = 0
+	}
 	return stub.updateErr
+}
+
+func (stub *stubTOTPUserRepo) ClaimTOTPStep(userID uint, step int64) (bool, error) {
+	if stub.claimErr != nil {
+		return false, stub.claimErr
+	}
+	if stub.claimedSteps == nil {
+		stub.claimedSteps = map[uint]int64{}
+	}
+	stub.lastClaimUser = userID
+	stub.lastClaimStep = step
+	if stub.claimedSteps[userID] >= step {
+		return false, nil
+	}
+	stub.claimedSteps[userID] = step
+	return true, nil
 }
 
 func TestTOTPService_GenerateSetupKey(t *testing.T) {
@@ -164,13 +191,54 @@ func TestTOTPService_ValidateCode_ReplayRejected(t *testing.T) {
 		t.Fatal("ValidateCode() returned false for first valid use")
 	}
 
-	// Second use of the same code — must be rejected as replay.
+	// Second use of the same code — must be rejected as replay with the
+	// dedicated sentinel so the API layer can log it separately while still
+	// returning the same response shape as an invalid code.
 	valid, err = svc.ValidateCode(1, encryptedSecret, code)
-	if err != nil {
-		t.Fatalf("ValidateCode() replay call error: %v", err)
+	if !errors.Is(err, ErrTOTPReplayed) {
+		t.Fatalf("ValidateCode() replay error = %v, want ErrTOTPReplayed", err)
 	}
 	if valid {
 		t.Error("ValidateCode() accepted a replayed code — replay protection not working")
+	}
+}
+
+// TestTOTPService_ValidateCode_ReplaySurvivesServiceRestart simulates a
+// process restart by constructing a fresh TOTPService on top of the same
+// repository state. Pre-#7 the replay window lived in TOTPService.usedCodes
+// (an in-memory sync.Map) and a fresh instance accepted a captured code if
+// replayed within the original 90s window.
+func TestTOTPService_ValidateCode_ReplaySurvivesServiceRestart(t *testing.T) {
+	repo := &stubTOTPUserRepo{}
+	secretKey := []byte("test-secret-key-32-bytes-padding!")
+	svc := NewTOTPService(repo, secretKey, nil)
+
+	key, err := svc.GenerateSetupKey("Ovumcy", "user@example.com")
+	if err != nil {
+		t.Fatalf("GenerateSetupKey() error: %v", err)
+	}
+	if err := svc.EnableTOTP(1, key.Secret()); err != nil {
+		t.Fatalf("EnableTOTP() error: %v", err)
+	}
+	encryptedSecret := repo.updatedSecret
+
+	code, err := totp.GenerateCode(key.Secret(), time.Now())
+	if err != nil {
+		t.Fatalf("GenerateCode() error: %v", err)
+	}
+	valid, err := svc.ValidateCode(1, encryptedSecret, code)
+	if err != nil || !valid {
+		t.Fatalf("first use: valid=%v err=%v", valid, err)
+	}
+
+	// Fresh service, same repository (DB state survives).
+	restarted := NewTOTPService(repo, secretKey, nil)
+	valid, err = restarted.ValidateCode(1, encryptedSecret, code)
+	if !errors.Is(err, ErrTOTPReplayed) {
+		t.Fatalf("post-restart replay error = %v, want ErrTOTPReplayed", err)
+	}
+	if valid {
+		t.Error("replayed code accepted after service restart — replay state did not persist")
 	}
 }
 

--- a/internal/templates/settings.html
+++ b/internal/templates/settings.html
@@ -508,18 +508,14 @@
 
         <form
           id="settings-change-password-form"
-          action="/api/settings/change-password"
+          action="/api/settings/start-local-password-setup"
           method="post"
-          hx-post="/api/settings/change-password"
-          hx-target="#settings-change-password-status"
-          hx-swap="innerHTML"
           class="space-y-4"
           data-settings-local-password-form
           novalidate
           data-required-message="{{t .Messages "validation.required"}}"
           data-password-mismatch-message="{{t .Messages "auth.error.password_mismatch"}}"
-          data-weak-password-message="{{t .Messages "auth.password_requirements"}}"
-          data-save-feedback>
+          data-weak-password-message="{{t .Messages "auth.password_requirements"}}">
           <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
           {{template "password_username_context_field" (dict "Value" .CurrentUser.Email)}}
 

--- a/internal/templates/settings.html
+++ b/internal/templates/settings.html
@@ -580,9 +580,18 @@
         <form
           action="/api/settings/regenerate-recovery-code"
           method="post"
+          class="space-y-4"
           data-confirm="{{t .Messages "settings.confirm_regenerate_recovery_code"}}"
           data-confirm-accept="{{t .Messages "settings.recovery_code.submit"}}">
           <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
+          {{template "password_username_context_field" (dict "Value" .CurrentUser.Email)}}
+          {{template "password_toggle_field" (dict
+            "Messages" .Messages
+            "LabelKey" "settings.delete_account.password"
+            "FieldID" "settings-recovery-code-password"
+            "FieldName" "password"
+            "Autocomplete" "current-password"
+            "Required" true)}}
           <button type="submit" class="btn-secondary">{{t .Messages "settings.recovery_code.submit"}}</button>
         </form>
         {{else}}

--- a/internal/templates/settings_2fa.html
+++ b/internal/templates/settings_2fa.html
@@ -76,6 +76,7 @@
       hx-swap="innerHTML"
       class="space-y-4">
       <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
+      {{template "password_username_context_field" (dict "Value" .CurrentUser.Email)}}
 
       <div class="space-y-2">
         <label class="field-label" for="settings-2fa-code">
@@ -93,6 +94,14 @@
           class="input-field tracking-widest text-center text-xl w-40"
           placeholder="000000" />
       </div>
+
+      {{template "password_toggle_field" (dict
+        "Messages" .Messages
+        "LabelKey" "settings.delete_account.password"
+        "FieldID" "settings-2fa-enroll-password"
+        "FieldName" "password"
+        "Autocomplete" "current-password"
+        "Required" true)}}
 
       <div class="settings-form-actions">
         <button type="submit" class="btn-primary">

--- a/migrations/021_totp_replay_state.sql
+++ b/migrations/021_totp_replay_state.sql
@@ -1,0 +1,12 @@
+-- Persist TOTP replay-protection state so the 90s reuse window survives a
+-- process restart or rolling deploy (was previously held only in an in-memory
+-- sync.Map).
+--
+-- We store the RFC 6238 time step (floor(unix_seconds / 30)) of the last
+-- successfully consumed code. ClaimTOTPStep does an atomic
+--   UPDATE users SET totp_last_used_step = ?
+--   WHERE id = ? AND totp_last_used_step < ?
+-- so a replayed code (same or older step) and concurrent submissions of the
+-- same step collapse to a single winner.
+
+ALTER TABLE users ADD COLUMN totp_last_used_step BIGINT NOT NULL DEFAULT 0;

--- a/migrations/postgres/021_totp_replay_state.sql
+++ b/migrations/postgres/021_totp_replay_state.sql
@@ -1,0 +1,4 @@
+-- Postgres mirror of migrations/021_totp_replay_state.sql. ALTER TABLE …
+-- ADD COLUMN IF NOT EXISTS keeps the migration idempotent across the
+-- postgres test bootstrap and rolling deploys.
+ALTER TABLE users ADD COLUMN IF NOT EXISTS totp_last_used_step BIGINT NOT NULL DEFAULT 0;


### PR DESCRIPTION
Closes the seven findings from the May 12 audit and the four pre-existing TZ
regression tests that were blocking the suite. Each finding is a separate
commit with its own regression tests. SECURITY.md grows a Known
Information Disclosure section for the residual register Set-Cookie leak
and the inherent requires_totp leak in the 2FA login response.

Files: 27 changed, +1100 / -180 across handlers, services, templates, db,
migrations, e2e specs, docs.

- 46a9b05 fix(auth): require current password to regenerate recovery code
- 813672e fix(auth): require current password to enroll TOTP 2FA
- 1472074 fix(auth): equalize login bcrypt timing across all invalid-creds paths
- 6fcd003 fix(totp): persist 2FA replay state in DB to survive restarts
- 9d2e28b fix(oidc): require fresh re-auth before enabling local password on OIDC-only accounts
- e0db28f fix(export): use CalendarDayKey for date-only logs to keep ranges stable in negative-offset zones
- <hash for #5>