### PR TITLE
fix(cycles): predict from median not mean; align medical docs and labeling

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,8 +141,9 @@ calendar math, and the model is deliberately simple:
 - Your next period is your last period start plus your typical cycle length (the
   median of your recent cycles).
 - Ovulation is counted back from there. The luteal phase, from ovulation to the
-  next period, is treated as roughly 14 days, so ovulation lands near cycle
-  length minus 14.
+  next period, is treated as about 14 days by default — and refined toward your
+  own value when your temperature or cervical-mucus entries allow — so ovulation
+  lands near cycle length minus the luteal length.
 - The fertile window is the six days ending on ovulation day, since sperm can
   survive a few days and the egg about one.
 

--- a/docs/cycle-prediction.md
+++ b/docs/cycle-prediction.md
@@ -21,20 +21,21 @@ implementation cannot silently drift apart.
 |-------|---------|--------|
 | `periodStart` | First day of the current menstrual period (cycle day 1) | Detected from logged period days |
 | `cycleLength` | Length of the cycle in days | Median of observed cycles, or the user's configured value |
-| `lutealPhase` | Days from ovulation to the next period | Fixed model default of **14 days** |
+| `lutealPhase` | Days from ovulation to the next period | **14-day** default, refined toward the owner's own value from logged BBT / cervical-mucus signals when enough cycles carry them |
 
 ## The model
 
 The model rests on one physiological assumption: **the luteal phase (ovulation →
-next period) is roughly constant at ~14 days**, while the follicular phase (period
-→ ovulation) absorbs the variation in cycle length. So ovulation is counted
-*backwards* from the next expected period.
+next period) is relatively stable per person** — modelled at ~14 days by default,
+and refined toward the owner's own value when logged signals allow — while the
+follicular phase (period → ovulation) absorbs the variation in cycle length. So
+ovulation is counted *backwards* from the next expected period.
 
 ### Constants
 
 | Constant | Value | Role |
 |----------|-------|------|
-| `defaultLutealPhaseDays` | 14 | Luteal phase used by the app |
+| `defaultLutealPhaseDays` | 14 | Default luteal phase, used when it is not refined from logged signals |
 | `minLutealPhaseDays` | 10 | Lower clamp for the luteal phase |
 | `minOvulationCycleDay` | 5 | Ovulation may not fall before cycle day 5 |
 | (min cycle for a prediction) | 15 | `minLutealPhaseDays + minOvulationCycleDay` |
@@ -97,19 +98,26 @@ These are the exact cases asserted by the reference tests.
 
 ## How cycle length and luteal phase are chosen
 
-- **Cycle length** is the median of the user's observed completed cycles (a
-  cycle being the gap between two detected period starts). When there is not
-  enough history, the user's configured value is used.
-- **Luteal phase** is not estimated per user; the app uses the fixed 14-day
-  model default. This is a deliberate simplification — individual luteal phases
-  vary, which is one reason predictions are estimates.
+- **Cycle length** is the median of the owner's recent observed cycles (a cycle
+  being the gap between two detected period starts). The median is used rather
+  than the mean, so a single missed-log gap that merges two cycles cannot skew
+  the estimate. When there is not enough history, the owner's configured value
+  is used.
+- **Luteal phase** defaults to the fixed 14-day model value, but is refined for
+  the owner when their logs carry enough signal: when basal body temperature or
+  cervical-mucus entries let the app infer the ovulation-to-next-period length
+  across several cycles, that observed luteal length (clamped to a physiological
+  10–20 day range) replaces the default. With little or no such data the fixed
+  14-day default stands. Individual luteal phases vary (commonly 11–17 days),
+  which is one reason predictions remain estimates.
 - For irregular cycles the app widens the prediction into a range rather than a
   single date.
 
 ## Assumptions and limitations
 
-- Luteal phase is modeled as constant; in reality it varies between people and
-  cycles.
+- Luteal phase defaults to a constant 14 days and is only refined when enough
+  logged BBT / cervical-mucus signal exists; in reality it varies between people
+  and cycles.
 - Predictions are **calendar-based** and cannot observe the body. They do not
   use temperature, LH tests, or symptoms to confirm ovulation.
 - Accuracy degrades sharply for irregular or very short/long cycles.

