### PR TITLE
test: structural data-* rewrites + TOTP codec coverage docs

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -50,6 +50,29 @@ The runtime image is a `FROM scratch` multi-stage build running as a non-root
 user, with pinned base-image digests and dependency versions. Test code never
 ships in the image.
 
+### Sealed-cookie codec coverage
+
+All eleven AEAD-sealed cookie purposes are exercised by `internal/api/secure_cookie_codec_security_test.go`.
+Each purpose is bound to its own AAD so a ciphertext from one cookie cannot be opened as another.
+
+| Cookie | Roundtrip | Cross-purpose rejection | Tamper detection |
+|--------|:---------:|:----------------------:|:----------------:|
+| `ovumcy_auth` | ✓ | ✓ | ✓ (auth-tag, body byte, nonce) |
+| `ovumcy_flash` | ✓ | ✓ | †  |
+| `ovumcy_recovery_code` | ✓ | ✓ | †  |
+| `ovumcy_register_pickup` | ✓ | ✓ | †  |
+| `ovumcy_reset_password` | ✓ | ✓ | †  |
+| `ovumcy_oidc_auth` | ✓ | ✓ | †  |
+| `ovumcy_oidc_stepup` | ✓ | ✓ | †  |
+| `ovumcy_oidc_logout_bridge` | ✓ | ✓ | †  |
+| `ovumcy_oidc_link_pending` | ✓ | ✓ | ✓  |
+| `ovumcy_totp_pending` | ✓ | ✓ | ✓  |
+| `ovumcy_totp_setup` | ✓ | ✓ | ✓  |
+
+† AES-256-GCM guarantees tamper detection for all purposes by construction; explicit tests cover
+`ovumcy_auth` (three distinct mutation sites), `ovumcy_totp_pending`, `ovumcy_totp_setup`, and
+`ovumcy_oidc_link_pending` as representative high-value targets.
+
 ## Transparency
 
 The cycle-prediction algorithm is fully documented in

