### PR TITLE
test: raise internal/security and internal/db coverage

### DIFF
--- a/internal/db/daily_log_repository_test.go
+++ b/internal/db/daily_log_repository_test.go
@@ -1,0 +1,135 @@
+package db
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"gorm.io/gorm"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+)
+
+func createDailyLogTestUser(t *testing.T, database *gorm.DB, email string) uint {
+	t.Helper()
+	if err := database.Exec(
+		`INSERT INTO users (email, password_hash, role, created_at) VALUES (?, ?, 'owner', CURRENT_TIMESTAMP)`,
+		email, "test-hash",
+	).Error; err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+	var row struct {
+		ID uint `gorm:"column:id"`
+	}
+	if err := database.Raw(`SELECT id FROM users WHERE email = ?`, email).Scan(&row).Error; err != nil {
+		t.Fatalf("load user id: %v", err)
+	}
+	if row.ID == 0 {
+		t.Fatal("expected non-zero user id")
+	}
+	return row.ID
+}
+
+// TestDailyLogRepositoryRangeQueriesAndWhitelist covers the daily-log read
+// paths (including the FindByUserAndDayRange column whitelist that carries
+// pregnancy_test), range/period filtering and ordering, save, and range delete.
+func TestDailyLogRepositoryRangeQueriesAndWhitelist(t *testing.T) {
+	database := openSQLiteForMigrationBootstrapTest(t, filepath.Join(t.TempDir(), "daily.db"))
+	userID := createDailyLogTestUser(t, database, "daily-log-repo@example.com")
+	repo := NewDailyLogRepository(database)
+
+	day := func(d int) time.Time { return time.Date(2026, time.June, d, 0, 0, 0, 0, time.UTC) }
+	mk := func(d int, mutate func(*models.DailyLog)) *models.DailyLog {
+		entry := &models.DailyLog{
+			UserID:          userID,
+			Date:            day(d),
+			Flow:            "none",
+			SexActivity:     "none",
+			CervicalMucus:   "none",
+			PregnancyTest:   "none",
+			CycleFactorKeys: []string{},
+			SymptomIDs:      []uint{},
+		}
+		if mutate != nil {
+			mutate(entry)
+		}
+		return entry
+	}
+
+	if err := repo.Create(mk(1, func(e *models.DailyLog) { e.IsPeriod = true })); err != nil {
+		t.Fatalf("create d1: %v", err)
+	}
+	if err := repo.Create(mk(5, func(e *models.DailyLog) { e.PregnancyTest = "positive" })); err != nil {
+		t.Fatalf("create d5: %v", err)
+	}
+	if err := repo.Create(mk(10, func(e *models.DailyLog) { e.IsPeriod = true; e.CycleStart = true })); err != nil {
+		t.Fatalf("create d10: %v", err)
+	}
+
+	// FindByUserAndDayRange returns the pregnancy_test value via its column
+	// whitelist (regression guard: a missing column silently reads as empty).
+	entry, found, err := repo.FindByUserAndDayRange(userID, day(5), day(6))
+	if err != nil || !found {
+		t.Fatalf("find d5 = (found=%t, err=%v), want found", found, err)
+	}
+	if entry.PregnancyTest != "positive" {
+		t.Fatalf("expected pregnancy_test=positive to round-trip via read whitelist, got %q", entry.PregnancyTest)
+	}
+
+	// Empty range reports not-found.
+	if _, found, _ := repo.FindByUserAndDayRange(userID, day(20), day(21)); found {
+		t.Fatal("expected empty range to report not found")
+	}
+
+	// ListByUserDayRange returns the window in DESC order.
+	window, err := repo.ListByUserDayRange(userID, day(1), day(11))
+	if err != nil {
+		t.Fatalf("list day range: %v", err)
+	}
+	if len(window) != 3 {
+		t.Fatalf("expected 3 logs in window, got %d", len(window))
+	}
+	if !window[0].Date.Equal(day(10)) || !window[2].Date.Equal(day(1)) {
+		t.Fatalf("expected DESC date order [10..1], got %s..%s", window[0].Date, window[2].Date)
+	}
+
+	// ListByUserRange honors the lower bound only.
+	fromD5 := day(5)
+	ranged, err := repo.ListByUserRange(userID, &fromD5, nil)
+	if err != nil {
+		t.Fatalf("list range: %v", err)
+	}
+	if len(ranged) != 2 {
+		t.Fatalf("expected 2 logs from d5 onward, got %d", len(ranged))
+	}
+
+	// ListPeriodDays returns only period rows.
+	periods, err := repo.ListPeriodDays(userID)
+	if err != nil {
+		t.Fatalf("list period days: %v", err)
+	}
+	if len(periods) != 2 {
+		t.Fatalf("expected 2 period days (d1, d10), got %d", len(periods))
+	}
+
+	// Save persists a mutation on an existing row.
+	entry.Notes = "updated note"
+	if err := repo.Save(&entry); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if updated, _, _ := repo.FindByUserAndDayRange(userID, day(5), day(6)); updated.Notes != "updated note" {
+		t.Fatalf("expected Save to persist note, got %q", updated.Notes)
+	}
+
+	// DeleteByUserAndDayRange removes the [d1, d5) window (only d1).
+	if err := repo.DeleteByUserAndDayRange(userID, day(1), day(5)); err != nil {
+		t.Fatalf("delete range: %v", err)
+	}
+	remaining, err := repo.ListByUser(userID)
+	if err != nil {
+		t.Fatalf("list by user: %v", err)
+	}
+	if len(remaining) != 2 {
+		t.Fatalf("expected 2 logs after deleting d1, got %d", len(remaining))
+	}
+}