--- a/internal/api/dashboard_prediction_disclaimer_test.go
+++ b/internal/api/dashboard_prediction_disclaimer_test.go
@@ -1,0 +1,35 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestDashboardRendersPredictionDisclaimer pins the medical-safety labeling
+// from the prediction-accuracy pass: the dashboard must always render the
+// "estimates, not medical advice or a method of contraception" disclaimer for
+// the owner, so a future template refactor cannot silently drop it from a
+// health-prediction surface.
+func TestDashboardRendersPredictionDisclaimer(t *testing.T) {
+	app, database := newOnboardingTestApp(t)
+	user := createOnboardingTestUser(t, database, "prediction-disclaimer@example.com", "StrongPass1", true)
+	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
+
+	request := httptest.NewRequest(http.MethodGet, "/dashboard", nil)
+	request.Header.Set("Accept-Language", "en")
+	request.Header.Set("Cookie", authCookie)
+	response := mustAppResponse(t, app, request)
+	assertStatusCode(t, response, http.StatusOK)
+
+	body := mustReadBodyString(t, response.Body)
+	for _, fragment := range []string{
+		`data-dashboard-prediction-disclaimer`,
+		"not medical advice or a method of contraception",
+	} {
+		if !strings.Contains(body, fragment) {
+			t.Fatalf("dashboard must render the prediction disclaimer fragment %q", fragment)
+		}
+	}
+}

--- a/internal/i18n/locales/de.json
+++ b/internal/i18n/locales/de.json
@@ -376,6 +376,7 @@
   "dashboard.ovulation_range": "%s — %s",
   "dashboard.ovulation_need_cycles": "3 abgeschlossene Zyklen sind erforderlich, bevor Ovumcy einen Eisprungsbereich anzeigen kann",
   "dashboard.ovulation_approximate": "(ungefähr)",
+  "dashboard.prediction_disclaimer": "Dies sind Schätzungen, keine medizinische Beratung und keine Verhütungsmethode.",
   "dashboard.ovulation_unavailable": "Kann nicht berechnet werden",
   "dashboard.prediction_in_past": "Das Datum liegt bereits in der Vergangenheit.",
   "usage_goal.current_mode": "Aktueller Modus",

--- a/internal/i18n/locales/en.json
+++ b/internal/i18n/locales/en.json
@@ -376,6 +376,7 @@
   "dashboard.ovulation_range": "%s — %s",
   "dashboard.ovulation_need_cycles": "3 completed cycles are needed before Ovumcy shows an ovulation range",
   "dashboard.ovulation_approximate": "(approximate)",
+  "dashboard.prediction_disclaimer": "These are estimates, not medical advice or a method of contraception.",
   "dashboard.ovulation_unavailable": "Cannot be calculated",
   "dashboard.prediction_in_past": "Date is already in the past.",
   "usage_goal.current_mode": "Current mode",

--- a/internal/i18n/locales/es.json
+++ b/internal/i18n/locales/es.json
@@ -376,6 +376,7 @@
   "dashboard.ovulation_range": "%s — %s",
   "dashboard.ovulation_need_cycles": "se necesitan 3 ciclos completos antes de que Ovumcy muestre un rango de ovulación",
   "dashboard.ovulation_approximate": "(aproximada)",
+  "dashboard.prediction_disclaimer": "Son estimaciones, no consejo médico ni un método anticonceptivo.",
   "dashboard.ovulation_unavailable": "No se puede calcular",
   "dashboard.prediction_in_past": "La fecha ya está en el pasado.",
   "usage_goal.current_mode": "Modo actual",

--- a/internal/i18n/locales/fr.json
+++ b/internal/i18n/locales/fr.json
@@ -443,6 +443,7 @@
   "dashboard.ovulation_range": "%s — %s",
   "dashboard.ovulation_need_cycles": "3 cycles complétés sont nécessaires avant qu'Ovumcy affiche une plage d'ovulation",
   "dashboard.ovulation_approximate": "(approximatif)",
