### PR TITLE
ci: skip browser e2e jobs on docs-only pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,60 @@ jobs:
           BASE_REF: origin/${{ github.event.pull_request.base.ref }}
         run: go run ./scripts/patchcov
 
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      run_e2e: ${{ steps.detect.outputs.run_e2e }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Detect whether browser e2e is needed
+        id: detect
+        # Fail-safe default is to RUN the browser e2e jobs. The Playwright suite
+        # exercises the real Go app end-to-end, so backend, template, asset,
+        # locale, dependency, Docker, and CI changes can all affect it. We only
+        # skip when a pull request touches *nothing but* docs/meta files that
+        # cannot change the running app. Any path outside the allowlist runs e2e.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          # Deliberately no `set -e`: this job must never fail, because the
+          # required e2e jobs depend on it and a failed dependency would leave
+          # their required checks unsatisfied. Default to running e2e; only flip
+          # to false on a positive docs-only determination.
+          run_e2e=true
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            if git fetch --no-tags origin "$BASE_REF"; then
+              files="$(git diff --name-only "origin/${BASE_REF}...HEAD" || true)"
+              echo "Changed files:"
+              echo "$files"
+              if [ -n "$files" ]; then
+                # Anything NOT matching this docs/meta allowlist forces e2e to run.
+                app_changes="$(printf '%s\n' "$files" | grep -vE '^(docs/|LICENSE$|\.gitignore$|\.gitattributes$|.*\.md$)' || true)"
+                if [ -z "$app_changes" ]; then
+                  echo "Docs/meta-only change: skipping browser e2e jobs."
+                  run_e2e=false
+                else
+                  echo "App-affecting change detected: running browser e2e jobs."
+                fi
+              else
+                echo "Empty diff: defaulting to running e2e."
+              fi
+            else
+              echo "Base ref fetch failed: defaulting to running e2e."
+            fi
+          else
+            echo "Non-PR event ($EVENT_NAME): running e2e."
+          fi
+          echo "run_e2e=$run_e2e" >> "$GITHUB_OUTPUT"
+
   e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -183,32 +237,48 @@ jobs:
       contents: read
     needs:
       - test
+      - changes
+    # `e2e` is a required status check (branch protection) AND admins are
+    # enforced, so this job must always run and report a result. Skipping the
+    # whole job via a job-level `if` would leave the required check unsatisfied
+    # and could permanently block docs-only PRs. Instead the job always starts
+    # and each work step is gated: on a docs-only change every step is skipped
+    # and the job goes green in seconds, satisfying the required check.
+    env:
+      RUN_E2E: ${{ needs.changes.outputs.run_e2e }}
 
     steps:
       - name: Checkout
+        if: env.RUN_E2E == 'true'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Go
+        if: env.RUN_E2E == 'true'
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           cache: false
 
       - name: Setup Node.js
+        if: env.RUN_E2E == 'true'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
 
       - name: Install frontend and e2e dependencies
+        if: env.RUN_E2E == 'true'
         run: npm ci
 
       - name: Frontend build
+        if: env.RUN_E2E == 'true'
         run: npm run build
 
       - name: Install Playwright browser
+        if: env.RUN_E2E == 'true'
         run: npx playwright install --with-deps chromium
 
       - name: Run Playwright e2e (smoke on push, full otherwise)
+        if: env.RUN_E2E == 'true'
         run: |
           if [ "${{ github.event_name }}" = "push" ]; then
             npm run e2e:ci -- e2e/auth-login-register.spec.ts e2e/dashboard.spec.ts e2e/theme-dark-mode.spec.ts
@@ -236,32 +306,45 @@ jobs:
       contents: read
     needs:
       - test
+      - changes
+    # Required status check with admin enforcement: always run the job and gate
+    # the work per step (see the `e2e` job above) so docs-only PRs stay green
+    # without leaving this required check unsatisfied.
+    env:
+      RUN_E2E: ${{ needs.changes.outputs.run_e2e }}
 
     steps:
       - name: Checkout
+        if: env.RUN_E2E == 'true'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Go
+        if: env.RUN_E2E == 'true'
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           cache: false
 
       - name: Setup Node.js
+        if: env.RUN_E2E == 'true'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
 
       - name: Install frontend and e2e dependencies
+        if: env.RUN_E2E == 'true'
         run: npm ci
 
       - name: Frontend build
+        if: env.RUN_E2E == 'true'
         run: npm run build
 
       - name: Install Playwright browser
+        if: env.RUN_E2E == 'true'
         run: npx playwright install --with-deps chromium
 
       - name: Run Playwright Postgres smoke
+        if: env.RUN_E2E == 'true'
         run: npm run e2e:ci:postgres -- e2e/auth-login-register.spec.ts e2e/dashboard.spec.ts e2e/theme-dark-mode.spec.ts
         env:
           E2E_APP_PORT: 18081
@@ -284,6 +367,8 @@ jobs:
       contents: read
     needs:
       - test
+      - changes
+    if: needs.changes.outputs.run_e2e == 'true'
 
     steps:
       - name: Checkout


### PR DESCRIPTION
The Playwright suite (e2e, e2e-postgres-smoke, e2e-cross-browser) drives
the real Go app end-to-end, so it must run for any change that can affect
the running app: backend, templates, assets, locales, deps, Docker, CI.

Add a `changes` job that, on pull_request, diffs against the base branch
and sets run_e2e=false only when every changed path is docs/meta (docs/,
*.md, LICENSE, .gitignore, .gitattributes). The three browser jobs gate on
this output; lint, unit, go test, race, coverage, and patch-coverage are
unaffected. Fail-safe default: any non-PR event, empty diff, or path
outside the allowlist runs the full suite.
