### PR TITLE
Phase 2 — contract & privacy fixes (audit follow-up)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -108,7 +108,7 @@ Ovumcy uses only first-party cookies. Cookies marked **Sealed** are encrypted wi
 
 | Name | Purpose | TTL | Path | HttpOnly | SameSite | Secure | Sealed |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `ovumcy_auth` | Session token carrying user id, role, and `auth_session_version` | 7 days with remember-me, otherwise browser session | `/` | yes | Lax | `COOKIE_SECURE` | yes |
+| `ovumcy_auth` | Session token carrying user id, role, and `auth_session_version` | 30 days (persistent) with remember-me, otherwise a browser-session cookie (underlying token TTL 7 days) | `/` | yes | Lax | `COOKIE_SECURE` | yes |
 | `ovumcy_csrf` | CSRF double-submit token matched against the `csrf_token` form field on every state-changing request | browser session | `/` | yes | Lax | `COOKIE_SECURE` | no |
 | `ovumcy_lang` | User-selected UI language code | 1 year | `/` | no (JS-readable for i18n) | Lax | `COOKIE_SECURE` | no |
 | `ovumcy_tz` | Client IANA timezone for server-side calendar math | 1 year | `/` | no (JS-writable, server-validated) | Lax | `COOKIE_SECURE` | no |