--- a/internal/db/symptom_repository_test.go
+++ b/internal/db/symptom_repository_test.go
@@ -1,0 +1,81 @@
+package db
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+)
+
+// TestSymptomRepositoryOwnerScoping covers the owner-scoped symptom catalog
+// repository: batch/single create, per-user listing and counts, cross-owner
+// read refusal (FindByIDForUser / CountByUserAndIDs), and update.
+func TestSymptomRepositoryOwnerScoping(t *testing.T) {
+	database := openSQLiteForMigrationBootstrapTest(t, filepath.Join(t.TempDir(), "symptoms.db"))
+	repo := NewSymptomRepository(database)
+	ownerA := createDailyLogTestUser(t, database, "symptom-owner-a@example.com")
+	ownerB := createDailyLogTestUser(t, database, "symptom-owner-b@example.com")
+
+	mk := func(userID uint, name string, builtin bool) models.SymptomType {
+		return models.SymptomType{UserID: userID, Name: name, Icon: "x", Color: "#FF0000", IsBuiltin: builtin}
+	}
+
+	// Empty batch is a no-op; a real batch seeds owner A (1 builtin + 1 custom).
+	if err := repo.CreateBatch(nil); err != nil {
+		t.Fatalf("empty batch should be a no-op: %v", err)
+	}
+	if err := repo.CreateBatch([]models.SymptomType{mk(ownerA, "Cramps", true), mk(ownerA, "Custom A", false)}); err != nil {
+		t.Fatalf("create batch: %v", err)
+	}
+	bSymptom := mk(ownerB, "Custom B", false)
+	if err := repo.Create(&bSymptom); err != nil {
+		t.Fatalf("create B: %v", err)
+	}
+
+	// Listing is owner-scoped.
+	aSymptoms, err := repo.ListByUser(ownerA)
+	if err != nil {
+		t.Fatalf("list A: %v", err)
+	}
+	if len(aSymptoms) != 2 {
+		t.Fatalf("expected 2 symptoms for owner A, got %d", len(aSymptoms))
+	}
+	if bList, _ := repo.ListByUser(ownerB); len(bList) != 1 {
+		t.Fatalf("expected 1 symptom for owner B, got %d", len(bList))
+	}
+
+	// Builtin count.
+	if n, _ := repo.CountBuiltinByUser(ownerA); n != 1 {
+		t.Fatalf("expected 1 builtin for owner A, got %d", n)
+	}
+
+	// FindByIDForUser refuses cross-owner reads.
+	var aBuiltinID uint
+	for _, s := range aSymptoms {
+		if s.IsBuiltin {
+			aBuiltinID = s.ID
+		}
+	}
+	if _, err := repo.FindByIDForUser(aBuiltinID, ownerA); err != nil {
+		t.Fatalf("expected owner A to read own symptom, got %v", err)
+	}
+	if _, err := repo.FindByIDForUser(aBuiltinID, ownerB); err == nil {
+		t.Fatal("expected cross-owner symptom read to fail")
+	}
+
+	// CountByUserAndIDs filters by owner — owner B's id is excluded for A.
+	ids := []uint{aSymptoms[0].ID, aSymptoms[1].ID, bSymptom.ID}
+	if n, _ := repo.CountByUserAndIDs(ownerA, ids); n != 2 {
+		t.Fatalf("expected 2 owner-A matches (owner B excluded), got %d", n)
+	}
+
+	// Update persists a rename.
+	renamed, _ := repo.FindByIDForUser(aBuiltinID, ownerA)
+	renamed.Name = "Renamed"
+	if err := repo.Update(&renamed); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if got, _ := repo.FindByIDForUser(aBuiltinID, ownerA); got.Name != "Renamed" {
+		t.Fatalf("expected rename to persist, got %q", got.Name)
+	}
+}