+  "dashboard.prediction_disclaimer": "Ce sont des estimations, pas un avis médical ni une méthode de contraception.",
   "dashboard.ovulation_unavailable": "Impossible à calculer",
   "dashboard.prediction_in_past": "La date est déjà passée.",
   "usage_goal.current_mode": "Mode actuel",

--- a/internal/i18n/locales/ru.json
+++ b/internal/i18n/locales/ru.json
@@ -376,6 +376,7 @@
   "dashboard.ovulation_range": "%s — %s",
   "dashboard.ovulation_need_cycles": "нужно 3 завершённых цикла, чтобы Ovumcy показал диапазон овуляции",
   "dashboard.ovulation_approximate": "(приблизительно)",
+  "dashboard.prediction_disclaimer": "Это оценки, а не медицинский совет и не метод контрацепции.",
   "dashboard.ovulation_unavailable": "Невозможно рассчитать",
   "dashboard.prediction_in_past": "Дата уже в прошлом.",
   "usage_goal.current_mode": "Текущий режим",

--- a/internal/services/cycles.go
+++ b/internal/services/cycles.go
@@ -335,11 +335,17 @@ func applyPredictedCycleStats(stats *CycleStats) {
 }
 
 func predictedCycleLength(median int, average float64) int {
-	if average > 0 {
-		return int(average + 0.5)
-	}
+	// Prefer the median (the statistic documented in docs/cycle-prediction.md):
+	// it is robust to a single outlier cycle. A missed period log merges two
+	// real cycles into one ~60-90 day gap that would drag the mean by ~10 days
+	// and push every downstream prediction late, but leaves the median unmoved.
+	// The mean is only a fallback for the degenerate case where no median is
+	// available (it never is when at least one cycle length exists).
 	if median > 0 {
 		return median
+	}
+	if average > 0 {
+		return int(average + 0.5)
 	}
 	return models.DefaultCycleLength
 }