--- a/docs/export.md
+++ b/docs/export.md
@@ -28,6 +28,8 @@ Response body:
     {
       "date": "2026-05-17",
       "period": true,
+      "cycle_start": false,
+      "is_uncertain": false,
       "flow": "medium",
       "mood_rating": 3,
       "sex_activity": "protected",
@@ -77,6 +79,8 @@ Field semantics:
 | `symptoms` | object of booleans | Flags for the 15 built-in symptoms. Always present, even when all false. |
 | `other_symptoms` | array of strings | Names of owner-managed custom symptoms recorded that day. |
 | `notes` | string | Free-text note. |
+| `cycle_start` | boolean | Whether the day is the manually marked start of a cycle. Owner-only; never emitted for non-owner viewers. |
+| `is_uncertain` | boolean | Whether the owner flagged this day's data as uncertain. Owner-only; never emitted for non-owner viewers. |
 
 The `symptoms` object always contains the same 15 keys, in this order: `cramps`, `headache`, `acne`, `mood`, `bloating`, `fatigue`, `breast_tenderness`, `back_pain`, `nausea`, `spotting`, `irritability`, `insomnia`, `food_cravings`, `diarrhea`, `constipation`. Any other symptom configured by the owner appears in `other_symptoms` as a free-text name.
 
@@ -95,7 +99,8 @@ Columns (in order, single header row):
 Date, Period, Flow, Mood rating, Sex activity, BBT (C), Cervical mucus,
 Cramps, Headache, Acne, Mood, Bloating, Fatigue, Breast tenderness,
 Back pain, Nausea, Spotting, Irritability, Insomnia, Food cravings,
-Diarrhea, Constipation, Cycle factors, Other, Notes, Pregnancy test
+Diarrhea, Constipation, Cycle factors, Other, Notes, Pregnancy test,
+Cycle start, Uncertain
 ```
 
 Cell semantics:
@@ -107,7 +112,8 @@ Cell semantics:
 - `Cycle factors` is a `;`-separated list of factor keys; empty when none were recorded.
 - `Other` is a `;`-separated list of owner-managed custom symptom names; empty when none.
 - `Notes` is the free-text note; the CSV writer quotes the cell as needed.
-- `Pregnancy test` is one of `none`, `negative`, `positive`. It is the last column: introduced after the 1.1.1 layout and appended at the end so existing column positions stay stable, per the stability rule below.
+- `Pregnancy test` is one of `none`, `negative`, `positive`. It was introduced after the 1.1.1 layout and appended after the original columns so existing column positions stay stable, per the stability rule below.
+- `Cycle start` and `Uncertain` are `Yes`/`No`. They are the last two columns, appended after `Pregnancy test` so existing column positions stay stable, per the stability rule below. `Cycle start` marks the manually flagged start of a cycle; `Uncertain` marks a day the owner flagged as uncertain. Both are owner-only and never appear for non-owner viewers.
 
 ## Summary Export
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -103,9 +103,13 @@ components:
       description: |
         Double-submit CSRF token validated against the `ovumcy_csrf` cookie.
         Browser clients usually submit it via the `csrf_token` form field
-        instead of the header. Pure-GET, register/login/forgot-password
-        request paths, and the `/auth/oidc/callback` provider form-post path
-        are exempt. See [CSRF middleware configuration](../cmd/ovumcy/main.go).
+        instead of the header. Only pure-GET requests and the
+        `/auth/oidc/callback` provider form-post path are exempt; every other
+        state-changing request — including register, login, and password-reset
+        — requires the token. Programmatic clients read it from the
+        `ovumcy_csrf` cookie set on any GET (for example `GET /login`) and echo
+        it in the `X-CSRF-Token` header or `csrf_token` form field. See
+        [CSRF middleware configuration](../cmd/ovumcy/main.go).
 
   parameters:
     DateParam:
@@ -772,7 +776,8 @@ paths:
         cookie of fixed length, redirect to `/register/welcome`) for new and
         duplicate emails. See [SECURITY.md "Register enumeration"](../SECURITY.md#register-enumeration-pickup-cookie-follow-up-oracle-residual).
         Per-IP rate limit: default 8 / 15 min.
-      security: []
+      security:
+        - csrfToken: []
       requestBody:
         required: true
         content:
@@ -794,7 +799,8 @@ paths:
         Per-IP rate limit (default 8 / 15 min) plus per-account
         `AuthAttemptPolicy` budget. Constant-time password verification with
         equalized bcrypt timing on the missing-user branch.
-      security: []
+      security:
+        - csrfToken: []
       requestBody:
         required: true
         content:
@@ -892,7 +898,8 @@ paths:
       description: |
         Validates the `(email, recovery_code)` pair without leaking which one
         was wrong. Per-IP rate limit: default 8 / 1 hour.
-      security: []
+      security:
+        - csrfToken: []
       requestBody:
         required: true
         content:
@@ -916,7 +923,8 @@ paths:
       description: |
         Requires the `ovumcy_reset_password` cookie issued by `POST
         /api/v1/password-resets`. Bumps `auth_session_version` on success.
-      security: []
+      security:
+        - csrfToken: []
       requestBody:
         required: true
         content:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -484,6 +484,8 @@ components:
           type: string
           format: date
         period: { type: boolean }
+        cycle_start: { type: boolean }
+        is_uncertain: { type: boolean }
         flow:
           type: string
           enum: [none, spotting, light, medium, heavy]
@@ -497,6 +499,9 @@ components:
         cervical_mucus:
           type: string
           enum: [none, dry, moist, creamy, eggwhite]
+        pregnancy_test:
+          type: string
+          enum: [none, negative, positive]
         cycle_factors:
           type: array
           items: { type: string }

--- a/internal/api/day_response.go
+++ b/internal/api/day_response.go
@@ -1,0 +1,105 @@
+package api
+
+import (
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+	"github.com/ovumcy/ovumcy-web/internal/services"
+)
+
+// dayResponse is the transport DTO for a persisted day record on the public
+// /api/v1/days surface. It mirrors the `DailyLog` schema in docs/openapi.yaml
+// (snake_case keys, `date` as a calendar date-only string) so the wire format
+// conforms to the published contract. models.DailyLog stays transport-free per
+// AGENTS.md: serialization lives in the api layer, not on the model.
+type dayResponse struct {
+	ID              uint      `json:"id"`
+	UserID          uint      `json:"user_id"`
+	Date            string    `json:"date"`
+	IsPeriod        bool      `json:"is_period"`
+	CycleStart      bool      `json:"cycle_start"`
+	IsUncertain     bool      `json:"is_uncertain"`
+	Flow            string    `json:"flow"`
+	Mood            int       `json:"mood"`
+	SexActivity     string    `json:"sex_activity"`
+	BBT             float64   `json:"bbt"`
+	CervicalMucus   string    `json:"cervical_mucus"`
+	PregnancyTest   string    `json:"pregnancy_test"`
+	CycleFactorKeys []string  `json:"cycle_factor_keys"`
+	SymptomIDs      []uint    `json:"symptom_ids"`
+	Notes           string    `json:"notes"`
+	CreatedAt       time.Time `json:"created_at"`
+	UpdatedAt       time.Time `json:"updated_at"`
+}
+
+// newDayResponse maps a raw GORM day model onto its transport DTO. The stored
+// calendar date is emitted verbatim via services.CalendarDayKey (no timezone
+// shift) so the wire `date` matches docs/openapi.yaml `format: date`.
+func newDayResponse(entry models.DailyLog) dayResponse {
+	return dayResponse{
+		ID:              entry.ID,
+		UserID:          entry.UserID,
+		Date:            services.CalendarDayKey(entry.Date),
+		IsPeriod:        entry.IsPeriod,
+		CycleStart:      entry.CycleStart,
+		IsUncertain:     entry.IsUncertain,
+		Flow:            entry.Flow,
+		Mood:            entry.Mood,
+		SexActivity:     entry.SexActivity,
+		BBT:             entry.BBT,
+		CervicalMucus:   entry.CervicalMucus,
+		PregnancyTest:   entry.PregnancyTest,
+		CycleFactorKeys: entry.CycleFactorKeys,
+		SymptomIDs:      entry.SymptomIDs,
+		Notes:           entry.Notes,
+		CreatedAt:       entry.CreatedAt,
+		UpdatedAt:       entry.UpdatedAt,
+	}
+}
+
+// newDayResponses maps a slice of day models to their transport DTOs, preserving
+// order. A nil input yields an empty (non-nil) slice so the list endpoint always
+// serializes a JSON array.
+func newDayResponses(entries []models.DailyLog) []dayResponse {
+	out := make([]dayResponse, 0, len(entries))
+	for _, entry := range entries {
+		out = append(out, newDayResponse(entry))
+	}
+	return out
+}
+
+// symptomResponse is the transport DTO for a symptom type on the public
+// /api/v1/symptoms surface. It mirrors the `Symptom` schema in
+// docs/openapi.yaml (snake_case keys, nullable RFC3339 archived_at).
+type symptomResponse struct {
+	ID         uint       `json:"id"`
+	UserID     uint       `json:"user_id"`
+	Name       string     `json:"name"`
+	Icon       string     `json:"icon"`
+	Color      string     `json:"color"`
+	IsBuiltin  bool       `json:"is_builtin"`
+	ArchivedAt *time.Time `json:"archived_at"`
+}
+
+// newSymptomResponse maps a raw GORM symptom model onto its transport DTO.
+func newSymptomResponse(symptom models.SymptomType) symptomResponse {
+	return symptomResponse{
+		ID:         symptom.ID,
+		UserID:     symptom.UserID,
+		Name:       symptom.Name,
+		Icon:       symptom.Icon,
+		Color:      symptom.Color,
+		IsBuiltin:  symptom.IsBuiltin,
+		ArchivedAt: symptom.ArchivedAt,
+	}
+}
+
+// newSymptomResponses maps a slice of symptom models to their transport DTOs,
+// preserving order. A nil input yields an empty (non-nil) slice.
+func newSymptomResponses(symptoms []models.SymptomType) []symptomResponse {
+	out := make([]symptomResponse, 0, len(symptoms))
+	for _, symptom := range symptoms {
+		out = append(out, newSymptomResponse(symptom))
+	}
+	return out
+}

--- a/internal/api/day_response.go
+++ b/internal/api/day_response.go
@@ -10,8 +10,8 @@ import (
 // dayResponse is the transport DTO for a persisted day record on the public
 // /api/v1/days surface. It mirrors the `DailyLog` schema in docs/openapi.yaml
 // (snake_case keys, `date` as a calendar date-only string) so the wire format
-// conforms to the published contract. models.DailyLog stays transport-free per
-// AGENTS.md: serialization lives in the api layer, not on the model.
+// conforms to the published contract. models.DailyLog stays transport-free:
+// serialization lives in the api layer, not on the model.
 type dayResponse struct {
 	ID              uint      `json:"id"`
 	UserID          uint      `json:"user_id"`

--- a/internal/api/day_upsert_canonicalization_regression_test.go
+++ b/internal/api/day_upsert_canonicalization_regression_test.go
@@ -88,7 +88,10 @@ func TestUpsertDayCanonicalizesStoredDateToUTCMidnightForRequestTimezone(t *test
 				t.Fatalf("expected round-trip status 200, got %d", roundTripResponse.StatusCode)
 			}
 
-			var loaded models.DailyLog
+			// The /api/v1/days transport DTO emits `date` as a calendar
+			// date-only string (docs/openapi.yaml format: date), so decode
+			// into the response shape rather than models.DailyLog.
+			var loaded dayResponse
 			if err := json.NewDecoder(roundTripResponse.Body).Decode(&loaded); err != nil {
 				t.Fatalf("decode round-trip body: %v", err)
 			}
@@ -98,8 +101,8 @@ func TestUpsertDayCanonicalizesStoredDateToUTCMidnightForRequestTimezone(t *test
 			if loaded.Flow != models.FlowMedium {
 				t.Fatalf("expected flow %q, got %q", models.FlowMedium, loaded.Flow)
 			}
-			if loaded.Date.Format("2006-01-02") != postedDayRaw {
-				t.Fatalf("expected calendar day %s preserved through round-trip, got %s", postedDayRaw, loaded.Date.Format("2006-01-02"))
+			if loaded.Date != postedDayRaw {
+				t.Fatalf("expected calendar day %s preserved through round-trip, got %s", postedDayRaw, loaded.Date)
 			}
 		})
 	}

--- a/internal/api/days_read_request_timezone_regression_test.go
+++ b/internal/api/days_read_request_timezone_regression_test.go
@@ -42,7 +42,10 @@ func TestDayReadEndpointsUseRequestTimezoneForLocalCalendarDay(t *testing.T) {
 	listResponse := mustAppResponse(t, app, listRequest)
 	assertStatusCode(t, listResponse, http.StatusOK)
 
-	var listPayload []models.DailyLog
+	// The /api/v1/days transport DTO emits `date` as a calendar date-only
+	// string (docs/openapi.yaml format: date), so decode into the response
+	// shape rather than models.DailyLog (whose Date is RFC3339 time.Time).
+	var listPayload []dayResponse
 	if err := json.NewDecoder(listResponse.Body).Decode(&listPayload); err != nil {
 		t.Fatalf("decode day list payload: %v", err)
 	}
@@ -52,21 +55,27 @@ func TestDayReadEndpointsUseRequestTimezoneForLocalCalendarDay(t *testing.T) {
 	if listPayload[0].Notes != seed.Notes {
 		t.Fatalf("expected listed notes %q, got %q", seed.Notes, listPayload[0].Notes)
 	}
+	if listPayload[0].Date != localDayRaw {
+		t.Fatalf("expected listed date %q for request-local day, got %q", localDayRaw, listPayload[0].Date)
+	}
 
 	dayRequest := httptest.NewRequest(http.MethodGet, "/api/v1/days/"+localDayRaw, nil)
 	dayRequest.Header.Set("Accept", "application/json")
 	dayRequest.Header.Set("Cookie", cookieHeader)
 	dayRequest.Header.Set(timezoneHeaderName, timezoneName)
 
-	dayResponse := mustAppResponse(t, app, dayRequest)
-	assertStatusCode(t, dayResponse, http.StatusOK)
+	dayHTTPResponse := mustAppResponse(t, app, dayRequest)
+	assertStatusCode(t, dayHTTPResponse, http.StatusOK)
 
-	dayPayload := models.DailyLog{}
-	if err := json.NewDecoder(dayResponse.Body).Decode(&dayPayload); err != nil {
+	dayPayload := dayResponse{}
+	if err := json.NewDecoder(dayHTTPResponse.Body).Decode(&dayPayload); err != nil {
 		t.Fatalf("decode day payload: %v", err)
 	}
 	if dayPayload.Notes != seed.Notes {
 		t.Fatalf("expected fetched day notes %q, got %q", seed.Notes, dayPayload.Notes)
+	}
+	if dayPayload.Date != localDayRaw {
+		t.Fatalf("expected fetched date %q for request-local day, got %q", localDayRaw, dayPayload.Date)
 	}
 
 	existsRequest := httptest.NewRequest(http.MethodHead, "/api/v1/days/"+localDayRaw, nil)

--- a/internal/api/export_regressions_test.go
+++ b/internal/api/export_regressions_test.go
@@ -109,6 +109,8 @@ func TestExportCSVIncludesKnownAndOtherSymptoms(t *testing.T) {
 		SexActivity:     models.SexActivityUnprotected,
 		BBT:             36.70,
 		CervicalMucus:   models.CervicalMucusCreamy,
+		CycleStart:      true,
+		IsUncertain:     true,
 		CycleFactorKeys: []string{models.CycleFactorStress, models.CycleFactorSleepDisruption},
 		SymptomIDs:      []uint{symptoms[0].ID, symptoms[1].ID},
 		Notes:           "note",
@@ -151,6 +153,8 @@ func TestExportCSVIncludesKnownAndOtherSymptoms(t *testing.T) {
 		"Cramps":         "Yes",
 		"Other":          "Custom Symptom",
 		"Notes":          "note",
+		"Cycle start":    "Yes",
+		"Uncertain":      "Yes",
 	})
 }
 
@@ -202,6 +206,8 @@ func TestExportJSONNormalizesFlowAndMapsSymptoms(t *testing.T) {
 		SexActivity:     models.SexActivityProtected,
 		BBT:             36.55,
 		CervicalMucus:   models.CervicalMucusEggWhite,
+		CycleStart:      true,
+		IsUncertain:     true,
 		CycleFactorKeys: []string{models.CycleFactorStress, models.CycleFactorTravel},
 		SymptomIDs:      []uint{symptoms[0].ID, symptoms[1].ID},
 		Notes:           "json-note",
@@ -293,6 +299,12 @@ func assertExportJSONTrackingFields(t *testing.T, entry exportJSONEntry) {
 	}
 	if entry.Notes != "json-note" {
 		t.Fatalf("expected notes to be preserved, got %q", entry.Notes)
+	}
+	if !entry.CycleStart {
+		t.Fatalf("expected cycle_start=true in export json")
+	}
+	if !entry.IsUncertain {
+		t.Fatalf("expected is_uncertain=true in export json")
 	}
 }
 

--- a/internal/api/handlers_days_autofill_regressions_test.go
+++ b/internal/api/handlers_days_autofill_regressions_test.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -474,6 +475,34 @@ func TestDayAndSymptomJSONUseSnakeCaseWireKeys(t *testing.T) {
 	assertWireKeysAbsent(t, symptomKeys, "symptom", []string{
 		"UserID", "IsBuiltin", "ArchivedAt",
 	})
+
+	// Pin the symptom update JSON branch (PATCH content-negotiation) to the same
+	// snake_case DTO contract. A no-CSRF app is appropriate here: the test
+	// isolates content negotiation, while the valid-token CSRF update path is
+	// covered by the settings symptom HTMX regressions and the missing-token 403
+	// by state_mutation_csrf_missing_token_test.go (testing.md content-negotiation
+	// rule).
+	custom := models.SymptomType{
+		UserID:    user.ID,
+		Name:      "Wire custom symptom",
+		Icon:      "🌟",
+		Color:     "#AABBCC",
+		IsBuiltin: false,
+	}
+	if err := database.Create(&custom).Error; err != nil {
+		t.Fatalf("seed custom symptom: %v", err)
+	}
+	updatedKeys := patchSymptomJSON(t, app, authCookie, custom.ID, url.Values{
+		"name":  {"Wire custom renamed"},
+		"icon":  {"⭐"},
+		"color": {"#112233"},
+	})
+	assertWireKeysPresent(t, updatedKeys, "symptom-update", []string{
+		"id", "user_id", "name", "icon", "color", "is_builtin", "archived_at",
+	})
+	assertWireKeysAbsent(t, updatedKeys, "symptom-update", []string{
+		"UserID", "IsBuiltin", "ArchivedAt",
+	})
 }
 
 // decodeJSONObjectKeys issues an Accept: application/json GET and returns the
@@ -514,6 +543,27 @@ func decodeJSONArrayFirstObjectKeys(t *testing.T, app *fiber.App, authCookie, pa
 		t.Fatalf("GET %s: expected at least one element, got empty array", path)
 	}
 	return list[0]
+}
+
+// patchSymptomJSON updates a symptom via PATCH with Accept: application/json and
+// returns the response object's raw-message keys, so the update wire contract is
+// asserted the same way as the read endpoints.
+func patchSymptomJSON(t *testing.T, app *fiber.App, authCookie string, id uint, form url.Values) map[string]json.RawMessage {
+	t.Helper()
+	path := "/api/v1/symptoms/" + strconv.FormatUint(uint64(id), 10)
+	request := httptest.NewRequest(http.MethodPatch, path, strings.NewReader(form.Encode()))
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("Cookie", authCookie)
+	response := mustAppResponse(t, app, request)
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("PATCH %s: expected status 200, got %d", path, response.StatusCode)
+	}
+	var keys map[string]json.RawMessage
+	if err := json.NewDecoder(response.Body).Decode(&keys); err != nil {
+		t.Fatalf("decode %s object: %v", path, err)
+	}
+	return keys
 }
 
 func assertWireKeysPresent(t *testing.T, keys map[string]json.RawMessage, label string, expected []string) {

--- a/internal/api/handlers_days_autofill_regressions_test.go
+++ b/internal/api/handlers_days_autofill_regressions_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"regexp"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -410,4 +412,151 @@ func TestUpsertDayAutoFillPreservesManualNeighborsWhenAnchorToggledOff(t *testin
 	if !day13Entry.IsPeriod {
 		t.Fatalf("expected clearing to stop at the first manual day; day 13 should remain period")
 	}
+}
+
+var wireDateOnlyPattern = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}$`)
+
+// TestDayAndSymptomJSONUseSnakeCaseWireKeys is the public-contract lock for the
+// /api/v1/days and /api/v1/symptoms JSON surfaces. The handlers serialize
+// transport DTOs (api.dayResponse / api.symptomResponse), not the raw GORM
+// models, so the wire format must expose the snake_case keys documented in
+// docs/openapi.yaml (DailyLog / Symptom schemas) and must never leak the
+// PascalCase Go field names of models.DailyLog / models.SymptomType. `date`
+// must be a calendar date (format: date), not an RFC3339 timestamp.
+func TestDayAndSymptomJSONUseSnakeCaseWireKeys(t *testing.T) {
+	t.Parallel()
+
+	app, database := newOnboardingTestApp(t)
+	user := createOnboardingTestUser(t, database, "wire-keys-day-symptom@example.com", "StrongPass1", true)
+	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
+
+	// Seed a fully-populated day directly so every documented field is present
+	// on the wire regardless of owner hidden-field preferences.
+	day := time.Date(2026, time.May, 17, 0, 0, 0, 0, time.UTC)
+	seed := models.DailyLog{
+		UserID:          user.ID,
+		Date:            day,
+		IsPeriod:        true,
+		CycleStart:      true,
+		IsUncertain:     true,
+		Flow:            models.FlowMedium,
+		Mood:            3,
+		SexActivity:     models.SexActivityProtected,
+		BBT:             36.6,
+		CervicalMucus:   models.CervicalMucusCreamy,
+		PregnancyTest:   models.PregnancyTestNegative,
+		CycleFactorKeys: []string{"stress"},
+		SymptomIDs:      []uint{},
+		Notes:           "wire-key note",
+	}
+	if err := database.Create(&seed).Error; err != nil {
+		t.Fatalf("seed daily log: %v", err)
+	}
+
+	dayKeys := decodeJSONObjectKeys(t, app, authCookie, "/api/v1/days/2026-05-17")
+	assertWireKeysPresent(t, dayKeys, "day", []string{
+		"id", "user_id", "date", "is_period", "cycle_start", "is_uncertain",
+		"flow", "mood", "sex_activity", "bbt", "cervical_mucus", "pregnancy_test",
+		"cycle_factor_keys", "symptom_ids", "notes", "created_at", "updated_at",
+	})
+	assertWireKeysAbsent(t, dayKeys, "day", []string{
+		"IsPeriod", "CycleStart", "IsUncertain", "SexActivity", "CervicalMucus",
+		"PregnancyTest", "CycleFactorKeys", "SymptomIDs",
+	})
+	assertWireDateOnly(t, dayKeys, "day", "/api/v1/days/2026-05-17", "2026-05-17")
+
+	// FetchSymptoms backfills builtin symptoms, so the list is always non-empty
+	// and includes is_builtin=true rows whose archived_at is null.
+	symptomKeys := decodeJSONArrayFirstObjectKeys(t, app, authCookie, "/api/v1/symptoms")
+	assertWireKeysPresent(t, symptomKeys, "symptom", []string{
+		"id", "user_id", "name", "icon", "color", "is_builtin", "archived_at",
+	})
+	assertWireKeysAbsent(t, symptomKeys, "symptom", []string{
+		"UserID", "IsBuiltin", "ArchivedAt",
+	})
+}
+
+// decodeJSONObjectKeys issues an Accept: application/json GET and returns the
+// top-level object decoded as raw-message keys so tests can assert exact wire
+// key names without binding to a Go struct.
+func decodeJSONObjectKeys(t *testing.T, app *fiber.App, authCookie, path string) map[string]json.RawMessage {
+	t.Helper()
+	request := httptest.NewRequest(http.MethodGet, path, nil)
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("Cookie", authCookie)
+	response := mustAppResponse(t, app, request)
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("GET %s: expected status 200, got %d", path, response.StatusCode)
+	}
+	var keys map[string]json.RawMessage
+	if err := json.NewDecoder(response.Body).Decode(&keys); err != nil {
+		t.Fatalf("decode %s object: %v", path, err)
+	}
+	return keys
+}
+
+// decodeJSONArrayFirstObjectKeys issues an Accept: application/json GET against
+// a list endpoint and returns the first element's raw-message keys.
+func decodeJSONArrayFirstObjectKeys(t *testing.T, app *fiber.App, authCookie, path string) map[string]json.RawMessage {
+	t.Helper()
+	request := httptest.NewRequest(http.MethodGet, path, nil)
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("Cookie", authCookie)
+	response := mustAppResponse(t, app, request)
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("GET %s: expected status 200, got %d", path, response.StatusCode)
+	}
+	var list []map[string]json.RawMessage
+	if err := json.NewDecoder(response.Body).Decode(&list); err != nil {
+		t.Fatalf("decode %s array: %v", path, err)
+	}
+	if len(list) == 0 {
+		t.Fatalf("GET %s: expected at least one element, got empty array", path)
+	}
+	return list[0]
+}
+
+func assertWireKeysPresent(t *testing.T, keys map[string]json.RawMessage, label string, expected []string) {
+	t.Helper()
+	for _, key := range expected {
+		if _, ok := keys[key]; !ok {
+			t.Fatalf("%s JSON: expected snake_case key %q to be present, got keys %v", label, key, sortedKeys(keys))
+		}
+	}
+}
+
+func assertWireKeysAbsent(t *testing.T, keys map[string]json.RawMessage, label string, forbidden []string) {
+	t.Helper()
+	for _, key := range forbidden {
+		if _, ok := keys[key]; ok {
+			t.Fatalf("%s JSON: PascalCase Go field %q leaked onto the wire; serialize the DTO, not the model", label, key)
+		}
+	}
+}
+
+func assertWireDateOnly(t *testing.T, keys map[string]json.RawMessage, label, path, expected string) {
+	t.Helper()
+	raw, ok := keys["date"]
+	if !ok {
+		t.Fatalf("%s JSON %s: missing date key", label, path)
+	}
+	var dateValue string
+	if err := json.Unmarshal(raw, &dateValue); err != nil {
+		t.Fatalf("%s JSON %s: decode date value: %v", label, path, err)
+	}
+	if !wireDateOnlyPattern.MatchString(dateValue) {
+		t.Fatalf("%s JSON %s: expected date-only value matching YYYY-MM-DD, got %q (a timestamp would break openapi format: date)", label, path, dateValue)
+	}
+	if dateValue != expected {
+		t.Fatalf("%s JSON %s: expected date %q, got %q", label, path, expected, dateValue)
+	}
+}
+
+func sortedKeys(keys map[string]json.RawMessage) []string {
+	out := make([]string, 0, len(keys))
+	for key := range keys {
+		out = append(out, key)
+	}
+	sort.Strings(out)
+	return out
 }