--- a/internal/db/ttl_repositories_test.go
+++ b/internal/db/ttl_repositories_test.go
@@ -1,0 +1,151 @@
+package db
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+)
+
+// TestRegisterPickupTokenRepositoryIssueConsumeTTL locks the single-use +
+// TTL contract of the register pickup nonce: a successful Consume marks the
+// row consumed in the same transaction (replay is indistinguishable from
+// missing), expired rows never consume, and DeleteExpired drops only the
+// expired ones.
+func TestRegisterPickupTokenRepositoryIssueConsumeTTL(t *testing.T) {
+	database := openSQLiteForMigrationBootstrapTest(t, filepath.Join(t.TempDir(), "pickup.db"))
+	repo := NewRegisterPickupTokenRepository(database)
+	base := time.Date(2026, time.June, 9, 12, 0, 0, 0, time.UTC)
+
+	// Issue validation.
+	if err := repo.Issue("", 42, base.Add(5*time.Minute)); err == nil {
+		t.Fatal("expected empty nonce to be rejected")
+	}
+	if err := repo.Issue("nonce-a", 0, base.Add(5*time.Minute)); err == nil {
+		t.Fatal("expected zero user id to be rejected")
+	}
+	if err := repo.Issue("nonce-a", 42, time.Time{}); err == nil {
+		t.Fatal("expected zero expiry to be rejected")
+	}
+
+	// Issue + consume returns the original user id once.
+	if err := repo.Issue("nonce-a", 42, base.Add(5*time.Minute)); err != nil {
+		t.Fatalf("issue: %v", err)
+	}
+	if userID, ok, err := repo.Consume("nonce-a", base); err != nil || !ok || userID != 42 {
+		t.Fatalf("first consume = (%d, %t, %v), want (42, true, nil)", userID, ok, err)
+	}
+
+	// Single-use: replay returns the same indistinguishable (0,false,nil).
+	if userID, ok, err := repo.Consume("nonce-a", base); err != nil || ok || userID != 0 {
+		t.Fatalf("replay consume = (%d, %t, %v), want (0, false, nil)", userID, ok, err)
+	}
+
+	// Expired token cannot be consumed.
+	if err := repo.Issue("nonce-expired", 7, base.Add(-1*time.Minute)); err != nil {
+		t.Fatalf("issue expired: %v", err)
+	}
+	if userID, ok, err := repo.Consume("nonce-expired", base); err != nil || ok || userID != 0 {
+		t.Fatalf("expired consume = (%d, %t, %v), want (0, false, nil)", userID, ok, err)
+	}
+
+	// Missing / empty nonce never consume.
+	if _, ok, _ := repo.Consume("does-not-exist", base); ok {
+		t.Fatal("expected missing nonce to not consume")
+	}
+	if _, ok, _ := repo.Consume("", base); ok {
+		t.Fatal("expected empty nonce to not consume")
+	}
+
+	// DeleteExpired drops only expired rows.
+	if err := repo.Issue("nonce-future", 9, base.Add(5*time.Minute)); err != nil {
+		t.Fatalf("issue future: %v", err)
+	}
+	if err := repo.Issue("nonce-stale", 9, base.Add(-2*time.Minute)); err != nil {
+		t.Fatalf("issue stale: %v", err)
+	}
+	if err := repo.DeleteExpired(base); err != nil {
+		t.Fatalf("delete expired: %v", err)
+	}
+	if _, ok, _ := repo.Consume("nonce-stale", base); ok {
+		t.Fatal("expected stale row to be deleted by DeleteExpired")
+	}
+	if _, ok, _ := repo.Consume("nonce-future", base); !ok {
+		t.Fatal("expected future row to survive DeleteExpired")
+	}
+}
+
+// TestOIDCLogoutStateRepositorySaveFindTTL covers the OIDC logout-state
+// persistence: save/find round-trip, session_id upsert, not-found, targeted
+// delete, and TTL sweep.
+func TestOIDCLogoutStateRepositorySaveFindTTL(t *testing.T) {
+	database := openSQLiteForMigrationBootstrapTest(t, filepath.Join(t.TempDir(), "logout.db"))
+	repo := NewOIDCLogoutStateRepository(database)
+	base := time.Date(2026, time.June, 9, 12, 0, 0, 0, time.UTC)
+
+	newState := func(sessionID, endpoint, hint string, expiresAt time.Time) *models.OIDCLogoutState {
+		return &models.OIDCLogoutState{
+			SessionID:             sessionID,
+			EndSessionEndpoint:    endpoint,
+			IDTokenHint:           hint,
+			PostLogoutRedirectURL: "https://ovumcy.example.com/login",
+			ExpiresAt:             expiresAt,
+		}
+	}
+
+	// nil is a no-op.
+	if err := repo.Save(nil); err != nil {
+		t.Fatalf("save nil: %v", err)
+	}
+
+	if err := repo.Save(newState("sess-1", "https://id.example.com/logout", "hint-1", base.Add(10*time.Minute))); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	got, ok, err := repo.FindBySessionID("sess-1")
+	if err != nil || !ok {
+		t.Fatalf("find = (ok=%t, err=%v), want found", ok, err)
+	}
+	if got.EndSessionEndpoint != "https://id.example.com/logout" || got.IDTokenHint != "hint-1" {
+		t.Fatalf("find returned unexpected state: %#v", got)
+	}
+
+	// Upsert on session_id conflict updates the mutable columns.
+	if err := repo.Save(newState("sess-1", "https://id.example.com/logout-v2", "hint-2", base.Add(10*time.Minute))); err != nil {
+		t.Fatalf("re-save: %v", err)
+	}
+	got, _, _ = repo.FindBySessionID("sess-1")
+	if got.EndSessionEndpoint != "https://id.example.com/logout-v2" || got.IDTokenHint != "hint-2" {
+		t.Fatalf("expected upsert to update columns, got %#v", got)
+	}
+
+	// Missing session.
+	if _, ok, _ := repo.FindBySessionID("nope"); ok {
+		t.Fatal("expected missing session to return not-found")
+	}
+
+	// Targeted delete.
+	if err := repo.DeleteBySessionID("sess-1"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, ok, _ := repo.FindBySessionID("sess-1"); ok {
+		t.Fatal("expected deleted session to be gone")
+	}
+
+	// TTL sweep drops only expired rows.
+	if err := repo.Save(newState("valid", "https://id.example.com/l", "h", base.Add(10*time.Minute))); err != nil {
+		t.Fatalf("save valid: %v", err)
+	}
+	if err := repo.Save(newState("stale", "https://id.example.com/l", "h", base.Add(-1*time.Minute))); err != nil {
+		t.Fatalf("save stale: %v", err)
+	}
+	if err := repo.DeleteExpired(base); err != nil {
+		t.Fatalf("delete expired: %v", err)
+	}
+	if _, ok, _ := repo.FindBySessionID("stale"); ok {
+		t.Fatal("expected stale logout state to be deleted")
+	}
+	if _, ok, _ := repo.FindBySessionID("valid"); !ok {
+		t.Fatal("expected valid logout state to survive")
+	}
+}

--- a/internal/security/oidc_validate_test.go
+++ b/internal/security/oidc_validate_test.go
@@ -1,0 +1,97 @@
+package security
+
+import "testing"
+
+func validOIDCConfigForTest() OIDCConfig {
+	return OIDCConfig{
+		Enabled:      true,
+		IssuerURL:    "https://id.example.com",
+		ClientID:     "ovumcy",
+		ClientSecret: "secret",
+		RedirectURL:  "https://ovumcy.example.com/auth/oidc/callback",
+		LoginMode:    OIDCLoginModeHybrid,
+		LogoutMode:   OIDCLogoutModeLocal,
+	}
+}
+
+// TestOIDCConfigValidateBranches exercises the security-relevant rejection and
+// acceptance branches of OIDCConfig.Validate and its sub-validators (runtime
+// modes, required fields, https/path shape of issuer/redirect, same-origin
+// post-logout pinning, provisioning-domain allowlist).
+func TestOIDCConfigValidateBranches(t *testing.T) {
+	cases := []struct {
+		name             string
+		mutate           func(*OIDCConfig)
+		cookieSecure     bool
+		registrationOpen bool
+		wantErr          bool
+	}{
+		{name: "valid baseline", cookieSecure: true, registrationOpen: true},
+		{name: "disabled ignores other fields", mutate: func(c *OIDCConfig) { *c = OIDCConfig{Enabled: false, IssuerURL: "not-a-url"} }, cookieSecure: false, registrationOpen: false},
+		{name: "requires cookie secure", cookieSecure: false, registrationOpen: true, wantErr: true},
+		{name: "rejects unknown login mode", mutate: func(c *OIDCConfig) { c.LoginMode = "bogus" }, cookieSecure: true, registrationOpen: true, wantErr: true},
+		{name: "rejects unknown logout mode", mutate: func(c *OIDCConfig) { c.LogoutMode = "bogus" }, cookieSecure: true, registrationOpen: true, wantErr: true},
+		{name: "auto-provision requires open registration", mutate: func(c *OIDCConfig) { c.AutoProvision = true }, cookieSecure: true, registrationOpen: false, wantErr: true},
+		{name: "missing issuer", mutate: func(c *OIDCConfig) { c.IssuerURL = "" }, cookieSecure: true, registrationOpen: true, wantErr: true},
+		{name: "missing client id", mutate: func(c *OIDCConfig) { c.ClientID = "" }, cookieSecure: true, registrationOpen: true, wantErr: true},
+		{name: "missing client secret", mutate: func(c *OIDCConfig) { c.ClientSecret = "" }, cookieSecure: true, registrationOpen: true, wantErr: true},
+		{name: "missing redirect", mutate: func(c *OIDCConfig) { c.RedirectURL = "" }, cookieSecure: true, registrationOpen: true, wantErr: true},
+		{name: "issuer not https", mutate: func(c *OIDCConfig) { c.IssuerURL = "http://id.example.com" }, cookieSecure: true, registrationOpen: true, wantErr: true},
+		{name: "issuer not absolute", mutate: func(c *OIDCConfig) { c.IssuerURL = "id.example.com" }, cookieSecure: true, registrationOpen: true, wantErr: true},
+		{name: "issuer carries query", mutate: func(c *OIDCConfig) { c.IssuerURL = "https://id.example.com?probe=1" }, cookieSecure: true, registrationOpen: true, wantErr: true},
+		{name: "redirect wrong path", mutate: func(c *OIDCConfig) { c.RedirectURL = "https://ovumcy.example.com/not-the-callback" }, cookieSecure: true, registrationOpen: true, wantErr: true},
+		{name: "redirect not https", mutate: func(c *OIDCConfig) { c.RedirectURL = "http://ovumcy.example.com/auth/oidc/callback" }, cookieSecure: true, registrationOpen: true, wantErr: true},
+		{name: "post-logout cross origin", mutate: func(c *OIDCConfig) { c.PostLogoutRedirectURL = "https://attacker.example.net/login" }, cookieSecure: true, registrationOpen: true, wantErr: true},
+		{name: "post-logout not https", mutate: func(c *OIDCConfig) { c.PostLogoutRedirectURL = "http://ovumcy.example.com/login" }, cookieSecure: true, registrationOpen: true, wantErr: true},
+		{name: "post-logout same origin ok", mutate: func(c *OIDCConfig) { c.PostLogoutRedirectURL = "https://ovumcy.example.com/logout-complete" }, cookieSecure: true, registrationOpen: true},
+		{name: "oidc-only login and provider logout ok", mutate: func(c *OIDCConfig) {
+			c.LoginMode = OIDCLoginModeOIDCOnly
+			c.LogoutMode = OIDCLogoutModeProvider
+		}, cookieSecure: true, registrationOpen: true},
+		{name: "auto-provision with valid domain ok", mutate: func(c *OIDCConfig) {
+			c.AutoProvision = true
+			c.AutoProvisionAllowedDomains = []string{"example.com"}
+		}, cookieSecure: true, registrationOpen: true},
+		{name: "auto-provision with invalid domain", mutate: func(c *OIDCConfig) {
+			c.AutoProvision = true
+			c.AutoProvisionAllowedDomains = []string{"missing-dot"}
+		}, cookieSecure: true, registrationOpen: true, wantErr: true},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			config := validOIDCConfigForTest()
+			if tc.mutate != nil {
+				tc.mutate(&config)
+			}
+			err := config.Validate(tc.cookieSecure, tc.registrationOpen)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected validation error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("expected no validation error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestIsValidProvisioningDomain(t *testing.T) {
+	cases := []struct {
+		domain string
+		want   bool
+	}{
+		{"example.com", true},
+		{"staff.example.com", true},
+		{"missing-dot", false},
+		{"", false},
+		{"has space.com", false},
+		{".leading.com", false},
+		{"trailing.com.", false},
+	}
+	for _, tc := range cases {
+		if got := isValidProvisioningDomain(tc.domain); got != tc.want {
+			t.Fatalf("isValidProvisioningDomain(%q) = %t, want %t", tc.domain, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Test-only additions surfaced by a coverage audit; no production code changes.

- `internal/security`: table-driven tests for `OIDCConfig.Validate` and its sub-validators (runtime modes, required fields, issuer/redirect https+path shape, same-origin post-logout pinning, provisioning-domain allowlist) and `isValidProvisioningDomain`. Validators go from 25-67% to 100%; the package from 69% to 78%.
- `internal/db`: round-trip tests for the register-pickup nonce (single-use + TTL), OIDC logout-state (upsert + TTL), daily-log range/period queries including the `FindByUserAndDayRange` `pregnancy_test` column whitelist, and the owner-scoped symptom catalog (cross-owner read refusal). The package goes from 44% to 66%.