### PR TITLE
fix(cycles): count baseline current cycle day on a DST-immune calendar basis

### DIFF
--- a/internal/services/cycle_baseline.go
+++ b/internal/services/cycle_baseline.go
@@ -107,10 +107,24 @@ func locationDateOrZero(day time.Time, location *time.Location) time.Time {
 }
 
 func baselineCurrentCycleDay(lastPeriodStart time.Time, today time.Time) int {
-	if lastPeriodStart.IsZero() || today.Before(lastPeriodStart) {
+	if lastPeriodStart.IsZero() {
 		return 0
 	}
-	return int(today.Sub(lastPeriodStart).Hours()/24) + 1
+	// Both arguments already carry the intended calendar day: `today` is the
+	// viewer's local calendar day (DateAtLocation per issue #48) and
+	// `lastPeriodStart` is the stored anchor's calendar day. Their wall clocks
+	// sit in the request location, so subtracting them as instants is
+	// DST-sensitive — a spring-forward between the two dates makes the span
+	// 1h short of a whole number of days and truncates the cycle day by one.
+	// Re-anchor each to UTC-midnight of its calendar components (the same
+	// normalization the UTC-safe main path applies via dateOnly) so the count
+	// is a pure calendar-day difference, immune to offset and DST.
+	start := dateOnly(lastPeriodStart)
+	current := dateOnly(today)
+	if current.Before(start) {
+		return 0
+	}
+	return int(current.Sub(start).Hours()/24) + 1
 }
 
 func DetectCurrentPhase(stats CycleStats, logs []models.DailyLog, today time.Time, location *time.Location) string {

--- a/internal/services/cycle_baseline_test.go
+++ b/internal/services/cycle_baseline_test.go
@@ -146,6 +146,81 @@ func TestApplyUserCycleBaselineClampsShortCyclePredictionsAwayFromDayOne(t *test
 	}
 }
 
+// TestApplyUserCycleBaselineCurrentCycleDayMatchesLocalCalendarAcrossTimezonesAndDST
+// pins the displayed baseline "current cycle day" to the viewer's local
+// calendar-day count, independent of UTC offset and DST transitions. The
+// owner baseline path derives `today` from the request location (issue #48),
+// so both operands of the day count carry a non-UTC wall clock; counting
+// elapsed days by instant subtraction would lose a day whenever a DST
+// spring-forward falls between the anchor and today. The expected values are
+// pure calendar-day differences (anchor is cycle day 1).
+func TestApplyUserCycleBaselineCurrentCycleDayMatchesLocalCalendarAcrossTimezonesAndDST(t *testing.T) {
+	cases := []struct {
+		name       string
+		locationID string
+		anchor     string
+		now        time.Time
+		wantDay    int
+	}{
+		{
+			// UTC-5, no DST transition in the window: regression guard that a
+			// negative-offset zone still counts the plain calendar difference.
+			name:       "America/New_York without DST transition",
+			locationID: "America/New_York",
+			anchor:     "2026-02-07",
+			now:        time.Date(2026, 2, 17, 12, 0, 0, 0, time.UTC),
+			wantDay:    11, // 2026-02-07 -> 2026-02-17 local = 10 elapsed days
+		},
+		{
+			// UTC+9, no DST ever: cross-timezone regression guard.
+			name:       "Asia/Tokyo cross-timezone UTC+9",
+			locationID: "Asia/Tokyo",
+			anchor:     "2026-02-07",
+			now:        time.Date(2026, 2, 17, 12, 0, 0, 0, time.UTC),
+			wantDay:    11,
+		},
+		{
+			// Spring-forward is 2026-03-29 02:00->03:00 in Berlin; the cycle
+			// spans it, so instant subtraction would yield 695h (-> day 29).
+			name:       "Europe/Berlin across spring-forward",
+			locationID: "Europe/Berlin",
+			anchor:     "2026-03-01",
+			now:        time.Date(2026, 3, 30, 12, 0, 0, 0, time.UTC),
+			wantDay:    30, // 2026-03-01 -> 2026-03-30 local = 29 elapsed days
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			location, err := time.LoadLocation(tc.locationID)
+			if err != nil {
+				t.Fatalf("load location %q: %v", tc.locationID, err)
+			}
+
+			anchor := mustParseBaselineDay(t, tc.anchor)
+			user := &models.User{
+				Role:            models.RoleOwner,
+				CycleLength:     28,
+				PeriodLength:    5,
+				LastPeriodStart: &anchor,
+			}
+			logs := []models.DailyLog{
+				{Date: anchor, IsPeriod: true, CycleStart: true, Flow: models.FlowMedium},
+			}
+
+			stats := BuildCycleStats(logs, tc.now)
+			stats = ApplyUserCycleBaseline(user, logs, stats, tc.now, location)
+
+			if got := stats.LastPeriodStart.Format("2006-01-02"); got != tc.anchor {
+				t.Fatalf("baseline LastPeriodStart = %s, want anchor %s (test setup drifted)", got, tc.anchor)
+			}
+			if stats.CurrentCycleDay != tc.wantDay {
+				t.Fatalf("CurrentCycleDay = %d, want %d (local calendar day in %s)", stats.CurrentCycleDay, tc.wantDay, tc.locationID)
+			}
+		})
+	}
+}
+
 func mustParseBaselineDay(t *testing.T, raw string) time.Time {
 	t.Helper()
 	parsed, err := time.ParseInLocation("2006-01-02", raw, time.UTC)

--- a/internal/services/cycle_baseline_test.go
+++ b/internal/services/cycle_baseline_test.go
@@ -221,6 +221,26 @@ func TestApplyUserCycleBaselineCurrentCycleDayMatchesLocalCalendarAcrossTimezone
 	}
 }
 
