### PR TITLE
Coverage quality pass: dead symbols, vacuous 2FA tests, meaningful gaps, browser a11y

### DIFF
--- a/e2e/visual-a11y.spec.ts
+++ b/e2e/visual-a11y.spec.ts
@@ -125,6 +125,64 @@ test.describe('Visual and accessibility regressions', () => {
     await expectVisibleFocusIndicator(logoutButton);
   });
 
+  test('skip-to-content link appears on focus and moves focus into main content', async ({
+    page,
+  }) => {
+    await registerOwnerAndReachDashboard(page, 'visual-skip-link');
+    await page.setViewportSize({ width: 1280, height: 900 });
+
+    await page.goto('/dashboard');
+    await expect(page).toHaveURL(/\/dashboard$/);
+
+    const skipLink = page.locator('a.skip-link');
+    // Visually parked off-screen until focused — this is CSS behavior only a
+    // real browser can verify (the jsdom unit suite cannot see it).
+    await expect(skipLink).toHaveCSS('position', 'absolute');
+    const hiddenBox = await skipLink.boundingBox();
+    expect(hiddenBox === null || hiddenBox.y < 0).toBeTruthy();
+
+    // First Tab from a fresh page lands on the skip link and reveals it.
+    await page.keyboard.press('Tab');
+    await expect(skipLink).toBeFocused();
+    const visibleBox = await skipLink.boundingBox();
+    expect(visibleBox).not.toBeNull();
+    expect(visibleBox!.y).toBeGreaterThanOrEqual(0);
+
+    // Activating it moves focus into the main landmark, past the header.
+    await page.keyboard.press('Enter');
+    await expect(page.locator('#main-content')).toBeFocused();
+  });
+
+  test('logout confirm dialog traps Tab and restores focus on dismiss', async ({
+    page,
+  }) => {
+    await registerOwnerAndReachDashboard(page, 'visual-focus-trap');
+    await page.setViewportSize({ width: 1280, height: 900 });
+
+    await page.goto('/dashboard');
+    const logoutButton = page.locator('.nav-logout-form button[type="submit"]').first();
+    await logoutButton.click();
+
+    const modal = page.locator('#confirm-modal');
+    await expect(modal).toBeVisible();
+    await expect(page.locator('#confirm-modal-cancel')).toBeFocused();
+
+    // Native Tab order must cycle inside the dialog: cancel -> accept ->
+    // back to cancel, never into the page behind the backdrop.
+    await page.keyboard.press('Tab');
+    await expect(page.locator('#confirm-modal-accept')).toBeFocused();
+    await page.keyboard.press('Tab');
+    await expect(page.locator('#confirm-modal-cancel')).toBeFocused();
+    await page.keyboard.press('Shift+Tab');
+    await expect(page.locator('#confirm-modal-accept')).toBeFocused();
+
+    // Escape closes the dialog and returns focus to the invoking button.
+    await page.keyboard.press('Escape');
+    await expect(modal).toBeHidden();
+    await expect(logoutButton).toBeFocused();
+    await expect(page).toHaveURL(/\/dashboard$/);
+  });
+
   test('stats insight state stays readable on mobile and exposes accessible summaries', async ({
     page,
   }) => {

--- a/internal/api/handlers_settings_2fa_test.go
+++ b/internal/api/handlers_settings_2fa_test.go
@@ -280,10 +280,18 @@ func TestDisableTOTP2FA_WrongPassword_ReturnsError(t *testing.T) {
 	if err := svc.EnableTOTP(context.Background(), ctx.user.ID, "JBSWY3DPEHPK3PXP"); err != nil {
 		t.Fatalf("EnableTOTP: %v", err)
 	}
+	// EnableTOTP bumped auth_session_version; without a refreshed cookie the
+	// request dies at AuthRequired and the test goes green without ever
+	// exercising the handler (the bug this fix removes).
+	ctx.refreshAuthCookie(t)
 
 	form := url.Values{"password": {"WrongPassword1"}}
-	resp := settingsFormRequestWithCSRF(t, ctx, http.MethodDelete, "/api/v1/users/current/2fa", form, map[string]string{"Accept-Language": "en"})
+	resp := settingsFormRequestWithCSRF(t, ctx, http.MethodDelete, "/api/v1/users/current/2fa", form, map[string]string{"Accept-Language": "en", "Accept": "application/json"})
 	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("wrong password: status = %d, want 401", resp.StatusCode)
+	}
 
 	var reloaded models.User
 	if err := ctx.database.First(&reloaded, ctx.user.ID).Error; err != nil {
@@ -305,16 +313,28 @@ func TestDisableTOTP2FA_RateLimited_AfterRepeatedWrongPassword(t *testing.T) {
 		t.Fatalf("EnableTOTP: %v", err)
 	}
 
+	// EnableTOTP bumped auth_session_version; refresh so the requests reach
+	// the handler instead of dying at AuthRequired (which previously made
+	// this test pass without the limiter ever firing).
+	ctx.refreshAuthCookie(t)
+
 	wrongForm := url.Values{"password": {"WrongPassword1"}}
 	for attempt := 0; attempt < services.DefaultTOTPDisableAttemptsLimit; attempt++ {
-		resp := settingsFormRequestWithCSRF(t, ctx, http.MethodDelete, "/api/v1/users/current/2fa", wrongForm, map[string]string{"Accept-Language": "en"})
+		resp := settingsFormRequestWithCSRF(t, ctx, http.MethodDelete, "/api/v1/users/current/2fa", wrongForm, map[string]string{"Accept-Language": "en", "Accept": "application/json"})
+		if resp.StatusCode != http.StatusUnauthorized && resp.StatusCode != http.StatusTooManyRequests {
+			t.Fatalf("attempt %d: status = %d, want 401 or 429", attempt, resp.StatusCode)
+		}
 		resp.Body.Close()
 	}
 
 	// Even the correct password must be rejected once the limiter has tripped.
 	correctForm := url.Values{"password": {"StrongPass1"}}
-	resp := settingsFormRequestWithCSRF(t, ctx, http.MethodDelete, "/api/v1/users/current/2fa", correctForm, map[string]string{"Accept-Language": "en"})
+	resp := settingsFormRequestWithCSRF(t, ctx, http.MethodDelete, "/api/v1/users/current/2fa", correctForm, map[string]string{"Accept-Language": "en", "Accept": "application/json"})
 	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Errorf("rate-limited disable: status = %d, want 429", resp.StatusCode)
+	}
 
 	var reloaded models.User
 	if err := ctx.database.First(&reloaded, ctx.user.ID).Error; err != nil {

--- a/internal/api/handlers_template_format_helpers.go
+++ b/internal/api/handlers_template_format_helpers.go
@@ -10,13 +10,6 @@ import (
 	"github.com/ovumcy/ovumcy-web/internal/services"
 )
 
-func formatTemplateDate(value time.Time, layout string) string {
-	if value.IsZero() {
-		return ""
-	}
-	return value.Format(layout)
-}
-
 func formatTemplateLocalizedDate(language string, value time.Time, style string) string {
 	switch style {
 	case "short":

--- a/internal/api/handlers_template_helpers.go
+++ b/internal/api/handlers_template_helpers.go
@@ -10,7 +10,6 @@ import (
 
 func newTemplateFuncMap() template.FuncMap {
 	return template.FuncMap{
-		"formatDate":          formatTemplateDate,
 		"formatLocalizedDate": formatTemplateLocalizedDate,
 		"formatFloat":         formatTemplateFloat,
 		"t": func(messages map[string]string, key string) string {

--- a/internal/api/mutation_error_branch_coverage_test.go
+++ b/internal/api/mutation_error_branch_coverage_test.go
@@ -32,6 +32,11 @@ func newMutationBranchTestApp(t *testing.T, injectUser bool) (*fiber.App, *gorm.
 		})
 	}
 
+	app.Get("/api/days", handler.GetDays)
+	app.Get("/api/days/:date", handler.GetDay)
+	app.Get("/api/v1/symptoms", handler.GetSymptoms)
+	app.Get("/api/v1/exports/csv", handler.ExportCSV)
+	app.Get("/api/v1/exports/json", handler.ExportJSON)
 	app.Delete("/api/days", handler.DeleteDailyLog)
 	app.Put("/api/days/:date", handler.UpsertDay)
 	app.Delete("/api/days/:date", handler.DeleteDay)
@@ -153,6 +158,11 @@ func TestMutationHandlersMapServiceFailuresThroughFailMutation(t *testing.T) {
 		{"cycle start mark", http.MethodPost, "/api/days/2026-02-17/cycle-start", "", ""},
 		{"cycle settings save", http.MethodPatch, "/api/v1/users/current/cycle", url.Values{"cycle_length": {"28"}, "period_length": {"5"}}.Encode(), form},
 		{"tracking settings save", http.MethodPatch, "/api/v1/users/current/tracking", url.Values{"track_bbt": {"true"}}.Encode(), form},
+		{"day list fetch", http.MethodGet, "/api/days?from=2026-01-01&to=2026-02-01", "", ""},
+		{"day fetch", http.MethodGet, "/api/days/2026-02-17", "", ""},
+		{"symptom list fetch", http.MethodGet, "/api/v1/symptoms", "", ""},
+		{"export csv fetch", http.MethodGet, "/api/v1/exports/csv", "", ""},
+		{"export json fetch", http.MethodGet, "/api/v1/exports/json", "", ""},
 	}
 	for _, testCase := range cases {
 		t.Run(testCase.name, func(t *testing.T) {

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -124,18 +124,6 @@ func (manager *Manager) Messages(language string) map[string]string {
 	return result
 }
 
-func (manager *Manager) Translate(language string, key string) string {
-	messages := manager.Messages(language)
-	if value, ok := messages[key]; ok && strings.TrimSpace(value) != "" {
-		return value
-	}
-	return key
-}
-
-func (manager *Manager) Translatef(language string, key string, args ...any) string {
-	return fmt.Sprintf(manager.Translate(language, key), args...)
-}
-
 func (manager *Manager) isSupported(language string) bool {
 	if language == "" {
 		return false

--- a/internal/services/auth_service.go
+++ b/internal/services/auth_service.go
@@ -350,10 +350,6 @@ func (service *AuthService) ResolveUserByResetToken(ctx context.Context, secretK
 	return &user, nil
 }
 
-func (service *AuthService) GenerateRecoveryCodeHash() (string, string, error) {
-	return GenerateRecoveryCodeHash()
-}
-
 func (service *AuthService) RegenerateRecoveryCode(ctx context.Context, userID uint) (string, error) {
 	recoveryCode, recoveryHash, err := GenerateRecoveryCodeHash()
 	if err != nil {

--- a/internal/services/day_service_workflow_test.go
+++ b/internal/services/day_service_workflow_test.go
@@ -17,15 +17,22 @@ type dayLogRepositoryStub struct {
 	findErrByDay   map[string]error
 	createErrByDay map[string]error
 	saveErrByDay   map[string]error
+	// saveErrFromCall makes saveErrByDay fire only from the N-th Save call
+	// for that day (1-based), so a test can pass an earlier upsert and fail
+	// a later flag write on the same calendar day.
+	saveErrFromCall map[string]int
+	saveCalls       map[string]int
 }
 
 func newDayLogRepositoryStub() *dayLogRepositoryStub {
 	return &dayLogRepositoryStub{
-		entries:        make(map[string]models.DailyLog),
-		nextID:         1,
-		findErrByDay:   make(map[string]error),
-		createErrByDay: make(map[string]error),
-		saveErrByDay:   make(map[string]error),
+		entries:         make(map[string]models.DailyLog),
+		nextID:          1,
+		findErrByDay:    make(map[string]error),
+		createErrByDay:  make(map[string]error),
+		saveErrByDay:    make(map[string]error),
+		saveErrFromCall: make(map[string]int),
+		saveCalls:       make(map[string]int),
 	}
 }
 
@@ -120,8 +127,11 @@ func (stub *dayLogRepositoryStub) Create(ctx context.Context, entry *models.Dail
 
 func (stub *dayLogRepositoryStub) Save(ctx context.Context, entry *models.DailyLog) error {
 	key := stub.dayKey(entry.Date)
+	stub.saveCalls[key]++
 	if err, ok := stub.saveErrByDay[key]; ok {
-		return err
+		if from, gated := stub.saveErrFromCall[key]; !gated || stub.saveCalls[key] >= from {
+			return err
+		}
 	}
 	stub.entries[key] = *entry
 	return nil
@@ -500,5 +510,36 @@ func TestMarkCycleStartManuallyAllowsFutureDateWithinTwoDays(t *testing.T) {
 	}
 	if !entry.IsPeriod || !entry.CycleStart {
 		t.Fatalf("expected tomorrow entry to be period+cycle_start, got %#v", entry)
+	}
+}
+
+// TestMarkCycleStartManuallyWrapsPersistenceFailure pins the typed-error
+// contract for the manual cycle-start write path: repository failures while
+// persisting the cycle-start flags surface as ErrManualCycleStartFailed
+// (errors.Is-matchable for the API error mapping), not as a raw repo error.
+func TestMarkCycleStartManuallyWrapsPersistenceFailure(t *testing.T) {
+	logs := newDayLogRepositoryStub()
+	users := &dayUserRepositoryStub{}
+	service := NewDayService(logs, users)
+
+	targetDay := time.Date(2026, time.February, 8, 0, 0, 0, 0, time.UTC)
+	logs.entries["2026-02-08"] = models.DailyLog{
+		ID:       2,
+		UserID:   10,
+		Date:     targetDay,
+		IsPeriod: true,
+		Flow:     models.FlowLight,
+	}
+	logs.saveErrByDay["2026-02-08"] = errors.New("disk full")
+	// Let the day upsert (first Save) succeed and fail the cycle-start flag
+	// write (second Save), so the error surfaces from the persist stage.
+	logs.saveErrFromCall["2026-02-08"] = 2
+
+	err := service.MarkCycleStartManually(context.Background(), 10, targetDay, targetDay, time.UTC, ManualCycleStartOptions{})
+	if !errors.Is(err, ErrManualCycleStartFailed) {
+		t.Fatalf("expected ErrManualCycleStartFailed wrap, got %v", err)
+	}
+	if logs.entries["2026-02-08"].CycleStart {
+		t.Fatalf("failed persistence must not leave the cycle-start flag set in the read model")
 	}
 }

--- a/internal/services/oidc_login_service.go
+++ b/internal/services/oidc_login_service.go
@@ -113,10 +113,6 @@ func (service *OIDCLoginService) LocalPublicAuthEnabled() bool {
 	return service.config.LocalPublicAuthEnabled()
 }
 
-func (service *OIDCLoginService) OIDCOnly() bool {
-	return service.Enabled() && !service.LocalPublicAuthEnabled()
-}
-
 func (service *OIDCLoginService) StartAuth(ctx context.Context, state string, nonce string, codeVerifier string) (string, error) {
 	return service.startAuthWithExtra(ctx, state, nonce, codeVerifier, nil)
 }

--- a/internal/services/password_reset_service.go
+++ b/internal/services/password_reset_service.go
@@ -45,10 +45,6 @@ func (service *PasswordResetService) IssueResetTokenForUser(secretKey []byte, us
 	return service.auth.BuildPasswordResetToken(secretKey, user.ID, user.PasswordHash, ttl, now)
 }
 
-func (service *PasswordResetService) ParseResetToken(secretKey []byte, rawToken string, now time.Time) (*PasswordResetClaims, error) {
-	return ParsePasswordResetToken(secretKey, rawToken, now)
-}
-
 func (service *PasswordResetService) StartRecovery(ctx context.Context, secretKey []byte, limiterKey string, email string, rawRecoveryCode string, now time.Time, tokenTTL time.Duration) (string, error) {
 	if service.auth == nil {
 		return "", errors.New("auth service is required")

--- a/internal/services/registration_service_test.go
+++ b/internal/services/registration_service_test.go
@@ -211,3 +211,73 @@ func newRegistrationServiceForTest(fixture stubRegistrationFixture) (*Registrati
 	store := &stubRegistrationStore{err: fixture.storeErr}
 	return NewRegistrationService(auth, store, RegistrationModeOpen), store
 }
+
+func TestRegistrationServiceAutoProvisionOwnerAccountErrorBranches(t *testing.T) {
+	cases := []struct {
+		name     string
+		mode     RegistrationMode
+		authErr  error
+		storeErr error
+		want     error
+	}{
+		{name: "closed registration refuses provisioning", mode: RegistrationModeClosed, want: ErrAuthRegistrationDisabled},
+		{name: "owner build failure maps to register failed", mode: RegistrationModeOpen, authErr: errors.New("build broke"), want: ErrAuthRegisterFailed},
+		{name: "duplicate email maps to email exists", mode: RegistrationModeOpen, storeErr: stubRegistrationUniqueConstraintError{}, want: ErrAuthEmailExists},
+		{name: "symptom seed failure maps to seed error", mode: RegistrationModeOpen, storeErr: stubRegistrationSeedWriteError{}, want: ErrRegistrationSeedSymptoms},
+		{name: "generic persistence failure maps to register failed", mode: RegistrationModeOpen, storeErr: errors.New("db down"), want: ErrAuthRegisterFailed},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			auth := &stubRegistrationAuthService{
+				user: models.User{ID: 7, Email: "owner@example.com"},
+				err:  testCase.authErr,
+			}
+			store := &stubRegistrationStore{err: testCase.storeErr}
+			service := NewRegistrationService(auth, store, testCase.mode)
+
+			_, err := service.AutoProvisionOwnerAccount(context.Background(), "owner@example.com", registrationServiceTestNow)
+			if !errors.Is(err, testCase.want) {
+				t.Fatalf("expected %v, got %v", testCase.want, err)
+			}
+			if testCase.mode == RegistrationModeClosed && (auth.oidcCalled || store.called) {
+				t.Fatalf("closed mode must refuse before building or persisting anything")
+			}
+		})
+	}
+}
+
+// TestBuildOIDCOwnerUserShape pins the security-relevant shape of an
+// auto-provisioned OIDC owner: no local password hash, local auth disabled,
+// no recovery hash, owner role with cycle defaults, and session version 1.
+func TestBuildOIDCOwnerUserShape(t *testing.T) {
+	auth := NewAuthService(nil)
+
+	user, err := auth.BuildOIDCOwnerUser("owner@example.com", registrationServiceTestNow)
+	if err != nil {
+		t.Fatalf("BuildOIDCOwnerUser() unexpected error: %v", err)
+	}
+	if user.PasswordHash != "" || user.RecoveryCodeHash != "" {
+		t.Fatalf("OIDC-provisioned owner must carry no local secrets, got hash=%q recovery=%q", user.PasswordHash, user.RecoveryCodeHash)
+	}
+	if user.LocalAuthEnabled {
+		t.Fatalf("OIDC-provisioned owner must have local auth disabled")
+	}
+	if user.Role != models.RoleOwner || user.AuthSessionVersion != 1 {
+		t.Fatalf("expected owner role with session version 1, got role=%q sv=%d", user.Role, user.AuthSessionVersion)
+	}
+	if user.CycleLength != models.DefaultCycleLength || user.PeriodLength != models.DefaultPeriodLength || !user.AutoPeriodFill {
+		t.Fatalf("expected default cycle settings on provisioning")
+	}
+	if !user.CreatedAt.Equal(registrationServiceTestNow) {
+		t.Fatalf("expected explicit createdAt to be preserved, got %s", user.CreatedAt)
+	}
+
+	zeroTime, err := auth.BuildOIDCOwnerUser("owner@example.com", time.Time{})
+	if err != nil {
+		t.Fatalf("BuildOIDCOwnerUser(zero) unexpected error: %v", err)
+	}
+	if zeroTime.CreatedAt.IsZero() {
+		t.Fatalf("zero createdAt must default to a real timestamp")
+	}
+}


### PR DESCRIPTION
Test-suite audit pass driven by a fresh function-level coverage profile (83.3% total) — explicitly gap-driven, not line-chasing. Five commits.

## The headline finding: two 2FA tests were green vacuously

`TestDisableTOTP2FA_WrongPassword_ReturnsError` and
`TestDisableTOTP2FA_RateLimited_AfterRepeatedWrongPassword` never reached the handler: `EnableTOTP` bumps `auth_session_version`, and unlike their correct-password sibling they never refreshed the auth cookie — every DELETE died with 401 at `AuthRequired`. The rate-limit regression therefore did **not** enforce the SECURITY.md brute-force claim it exists for (the `totpDisableRateLimitedErrorSpec` branch sat at 0%). Fixed: cookies refreshed, transport contract pinned (401 wrong password, 429 once the limiter trips even with the correct password); the spec branch now verifiably executes (100% in an isolated coverage run).

## Dead symbols (verified zero callers, deleted)

`AuthService.GenerateRecoveryCodeHash` (method wrapper), `PasswordResetService.ParseResetToken`, `OIDCLoginService.OIDCOnly`, `formatTemplateDate` + its `formatDate` funcMap entry, `i18n Manager.Translate/Translatef`.

## Meaningful gaps covered

- **OIDC auto-provision** error branches (closed mode refuses before building/persisting; duplicate-email/seed/generic failures map to typed errors) + the security-relevant shape of `BuildOIDCOwnerUser` (no local secrets, local auth disabled, owner role, session version 1).
- **Manual cycle-start failure wrap**: repo failure during the flag write surfaces as `errors.Is`-matchable `ErrManualCycleStartFailed` and doesn't leave the flag set (day-log stub gains an additive fail-from-Nth-Save gate).
- **Read-path 500 contracts**: the closed-DB table now covers day list/single-day/symptom-list/export fetches. `exportBuildErrorSpec` left uncovered deliberately (writer-failure-only — forcing it would be test theater).
- **Browser-only a11y**: skip-link CSS reveal-on-focus + Enter→`#main-content`, and native Tab cycling inside the logout confirm dialog with Escape restoring focus (jsdom can't verify either).

## Deliberately NOT covered

cli prompt I/O (terminal interaction), `security.AuthCodeURL/ExchangeCode` (thin oauth2 wrappers exercised by the CI OIDC e2e lane), `setEncodedResponseNotice` warning transport (covered by Playwright dashboard-warnings/fertility specs — go-cover can't see e2e), low-value branch slivers (`privacyBackLabelKeyForPath` etc.).

## Validation

`go test ./...` all packages, `go vet`, `gofmt`, unit JS 34/34, visual-a11y e2e 5/5 in real Chromium.

## Follow-up after merge

`scripts/mutation.sh baseline` to refresh `.mutation/*.md` + TESTING.md figures (stale since the dead-code removals; survivors list itself unaffected).