### PR TITLE
refactor(auth): remove dead reset-token CAS fallback

### DIFF
--- a/internal/api/auth_logout_rate_limit_regression_test.go
+++ b/internal/api/auth_logout_rate_limit_regression_test.go
@@ -50,6 +50,10 @@ func (stubLogoutAuthRepo) UpdatePasswordRecoveryCodeAndRevokeSessions(context.Co
 	return nil
 }
 
+func (stubLogoutAuthRepo) UpdatePasswordRecoveryCodeAndRevokeSessionsCAS(context.Context, uint, string, string, string) error {
+	return nil
+}
+
 func (stubLogoutAuthRepo) BumpAuthSessionVersion(context.Context, uint) error { return nil }
 
 // TestLogoutHandlerEnforcesPerAccountRateLimit asserts that Handler.Logout

--- a/internal/services/auth_service.go
+++ b/internal/services/auth_service.go
@@ -49,18 +49,8 @@ type AuthUserRepository interface {
 	UpdateRecoveryCodeHashAndRevokeSessions(ctx context.Context, userID uint, recoveryHash string) error
 	UpdatePasswordAndRevokeSessions(ctx context.Context, userID uint, passwordHash string, mustChangePassword bool) error
 	UpdatePasswordRecoveryCodeAndRevokeSessions(ctx context.Context, userID uint, passwordHash string, recoveryHash string, mustChangePassword bool) error
-	BumpAuthSessionVersion(ctx context.Context, userID uint) error
-}
-
-// passwordResetCASRepository is a narrow extension of AuthUserRepository that
-// the production *db.UserRepository implements. AuthService probes for it via
-// type assertion so the public AuthUserRepository interface stays stable (test
-// doubles that implement only the main interface continue to compile). Any
-// implementation that does NOT satisfy this narrower interface falls back to
-// the non-CAS UPDATE path; that path has no race window in practice because
-// test doubles are not concurrent.
-type passwordResetCASRepository interface {
 	UpdatePasswordRecoveryCodeAndRevokeSessionsCAS(ctx context.Context, userID uint, oldPasswordHash string, newPasswordHash string, recoveryHash string) error
+	BumpAuthSessionVersion(ctx context.Context, userID uint) error
 }
 
 const (
@@ -446,12 +436,10 @@ func (service *AuthService) ResetPasswordAndRotateRecoveryCode(ctx context.Conte
 // oldPasswordHash must be the hash that was current when the reset token was
 // issued (sourced from the resolved user before any write).
 //
-// When the underlying repository implements passwordResetCASRepository (the
-// production *db.UserRepository does), the UPDATE carries the predicate
+// The UPDATE carries the predicate
 // `WHERE id = ? AND password_hash = oldPasswordHash`. Concurrent or replayed
 // redeems both reach the UPDATE, but only one sees RowsAffected == 1; the
-// loser receives ErrResetTokenAlreadyConsumed. Test doubles that implement
-// only the base AuthUserRepository fall back to the unconditional UPDATE.
+// loser receives ErrResetTokenAlreadyConsumed.
 func (service *AuthService) ResetPasswordAndRotateRecoveryCodeCAS(ctx context.Context, user *models.User, oldPasswordHash string, newPassword string) (string, error) {
 	if user == nil {
 		return "", ErrAuthUserRequired // codecov:ignore -- defensive; callers always pass a resolved user
@@ -466,17 +454,9 @@ func (service *AuthService) ResetPasswordAndRotateRecoveryCodeCAS(ctx context.Co
 		return "", err // codecov:ignore -- crypto/rand failure, not reachable in tests
 	}
 
-	if casRepo, ok := service.users.(passwordResetCASRepository); ok {
-		// Production path: CAS predicate prevents concurrent / replayed redeems.
-		if err := casRepo.UpdatePasswordRecoveryCodeAndRevokeSessionsCAS(ctx, user.ID, oldPasswordHash, string(passwordHash), recoveryHash); err != nil {
-			return "", err
-		}
-	} else {
-		// codecov:ignore:start -- fallback only for non-CAS test doubles; the production *db.UserRepository satisfies passwordResetCASRepository, so the shipped binary always takes the CAS path above
-		if err := service.users.UpdatePasswordRecoveryCodeAndRevokeSessions(ctx, user.ID, string(passwordHash), recoveryHash, false); err != nil {
-			return "", err
-		}
-		// codecov:ignore:end
+	// CAS predicate prevents concurrent / replayed redeems.
+	if err := service.users.UpdatePasswordRecoveryCodeAndRevokeSessionsCAS(ctx, user.ID, oldPasswordHash, string(passwordHash), recoveryHash); err != nil {
+		return "", err
 	}
 	user.PasswordHash = string(passwordHash)
 	user.RecoveryCodeHash = recoveryHash

--- a/internal/services/auth_service_recovery_test.go
+++ b/internal/services/auth_service_recovery_test.go
@@ -133,6 +133,10 @@ func (stub *stubAuthUserRepo) UpdatePasswordRecoveryCodeAndRevokeSessions(ctx co
 	return nil
 }
 
+func (stub *stubAuthUserRepo) UpdatePasswordRecoveryCodeAndRevokeSessionsCAS(ctx context.Context, userID uint, oldPasswordHash string, newPasswordHash string, recoveryHash string) error {
+	return stub.UpdatePasswordRecoveryCodeAndRevokeSessions(ctx, userID, newPasswordHash, recoveryHash, false)
+}
+
 func (stub *stubAuthUserRepo) BumpAuthSessionVersion(ctx context.Context, userID uint) error {
 	if stub.bumpSessionErr != nil {
 		return stub.bumpSessionErr


### PR DESCRIPTION
## What

Folds the reset-token CAS write into the `AuthUserRepository` interface and removes the dead non-CAS fallback in `ResetPasswordAndRotateRecoveryCodeCAS`.

Previously the method probed `service.users` with a type assertion against a narrow `passwordResetCASRepository` interface and fell back to an unconditional UPDATE when it didn't match. That fallback only ever served test doubles — the production `*db.UserRepository` always implements CAS, so the shipped binary always took the CAS path (the fallback was `// codecov:ignore`'d for exactly this reason).

## Changes

- Add `UpdatePasswordRecoveryCodeAndRevokeSessionsCAS` to `AuthUserRepository`.
- Delete the `passwordResetCASRepository` interface and the type-assertion branch; call CAS directly.
- Add minimal CAS methods to the two affected test stubs (`stubAuthUserRepo`, `stubLogoutAuthRepo`); `casStubAuthUserRepo` already had one.
- Drop the now-orphaned `// codecov:ignore:start/:end` markers. The remaining `// codecov:ignore` defensive branches (nil-user, bcrypt, crypto/rand) are unchanged.

## Behavior

Zero behavior change — the CAS path was already the only one taken in production.

## Validation

- `go build ./...`, `go vet ./...`, `gofmt -l cmd internal` (clean)
- `go test ./...` green (incl. TestCompleteResetSingleUseViaCAS, TestResetPasswordAndRotateRecoveryCodeCASRejectsReplay, FinalizeLocalPasswordSetup / settings-password)
- patch-coverage gate (`scripts/patchcov` vs `origin/main`): **OK**