--- a/docs/SECURITY_INVARIANTS.md
+++ b/docs/SECURITY_INVARIANTS.md
@@ -19,7 +19,7 @@ Every entry has a corresponding test or set of tests in `SECURITY.md → Test En
 
 ## Authentication and sessions
 
-- Auth, recovery, reset, OIDC state, OIDC step-up, OIDC logout bridge, register pickup, and flash cookies are sealed with AES-256-GCM under an HKDF-derived key, with the cookie name (or row id, for field encryption) bound to the AEAD AAD. The codec is `internal/api/secure_cookie_codec.go`; the version envelope is `v2` and `v1` payloads are rejected on read.
+- Auth, recovery, reset, OIDC state, OIDC step-up, OIDC logout bridge, OIDC link-pending, TOTP pending, TOTP setup, register pickup, and flash cookies are sealed with AES-256-GCM under an HKDF-derived key, with the cookie name (or row id, for field encryption) bound to the AEAD AAD. The codec is `internal/api/secure_cookie_codec.go`; the version envelope is `v2` and `v1` payloads are rejected on read.
 - TOTP secrets are field-encrypted under a distinct HKDF label set and AAD-bound to `users.id`. See `internal/security/field_crypto.go`.
 - Operations that rotate a long-lived credential (password change, password reset, recovery-code regeneration, forced operator reset, TOTP enable/disable, clear-data) must bump `users.auth_session_version` in the same atomic database update, invalidating every active auth cookie for that user. The originating device gets a freshly issued cookie inline.
 - Auth session tokens use `jwt.SigningMethodHS256`. The parser explicitly rejects non-HMAC and `none` algorithms.

--- a/docs/gdpr.md
+++ b/docs/gdpr.md
@@ -55,7 +55,7 @@ The full data inventory lives in [`SECURITY.md`](../SECURITY.md#data-inventory) 
 | Control | File | Test |
 | --- | --- | --- |
 | Owner-only middleware on every state-mutating `/api/*` endpoint | [`internal/api/routes.go`](../internal/api/routes.go) | [`internal/api/owner_only_coverage_regression_test.go`](../internal/api/owner_only_coverage_regression_test.go) |
-| Sealed (AEAD) auth, recovery, reset, OIDC, flash cookies | [`internal/api/secure_cookie_codec.go`](../internal/api/secure_cookie_codec.go) | `internal/api/secure_cookie_codec_*_test.go` |
+| Sealed (AEAD) auth, recovery, reset, OIDC, TOTP, flash cookies (11 purposes) | [`internal/api/secure_cookie_codec.go`](../internal/api/secure_cookie_codec.go) | `internal/api/secure_cookie_codec_*_test.go` |
 | CSRF protection on every state-changing request | [`cmd/ovumcy/main.go`](../cmd/ovumcy/main.go) | `internal/api/state_mutation_csrf_regression_test.go` |
 | Session revocation on credential rotation | [`internal/services/auth_service.go`](../internal/services/auth_service.go) | `internal/api/auth_password_change_session_regression_test.go` and siblings |
 | PII never logged | [`internal/api/request_logging.go`](../internal/api/request_logging.go) | `cmd/ovumcy/main_test.go` (`TestAuthRateLimitHandlerLogsSecurityEventWithoutPII`, `TestCSRFMiddlewareErrorHandlerLogsSecurityEventWithoutPII`) |

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -497,8 +497,9 @@ test.describe('Dashboard: today editor', () => {
     const replacementPage = await context.newPage();
     await replacementPage.goto('/dashboard');
     await expect(replacementPage).toHaveURL(/\/dashboard$/);
-    await replacementPage.waitForTimeout(1000);
-    await replacementPage.reload();
-    await expect(replacementPage.locator('#today-notes')).toHaveValue(noteText);
+    await expect.poll(async () => {
+      await replacementPage.reload();
+      return replacementPage.locator('#today-notes').inputValue();
+    }, { timeout: 5000 }).toBe(noteText);
   });
 });

--- a/e2e/support/mobile-layout-helpers.ts
+++ b/e2e/support/mobile-layout-helpers.ts
@@ -84,7 +84,7 @@ export async function expectElementAboveMobileTabbar(
       await page.evaluate((delta) => {
         window.scrollBy(0, delta);
       }, Math.min(remainingScroll, neededScroll));
-      await page.waitForTimeout(150);
+      await expect.poll(() => element.boundingBox()).not.toBeNull();
 
       [elementBox, tabbarBox] = await Promise.all([element.boundingBox(), tabbar.boundingBox()]);
       expect(elementBox, 'expected target element to have a visible bounding box after scrolling').not.toBeNull();

--- a/internal/api/auth_register_first_launch_subtitle_regressions_test.go
+++ b/internal/api/auth_register_first_launch_subtitle_regressions_test.go
@@ -1,11 +1,11 @@
 package api
 
 import (
-	"io"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
+
+	"golang.org/x/net/html"
 )
 
 func TestRegisterPageShowsFirstLaunchSubtitleWhenNoUsers(t *testing.T) {
@@ -24,12 +24,11 @@ func TestRegisterPageShowsFirstLaunchSubtitleWhenNoUsers(t *testing.T) {
 		t.Fatalf("expected status 200, got %d", response.StatusCode)
 	}
 
-	body, err := io.ReadAll(response.Body)
-	if err != nil {
-		t.Fatalf("read body: %v", err)
-	}
-	if !strings.Contains(string(body), firstLaunchRegisterSubtitle) {
-		t.Fatalf("expected first launch subtitle to be present")
+	document := mustParseHTMLDocument(t, mustReadBodyString(t, response.Body))
+	if htmlFindElement(document, func(node *html.Node) bool {
+		return node.Type == html.ElementNode && htmlAttr(node, "data-subtitle-key") == "auth.register_subtitle"
+	}) == nil {
+		t.Fatalf("expected first launch subtitle with data-subtitle-key hook")
 	}
 }
 
@@ -50,11 +49,10 @@ func TestRegisterPageHidesFirstLaunchSubtitleWhenUserExists(t *testing.T) {
 		t.Fatalf("expected status 200, got %d", response.StatusCode)
 	}
 
-	body, err := io.ReadAll(response.Body)
-	if err != nil {
-		t.Fatalf("read body: %v", err)
-	}
-	if strings.Contains(string(body), firstLaunchRegisterSubtitle) {
+	document := mustParseHTMLDocument(t, mustReadBodyString(t, response.Body))
+	if htmlFindElement(document, func(node *html.Node) bool {
+		return node.Type == html.ElementNode && htmlAttr(node, "data-subtitle-key") == "auth.register_subtitle"
+	}) != nil {
 		t.Fatalf("expected first launch subtitle to be hidden when users already exist")
 	}
 }

--- a/internal/api/auth_validation_constants_test.go
+++ b/internal/api/auth_validation_constants_test.go
@@ -1,4 +1,3 @@
 package api
 
-const firstLaunchRegisterSubtitle = "First launch of Ovumcy. After sign up, complete cycle setup."
 const weakPasswordErrorText = "Use at least 8 characters with uppercase, lowercase, and a number."

--- a/internal/api/auth_validation_constants_test.go
+++ b/internal/api/auth_validation_constants_test.go
@@ -1,3 +1,0 @@
-package api
-
-const weakPasswordErrorText = "Use at least 8 characters with uppercase, lowercase, and a number."

--- a/internal/api/blocking_p0_auth_regressions_test.go
+++ b/internal/api/blocking_p0_auth_regressions_test.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -24,16 +23,12 @@ func TestLoginPageUsesLoginHeadingOnFirstLaunch(t *testing.T) {
 		t.Fatalf("expected login status 200, got %d", response.StatusCode)
 	}
 
-	body, err := io.ReadAll(response.Body)
-	if err != nil {
-		t.Fatalf("read login body: %v", err)
+	document := mustParseHTMLDocument(t, mustReadBodyString(t, response.Body))
+	if htmlElementByID(document, "login-form") == nil {
+		t.Fatalf("expected login form on login page")
 	}
-	rendered := string(body)
-	if !strings.Contains(rendered, "Войти в аккаунт") {
-		t.Fatalf("expected login heading in russian")
-	}
-	if strings.Contains(rendered, "Создайте аккаунт") {
-		t.Fatalf("did not expect registration heading on login page")
+	if htmlElementByID(document, "register-form") != nil {
+		t.Fatalf("did not expect register form on login page")
 	}
 }
 
@@ -61,41 +56,8 @@ func TestOnboardingStep1ShowsLocalizedErrorWhenDateMissing(t *testing.T) {
 		t.Fatalf("expected step1 status 400, got %d", response.StatusCode)
 	}
 
-	body, err := io.ReadAll(response.Body)
-	if err != nil {
-		t.Fatalf("read step1 body: %v", err)
-	}
-	rendered := string(body)
-	if !strings.Contains(rendered, "status-error") {
-		t.Fatalf("expected status-error markup in response")
-	}
-	if !strings.Contains(rendered, "Пожалуйста, выберите дату") {
-		t.Fatalf("expected localized missing-date error in russian, got response: %q", rendered)
-	}
-}
-
-func TestOnboardingStep1NextButtonIsNotDisabledWithoutDate(t *testing.T) {
-	app, database := newOnboardingTestApp(t)
-	user := createOnboardingTestUser(t, database, "onboarding-ui@example.com", "StrongPass1", false)
-	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
-
-	request := httptest.NewRequest(http.MethodGet, "/onboarding", nil)
-	request.Header.Set("Cookie", authCookie)
-	response, err := app.Test(request, -1)
-	if err != nil {
-		t.Fatalf("onboarding request failed: %v", err)
-	}
-	defer response.Body.Close()
-
-	if response.StatusCode != http.StatusOK {
-		t.Fatalf("expected onboarding status 200, got %d", response.StatusCode)
-	}
-
-	body, err := io.ReadAll(response.Body)
-	if err != nil {
-		t.Fatalf("read onboarding body: %v", err)
-	}
-	if strings.Contains(string(body), `:disabled="!selectedDate"`) {
-		t.Fatalf("did not expect client-side disabled next button binding on step1")
+	document := mustParseHTMLDocument(t, mustReadBodyString(t, response.Body))
+	if htmlFlashByKey(document, "onboarding.error.date_required") == nil {
+		t.Fatalf("expected flash key onboarding.error.date_required in error response")
 	}
 }

--- a/internal/api/dashboard_journal_regressions_test.go
+++ b/internal/api/dashboard_journal_regressions_test.go
@@ -88,12 +88,6 @@ func TestDashboardEmptyNotesUseAddNoteDisclosure(t *testing.T) {
 	if disclosure == nil {
 		t.Fatalf("expected dashboard note field to render as a disclosure")
 	}
-	summary := htmlFindElement(disclosure, func(node *html.Node) bool {
-		return node.Type == html.ElementNode && node.Data == "summary"
-	})
-	if !strings.Contains(htmlDocumentText(summary), "Add note") {
-		t.Fatalf("expected empty dashboard note disclosure to use Add note copy")
-	}
 	if htmlHasAttr(disclosure, "open") {
 		t.Fatalf("expected empty dashboard note disclosure to stay closed")
 	}
@@ -139,6 +133,7 @@ func TestDashboardShowsCurrentUsageGoalSummaryForOwner(t *testing.T) {
 func assertDashboardSavedNoteDisclosure(t *testing.T, document *html.Node) {
 	t.Helper()
 
+	// "Remember to hydrate" is user-entered note content verifying data round-trip, not UI copy.
 	if !strings.Contains(htmlDocumentText(document), "Remember to hydrate") {
 		t.Fatalf("expected saved note to stay visible in dashboard form")
 	}
@@ -148,12 +143,6 @@ func assertDashboardSavedNoteDisclosure(t *testing.T, document *html.Node) {
 	}
 	if !htmlHasAttr(disclosure, "open") {
 		t.Fatalf("expected saved dashboard note disclosure to stay open")
-	}
-	summary := htmlFindElement(disclosure, func(node *html.Node) bool {
-		return node.Type == html.ElementNode && node.Data == "summary"
-	})
-	if !strings.Contains(htmlDocumentText(summary), "Hide note") {
-		t.Fatalf("expected saved dashboard note disclosure to use Hide note copy")
 	}
 	noteField := htmlElementByID(document, "today-notes")
 	if noteField == nil {

--- a/internal/api/settings_cycle_test_helpers_test.go
+++ b/internal/api/settings_cycle_test_helpers_test.go
@@ -37,7 +37,7 @@ func submitSettingsCycleUpdate(t *testing.T, app *fiber.App, authCookie string, 
 func assertSettingsCycleHTMXSuccess(t *testing.T, body string) {
 	t.Helper()
 
-	if !strings.Contains(body, "status-ok") {
+	if htmlElementByTagAndClass(mustParseHTMLDocument(t, body), "div", "status-ok") == nil {
 		t.Fatalf("expected htmx success status markup")
 	}
 }

--- a/internal/api/settings_cycle_validation_regression_test.go
+++ b/internal/api/settings_cycle_validation_regression_test.go
@@ -18,7 +18,7 @@ func TestSettingsCycleRejectsOutOfRangePeriodLength(t *testing.T) {
 	assertSettingsCycleStatusError(t, app, authCookie, url.Values{
 		"cycle_length":  {"28"},
 		"period_length": {"15"},
-	}, "period_length=15")
+	}, "onboarding.error.period_length_range")
 }
 
 func TestSettingsCycleRejectsIncompatibleCycleAndPeriodLength(t *testing.T) {
@@ -29,7 +29,7 @@ func TestSettingsCycleRejectsIncompatibleCycleAndPeriodLength(t *testing.T) {
 	assertSettingsCycleStatusError(t, app, authCookie, url.Values{
 		"cycle_length":  {"21"},
 		"period_length": {"14"},
-	}, "incompatible cycle/period values")
+	}, "settings.cycle.error_incompatible")
 }
 
 func TestSettingsCycleRejectsFutureLastPeriodStart(t *testing.T) {
@@ -41,7 +41,7 @@ func TestSettingsCycleRejectsFutureLastPeriodStart(t *testing.T) {
 		"cycle_length":      {"28"},
 		"period_length":     {"6"},
 		"last_period_start": {"2999-01-01"},
-	}, "future last_period_start")
+	}, "settings.error.invalid_last_period_start")
 }
 
 func TestSettingsCycleRejectsTooOldLastPeriodStart(t *testing.T) {
@@ -53,10 +53,10 @@ func TestSettingsCycleRejectsTooOldLastPeriodStart(t *testing.T) {
 		"cycle_length":      {"28"},
 		"period_length":     {"6"},
 		"last_period_start": {"1969-12-31"},
-	}, "too-old last_period_start")
+	}, "settings.error.invalid_last_period_start")
 }
 
-func assertSettingsCycleStatusError(t *testing.T, app *fiber.App, authCookie string, form url.Values, scenario string) {
+func assertSettingsCycleStatusError(t *testing.T, app *fiber.App, authCookie string, form url.Values, flashKey string) {
 	t.Helper()
 
 	request := httptest.NewRequest(http.MethodPatch, "/api/v1/users/current/cycle", strings.NewReader(form.Encode()))
@@ -67,8 +67,8 @@ func assertSettingsCycleStatusError(t *testing.T, app *fiber.App, authCookie str
 	response := mustAppResponse(t, app, request)
 	assertStatusCode(t, response, http.StatusOK)
 
-	body := mustReadBodyString(t, response.Body)
-	if !strings.Contains(body, "status-error") {
-		t.Fatalf("expected status-error markup for %s, got %q", scenario, body)
+	document := mustParseHTMLDocument(t, mustReadBodyString(t, response.Body))
+	if htmlFlashByKey(document, flashKey) == nil {
+		t.Fatalf("expected flash key %q in error response", flashKey)
 	}
 }

--- a/internal/api/settings_flash_success_helpers_test.go
+++ b/internal/api/settings_flash_success_helpers_test.go
@@ -4,8 +4,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"strings"
 	"testing"
+
+	"golang.org/x/net/html"
 )
 
 func assertSettingsFlashSuccessScenario(t *testing.T, method string, path string, form url.Values, successKey string) {
@@ -51,8 +52,10 @@ func assertSettingsFlashSuccessScenario(t *testing.T, method string, path string
 	if htmlFlashByKey(followDocument, successKey) == nil {
 		t.Fatalf("expected flash success key %q in settings page", successKey)
 	}
-	if strings.Contains(followBody, weakPasswordErrorText) {
-		t.Fatalf("did not expect weak password error on success page")
+	if htmlFindElement(followDocument, func(node *html.Node) bool {
+		return node.Type == html.ElementNode && htmlAttr(node, "data-flash-status") == "error"
+	}) != nil {
+		t.Fatalf("did not expect error flash on settings success page")
 	}
 
 	afterFlashRequest := httptest.NewRequest(http.MethodGet, "/settings", nil)

--- a/internal/api/stats_stale_cycle_ui_regression_test.go
+++ b/internal/api/stats_stale_cycle_ui_regression_test.go
@@ -3,7 +3,7 @@ package api
 import (
 	"net/http"
 	"net/http/httptest"
-	"strings"
+	"strconv"
 	"testing"
 	"time"
 
@@ -13,9 +13,19 @@ import (
 )
 
 func TestStatsPageShowsUnknownPhaseWhenCycleDataIsStale(t *testing.T) {
-	documentText := htmlDocumentText(renderStatsPageWithStaleCycleData(t))
-	if !strings.Contains(documentText, "Complete 2 cycles to unlock insights. Start by entering the first day of your next period.") {
-		t.Fatalf("expected updated empty-state guidance before the first completed cycle")
+	document := renderStatsPageWithStaleCycleData(t)
+	emptyState := htmlFindElement(document, func(node *html.Node) bool {
+		return node.Type == html.ElementNode && htmlHasAttr(node, "data-stats-empty-state")
+	})
+	if emptyState == nil {
+		t.Fatalf("expected stats empty-state element with data-stats-empty-state attribute")
+	}
+	completedCycles, err := strconv.Atoi(htmlAttr(emptyState, "data-stats-completed-cycles"))
+	if err != nil {
+		t.Fatalf("expected data-stats-completed-cycles to be numeric, got %q", htmlAttr(emptyState, "data-stats-completed-cycles"))
+	}
+	if completedCycles >= 2 {
+		t.Fatalf("expected data-stats-completed-cycles < 2 (gating reason), got %d", completedCycles)
 	}
 }
 

--- a/internal/templates/register.html
+++ b/internal/templates/register.html
@@ -14,7 +14,7 @@
     <div>
       <h1 class="journal-title">{{t .Messages "auth.create_account"}}</h1>
       {{if and .IsFirstLaunch .RegistrationOpen}}
-      <p class="journal-muted mt-2">{{t .Messages "auth.register_subtitle"}}</p>
+      <p class="journal-muted mt-2" data-subtitle-key="auth.register_subtitle">{{t .Messages "auth.register_subtitle"}}</p>
       {{end}}
     </div>
 


### PR DESCRIPTION
## Summary

- **M4** `TestStatsPageShowsUnknownPhaseWhenCycleDataIsStale` — replace full-sentence copy assert with `data-stats-empty-state` element check + `data-stats-completed-cycles < 2`
- **M5** `blocking_p0_auth_regressions_test.go` — login/register page identity via form IDs; date-error via `htmlFlashByKey("onboarding.error.date_required")`; delete vacuous Alpine `:disabled` test
- **L6** Add `data-subtitle-key="auth.register_subtitle"` to `register.html`; rewrite first-launch subtitle tests on the attribute hook; remove exhausted `firstLaunchRegisterSubtitle` constant
- **L7** Replace `weakPasswordErrorText` copy check with `data-flash-status="error"` absence assert; delete now-empty constants file
- **L8** `assertSettingsCycleHTMXSuccess` → `htmlElementByTagAndClass`; `assertSettingsCycleStatusError` → `htmlFlashByKey` with concrete i18n keys (`onboarding.error.period_length_range`, `settings.cycle.error_incompatible`, `settings.error.invalid_last_period_start`)
- **L9** Drop `"Add note"` / `"Hide note"` UI-copy asserts from dashboard journal tests; keep `open`-attribute check and document the `"Remember to hydrate"` note-content exception
- **L10 e2e** Replace `waitForTimeout(1000)` (beforeunload autosave) with `expect.poll`+reload; replace `waitForTimeout(150)` (scroll settle) with `expect.poll(boundingBox)`
- **docs** TESTING.md: add sealed-cookie codec coverage matrix (all 11 purposes); `SECURITY_INVARIANTS.md` + `gdpr.md`: add TOTP pending/setup + OIDC link-pending to AEAD cookie list

## Test plan

- [x] `go test ./internal/api/ -run <each changed test>` green after each fix
- [x] `go test ./...` green on final HEAD
- [x] `npm run lint` clean
- [ ] Browser e2e (`npm run e2e`) — deferred; L10 Playwright changes are timing-hardening only, not behavioral