--- a/internal/api/handlers_days_read.go
+++ b/internal/api/handlers_days_read.go
@@ -21,7 +21,7 @@ func (handler *Handler) GetDays(c *fiber.Ctx) error {
 		return handler.respondMappedError(c, dayLogsFetchErrorSpec())
 	}
 
-	return c.JSON(logs)
+	return c.JSON(newDayResponses(logs))
 }
 
 func (handler *Handler) GetDay(c *fiber.Ctx) error {
@@ -40,7 +40,7 @@ func (handler *Handler) GetDay(c *fiber.Ctx) error {
 		return handler.respondMappedError(c, dayFetchErrorSpec())
 	}
 
-	return c.JSON(logEntry)
+	return c.JSON(newDayResponse(logEntry))
 }
 
 func (handler *Handler) CheckDayExists(c *fiber.Ctx) error {

--- a/internal/api/handlers_days_symptoms.go
+++ b/internal/api/handlers_days_symptoms.go
@@ -15,7 +15,7 @@ func (handler *Handler) GetSymptoms(c *fiber.Ctx) error {
 	if err != nil {
 		return handler.respondMappedError(c, symptomsFetchErrorSpec())
 	}
-	return c.JSON(symptoms)
+	return c.JSON(newSymptomResponses(symptoms))
 }
 
 func (handler *Handler) CreateSymptom(c *fiber.Ctx) error {
@@ -47,7 +47,7 @@ func (handler *Handler) CreateSymptom(c *fiber.Ctx) error {
 	handler.logHealthDataMutation(c, "health.symptom_create", "success", "symptom")
 
 	if acceptsJSON(c) {
-		return c.Status(fiber.StatusCreated).JSON(symptom)
+		return c.Status(fiber.StatusCreated).JSON(newSymptomResponse(symptom))
 	}
 	return handler.respondSymptomMutationSuccess(c, user, fiber.StatusCreated, "symptom_created", settingsSymptomSectionState{})
 }
@@ -100,7 +100,7 @@ func (handler *Handler) UpdateSymptom(c *fiber.Ctx) error {
 	handler.logHealthDataMutation(c, "health.symptom_update", "success", "symptom")
 
 	if acceptsJSON(c) {
-		return c.JSON(symptom)
+		return c.JSON(newSymptomResponse(symptom))
 	}
 	return handler.respondSymptomMutationSuccess(c, user, fiber.StatusOK, "symptom_updated", settingsSymptomSectionState{
 		Row: settingsSymptomRowState{SymptomID: id},

--- a/internal/api/handlers_days_write.go
+++ b/internal/api/handlers_days_write.go
@@ -129,7 +129,7 @@ func (handler *Handler) respondUpsertDaySuccess(c *fiber.Ctx, entry models.Daily
 		}
 		return handler.sendDaySaveStatus(c, "")
 	}
-	return c.JSON(entry)
+	return c.JSON(newDayResponse(entry))
 }
 
 func (handler *Handler) MarkCycleStart(c *fiber.Ctx) error {

--- a/internal/services/export_service.go
+++ b/internal/services/export_service.go
@@ -39,6 +39,8 @@ var ExportCSVHeaders = []string{
 	"Other",
 	"Notes",
 	"Pregnancy test",
+	"Cycle start",
+	"Uncertain",
 }
 
 var exportSymptomColumnsByName = map[string]string{
@@ -149,6 +151,8 @@ type ExportSymptomFlags struct {
 type ExportJSONEntry struct {
 	Date          string             `json:"date"`
 	Period        bool               `json:"period"`
+	CycleStart    bool               `json:"cycle_start"`
+	IsUncertain   bool               `json:"is_uncertain"`
 	Flow          string             `json:"flow"`
 	MoodRating    int                `json:"mood_rating"`
 	SexActivity   string             `json:"sex_activity"`
@@ -164,6 +168,8 @@ type ExportJSONEntry struct {
 type ExportCSVRow struct {
 	Date          string
 	Period        bool
+	CycleStart    bool
+	IsUncertain   bool
 	Flow          string
 	MoodRating    int
 	SexActivity   string
@@ -247,6 +253,8 @@ func (service *ExportService) BuildJSONEntries(ctx context.Context, userID uint,
 		entries = append(entries, ExportJSONEntry{
 			Date:          CalendarDay(logEntry.Date, location).Format(exportDateLayout),
 			Period:        logEntry.IsPeriod,
+			CycleStart:    logEntry.CycleStart,
+			IsUncertain:   logEntry.IsUncertain,
 			Flow:          normalizeExportFlow(logEntry.Flow),
 			MoodRating:    normalizeExportMood(logEntry.Mood),
 			SexActivity:   normalizeExportSexActivity(logEntry.SexActivity),
@@ -274,6 +282,8 @@ func (service *ExportService) BuildCSVRows(ctx context.Context, userID uint, fro
 		rows = append(rows, ExportCSVRow{
 			Date:          CalendarDay(logEntry.Date, location).Format(exportDateLayout),
 			Period:        logEntry.IsPeriod,
+			CycleStart:    logEntry.CycleStart,
+			IsUncertain:   logEntry.IsUncertain,
 			Flow:          csvFlowLabel(logEntry.Flow),
 			MoodRating:    normalizeExportMood(logEntry.Mood),
 			SexActivity:   csvSexActivityLabel(logEntry.SexActivity),
@@ -321,6 +331,8 @@ func (row ExportCSVRow) Columns() []string {
 		otherSymptoms,
 		notes,
 		row.PregnancyTest,
+		csvYesNo(row.CycleStart),
+		csvYesNo(row.IsUncertain),
 	}
 }
 

--- a/internal/services/export_service_test.go
+++ b/internal/services/export_service_test.go
@@ -96,6 +96,8 @@ func TestExportBuildJSONEntriesNormalizesFlowAndMapsSymptoms(t *testing.T) {
 					BBT:             36.55,
 					CervicalMucus:   models.CervicalMucusEggWhite,
 					PregnancyTest:   models.PregnancyTestPositive,
+					CycleStart:      true,
+					IsUncertain:     true,
 					CycleFactorKeys: []string{models.CycleFactorStress, models.CycleFactorTravel},
 					SymptomIDs:      []uint{1, 2, 3, 3},
 					Notes:           "json-note",
@@ -138,6 +140,8 @@ func TestExportBuildCSVRowsBuildsExpectedColumns(t *testing.T) {
 					BBT:             36.7,
 					CervicalMucus:   models.CervicalMucusCreamy,
 					PregnancyTest:   models.PregnancyTestNegative,
+					CycleStart:      true,
+					IsUncertain:     true,
 					CycleFactorKeys: []string{models.CycleFactorStress, models.CycleFactorMedicationChange},
 					SymptomIDs:      []uint{1, 2},
 					Notes:           "note",
@@ -287,6 +291,12 @@ func assertExportJSONEntryTrackingFields(t *testing.T, entry ExportJSONEntry) {
 	if entry.PregnancyTest != models.PregnancyTestPositive {
 		t.Fatalf("expected positive pregnancy test, got %q", entry.PregnancyTest)
 	}
+	if !entry.CycleStart {
+		t.Fatalf("expected cycle_start=true")
+	}
+	if !entry.IsUncertain {
+		t.Fatalf("expected is_uncertain=true")
+	}
 	if len(entry.CycleFactors) != 2 || entry.CycleFactors[0] != models.CycleFactorStress || entry.CycleFactors[1] != models.CycleFactorTravel {
 		t.Fatalf("expected normalized cycle factors, got %#v", entry.CycleFactors)
 	}
@@ -331,6 +341,20 @@ func assertExportCSVTrackingColumns(t *testing.T, columns []string, indexByHeade
 	}
 	if columns[indexByHeader["Cycle factors"]] != "Stress; Medication change" {
 		t.Fatalf("expected cycle factors column, got %q", columns[indexByHeader["Cycle factors"]])
+	}
+	if columns[indexByHeader["Cycle start"]] != "Yes" {
+		t.Fatalf("expected cycle start column Yes, got %q", columns[indexByHeader["Cycle start"]])
+	}
+	if columns[indexByHeader["Uncertain"]] != "Yes" {
+		t.Fatalf("expected uncertain column Yes, got %q", columns[indexByHeader["Uncertain"]])
+	}
+	// Append-only stability contract: the two new tracking columns must remain the
+	// final two headers, after Pregnancy test (docs/export.md "Stability").
+	if got := ExportCSVHeaders[len(ExportCSVHeaders)-2]; got != "Cycle start" {
+		t.Fatalf("expected second-to-last header to be Cycle start, got %q", got)
+	}
+	if got := ExportCSVHeaders[len(ExportCSVHeaders)-1]; got != "Uncertain" {
+		t.Fatalf("expected last header to be Uncertain, got %q", got)
 	}
 }
 

--- a/internal/services/viewer_policy.go
+++ b/internal/services/viewer_policy.go
@@ -11,6 +11,8 @@ func SanitizeRestrictedViewerLog(entry models.DailyLog) models.DailyLog {
 	entry.CycleFactorKeys = []string{}
 	entry.Notes = ""
 	entry.SymptomIDs = []uint{}
+	entry.CycleStart = false
+	entry.IsUncertain = false
 	return entry
 }
 

--- a/internal/services/viewer_policy_test.go
+++ b/internal/services/viewer_policy_test.go
@@ -17,6 +17,8 @@ func TestSanitizeLogForViewerUnsupportedRoleHidesPrivateFields(t *testing.T) {
 		CycleFactorKeys: []string{models.CycleFactorStress},
 		Notes:           "private",
 		SymptomIDs:      []uint{1, 2},
+		CycleStart:      true,
+		IsUncertain:     true,
 	}
 
 	sanitized := SanitizeLogForViewer(unsupported, entry)
@@ -43,6 +45,12 @@ func TestSanitizeLogForViewerUnsupportedRoleHidesPrivateFields(t *testing.T) {
 	}
 	if len(sanitized.SymptomIDs) != 0 {
 		t.Fatalf("expected symptom IDs to be hidden, got %#v", sanitized.SymptomIDs)
+	}
+	if sanitized.CycleStart {
+		t.Fatalf("expected cycle start to be hidden, got true")
+	}
+	if sanitized.IsUncertain {
+		t.Fatalf("expected uncertain flag to be hidden, got true")
 	}
 }
 


### PR DESCRIPTION
Second phase of the audit-fix series. **Commit-per-fix** (please **merge, don't squash**, to keep revert/bisect granularity).

### Commits
1. **docs(security)** — `ovumcy_auth` remember-me cookie TTL corrected 7d → **30d** (the doc contradicted both the code, `rememberAuthTokenTTL`, and its own enforcing test). [#L17]
2. **docs(openapi)** — CSRF: removed the false "register/login/forgot-password are exempt" claim and the `security: []` on those four pre-auth ops; they now declare `csrfToken: []` (the server enforces CSRF on every unsafe method except `POST /auth/oidc/callback`). A spec-conformant client following the old doc got 403. [#L1]
3. **fix(export)** — thread `cycle_start` + `is_uncertain` through every SECURITY.md:36 surface: export (JSON + appended CSV columns), openapi `ExportJSONEntry` (also adds the previously-missing `pregnancy_test`), and — the privacy gap — `SanitizeRestrictedViewerLog` now zeros both (default-deny for non-owners). [#L3]
4. **fix(api)** — `/api/v1/days` and `/api/v1/symptoms` now serve documented **snake_case** DTOs with a date-only `date`, instead of the raw GORM models' PascalCase + RFC3339. Models stay transport-free. [#M1]

### Behaviour change (commit 4)
Live `/api/v1/days`/`/api/v1/symptoms` JSON changes from undocumented **PascalCase** to the **snake_case** the spec already publishes, and `date` from `2026-05-17T00:00:00Z` to `2026-05-17`. This is **conformance** — the openapi contract is unchanged, so no `/api/v2` is required; a client that reverse-engineered the old PascalCase would need to follow the spec. The **frontend is unaffected** (HTMX day flows use HTML partials, not `Accept: application/json`).

### Deferred
- **M2** (stale committed-bundle CI guard) — deferred to a Linux/CI context: committing regenerated bundles from a Windows dev box risks CRLF/tailwind-version byte drift that would make the `git diff --exit-code` guard flaky. Implementation notes are in the task.

### Tests
Full `go test ./...` green; `gofmt`/`go vet` clean. New regressions: snake_case wire-key contract (PascalCase-absent + date-format), viewer-sanitizer hides the two new fields, export contains them. staticcheck is CI-gated (local toolchain skew).