### PR TITLE
refactor(api): dedupe secure cookie codec via lazy Handler.cookieCodec()

### DIFF
--- a/internal/api/flash.go
+++ b/internal/api/flash.go
@@ -61,7 +61,7 @@ func (handler *Handler) popFlashCookie(c *fiber.Ctx) FlashPayload {
 	}
 	clearFlashCookie(c, handler.cookieSecure)
 
-	codec, err := newSecureCookieCodec(handler.secretKey)
+	codec, err := handler.cookieCodec()
 	if err != nil {
 		return FlashPayload{}
 	}

--- a/internal/api/handler_types.go
+++ b/internal/api/handler_types.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"html/template"
+	"sync"
 	"time"
 
 	"github.com/ovumcy/ovumcy-web/internal/i18n"
@@ -40,6 +41,9 @@ type OIDCWorkflowService interface {
 
 type Handler struct {
 	secretKey            []byte
+	cookieCodecOnce      sync.Once
+	cookieCodecCached    *secureCookieCodec
+	cookieCodecErr       error
 	location             *time.Location
 	cookieSecure         bool
 	i18n                 *i18n.Manager

--- a/internal/api/handlers_auth_token_helpers.go
+++ b/internal/api/handlers_auth_token_helpers.go
@@ -133,7 +133,7 @@ func (handler *Handler) encodeAuthCookieToken(rawToken string) (string, error) {
 		return "", errors.New("auth token is required")
 	}
 
-	codec, err := newSecureCookieCodec(handler.secretKey)
+	codec, err := handler.cookieCodec()
 	if err != nil {
 		return "", err
 	}
@@ -141,7 +141,7 @@ func (handler *Handler) encodeAuthCookieToken(rawToken string) (string, error) {
 }
 
 func (handler *Handler) decodeSealedAuthCookieToken(rawValue string) (string, error) {
-	codec, err := newSecureCookieCodec(handler.secretKey)
+	codec, err := handler.cookieCodec()
 	if err != nil {
 		return "", err
 	}

--- a/internal/api/oidc_link_pending_cookie.go
+++ b/internal/api/oidc_link_pending_cookie.go
@@ -76,7 +76,7 @@ func (handler *Handler) setOIDCLinkPendingCookie(c *fiber.Ctx, payload oidcLinkP
 	if err != nil {
 		return err
 	}
-	codec, err := newSecureCookieCodec(handler.secretKey)
+	codec, err := handler.cookieCodec()
 	if err != nil {
 		return err
 	}
@@ -102,7 +102,7 @@ func (handler *Handler) readOIDCLinkPendingCookie(c *fiber.Ctx) (oidcLinkPending
 	if raw == "" {
 		return oidcLinkPendingPayload{}, false
 	}
-	codec, err := newSecureCookieCodec(handler.secretKey)
+	codec, err := handler.cookieCodec()
 	if err != nil {
 		return oidcLinkPendingPayload{}, false
 	}

--- a/internal/api/oidc_logout_cookie.go
+++ b/internal/api/oidc_logout_cookie.go
@@ -104,7 +104,7 @@ func (handler *Handler) providerLogoutRedirectURLFromState(state services.OIDCLo
 }
 
 func (handler *Handler) sealCookieValue(cookieName string, plaintext []byte) (string, error) {
-	codec, err := newSecureCookieCodec(handler.secretKey)
+	codec, err := handler.cookieCodec()
 	if err != nil {
 		return "", err
 	}
@@ -112,7 +112,7 @@ func (handler *Handler) sealCookieValue(cookieName string, plaintext []byte) (st
 }
 
 func (handler *Handler) openCookieValue(cookieName string, raw string) ([]byte, error) {
-	codec, err := newSecureCookieCodec(handler.secretKey)
+	codec, err := handler.cookieCodec()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/api/oidc_state_cookie.go
+++ b/internal/api/oidc_state_cookie.go
@@ -70,7 +70,7 @@ func (handler *Handler) setOIDCStateCookie(c *fiber.Ctx, state oidcAuthState) er
 	if err != nil {
 		return err
 	}
-	codec, err := newSecureCookieCodec(handler.secretKey)
+	codec, err := handler.cookieCodec()
 	if err != nil {
 		return err
 	}
@@ -98,7 +98,7 @@ func (handler *Handler) popOIDCStateCookie(c *fiber.Ctx) oidcAuthState {
 	}
 	handler.clearOIDCStateCookie(c)
 
-	codec, err := newSecureCookieCodec(handler.secretKey)
+	codec, err := handler.cookieCodec()
 	if err != nil {
 		return oidcAuthState{}
 	}

--- a/internal/api/oidc_stepup_cookie.go
+++ b/internal/api/oidc_stepup_cookie.go
@@ -98,7 +98,7 @@ func (handler *Handler) setOIDCStepupCookie(c *fiber.Ctx, state oidcStepupState)
 	if err != nil {
 		return err
 	}
-	codec, err := newSecureCookieCodec(handler.secretKey)
+	codec, err := handler.cookieCodec()
 	if err != nil {
 		return err
 	}
@@ -126,7 +126,7 @@ func (handler *Handler) popOIDCStepupCookie(c *fiber.Ctx) oidcStepupState {
 	}
 	handler.clearOIDCStepupCookie(c)
 
-	codec, err := newSecureCookieCodec(handler.secretKey)
+	codec, err := handler.cookieCodec()
 	if err != nil {
 		return oidcStepupState{}
 	}

--- a/internal/api/recovery_code_page_cookie.go
+++ b/internal/api/recovery_code_page_cookie.go
@@ -58,7 +58,7 @@ func (handler *Handler) setRecoveryCodeIssuanceCookie(c *fiber.Ctx, userID uint,
 	if err != nil {
 		return err
 	}
-	codec, err := newSecureCookieCodec(handler.secretKey)
+	codec, err := handler.cookieCodec()
 	if err != nil {
 		return err
 	}
@@ -135,7 +135,7 @@ func (handler *Handler) readRecoveryCodeDisplayState(c *fiber.Ctx, userID uint, 
 		return state
 	}
 
-	codec, err := newSecureCookieCodec(handler.secretKey)
+	codec, err := handler.cookieCodec()
 	if err != nil {
 		handler.clearRecoveryCodePageCookie(c)
 		return state

--- a/internal/api/register_pickup_cookie.go
+++ b/internal/api/register_pickup_cookie.go
@@ -190,7 +190,7 @@ func (handler *Handler) setRegisterPickupCookie(c *fiber.Ctx, payload registerPi
 	if err != nil {
 		return err
 	}
-	codec, err := newSecureCookieCodec(handler.secretKey)
+	codec, err := handler.cookieCodec()
 	if err != nil {
 		return err
 	}
@@ -218,7 +218,7 @@ func (handler *Handler) popRegisterPickupCookie(c *fiber.Ctx) (registerPickupPay
 	}
 	handler.clearRegisterPickupCookie(c)
 
-	codec, err := newSecureCookieCodec(handler.secretKey)
+	codec, err := handler.cookieCodec()
 	if err != nil {
 		return registerPickupPayload{}, false
 	}

--- a/internal/api/reset_password_cookie.go
+++ b/internal/api/reset_password_cookie.go
@@ -32,7 +32,7 @@ func (handler *Handler) setResetPasswordCookie(c *fiber.Ctx, token string, force
 		return err
 	}
 
-	codec, err := newSecureCookieCodec(handler.secretKey)
+	codec, err := handler.cookieCodec()
 	if err != nil {
 		return err
 	}
@@ -59,7 +59,7 @@ func (handler *Handler) readResetPasswordCookie(c *fiber.Ctx) (string, bool) {
 		return "", false
 	}
 
-	codec, err := newSecureCookieCodec(handler.secretKey)
+	codec, err := handler.cookieCodec()
 	if err != nil {
 		handler.clearResetPasswordCookie(c)
 		return "", false

--- a/internal/api/secure_cookie_codec.go
+++ b/internal/api/secure_cookie_codec.go
@@ -38,6 +38,18 @@ func newSecureCookieCodec(secretKey []byte) (*secureCookieCodec, error) {
 	return &secureCookieCodec{aead: aead}, nil
 }
 
+// cookieCodec returns the handler's secureCookieCodec, building it from
+// handler.secretKey on first use and caching both the codec and the error.
+// Initialization is lazy rather than done in NewHandler because tests
+// construct Handler as a bare literal; sync.Once keeps first use race-free
+// under concurrent requests.
+func (handler *Handler) cookieCodec() (*secureCookieCodec, error) {
+	handler.cookieCodecOnce.Do(func() {
+		handler.cookieCodecCached, handler.cookieCodecErr = newSecureCookieCodec(handler.secretKey)
+	})
+	return handler.cookieCodecCached, handler.cookieCodecErr
+}
+
 func (codec *secureCookieCodec) seal(purpose string, plaintext []byte) (string, error) {
 	trimmedPurpose := strings.TrimSpace(purpose)
 	if trimmedPurpose == "" {

--- a/internal/api/totp_cookies.go
+++ b/internal/api/totp_cookies.go
@@ -35,7 +35,7 @@ func (handler *Handler) setTOTPPendingCookie(c *fiber.Ctx, userID uint, remember
 		return err
 	}
 
-	codec, err := newSecureCookieCodec(handler.secretKey)
+	codec, err := handler.cookieCodec()
 	if err != nil {
 		return err
 	}
@@ -64,7 +64,7 @@ func (handler *Handler) parseTOTPPendingCookie(c *fiber.Ctx) (uint, bool, error)
 		return 0, false, errors.New("totp pending cookie missing")
 	}
 
-	codec, err := newSecureCookieCodec(handler.secretKey)
+	codec, err := handler.cookieCodec()
 	if err != nil {
 		return 0, false, err
 	}
@@ -112,7 +112,7 @@ func (handler *Handler) setTOTPSetupCookie(c *fiber.Ctx, rawSecret string) error
 		return err
 	}
 
-	codec, err := newSecureCookieCodec(handler.secretKey)
+	codec, err := handler.cookieCodec()
 	if err != nil {
 		return err
 	}
@@ -140,7 +140,7 @@ func (handler *Handler) parseTOTPSetupCookie(c *fiber.Ctx) (string, error) {
 		return "", errors.New("totp setup cookie missing")
 	}
 
-	codec, err := newSecureCookieCodec(handler.secretKey)
+	codec, err := handler.cookieCodec()
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## What

`newSecureCookieCodec(handler.secretKey)` was rebuilt — a fresh HKDF derivation + AES-GCM init — at 21 call sites across 10 files in `internal/api`. The Handler now builds the codec once and reuses it.

## How

- `Handler` gains three unexported fields (`cookieCodecOnce sync.Once`, `cookieCodecCached`, `cookieCodecErr`).
- New `(h *Handler) cookieCodec()` lazily builds the codec from `h.secretKey` on first use and caches both the codec and the error.
- Every `newSecureCookieCodec(handler.secretKey)` call site becomes `handler.cookieCodec()`; per-site error handling is unchanged.

## Why lazy (not in NewHandler)

Many tests construct `&Handler{secretKey: ...}` literals directly, bypassing `NewHandler`. Eager init would leave the codec nil there (this exact failure got a previous attempt reverted). Lazy init keeps those literals working — zero test-file changes, `NewHandler` signature untouched.

## Out of scope

`writeFlashCookie` (flash.go) keeps building its own codec: it backs the exported `SetFlashCookie`/`SetFlashCookieWithSecure` helpers that take a caller-supplied `secretKey` with no Handler in scope.

## Validation

- `go test ./internal/api/...` green
- `go vet ./...` clean (incl. copylocks — all Handler receivers are pointers)
- `gofmt -l` clean
- `-race` not runnable on this machine (no cgo/gcc); concurrency is a bare `sync.Once`