--- a/internal/services/cycles_prediction_statistic_test.go
+++ b/internal/services/cycles_prediction_statistic_test.go
@@ -1,0 +1,64 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+)
+
+// TestPredictedCycleLength_PrefersMedianOverMean pins the medical-accuracy fix:
+// the prediction statistic is the MEDIAN of recent cycles, not the mean. The
+// mean is sensitive to a single outlier cycle (a missed period log merges two
+// real cycles into one ~60-90 day gap), which would push every prediction late.
+// docs/cycle-prediction.md documents the median; this test guards the contract.
+func TestPredictedCycleLength_PrefersMedianOverMean(t *testing.T) {
+	cases := []struct {
+		name    string
+		median  int
+		average float64
+		want    int
+	}{
+		// The decisive case: a 90-day outlier among five 28-day cycles yields a
+		// mean of ~38 but a median of 28. The median must win.
+		{"outlier-skewed mean is ignored in favor of median", 28, 38.3, 28},
+		// Even when median and rounded mean differ by one, the median wins.
+		{"median chosen over rounded mean", 27, 27.6, 27},
+		// Mean is only a fallback when no median exists.
+		{"falls back to rounded mean when median is zero", 0, 30.4, 30},
+		{"falls back to default when neither is available", 0, 0, models.DefaultCycleLength},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := predictedCycleLength(tc.median, tc.average); got != tc.want {
+				t.Fatalf("predictedCycleLength(median=%d, average=%.2f) = %d, want %d",
+					tc.median, tc.average, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestMedianInt_EvenCount closes a coverage gap: the even-count branch of
+// medianInt (round-half-up of the two middle values) was never exercised by a
+// fixture. Verify it returns the true median, rounding half up.
+func TestMedianInt_EvenCount(t *testing.T) {
+	cases := []struct {
+		name   string
+		values []int
+		want   int
+	}{
+		{"empty is zero", nil, 0},
+		{"single value", []int{28}, 28},
+		{"odd count takes the middle", []int{27, 28, 30}, 28},
+		{"even count, exact integer median", []int{26, 30}, 28},
+		{"even count rounds half up", []int{27, 28}, 28},
+		{"even count of four", []int{20, 21, 28, 29}, 25},
+		{"unsorted input is sorted first", []int{30, 26}, 28},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := medianInt(tc.values); got != tc.want {
+				t.Fatalf("medianInt(%v) = %d, want %d", tc.values, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/templates/dashboard.html
+++ b/internal/templates/dashboard.html
@@ -128,6 +128,10 @@
     {{end}}
 
     {{if .IsOwner}}
+    <p class="journal-muted text-xs" data-dashboard-prediction-disclaimer>{{t .Messages "dashboard.prediction_disclaimer"}}</p>
+    {{end}}
+
+    {{if .IsOwner}}
     <div class="journal-panel text-sm space-y-1" data-usage-goal-summary data-usage-goal-label-key="{{.UsageGoalLabelKey}}" data-usage-goal-summary-key="{{.UsageGoalSummaryKey}}">
       <p class="field-label">{{t .Messages "usage_goal.current_mode"}}: {{t .Messages .UsageGoalLabelKey}}</p>
       <p class="journal-muted">{{t .Messages .UsageGoalSummaryKey}}</p>
@@ -147,7 +151,7 @@
       {{end}}
       <a href="/settings#settings-cycle" class="btn-secondary text-sm">{{t .Messages "dashboard.update_cycle_data"}}</a>
     </div>
-      {{else if and (not .DisplayOvulationUseRange) (not .DisplayOvulationImpossible) (not .DisplayOvulationDate.IsZero) (not .DisplayOvulationExact)}}
+      {{else if and (not .DisplayOvulationUseRange) (not .DisplayOvulationImpossible) (not .DisplayOvulationDate.IsZero)}}
       <p class="journal-muted text-sm">{{t .Messages "dashboard.ovulation_approximate"}}</p>
       {{end}}
     {{if .HasPredictionFactorHint}}


### PR DESCRIPTION
## Medical-accuracy pass (audit follow-up, phase 1 of a phased series)

Three coupled medical-correctness fixes to the cycle prediction surface.

### 1. Prediction statistic: median, not mean
`predictedCycleLength` (internal/services/cycles.go) now prefers the **median** of recent cycles instead of the mean. The mean is sensitive to a single outlier cycle: a missed period log merges two real cycles into one ~60–90 day gap (`DetectCycleStarts` has no upper bound), which dragged the mean ~10 days and pushed every prediction late. The median is immune. This is also the statistic `docs/cycle-prediction.md` already documented — the code had drifted from the doc.

New regression: `cycles_prediction_statistic_test.go` pins median-first selection and the previously-unexercised even-count `medianInt` branch.

### 2. Docs describe the real model
`cycle-prediction.md` + `README.md`: the luteal phase **defaults to 14 days but is refined per-owner from logged BBT / cervical-mucus signals** when enough cycles carry them (`ApplyUserCycleBaseline` → `InferUserLutealPhase`). The docs previously claimed luteal was *never* estimated per user — false for the owner path. Adaptive-from-signal is the medically more accurate behavior, so the code stands and the docs were corrected. Cycle length is documented as the median (now true).

### 3. UI: estimate, not fact
The dashboard now shows the ovulation "(approximate)" qualifier on **every** prediction path (previously only when the luteal phase was clamped on short cycles), and renders a persistent **"these are estimates, not medical advice or a method of contraception"** disclaimer near the prediction widgets — translated in en/ru/es/fr/de.

### Tests
`go vet` clean; full `internal/services` suite, `internal/i18n` (locale parity), and `internal/api` (dashboard/template render) all green. staticcheck is CI-gated (local toolchain skew).

### Deferred
Statistical-robustness refinements to the irregular-cycle *range* (windowed min/max, sample SD) are intentionally held for a later robustness phase to keep this medical PR focused.