### PR TITLE
ci: enforce patch coverage in-CI via scripts/patchcov (replaces deadl…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,45 @@ jobs:
         if: ${{ github.event_name == 'push' && steps.codecov.outcome == 'failure' }}
         run: echo "::warning::Codecov upload failed on push. Coverage artifact was generated successfully, but Codecov ingest returned an external error."
 
+  patch-coverage:
+    runs-on: ubuntu-latest
+    needs:
+      - test
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Download coverage artifact
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name: coverage-out
+          path: .
+
+      - name: Fetch base branch
+        run: git fetch --no-tags origin ${{ github.event.pull_request.base.ref }}
+
+      - name: Enforce patch coverage
+        # Fails when a modified, coverable Go line is not covered by tests. This
+        # is the in-CI, self-contained replacement for the external codecov patch
+        # status, which can stall and deadlock a required check. See
+        # scripts/patchcov for the gate logic (test files and tooling excluded).
+        env:
+          COVERAGE_FILE: coverage.out
+          BASE_REF: origin/${{ github.event.pull_request.base.ref }}
+        run: go run ./scripts/patchcov
+
   e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 45

--- a/codecov.yml
+++ b/codecov.yml
@@ -21,5 +21,11 @@ coverage:
         threshold: 0%
         informational: false
 
+# Tooling and test-only helpers are excluded from coverage reporting, matching
+# the in-CI scripts/patchcov gate. These are not product code.
+ignore:
+  - "scripts"
+  - "internal/testdb"
+
 github_checks:
   annotations: true

--- a/scripts/patchcov/main.go
+++ b/scripts/patchcov/main.go
@@ -1,0 +1,248 @@
+// Command patchcov enforces the "every modified, coverable line is covered by
+// tests" policy locally in CI, without depending on an external coverage
+// service (which can stall and deadlock a required status check).
+//
+// It reads a Go coverage profile (go test -coverprofile, covermode=atomic) and
+// the git diff of the current branch against a base ref, then fails when any
+// added or modified Go line that is coverable (appears in the profile) has a
+// zero execution count. Test files and tooling paths (scripts/, internal/testdb/)
+// are excluded. Lines that do not appear in the profile at all are treated as
+// non-coverable and ignored, matching codecov's "coverable lines" semantics.
+//
+// Usage (env): COVERAGE_FILE (default coverage.out), BASE_REF (default
+// origin/main). Exit 0 when clean, 1 when uncovered modified lines exist.
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type coverBlock struct {
+	start, end int
+	covered    bool
+}
+
+const (
+	stateNonCoverable = iota
+	stateCovered
+	stateUncovered
+)
+
+func main() {
+	coverageFile := envOr("COVERAGE_FILE", "coverage.out")
+	baseRef := envOr("BASE_REF", "origin/main")
+
+	modulePath, err := readModulePath("go.mod")
+	if err != nil {
+		fatalf("read module path: %v", err)
+	}
+
+	profileData, err := os.ReadFile(coverageFile)
+	if err != nil {
+		fatalf("read coverage file %s: %v", coverageFile, err)
+	}
+	coverage := parseCoverageProfile(string(profileData), modulePath)
+
+	diffOut, err := gitDiff(baseRef)
+	if err != nil {
+		fatalf("git diff against %s: %v", baseRef, err)
+	}
+	changed := parseDiffAddedLines(diffOut)
+
+	var uncovered []string
+	for file, lines := range changed {
+		blocks, ok := coverage[file]
+		if !ok {
+			continue // file absent from the profile -> non-coverable (no-test pkg, tooling)
+		}
+		for _, line := range lines {
+			if lineState(blocks, line) == stateUncovered {
+				uncovered = append(uncovered, fmt.Sprintf("%s:%d", file, line))
+			}
+		}
+	}
+
+	if len(uncovered) > 0 {
+		sort.Strings(uncovered)
+		fmt.Fprintf(os.Stderr, "patch coverage gate FAILED: %d modified coverable line(s) not covered by tests:\n", len(uncovered))
+		for _, u := range uncovered {
+			fmt.Fprintf(os.Stderr, "  %s\n", u)
+		}
+		fmt.Fprintln(os.Stderr, "\nAdd tests covering these lines, or, for a genuinely unreachable line,")
+		fmt.Fprintln(os.Stderr, "mark it // codecov:ignore and exclude its path from the gate.")
+		os.Exit(1)
+	}
+	fmt.Println("patch coverage gate OK: every modified coverable line is covered by tests.")
+}
+
+// parseCoverageProfile maps each repo-relative .go file to its coverage blocks.
+// Profile lines look like:
+//
+//	<module>/<relpath>.go:<sl>.<sc>,<el>.<ec> <numStmts> <count>
+func parseCoverageProfile(content, modulePath string) map[string][]coverBlock {
+	result := map[string][]coverBlock{}
+	scanner := bufio.NewScanner(strings.NewReader(content))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "mode:") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) != 3 {
+			continue
+		}
+		count, err := strconv.Atoi(fields[2])
+		if err != nil {
+			continue
+		}
+		colon := strings.LastIndex(fields[0], ":")
+		if colon < 0 {
+			continue
+		}
+		rel := strings.TrimPrefix(fields[0][:colon], modulePath+"/")
+		startLine, endLine, ok := parseSpan(fields[0][colon+1:])
+		if !ok {
+			continue
+		}
+		result[rel] = append(result[rel], coverBlock{start: startLine, end: endLine, covered: count > 0})
+	}
+	return result
+}
+
+// parseSpan parses "<sl>.<sc>,<el>.<ec>" into start and end line numbers.
+func parseSpan(span string) (start, end int, ok bool) {
+	left, right, found := strings.Cut(span, ",")
+	if !found {
+		return 0, 0, false
+	}
+	start = lineNumber(left)
+	end = lineNumber(right)
+	if start == 0 || end == 0 {
+		return 0, 0, false
+	}
+	return start, end, true
+}
+
+func lineNumber(s string) int {
+	dot := strings.IndexByte(s, '.')
+	if dot < 0 {
+		return 0
+	}
+	n, err := strconv.Atoi(s[:dot])
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+// lineState reports whether a line is covered, uncovered, or non-coverable
+// across the blocks of its file. A line is covered if it falls in any block
+// with a non-zero count; uncovered if it falls only in zero-count blocks.
+func lineState(blocks []coverBlock, line int) int {
+	state := stateNonCoverable
+	for _, b := range blocks {
+		if line >= b.start && line <= b.end {
+			if b.covered {
+				return stateCovered
+			}
+			state = stateUncovered
+		}
+	}
+	return state
+}
+
+// parseDiffAddedLines parses `git diff --unified=0` output into the set of added
+// new-file line numbers per gated .go file.
+func parseDiffAddedLines(diff string) map[string][]int {
+	result := map[string][]int{}
+	var file string
+	newLine := 0
+	scanner := bufio.NewScanner(strings.NewReader(diff))
+	scanner.Buffer(make([]byte, 1024*1024), 32*1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		switch {
+		case strings.HasPrefix(line, "+++ b/"):
+			file = strings.TrimPrefix(line, "+++ b/")
+		case strings.HasPrefix(line, "@@"):
+			newLine = hunkNewStart(line)
+		case strings.HasPrefix(line, "+") && !strings.HasPrefix(line, "+++"):
+			if isGatedFile(file) {
+				result[file] = append(result[file], newLine)
+			}
+			newLine++
+		}
+	}
+	return result
+}
+
+// hunkNewStart extracts c from a "@@ -a,b +c,d @@" hunk header.
+func hunkNewStart(hunk string) int {
+	plus := strings.IndexByte(hunk, '+')
+	if plus < 0 {
+		return 0
+	}
+	rest := hunk[plus+1:]
+	end := strings.IndexAny(rest, ", ")
+	if end < 0 {
+		return 0
+	}
+	n, err := strconv.Atoi(rest[:end])
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+// isGatedFile reports whether a path is production Go code subject to the gate.
+func isGatedFile(file string) bool {
+	if !strings.HasSuffix(file, ".go") || strings.HasSuffix(file, "_test.go") {
+		return false
+	}
+	for _, skip := range []string{"scripts/", "internal/testdb/"} {
+		if strings.HasPrefix(file, skip) {
+			return false
+		}
+	}
+	return true
+}
+
+func readModulePath(goMod string) (string, error) {
+	data, err := os.ReadFile(goMod)
+	if err != nil {
+		return "", err
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if rest, ok := strings.CutPrefix(line, "module "); ok {
+			return strings.TrimSpace(rest), nil
+		}
+	}
+	return "", fmt.Errorf("module directive not found in %s", goMod)
+}
+
+func gitDiff(baseRef string) (string, error) {
+	out, err := exec.Command("git", "diff", "--unified=0", "--no-color", baseRef+"...HEAD", "--", "*.go").Output()
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+func envOr(key, fallback string) string {
+	if v := strings.TrimSpace(os.Getenv(key)); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func fatalf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(2)
+}

--- a/scripts/patchcov/main_test.go
+++ b/scripts/patchcov/main_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestParseCoverageProfileAndLineState(t *testing.T) {
+	profile := "mode: atomic\n" +
+		"github.com/ovumcy/ovumcy-web/internal/db/sqlite.go:12.45,17.2 3 1\n" +
+		"github.com/ovumcy/ovumcy-web/internal/db/sqlite.go:20.2,22.3 2 0\n"
+
+	cov := parseCoverageProfile(profile, "github.com/ovumcy/ovumcy-web")
+	blocks, ok := cov["internal/db/sqlite.go"]
+	if !ok {
+		t.Fatalf("expected internal/db/sqlite.go in coverage map")
+	}
+	if len(blocks) != 2 {
+		t.Fatalf("expected 2 blocks, got %d", len(blocks))
+	}
+
+	cases := []struct {
+		line int
+		want int
+	}{
+		{line: 12, want: stateCovered},
+		{line: 15, want: stateCovered},
+		{line: 21, want: stateUncovered},
+		{line: 100, want: stateNonCoverable},
+	}
+	for _, c := range cases {
+		if got := lineState(blocks, c.line); got != c.want {
+			t.Fatalf("lineState(line=%d) = %d, want %d", c.line, got, c.want)
+		}
+	}
+}
+
+func TestParseDiffAddedLinesGatesProductionGoOnly(t *testing.T) {
+	diff := "" +
+		"diff --git a/internal/db/sqlite.go b/internal/db/sqlite.go\n" +
+		"--- a/internal/db/sqlite.go\n" +
+		"+++ b/internal/db/sqlite.go\n" +
+		"@@ -16,1 +16,2 @@\n" +
+		"+\tdsn := \"new\"\n" +
+		"+\t_ = dsn\n" +
+		"diff --git a/internal/db/sqlite_test.go b/internal/db/sqlite_test.go\n" +
+		"+++ b/internal/db/sqlite_test.go\n" +
+		"@@ -1,0 +5,1 @@\n" +
+		"+// test-only line\n" +
+		"diff --git a/scripts/patchcov/main.go b/scripts/patchcov/main.go\n" +
+		"+++ b/scripts/patchcov/main.go\n" +
+		"@@ -1,0 +1,1 @@\n" +
+		"+// tooling line\n"
+
+	added := parseDiffAddedLines(diff)
+	want := map[string][]int{"internal/db/sqlite.go": {16, 17}}
+	if !reflect.DeepEqual(added, want) {
+		t.Fatalf("parseDiffAddedLines = %v, want %v (test files and scripts/ must be excluded)", added, want)
+	}
+}
+
+func TestHunkNewStart(t *testing.T) {
+	cases := map[string]int{
+		"@@ -16,1 +16,2 @@":          16,
+		"@@ -1,0 +5,1 @@ func Foo()": 5,
+		"@@ -10 +10 @@":              10,
+	}
+	for hunk, want := range cases {
+		if got := hunkNewStart(hunk); got != want {
+			t.Fatalf("hunkNewStart(%q) = %d, want %d", hunk, got, want)
+		}
+	}
+}
+
+func TestIsGatedFile(t *testing.T) {
+	for _, f := range []string{"internal/db/sqlite.go", "cmd/ovumcy/main.go"} {
+		if !isGatedFile(f) {
+			t.Fatalf("expected %q to be gated", f)
+		}
+	}
+	for _, f := range []string{
+		"internal/db/sqlite_test.go",
+		"scripts/patchcov/main.go",
+		"internal/testdb/postgres.go",
+		"README.md",
+		"web/static/js/app.js",
+	} {
+		if isGatedFile(f) {
+			t.Fatalf("expected %q to NOT be gated", f)
+		}
+	}
+}
+
+func TestReadModulePath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "go.mod")
+	if err := os.WriteFile(path, []byte("module github.com/ovumcy/ovumcy-web\n\ngo 1.26.4\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := readModulePath(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "github.com/ovumcy/ovumcy-web" {
+		t.Fatalf("readModulePath = %q", got)
+	}
+}


### PR DESCRIPTION
…ock-prone codecov-required)

go run ./scripts/patchcov reads the coverage profile and git diff and fails when any modified, coverable Go line is uncovered. Self-contained (no external coverage service), so it always completes pass/fail and cannot deadlock a required check the way the external codecov/patch status did. Test files and tooling paths are excluded; the tool ships with unit tests for its parsing and gating logic.

## Summary

<!-- What does this change and why? -->

## Related issues

<!-- e.g. Closes #123 -->

## Checklist

- [ ] Change is scoped and atomic
- [ ] Tests added/adjusted for behavioral changes
- [ ] Existing checks pass locally
- [ ] No plaintext health data, secrets, or telemetry introduced
- [ ] Docs updated if behavior/config changed