+// TestBaselineCurrentCycleDayGuardsAgainstFutureAnchor pins the defensive
+// today-before-anchor branch of baselineCurrentCycleDay. ApplyUserCycleBaseline
+// gates the resolved anchor to <= today, so this guard is unreachable through
+// the public path and is exercised directly: a today strictly before the anchor
+// (or a zero anchor) must yield 0, never a negative or wrapped cycle day, and
+// the anchor day itself is cycle day 1.
+func TestBaselineCurrentCycleDayGuardsAgainstFutureAnchor(t *testing.T) {
+	anchor := mustParseBaselineDay(t, "2026-03-10")
+
+	if got := baselineCurrentCycleDay(anchor, mustParseBaselineDay(t, "2026-03-09")); got != 0 {
+		t.Fatalf("today before anchor must be 0, got %d", got)
+	}
+	if got := baselineCurrentCycleDay(time.Time{}, mustParseBaselineDay(t, "2026-03-09")); got != 0 {
+		t.Fatalf("zero anchor must be 0, got %d", got)
+	}
+	if got := baselineCurrentCycleDay(anchor, anchor); got != 1 {
+		t.Fatalf("anchor day itself must be cycle day 1, got %d", got)
+	}
+}
+
 func mustParseBaselineDay(t *testing.T, raw string) time.Time {
 	t.Helper()
 	parsed, err := time.ParseInLocation("2006-01-02", raw, time.UTC)


### PR DESCRIPTION
## Problem
The displayed owner-baseline *current cycle day* (`stats.CurrentCycleDay` via `baselineCurrentCycleDay`) was computed by subtracting `today` and `lastPeriodStart` as instants. Both carry a non-UTC wall clock in the request location — `today` via `DateAtLocation` (issue #48), `lastPeriodStart` via `CalendarDay`. When a DST spring-forward falls between the two dates, the span is 1h short of a whole number of days, so integer division truncated the cycle day by one.

Concretely, a viewer in `Europe/Berlin` whose cycle spans the 2026-03-29 spring-forward saw cycle day **29 instead of 30**. Cross-timezone offsets *without* a transition (e.g. `Asia/Tokyo`, UTC+9) were already correct, since both operands share the same zone — so this is a DST bug, not a generic cross-tz one.

This affects only the owner baseline path (users with little history); the main `cycleDayAt` path is already DST-immune because it keeps both operands at UTC-midnight via `dateOnly`.

## Fix
Re-anchor both operands to UTC-midnight of their calendar components using the existing `dateOnly` helper — the same normalization the UTC-safe main path uses. The day count becomes a pure calendar-day difference, immune to UTC offset and DST. The calendar day each operand represents is unchanged, so the #48 fix (today derived from the request location) is preserved.

## Tests
New table-driven `TestApplyUserCycleBaselineCurrentCycleDayMatchesLocalCalendarAcrossTimezonesAndDST`:
- `America/New_York` (no transition in window) — negative-offset regression guard → day 11
- `Asia/Tokyo` (UTC+9) — cross-timezone regression guard → day 11
- `Europe/Berlin` across spring-forward — the DST fix → day 30 (the pre-fix code yields 29)

Confirmed the Berlin vector fails on the pre-fix code and passes after.

## Scope / safety
- No change to the main `cycleDayAt` path, `cycle_signals.go` DST behavior, or the #48 `today` derivation.
- Pinned values intact: baseline 11/4, main-path 8.
- `cycle_signals` DST pin passes; the intentionally-skipped baseline calendar-stability invariant stays skipped.
- `gofmt`, `go vet`, `go build ./...`, `go test ./...` all green.

Two files: `internal/services/cycle_baseline.go`, `internal/services/cycle_baseline_test.go`.