### PR TITLE
chore(css): document tailwind content globs

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,3 +1,6 @@
+// Tailwind scans the Go HTML templates and handler markup listed under
+// `content` for utility classes (these globs drive purge). The stylesheet is
+// built by scripts/build-css.mjs into web/static/css/tailwind.css.
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [


### PR DESCRIPTION
Adds a short comment to `tailwind.config.js` documenting the `content` globs (which drive Tailwind purge) and that the stylesheet is built by `scripts/build-css.mjs` into `web/static/css/tailwind.css`. Docs-only, no behavior change.