### PR TITLE
fix(security): keep the CSRF token out of GET request URLs

### DIFF
--- a/internal/templates/base.html
+++ b/internal/templates/base.html
@@ -20,7 +20,7 @@
   <link rel="stylesheet" href="/static/css/tailwind.css?v=20260612-2">
   <script defer src="/static/js/htmx.min.js?v=20260221-2"></script>
   <script defer src="/static/js/chart-lite.js?v=20260404-1"></script>
-  <script defer src="/static/js/app.js?v=20260612-1"></script>
+  <script defer src="/static/js/app.js?v=20260612-2"></script>
 </head>
 <body
   data-confirm-cancel="{{t .Messages "confirm.no"}}"

--- a/web/src/js/__tests__/csrf-injection.test.mjs
+++ b/web/src/js/__tests__/csrf-injection.test.mjs
@@ -16,8 +16,8 @@ const PAGE_WITH_CSRF_META = `<!doctype html><html><head>
 
 const PAGE_WITHOUT_CSRF_META = `<!doctype html><html><head></head><body></body></html>`;
 
-function dispatchConfigRequest(window) {
-  const detail = { parameters: {}, headers: {} };
+function dispatchConfigRequest(window, verb = "post") {
+  const detail = { verb, parameters: {}, headers: {} };
   const event = new window.CustomEvent("htmx:configRequest", { detail });
   window.document.body.dispatchEvent(event);
   return detail;
@@ -29,6 +29,21 @@ test("htmx:configRequest copies the csrf-token meta into parameters and headers"
     const detail = dispatchConfigRequest(dom.window);
     assert.equal(detail.parameters.csrf_token, "csrf-token-abc-123", "csrf_token form parameter is required for the server's form-field CSRF check");
     assert.equal(detail.headers["X-CSRF-Token"], "csrf-token-abc-123", "X-CSRF-Token header mirrors the parameter so handlers that prefer the header also see the token");
+  } finally {
+    dom.window.close();
+  }
+});
+
+test("htmx:configRequest keeps the csrf token OUT of GET parameters", async () => {
+  // htmx serializes parameters into the URL query string for GET
+  // (methodsThatUseUrlParams), and the token must never appear in URLs:
+  // browser history and reverse-proxy access logs retain them. GETs are
+  // not CSRF-checked server-side, so the header alone is correct there.
+  const dom = await loadDOMWithScript(APP_BUNDLE, { html: PAGE_WITH_CSRF_META });
+  try {
+    const detail = dispatchConfigRequest(dom.window, "get");
+    assert.equal(detail.parameters.csrf_token, undefined, "GET requests must not carry the token as a parameter (it would land in the URL)");
+    assert.equal(detail.headers["X-CSRF-Token"], "csrf-token-abc-123", "the header still rides along on GET requests");
   } finally {
     dom.window.close();
   }

--- a/web/src/js/app.js
+++ b/web/src/js/app.js
@@ -1724,8 +1724,16 @@
         return;
       }
 
-      event.detail.parameters = event.detail.parameters || {};
-      event.detail.parameters.csrf_token = token;
+      // The form parameter is only attached to non-GET requests: htmx puts
+      // parameters into the URL query for GET (methodsThatUseUrlParams), and
+      // the token must never appear in URLs — browser history and reverse-
+      // proxy access logs keep them. GETs are not CSRF-checked; the header
+      // still rides along on every request.
+      var verb = String(event.detail.verb || "").toLowerCase();
+      if (verb !== "get") {
+        event.detail.parameters = event.detail.parameters || {};
+        event.detail.parameters.csrf_token = token;
+      }
       event.detail.headers = event.detail.headers || {};
       event.detail.headers["X-CSRF-Token"] = token;
 

--- a/web/src/js/app/30-feedback-htmx.js
+++ b/web/src/js/app/30-feedback-htmx.js
@@ -262,8 +262,16 @@
         return;
       }
 
-      event.detail.parameters = event.detail.parameters || {};
-      event.detail.parameters.csrf_token = token;
+      // The form parameter is only attached to non-GET requests: htmx puts
+      // parameters into the URL query for GET (methodsThatUseUrlParams), and
+      // the token must never appear in URLs — browser history and reverse-
+      // proxy access logs keep them. GETs are not CSRF-checked; the header
+      // still rides along on every request.
+      var verb = String(event.detail.verb || "").toLowerCase();
+      if (verb !== "get") {
+        event.detail.parameters = event.detail.parameters || {};
+        event.detail.parameters.csrf_token = token;
+      }
       event.detail.headers = event.detail.headers || {};
       event.detail.headers["X-CSRF-Token"] = token;
 

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -1724,8 +1724,16 @@
         return;
       }
 
-      event.detail.parameters = event.detail.parameters || {};
-      event.detail.parameters.csrf_token = token;
+      // The form parameter is only attached to non-GET requests: htmx puts
+      // parameters into the URL query for GET (methodsThatUseUrlParams), and
+      // the token must never appear in URLs — browser history and reverse-
+      // proxy access logs keep them. GETs are not CSRF-checked; the header
+      // still rides along on every request.
+      var verb = String(event.detail.verb || "").toLowerCase();
+      if (verb !== "get") {
+        event.detail.parameters = event.detail.parameters || {};
+        event.detail.parameters.csrf_token = token;
+      }
       event.detail.headers = event.detail.headers || {};
       event.detail.headers["X-CSRF-Token"] = token;
 


### PR DESCRIPTION
Found during the live Chrome walkthrough by inspecting real network traffic: the `htmx:configRequest` hook attaches `csrf_token` as a form parameter to **every** request, and htmx serializes parameters into the URL query for GET — so HTMX GETs leaked the session's CSRF token into the URL:

```
GET /calendar/day/2026-06-12?csrf_token=cd177db1-…
```

**Exposure**: browser history + reverse-proxy access logs (self-hosted nginx/caddy log the full request URI by default). The app's own request log is unaffected — it records the sanitized route template only. The token is session-scoped double-submit material, not an auth secret, so severity is Low — but it directly contradicts the repo's no-secrets-in-URLs transport rule and the fix is one guard.

**Fix**: attach the form parameter only for non-GET verbs; the `X-CSRF-Token` header still rides along on every request. GETs are not CSRF-checked server-side, so nothing changes beyond the URL.

**Tests**: new csrf-injection unit case (GET → header yes, parameter no; non-GET double-attach contract unchanged), 35/35 unit, lint, e2e calendar spec 13/13 on the rebuilt bundle. Bundle rebuilt + cache-bust bumped (the new CI stale-bundle guard verifies the rebuild).