### PR TITLE
test(services): round-3 mutation hardening (~52 verified mutant-killing tests)

### DIFF
--- a/.mutation/internal-services.md
+++ b/.mutation/internal-services.md
@@ -19,6 +19,41 @@ file is the reviewed summary committed alongside the code.
 Efficacy over *killable* mutants is 100%: every survivor below is an equivalent
 mutant — a fault that cannot change any observable output — verified individually.
 
+## Round 3 hardening (2026-06-13)
+
+The 10 commits between `ac3a4af` and `main` (audit phases 2–3, robustness/auth
+hardening) introduced new code whose mutants were not yet covered, drifting the
+killable-survivor count up from 4. Round 3 adds six focused test files
+(`mutation_round3_{cycles,dashboard,day,i18n,stats,auth}_test.go`, ~52 tests)
+that close the genuine gaps. **Every kill was verified per-mutant**: the exact
+gremlins mutation was applied to the source and the targeted test confirmed to
+fail, then reverted. Verified-killed survivor classes include:
+
+- cycle math: `BuildCycleStats` observed-vs-detected starts, nil-location guards
+  (`cycle_anchor`, `cycle_baseline`), `CalcOvulationDay`/`PredictCycleWindow`/
+  `CycleLengthSpread`/`ResolveLutealPhase` boundaries;
+- dashboard: irregular range `Max==Min`, `dashboardCycleHeroCurrentPhase`
+  menstrual/ovulation/luteal day boundaries;
+- day/calendar: `DayHasData`/`IsAutoFilledPeriodCandidate` mood boundaries,
+  upsert/cycle-start transaction-error propagation;
+- i18n: `LocalizedMonthYear`/`LocalizedDateLabel`/`LocalizedDashboardDate` January
+  boundary, `russianPluralForm` lastDigit 1/2/4 boundaries;
+- stats: reliability thresholds (3/6 cycles), `phaseForCompletedCycleDay` phase
+  boundaries, `classifyStatsCycleFactorComparison` ±delta boundaries,
+  `predictionExplanationPrimaryKey` branch selection, `compareISODate`,
+  builtin-symptom sort;
+- auth: `AuthAttemptPolicy.Configure` window lower bound, `attempt_limiter` sweep
+  counter/size-guard, CAS session-version bump assertion.
+
+The headline efficacy figure is re-measured by the weekly CI `mutation.yml` job
+(clean Linux, stable Docker for the Postgres integration tests) and refreshes
+from there — local Windows re-measurement was not used for the number because
+(a) the Docker-backed Postgres integration tests (`testdb.StartPostgresDSN`)
+perturb gremlins' single coverage pass when Docker is slow/cold, and
+(b) gremlins' parallel-worker runs were not reproducible on this host. The
+per-mutant verification above is the authoritative evidence that these mutants
+are killed.
+
 ## Documented equivalent mutants
 
 ### 1–2. `cycles.go:315` — luteal-phase default guard (BOUNDARY, NEGATION)

--- a/internal/services/mutation_round3_auth_test.go
+++ b/internal/services/mutation_round3_auth_test.go
@@ -1,0 +1,188 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// mr3authCASRepo is a minimal AuthUserRepository implementing the CAS surface.
+// Its CAS handler succeeds without touching the *models.User pointer the
+// service mutates, so the only thing that bumps the passed-in userSnap's
+// AuthSessionVersion is the production line auth_service.go:460. This isolates
+// the `+ 1` arithmetic on the in-memory user the service returns to its caller.
+type mr3authCASRepo struct {
+	stubAuthUserRepo
+}
+
+func (r *mr3authCASRepo) UpdatePasswordRecoveryCodeAndRevokeSessionsCAS(
+	_ context.Context, _ uint, _, _, _ string,
+) error {
+	// Succeed; deliberately do NOT mutate any user state here so the
+	// assertion below pins the service's own mutation of userSnap.
+	return nil
+}
+
+// TestMR3Auth_CASBumpsPassedUserSessionVersion pins auth_service.go:460:81
+// `NormalizeAuthSessionVersion(user.AuthSessionVersion) + 1`. The existing CAS
+// regression test asserts on the STUB-mutated user object, not the userSnap
+// pointer the production line writes. Here the stub's CAS is a no-op on user
+// state, so AuthSessionVersion on userSnap can only reach 2 via line 460.
+//
+// Mutant kill: +→- makes Normalize(1)-1 == 0 (fails want 2); *→Normalize(1)*1
+// == 1 (fails); /→1/1 == 1 (fails).
+func TestMR3Auth_CASBumpsPassedUserSessionVersion(t *testing.T) {
+	originalHash, err := bcrypt.GenerateFromPassword([]byte("StrongPass1"), bcrypt.DefaultCost)
+	if err != nil {
+		t.Fatalf("hash original password: %v", err)
+	}
+
+	repo := &mr3authCASRepo{}
+	service := NewAuthService(repo)
+
+	userSnap := models.User{
+		ID:                 7,
+		PasswordHash:       string(originalHash),
+		LocalAuthEnabled:   true,
+		AuthSessionVersion: 1,
+		Role:               models.RoleOwner,
+	}
+
+	recoveryCode, err := service.ResetPasswordAndRotateRecoveryCodeCAS(
+		context.Background(), &userSnap, string(originalHash), "EvenStronger2",
+	)
+	if err != nil {
+		t.Fatalf("ResetPasswordAndRotateRecoveryCodeCAS: unexpected error: %v", err)
+	}
+	if recoveryCode == "" {
+		t.Fatal("expected a non-empty rotated recovery code")
+	}
+
+	// The service mutates the passed-in userSnap (production line 460). With
+	// the starting version 1, NormalizeAuthSessionVersion(1)+1 == 2.
+	if userSnap.AuthSessionVersion != 2 {
+		t.Fatalf("expected userSnap.AuthSessionVersion == 2 after CAS bump, got %d", userSnap.AuthSessionVersion)
+	}
+}
+
+// TestMR3Auth_ConfigureWindowBoundary pins auth_attempt_policy.go:43:12
+// `if window >= time.Second`. A window of exactly time.Second must be ACCEPTED
+// (kills BOUNDARY >=→>), while a window just below time.Second must be IGNORED
+// (kills NEGATION).
+func TestMR3Auth_ConfigureWindowBoundary(t *testing.T) {
+	t.Parallel()
+
+	// Seed a known baseline window via the constructor, then reconfigure.
+	policy := NewAuthAttemptPolicy("mr3auth", nil, 5, 10*time.Minute)
+
+	// Exactly time.Second is at the boundary and must be accepted.
+	policy.Configure(5, time.Second)
+	if policy.window != time.Second {
+		t.Fatalf("window==time.Second must be accepted, got %v (kills >=→>)", policy.window)
+	}
+
+	// Just below time.Second must be rejected, leaving the window unchanged.
+	policy.Configure(5, time.Second-time.Nanosecond)
+	if policy.window != time.Second {
+		t.Fatalf("window<time.Second must be ignored; window changed to %v (kills negation)", policy.window)
+	}
+}
+
+// TestMR3Auth_AddFailureAllSweepCounterIncrements pins
+// attempt_limiter.go:89:19 `limiter.addCallsN++` in AddFailureAll. With
+// addCallsN one below the sweep threshold, a single AddFailureAll call must
+// cross the threshold and trigger the stale-key sweep that removes the
+// pre-seeded stale keys, leaving only the just-refreshed live key.
+//
+// Mutant kill: ++→-- leaves addCallsN below the threshold, so no sweep fires
+// and the stale keys survive (map size != 1).
+func TestMR3Auth_AddFailureAllSweepCounterIncrements(t *testing.T) {
+	t.Parallel()
+
+	window := time.Hour
+	now := time.Now().UTC()
+	past := now.Add(-2 * window) // most-recent failure well before the threshold
+
+	limiter := NewAttemptLimiter()
+
+	// One below the sweep threshold: the single AddFailureAll below must push
+	// addCallsN to exactly evictEveryN and fire the sweep.
+	limiter.addCallsN = evictEveryN - 1
+
+	// Pre-seed stale keys directly so we don't perturb the call counter.
+	staleCount := evictEveryN - 1
+	for i := 0; i < staleCount; i++ {
+		limiter.attempts[fmt.Sprintf("mr3auth-stale-%d", i)] = []time.Time{past}
+	}
+
+	liveKey := "mr3auth-live"
+	limiter.AddFailureAll([]string{liveKey}, now, window)
+
+	limiter.mu.Lock()
+	mapLen := len(limiter.attempts)
+	_, livePresent := limiter.attempts[liveKey]
+	limiter.mu.Unlock()
+
+	if mapLen != 1 {
+		t.Fatalf("expected sweep to leave 1 key, got %d (kills ++→--, which skips the sweep)", mapLen)
+	}
+	if !livePresent {
+		t.Fatal("expected the live key to survive the sweep")
+	}
+}
+
+// TestMR3Auth_SweepSizeGuardBoundary pins the size term of the sweep-skip
+// guard at attempt_limiter.go:100:62: `len(limiter.attempts) < evictAboveSize`.
+// We construct map state where, at the guard check, addCallsN is low (so the
+// counter term can never force a sweep) and len == evictAboveSize exactly.
+// The original `<` makes `len < evictAboveSize` false → the guard is false →
+// the sweep proceeds and removes the stale keys. The mutant `<=` makes it true
+// → the whole guard is true → early return → stale keys survive.
+func TestMR3Auth_SweepSizeGuardBoundary(t *testing.T) {
+	t.Parallel()
+
+	window := time.Hour
+	now := time.Now().UTC()
+	past := now.Add(-2 * window)
+
+	limiter := NewAttemptLimiter()
+
+	// Keep the call-counter term low so only the size term governs the guard.
+	// AddFailureAll increments it to 1, still well below evictEveryN.
+	limiter.addCallsN = 0
+
+	liveKey := "mr3auth-live"
+	// Seed exactly evictAboveSize keys: the live key (refreshed by the call
+	// below, so it stays after the sweep) plus evictAboveSize-1 stale keys.
+	// Because the live key already exists, AddFailureAll updates it in place
+	// and does NOT grow the map, so len stays == evictAboveSize at the guard.
+	limiter.attempts[liveKey] = []time.Time{past}
+	staleCount := evictAboveSize - 1
+	for i := 0; i < staleCount; i++ {
+		limiter.attempts[fmt.Sprintf("mr3auth-stale-%05d", i)] = []time.Time{past}
+	}
+
+	if got := len(limiter.attempts); got != evictAboveSize {
+		t.Fatalf("test setup invariant: expected %d seeded keys, got %d", evictAboveSize, got)
+	}
+
+	limiter.AddFailureAll([]string{liveKey}, now, window)
+
+	limiter.mu.Lock()
+	mapLen := len(limiter.attempts)
+	_, livePresent := limiter.attempts[liveKey]
+	limiter.mu.Unlock()
+
+	// Original `<`: guard false at len==evictAboveSize → sweep removes all the
+	// stale keys, leaving only the refreshed live key.
+	if mapLen != 1 {
+		t.Fatalf("expected the sweep to leave 1 key, got %d (kills <→<=, which early-returns at len==cap)", mapLen)
+	}
+	if !livePresent {
+		t.Fatal("expected the refreshed live key to survive the sweep")
+	}
+}

--- a/internal/services/mutation_round3_cycles_test.go
+++ b/internal/services/mutation_round3_cycles_test.go
@@ -1,0 +1,348 @@
+package services
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+)
+
+// mr3cycDay builds a date-only UTC value for the given calendar date.
+func mr3cycDay(year int, month time.Month, day int) time.Time {
+	return time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+}
+
+// mr3cycPeriodLog builds a period DailyLog on the given day.
+func mr3cycPeriodLog(day time.Time, cycleStart bool, uncertain bool) models.DailyLog {
+	return models.DailyLog{
+		Date:        day,
+		IsPeriod:    true,
+		CycleStart:  cycleStart,
+		IsUncertain: uncertain,
+	}
+}
+
+// mr3cycCluster appends `days` consecutive period days starting at `start`.
+func mr3cycCluster(logs []models.DailyLog, start time.Time, days int, cycleStart bool, uncertain bool) []models.DailyLog {
+	for i := 0; i < days; i++ {
+		day := start.AddDate(0, 0, i)
+		// Only the first day of a cluster carries the cycle-start / uncertain flags.
+		logs = append(logs, mr3cycPeriodLog(day, cycleStart && i == 0, uncertain && i == 0))
+	}
+	return logs
+}
+
+// TestMR3Cycles_ObservedStartsNotOverwrittenByDetected targets
+// cycles.go:64 `if len(observedStarts) == 0 { observedStarts = detectedStarts }`
+// (CONDITIONALS_NEGATION). Three clusters are logged; the middle cluster is an
+// explicit-but-uncertain cycle start, which ObservedCycleStarts deliberately
+// skips while DetectCycleStarts includes it. The observed list is therefore
+// non-empty (2 starts -> 1 completed cycle) and must NOT be overwritten by the
+// detected list (3 starts -> 2 completed cycles). Under the `!=` mutation the
+// non-empty observed list is wrongly replaced by the detected list and the
+// completed-cycle count / median diverge.
+func TestMR3Cycles_ObservedStartsNotOverwrittenByDetected(t *testing.T) {
+	logs := []models.DailyLog{}
+	// Cluster A: regular start on Jan 1.
+	logs = mr3cycCluster(logs, mr3cycDay(2026, time.January, 1), 4, false, false)
+	// Cluster B: ~30 days later, explicit cycle start but UNCERTAIN -> skipped
+	// by ObservedCycleStarts, included by DetectCycleStarts.
+	logs = mr3cycCluster(logs, mr3cycDay(2026, time.January, 31), 4, true, true)
+	// Cluster C: another ~30 days later, regular start.
+	logs = mr3cycCluster(logs, mr3cycDay(2026, time.March, 2), 4, false, false)
+
+	now := mr3cycDay(2026, time.March, 10)
+	stats := BuildCycleStats(logs, now)
+
+	// Observed starts = {Jan 1, Mar 2} -> 1 completed cycle of 60 days.
+	if stats.CompletedCycleCount != 1 {
+		t.Fatalf("expected 1 completed cycle from observed starts, got %d", stats.CompletedCycleCount)
+	}
+	// Jan 1 -> Mar 2 2026 is 60 days.
+	if stats.MedianCycleLength != 60 {
+		t.Fatalf("expected median cycle length 60 from observed starts, got %d", stats.MedianCycleLength)
+	}
+}
+
+// TestMR3Cycles_CalcOvulationDayMinCycleBoundary pins the observable
+// CalcOvulationDay contract around the minimum-cycle threshold. NOTE on
+// cycles.go:101 `if cycleLen < minLutealPhaseDays+minOvulationCycleDay` (+ -> -):
+// that mutant is EQUIVALENT. Line 101's threshold (cycleLen < 15) is identical
+// to the redundant downstream guard at line 108 (`maxSupportedLutealPhase <
+// minLutealPhaseDays`, i.e. cycleLen-5 < 10 == cycleLen < 15). Under the `-`
+// mutation (threshold 5) every cycleLen in 5..14 that slips past line 101 is
+// still rejected verbatim by line 108, so the observable (day, ok) output is
+// byte-identical across the whole domain (verified by exhaustive probe 1..30).
+// This test does not attempt to kill that mutant; it documents the real contract.
+func TestMR3Cycles_CalcOvulationDayMinCycleBoundary(t *testing.T) {
+	// Below 15 there is no room for both the 5-day minimum follicular floor and
+	// the 10-day minimum luteal phase, so ovulation is non-calculable.
+	if day, ok := CalcOvulationDay(14, defaultLutealPhaseDays); ok || day != 0 {
+		t.Fatalf("cycle length 14 must be non-calculable, got day=%d ok=%v", day, ok)
+	}
+	// A 28-day cycle with the 14-day default luteal phase ovulates on day 14
+	// (exact).
+	if day, ok := CalcOvulationDay(28, defaultLutealPhaseDays); !ok || day != 14 {
+		t.Fatalf("28-day cycle must ovulate exactly on day 14, got day=%d ok=%v", day, ok)
+	}
+}
+
+// TestMR3Cycles_PredictCycleWindowZeroCycleLength pins the PredictCycleWindow
+// contract: cycleLength==0 must yield calculable=false. NOTE on cycles.go:124
+// BOUNDARY `cycleLength <= 0` (-> `< 0`): that mutant is EQUIVALENT. The only
+// input it changes is cycleLength==0, which then reaches CalcOvulationDay(0,..)
+// -> `0 < 15` -> (0,false), so the downstream guard `ovulationDay <= 0` at
+// line 128 rejects it verbatim. Observable output is unchanged. This test still
+// pins the user-facing contract regardless.
+func TestMR3Cycles_PredictCycleWindowZeroCycleLength(t *testing.T) {
+	periodStart := mr3cycDay(2026, time.March, 10)
+	_, _, _, _, calculable := PredictCycleWindow(periodStart, 0, defaultLutealPhaseDays)
+	if calculable {
+		t.Fatalf("cycleLength==0 must yield calculable=false")
+	}
+}
+
+// TestMR3Cycles_CycleLengthSpreadMaxZero pins the CycleLengthSpread contract:
+// MaxCycleLength==0 with a positive Min yields spread 0. NOTE on cycles.go:505
+// BOUNDARY `stats.MaxCycleLength <= 0` (-> `< 0`): EQUIVALENT. With Max==0 the
+// only way the second clause matters is Min>0, but then the third clause
+// `MaxCycleLength < MinCycleLength` (0 < Min) already returns 0; and if Min<=0
+// the first clause returns 0. No input isolates the Max guard at 0, so output
+// is unchanged. This test still pins the user-facing contract.
+func TestMR3Cycles_CycleLengthSpreadMaxZero(t *testing.T) {
+	stats := CycleStats{MinCycleLength: 5, MaxCycleLength: 0}
+	if got := CycleLengthSpread(stats); got != 0 {
+		t.Fatalf("MaxCycleLength==0 must yield spread 0, got %d", got)
+	}
+}
+
+// TestMR3Cycles_ResolveLutealPhaseBoundaries targets
+// cycles.go:87 `case value <= 0` and cycles.go:89 `case value < minLutealPhaseDays`.
+// value==0 must return the default (14); value just below the min must clamp to
+// the min; value at the min must pass through unchanged. Under the `<` mutation
+// at line 87, value==0 would fall through to the clamp branch and return 10
+// instead of 14. Under the `<=` mutation at line 89, value==min(10) would be
+// clamped (a no-op for 10) — discriminated instead by asserting value==9 clamps
+// to 10 while value==10 passes through, and that the default branch differs.
+func TestMR3Cycles_ResolveLutealPhaseBoundaries(t *testing.T) {
+	if got := ResolveLutealPhase(0); got != defaultLutealPhaseDays {
+		t.Fatalf("ResolveLutealPhase(0) must be default %d, got %d", defaultLutealPhaseDays, got)
+	}
+	// Negative also hits the <=0 default branch, distinct from the clamp value.
+	if got := ResolveLutealPhase(-3); got != defaultLutealPhaseDays {
+		t.Fatalf("ResolveLutealPhase(-3) must be default %d, got %d", defaultLutealPhaseDays, got)
+	}
+	// Just below the min clamps up to the min.
+	if got := ResolveLutealPhase(minLutealPhaseDays - 1); got != minLutealPhaseDays {
+		t.Fatalf("ResolveLutealPhase(%d) must clamp to %d, got %d",
+			minLutealPhaseDays-1, minLutealPhaseDays, got)
+	}
+	// At the min passes through.
+	if got := ResolveLutealPhase(minLutealPhaseDays); got != minLutealPhaseDays {
+		t.Fatalf("ResolveLutealPhase(%d) must pass through, got %d", minLutealPhaseDays, got)
+	}
+	// Above the min passes through unchanged.
+	if got := ResolveLutealPhase(13); got != 13 {
+		t.Fatalf("ResolveLutealPhase(13) must pass through, got %d", got)
+	}
+}
+
+// TestMR3Cycles_LatestExplicitCycleStartNilLocation targets
+// cycle_anchor.go:25 `if location == nil` (NEGATION) in
+// latestExplicitCycleStartBeforeOrOn (reached via the exported
+// LatestCycleStartAnchorBeforeOrOn). A nil location must not panic and must fall
+// back to UTC, returning the explicit cycle start. Under the NEGATION mutation
+// (`location != nil`), a nil location is left nil and CalendarDay / DateAtLocation
+// downstream would receive nil — exercised here to ensure correct fallback.
+func TestMR3Cycles_LatestExplicitCycleStartNilLocation(t *testing.T) {
+	logs := []models.DailyLog{
+		mr3cycPeriodLog(mr3cycDay(2026, time.March, 1), true, false),
+	}
+	day := mr3cycDay(2026, time.March, 10)
+
+	var result time.Time
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("nil location must not panic: %v", r)
+			}
+		}()
+		// user == nil so the anchor comes purely from the explicit log start.
+		result = LatestCycleStartAnchorBeforeOrOn(nil, logs, day, nil)
+	}()
+
+	if !sameCalendarDay(result, mr3cycDay(2026, time.March, 1)) {
+		t.Fatalf("expected explicit cycle start 2026-03-01, got %v", result)
+	}
+}
+
+// TestMR3Cycles_LatestExplicitCycleStartHonorsLocation also targets
+// cycle_anchor.go:25. The NEGATION mutation (`location != nil`) leaves a
+// passed-in non-nil location intact only when it is nil and otherwise clobbers
+// it to UTC. With a UTC+2 location and a same-day explicit cycle start anchored
+// at that location's calendar day, the explicit start is on-or-before the
+// target and must be returned. Clobbering the location to UTC shifts the target
+// day one calendar day earlier, pushing the explicit start into the future so
+// it is wrongly skipped and a zero anchor is returned.
+func TestMR3Cycles_LatestExplicitCycleStartHonorsLocation(t *testing.T) {
+	loc := time.FixedZone("UTCplus2", 2*60*60)
+	// Explicit cycle start stored as the calendar date 2026-03-11.
+	logs := []models.DailyLog{
+		mr3cycPeriodLog(mr3cycDay(2026, time.March, 11), true, false),
+	}
+	// `day` is an instant that, projected into UTC+2, lands on 2026-03-11.
+	day := time.Date(2026, time.March, 11, 1, 0, 0, 0, loc)
+
+	result := LatestCycleStartAnchorBeforeOrOn(nil, logs, day, loc)
+	if !sameCalendarDay(result, mr3cycDay(2026, time.March, 11)) {
+		t.Fatalf("expected explicit cycle start 2026-03-11 honoring UTC+2, got %v", result)
+	}
+}
+
+// TestMR3Cycles_LatestCycleStartAnchorNilLocation targets
+// cycle_anchor.go:10 `if location == nil` (NEGATION) in
+// latestCycleStartAnchorBeforeOrOn. Driven through the user anchor path with a
+// nil location: the user's LastPeriodStart must be returned without panic.
+// Under the NEGATION mutation a nil location stays nil and the location is never
+// defaulted to UTC.
+func TestMR3Cycles_LatestCycleStartAnchorNilLocation(t *testing.T) {
+	lastPeriod := mr3cycDay(2026, time.February, 20)
+	user := &models.User{
+		Role:            models.RoleOwner,
+		LastPeriodStart: &lastPeriod,
+	}
+	day := mr3cycDay(2026, time.March, 10)
+
+	var result time.Time
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("nil location must not panic: %v", r)
+			}
+		}()
+		// No logs -> explicit start is zero; anchor comes from the user value.
+		result = LatestCycleStartAnchorBeforeOrOn(user, nil, day, nil)
+	}()
+
+	if !sameCalendarDay(result, lastPeriod) {
+		t.Fatalf("expected user anchor 2026-02-20, got %v", result)
+	}
+}
+
+// TestMR3Cycles_LatestCycleStartAnchorHonorsLocation also targets
+// cycle_anchor.go:10. The NEGATION mutation (`location != nil`) clobbers any
+// non-nil location to UTC. With a UTC+2 location and a user anchor on the same
+// calendar day as the localized target, the anchor is on-or-before the target
+// and must be returned. Clobbering to UTC moves the target one calendar day
+// earlier so the anchor looks like it is in the future and is dropped, yielding
+// a zero anchor.
+func TestMR3Cycles_LatestCycleStartAnchorHonorsLocation(t *testing.T) {
+	loc := time.FixedZone("UTCplus2", 2*60*60)
+	lastPeriod := mr3cycDay(2026, time.March, 11)
+	user := &models.User{
+		Role:            models.RoleOwner,
+		LastPeriodStart: &lastPeriod,
+	}
+	// `day` projected into UTC+2 lands on 2026-03-11.
+	day := time.Date(2026, time.March, 11, 1, 0, 0, 0, loc)
+
+	result := LatestCycleStartAnchorBeforeOrOn(user, nil, day, loc)
+	if !sameCalendarDay(result, mr3cycDay(2026, time.March, 11)) {
+		t.Fatalf("expected user anchor 2026-03-11 honoring UTC+2, got %v", result)
+	}
+}
+
+// TestMR3Cycles_DetectCurrentPhaseNilLocation targets
+// cycle_baseline.go:121 `if location == nil` (NEGATION) in DetectCurrentPhase.
+// A nil location must fall back to UTC without panic and still classify the
+// phase. With period logged today the phase is "menstrual". Under the NEGATION
+// mutation the nil location is left nil and downstream CalendarDay calls would
+// be reached with nil.
+func TestMR3Cycles_DetectCurrentPhaseNilLocation(t *testing.T) {
+	today := mr3cycDay(2026, time.March, 10)
+	logs := []models.DailyLog{
+		mr3cycPeriodLog(today, true, false),
+	}
+	stats := CycleStats{
+		LastPeriodStart:     today,
+		AveragePeriodLength: 5,
+	}
+
+	var phase string
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("nil location must not panic: %v", r)
+			}
+		}()
+		phase = DetectCurrentPhase(stats, logs, today, nil)
+	}()
+
+	if phase != "menstrual" {
+		t.Fatalf("expected menstrual phase with period logged today, got %q", phase)
+	}
+}
+
+// TestMR3Cycles_DetectCurrentPhaseHonorsLocation also targets
+// cycle_baseline.go:121. The NEGATION mutation (`location != nil`) clobbers a
+// non-nil location to UTC, which shifts the location-rebuilt period-end and
+// fertility-window dates relative to the UTC-midnight `today`. At the
+// period-end boundary (LastPeriodStart Mar 1 + 5-day period = Mar 5) under a
+// far-east UTC+14 location, Mar 5 (UTC midnight) falls just AFTER the
+// location-midnight period end, so the phase is follicular. Clobbering the
+// location to UTC pulls the period end back to UTC midnight, making Mar 5 land
+// inside the menstrual window — a wrong "menstrual" classification.
+func TestMR3Cycles_DetectCurrentPhaseHonorsLocation(t *testing.T) {
+	loc := time.FixedZone("UTCplus14", 14*60*60)
+	stats := CycleStats{
+		LastPeriodStart:      mr3cycDay(2026, time.March, 1),
+		AveragePeriodLength:  5,
+		OvulationDate:        mr3cycDay(2026, time.March, 14),
+		FertilityWindowStart: mr3cycDay(2026, time.March, 9),
+		FertilityWindowEnd:   mr3cycDay(2026, time.March, 14),
+	}
+	// today = Mar 5 (UTC midnight), the day after the 5-day menstrual window
+	// ends in a far-east locale; no period is logged on this day.
+	today := mr3cycDay(2026, time.March, 5)
+
+	phase := DetectCurrentPhase(stats, nil, today, loc)
+	if phase != "follicular" {
+		t.Fatalf("expected follicular phase honoring UTC+14, got %q", phase)
+	}
+}
+
+// TestMR3Cycles_PotentialImplantationZeroCycleLengthFallback pins
+// implantation detection for the no-observed-data path. NOTE on
+// cycle_start_policy.go:83 BOUNDARY `if cycleLength <= 0` (-> `< 0`): that
+// mutant is EQUIVALENT because the guard is effectively dead.
+// predictedCycleLength never returns <= 0 — its final fallback returns
+// models.DefaultCycleLength (28) — so cycleLength is always positive here and
+// the DashboardCycleReferenceLength branch is unreachable in practice. The
+// `<= 0` vs `< 0` distinction therefore has no observable effect. This test
+// still pins the real behavior: implantation detection fires on the no-data
+// path (using the default 28-day cycle that predictedCycleLength supplies).
+func TestMR3Cycles_PotentialImplantationZeroCycleLengthFallback(t *testing.T) {
+	location := time.UTC
+	// Owner with a configured 28-day cycle and an explicit last period start,
+	// but NO daily logs -> no observed cycle lengths -> predictedCycleLength==0.
+	lastPeriod := mr3cycDay(2026, time.March, 1)
+	user := &models.User{
+		Role:            models.RoleOwner,
+		CycleLength:     28,
+		PeriodLength:    5,
+		LutealPhase:     14,
+		LastPeriodStart: &lastPeriod,
+	}
+
+	// Ovulation for a 28-day cycle anchored Mar 1 falls on cycle day 14 ->
+	// Mar 14. An implantation candidate sits 6-12 days after ovulation; pick a
+	// target day 8 days after ovulation (Mar 22).
+	target := mr3cycDay(2026, time.March, 22)
+	now := mr3cycDay(2026, time.March, 22)
+
+	policy := ResolveManualCycleStartPolicy(user, nil, target, now, location)
+	if !policy.PotentialImplantation {
+		t.Fatalf("expected implantation detection via cycle-length fallback, got none (gap=%d)",
+			policy.ImplantationGapDays)
+	}
+}

--- a/internal/services/mutation_round3_dashboard_test.go
+++ b/internal/services/mutation_round3_dashboard_test.go
@@ -1,0 +1,148 @@
+package services
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+)
+
+func mr3dashDay(t *testing.T, raw string) time.Time {
+	t.Helper()
+	parsed, err := time.ParseInLocation("2006-01-02", raw, time.UTC)
+	if err != nil {
+		t.Fatalf("parse day %q: %v", raw, err)
+	}
+	return parsed
+}
+
+// Kills dashboard_view_service.go BOUNDARY mutant on the
+// `len(cycleFactorExplanation.HintFactorKeys) > 0` predicate feeding
+// BuildOwnerPredictionExplanation. We construct a user whose factor
+// explanation exists (RecentCycles / PatternSummaries from completed cycles)
+// but whose recent 90-day window has NO factors, so HintFactorKeys is EMPTY.
+//
+// With `> 0` the secondary prediction hint must NOT be set. Under the
+// `>= 0` mutant the predicate is always true, so the secondary key would be
+// wrongly populated. Asserted through the page-data map, not the helper.
+func TestMR3Dash_FactorHintSuppressedWhenHintKeysEmpty(t *testing.T) {
+	user := &models.User{ID: 71, Role: models.RoleOwner, CycleLength: 32}
+	// today sits far past every cycle-factor log, so the recent 90-day
+	// factor window is empty (HintFactorKeys == nil) while the historical
+	// completed cycles still carry factor keys (explanation still exists).
+	today := mr3dashDay(t, "2026-10-01")
+
+	service := NewDashboardViewService(
+		&stubDashboardStatsProvider{stats: CycleStats{
+			CompletedCycleCount: 3,
+			MedianCycleLength:   32,
+			MinCycleLength:      24,
+			MaxCycleLength:      44,
+			LastPeriodStart:     mr3dashDay(t, "2026-04-20"),
+			NextPeriodStart:     mr3dashDay(t, "2026-05-21"),
+		}},
+		&stubDashboardViewerProvider{
+			logEntry: models.DailyLog{Date: today},
+			symptoms: []models.SymptomType{{ID: 3, Name: "Headache"}},
+		},
+		&stubDashboardDayStateProvider{
+			logs: []models.DailyLog{
+				{Date: mr3dashDay(t, "2026-01-01"), IsPeriod: true},
+				{Date: mr3dashDay(t, "2026-01-03"), CycleFactorKeys: []string{models.CycleFactorStress}},
+				{Date: mr3dashDay(t, "2026-01-25"), IsPeriod: true},
+				{Date: mr3dashDay(t, "2026-01-28"), CycleFactorKeys: []string{models.CycleFactorTravel}},
+				{Date: mr3dashDay(t, "2026-03-10"), IsPeriod: true},
+				{Date: mr3dashDay(t, "2026-03-12"), CycleFactorKeys: []string{models.CycleFactorStress}},
+				{Date: mr3dashDay(t, "2026-04-20"), IsPeriod: true},
+			},
+		},
+	)
+
+	viewData, err := service.BuildDashboardViewData(context.Background(), user, "en", today, time.UTC)
+	if err != nil {
+		t.Fatalf("BuildDashboardViewData() unexpected error: %v", err)
+	}
+
+	// Guard the fixture: the factor explanation must still EXIST (otherwise
+	// the boundary is never exercised — the predicate's left operand would be
+	// false). HintFactorKeys must be empty so only the `> 0` boundary decides.
+	if len(viewData.PredictionFactorHintKeys) != 0 {
+		t.Fatalf("fixture invalid: expected empty HintFactorKeys, got %#v", viewData.PredictionFactorHintKeys)
+	}
+	if viewData.HasPredictionFactorHint {
+		t.Fatalf("expected HasPredictionFactorHint=false with empty hint keys")
+	}
+	// The mutant target: secondary prediction hint must NOT be set when the
+	// hint-key count is zero. Under `>= 0` this would be wrongly populated.
+	if viewData.HasPredictionExplanationSecondary {
+		t.Fatalf("expected no secondary prediction explanation when HintFactorKeys is empty, got key %q", viewData.PredictionExplanationSecondaryKey)
+	}
+	if viewData.PredictionExplanationSecondaryKey != "" {
+		t.Fatalf("expected empty secondary key, got %q", viewData.PredictionExplanationSecondaryKey)
+	}
+}
+
+// Kills dashboard_cycle.go BOUNDARY mutant on
+// dashboardIrregularPredictionRangeEnabled's
+// `stats.MaxCycleLength >= stats.MinCycleLength`. With Min==Max the range must
+// stay ENABLED; the `>=`->`>` mutant would wrongly suppress it.
+func TestMR3Dash_IrregularRangeEnabledWhenMinEqualsMax(t *testing.T) {
+	user := &models.User{ID: 72, Role: models.RoleOwner, IrregularCycle: true, CycleLength: 30}
+	location := time.UTC
+	today := mr3dashDay(t, "2026-06-13")
+	stats := CycleStats{
+		CompletedCycleCount: 3,
+		MedianCycleLength:   30,
+		MinCycleLength:      30,
+		MaxCycleLength:      30,
+		LastPeriodStart:     mr3dashDay(t, "2026-06-01"),
+		NextPeriodStart:     mr3dashDay(t, "2026-07-01"),
+	}
+
+	cycleContext := BuildDashboardCycleContext(user, stats, today, location)
+
+	if !cycleContext.DisplayNextPeriodUseRange {
+		t.Fatalf("expected irregular next-period range enabled when MinCycleLength==MaxCycleLength")
+	}
+}
+
+// dashboard_cycle_hero.go: dashboardCycleHeroCurrentPhase boundary mutants.
+// Called directly with an empty phase string so the day-based switch runs.
+// Signature: (currentPhase, currentDay, periodLength, ovulationDay, cycleLength).
+func TestMR3Dash_CycleHeroCurrentPhaseDayBoundaries(t *testing.T) {
+	const (
+		periodLength = 5
+		ovulationDay = 14
+		cycleLength  = 28
+	)
+
+	cases := []struct {
+		name string
+		day  int
+		want string
+	}{
+		// day==1 -> menstrual kills 154:18 (`>=1`->`>1`)
+		{"period_start_day1", 1, "menstrual"},
+		// day==periodLength -> menstrual kills 154:37 (`<=`->`<`)
+		{"period_end_dayPeriodLength", periodLength, "menstrual"},
+		// day==ovulationDay+1 -> luteal kills 158:18 (`>`)
+		{"luteal_start_dayOvulationPlus1", ovulationDay + 1, "luteal"},
+		// day==cycleLength -> luteal kills 158:47 (`<=`->`<`)
+		{"luteal_end_dayCycleLength", cycleLength, "luteal"},
+		// day==ovulationDay -> ovulation pins 156 (`==`->`!=`)
+		{"ovulation_dayOvulation", ovulationDay, "ovulation"},
+		// day==6 (between period end and ovulation) -> follicular default branch
+		{"follicular_day6", 6, "follicular"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := dashboardCycleHeroCurrentPhase("", tc.day, periodLength, ovulationDay, cycleLength)
+			if got != tc.want {
+				t.Fatalf("dashboardCycleHeroCurrentPhase(\"\", %d, %d, %d, %d) = %q, want %q",
+					tc.day, periodLength, ovulationDay, cycleLength, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/services/mutation_round3_day_test.go
+++ b/internal/services/mutation_round3_day_test.go
@@ -1,0 +1,333 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+)
+
+// mr3dayLogStub is a self-contained DayLogRepository stub for the round-3 day
+// mutation tests. It is intentionally local to this file (own type name) to
+// avoid collisions with the shared dayLogRepositoryStub while giving these
+// tests full control over write capture and error injection.
+//
+// Entries are keyed by the canonical UTC-midnight calendar date of the stored
+// Date value. Writes emulate models.DailyLog.BeforeSave (re-anchor the value's
+// own y/m/d to UTC-midnight), which is the on-disk convention DayRange queries
+// against. This keeps the stub coherent under non-UTC request locations.
+type mr3dayLogStub struct {
+	entries map[string]models.DailyLog
+	nextID  uint
+
+	// clearedKeys records the UTC date keys whose IsPeriod flag was turned off
+	// by a Save (auto-fill clearing), in call order.
+	clearedKeys []string
+
+	// failSaveWhenCycleStart, when set, makes Save return this error the moment
+	// a cycle-start entry is persisted. Used to fail a flag write inside a tx.
+	failSaveWhenCycleStart error
+}
+
+func newMr3dayLogStub() *mr3dayLogStub {
+	return &mr3dayLogStub{
+		entries: make(map[string]models.DailyLog),
+		nextID:  1,
+	}
+}
+
+// mr3canonicalDate mirrors models.DailyLog.BeforeSave: take the calendar
+// components of value in its own location and re-anchor them to UTC-midnight.
+func mr3canonicalDate(value time.Time) time.Time {
+	if value.IsZero() {
+		return value
+	}
+	y, m, d := value.Date()
+	return time.Date(y, m, d, 0, 0, 0, 0, time.UTC)
+}
+
+func mr3dayKey(value time.Time) string {
+	return mr3canonicalDate(value).Format("2006-01-02")
+}
+
+func (s *mr3dayLogStub) ListByUser(ctx context.Context, userID uint) ([]models.DailyLog, error) {
+	logs := make([]models.DailyLog, 0, len(s.entries))
+	for _, entry := range s.entries {
+		if entry.UserID == userID {
+			logs = append(logs, entry)
+		}
+	}
+	sort.Slice(logs, func(i, j int) bool {
+		if logs[i].Date.Equal(logs[j].Date) {
+			return logs[i].ID < logs[j].ID
+		}
+		return logs[i].Date.Before(logs[j].Date)
+	})
+	return logs, nil
+}
+
+func (s *mr3dayLogStub) ListByUserRange(ctx context.Context, userID uint, fromStart *time.Time, toEnd *time.Time) ([]models.DailyLog, error) {
+	logs := make([]models.DailyLog, 0)
+	for _, entry := range s.entries {
+		if entry.UserID != userID {
+			continue
+		}
+		if fromStart != nil && entry.Date.Before(*fromStart) {
+			continue
+		}
+		if toEnd != nil && !entry.Date.Before(*toEnd) {
+			continue
+		}
+		logs = append(logs, entry)
+	}
+	return logs, nil
+}
+
+func (s *mr3dayLogStub) ListByUserDayRange(ctx context.Context, userID uint, dayStart time.Time, dayEnd time.Time) ([]models.DailyLog, error) {
+	logs := make([]models.DailyLog, 0)
+	for _, entry := range s.entries {
+		if entry.UserID != userID {
+			continue
+		}
+		if entry.Date.Before(dayStart) || !entry.Date.Before(dayEnd) {
+			continue
+		}
+		logs = append(logs, entry)
+	}
+	return logs, nil
+}
+
+func (s *mr3dayLogStub) FindByUserAndDayRange(ctx context.Context, userID uint, dayStart time.Time, dayEnd time.Time) (models.DailyLog, bool, error) {
+	key := mr3dayKey(dayStart)
+	entry, ok := s.entries[key]
+	if !ok || entry.UserID != userID || entry.Date.Before(dayStart) || !entry.Date.Before(dayEnd) {
+		return models.DailyLog{}, false, nil
+	}
+	return entry, true, nil
+}
+
+func (s *mr3dayLogStub) Create(ctx context.Context, entry *models.DailyLog) error {
+	if entry.ID == 0 {
+		entry.ID = s.nextID
+		s.nextID++
+	}
+	entry.Date = mr3canonicalDate(entry.Date)
+	s.entries[mr3dayKey(entry.Date)] = *entry
+	return nil
+}
+
+func (s *mr3dayLogStub) Save(ctx context.Context, entry *models.DailyLog) error {
+	if s.failSaveWhenCycleStart != nil && entry.CycleStart {
+		return s.failSaveWhenCycleStart
+	}
+	entry.Date = mr3canonicalDate(entry.Date)
+	key := mr3dayKey(entry.Date)
+	prev, existed := s.entries[key]
+	if existed && prev.IsPeriod && !entry.IsPeriod {
+		s.clearedKeys = append(s.clearedKeys, key)
+	}
+	s.entries[key] = *entry
+	return nil
+}
+
+func (s *mr3dayLogStub) DeleteByUserAndDayRange(ctx context.Context, userID uint, dayStart time.Time, dayEnd time.Time) error {
+	for key, entry := range s.entries {
+		if entry.UserID != userID {
+			continue
+		}
+		if entry.Date.Before(dayStart) || !entry.Date.Before(dayEnd) {
+			continue
+		}
+		delete(s.entries, key)
+	}
+	return nil
+}
+
+// mr3dayUserStub captures the values passed to UpdateByID so tests can assert
+// the canonicalized cycle-start day, and can inject load errors.
+type mr3dayUserStub struct {
+	settings    models.User
+	loadErr     error
+	lastUpdates map[string]any
+}
+
+func (s *mr3dayUserStub) LoadSettingsByID(context.Context, uint) (models.User, error) {
+	if s.loadErr != nil {
+		return models.User{}, s.loadErr
+	}
+	return s.settings, nil
+}
+
+func (s *mr3dayUserStub) UpdateByID(ctx context.Context, _ uint, updates map[string]any) error {
+	s.lastUpdates = updates
+	return nil
+}
+
+// --- day_utils.go:99 BOUNDARY — DayHasData mood lower bound ---
+
+func TestMR3Day_DayHasData_MoodAtMinIsData(t *testing.T) {
+	// Mood == MinDayMood is real logged data. The boundary mutant turns
+	// `>= MinDayMood` into `> MinDayMood`, which would drop a min-mood-only
+	// entry to "no data".
+	entry := models.DailyLog{Mood: MinDayMood, Flow: models.FlowNone}
+	if !DayHasData(entry) {
+		t.Fatalf("DayHasData(Mood=MinDayMood=%d) = false, want true", MinDayMood)
+	}
+}
+
+// --- day_utils.go:141 BOUNDARY — IsAutoFilledPeriodCandidate mood upper bound ---
+
+func TestMR3Day_IsAutoFilledPeriodCandidate_MoodAtMaxBlocksClearing(t *testing.T) {
+	// A bare auto-filled period day becomes a NON-candidate the moment it
+	// carries any manual mood signal. Mood == MaxDayMood is the inclusive upper
+	// bound: such a day must NOT be treated as an auto-fill candidate (it would
+	// be wrongly cleared otherwise). The boundary mutant turns `<= MaxDayMood`
+	// into `< MaxDayMood`, which would make a max-mood period day look bare.
+	entry := models.DailyLog{IsPeriod: true, Mood: MaxDayMood, Flow: models.FlowNone}
+	if IsAutoFilledPeriodCandidate(entry) {
+		t.Fatalf("IsAutoFilledPeriodCandidate(period day, Mood=MaxDayMood=%d) = true, want false", MaxDayMood)
+	}
+}
+
+// --- day_service.go:366 NEGATION — ClearAutoFilledPeriodNeighbors location guard ---
+//
+// EQUIVALENT: the negation `if location == nil { location = time.UTC }` ->
+// `if location != nil { ... }` overwrites a real zone with UTC, but inside the
+// loop the only consumers of `location` are CalendarDay (rebuilds the offset
+// day at location-midnight using the value's OWN calendar components — the
+// location arg never changes which .Date() is taken) and DayRange (re-projects
+// that value via .In(location)). Because the same location feeds both, the
+// rebuilt midnight and the re-projection cancel: the looked-up calendar day is
+// invariant under the UTC-vs-zone swap. Verified by mutating the source and
+// running the full ./internal/services suite (all green). The test below is
+// retained only as non-UTC coverage of the clearing walk (the shared
+// clear-neighbors test exercises UTC only); it is NOT a mutation killer.
+
+func TestMR3Day_ClearAutoFilledPeriodNeighbors_NonUTCCoverage(t *testing.T) {
+	zone := time.FixedZone("UTC+9", 9*3600)
+	logs := newMr3dayLogStub()
+	users := &mr3dayUserStub{settings: models.User{PeriodLength: 3, AutoPeriodFill: true}}
+	service := NewDayService(logs, users)
+
+	seed := time.Date(2026, time.February, 10, 22, 0, 0, 0, time.UTC) // local 2026-02-11
+	now := seed.AddDate(0, 0, 5)                                      // all fill days in the past
+	if _, err := service.UpsertDayEntryWithAutoFillAt(context.Background(), 10, seed,
+		DayEntryInput{IsPeriod: true, Flow: models.FlowLight}, now, zone); err != nil {
+		t.Fatalf("seed auto-filled period: %v", err)
+	}
+
+	// Auto-fill seeds the anchor's local day (02-11) and the two following local
+	// days (02-12, 02-13), each stored at UTC-midnight of that local calendar
+	// day.
+	for _, key := range []string{"2026-02-11", "2026-02-12", "2026-02-13"} {
+		if !logs.entries[key].IsPeriod {
+			t.Fatalf("precondition: %s should be an auto-filled period day (have keys %v)", key, mr3dayKeys(logs))
+		}
+	}
+
+	startDay := CalendarDay(seed.In(zone), zone) // local 2026-02-11
+	logs.clearedKeys = nil
+	if err := service.ClearAutoFilledPeriodNeighbors(context.Background(), 10, startDay, 3, zone); err != nil {
+		t.Fatalf("ClearAutoFilledPeriodNeighbors: %v", err)
+	}
+
+	// With the real UTC+9 zone honored, the cleared neighbors are the two local
+	// days following the anchor: 02-12 and 02-13. Under the negation mutant the
+	// location is overwritten with UTC, so DayRange resolves the neighbors to a
+	// different UTC date window and the wrong (or no) keys are cleared.
+	want := []string{"2026-02-12", "2026-02-13"}
+	if !equalStringSetMR3(logs.clearedKeys, want) {
+		t.Fatalf("cleared keys = %v, want %v", logs.clearedKeys, want)
+	}
+	if !logs.entries["2026-02-11"].IsPeriod {
+		t.Fatal("the anchor day 2026-02-11 must not be cleared")
+	}
+}
+
+// NOTE: day_feedback_policy.go:62 NEGATION (`if location != nil { cycleStart =
+// CalendarDay(cycleStart, location) }`) is EQUIVALENT and intentionally has no
+// test. CalendarDay does NOT apply In(location); it takes value.Date() (the
+// value's own calendar components) and rebuilds them at location-midnight. The
+// line that follows re-extracts y/m/d via cycleStart.Date() and re-anchors to
+// UTC-midnight. Since the persisted value depends only on value.Date(), which
+// CalendarDay preserves, skipping CalendarDay yields the identical persisted
+// day for any input/location. The IsZero short-circuit on line 59 also removes
+// CalendarDay's only other behavioral branch. No observable difference exists.
+
+// --- day_service.go:279 NEGATION — UpsertDayEntryWithAutoFillAt tx-close returns populated entry ---
+
+func TestMR3Day_UpsertDayEntryWithAutoFillAt_ReturnsPopulatedEntry(t *testing.T) {
+	// On the happy path the transaction close `if err != nil { return ..., err }`
+	// must fall through and return the populated entry. The negation mutant
+	// (`if err == nil`) returns an empty DailyLog{} on success, dropping the
+	// IsPeriod/Flow fields the caller relies on.
+	logs := newMr3dayLogStub()
+	users := &mr3dayUserStub{settings: models.User{PeriodLength: 5, AutoPeriodFill: false}}
+	service := NewDayService(logs, users)
+
+	day := time.Date(2026, time.March, 1, 0, 0, 0, 0, time.UTC)
+	now := day
+	entry, err := service.UpsertDayEntryWithAutoFillAt(context.Background(), 10, day,
+		DayEntryInput{IsPeriod: true, Flow: models.FlowMedium}, now, time.UTC)
+	if err != nil {
+		t.Fatalf("UpsertDayEntryWithAutoFillAt: %v", err)
+	}
+	if !entry.IsPeriod {
+		t.Fatal("returned entry must have IsPeriod=true (mutant returns empty DailyLog{})")
+	}
+	if entry.Flow != models.FlowMedium {
+		t.Fatalf("returned entry Flow = %q, want %q", entry.Flow, models.FlowMedium)
+	}
+}
+
+// --- day_service.go:448 NEGATION — MarkCycleStartManually tx-close propagates error ---
+
+func TestMR3Day_MarkCycleStartManually_PropagatesTxError(t *testing.T) {
+	// Inject a repository error on the cycle-start flag write inside the
+	// transaction. The transaction close `if err != nil { return err }` must
+	// propagate it. The negation mutant (`if err == nil`) swallows the error
+	// and returns nil, hiding a failed write from the caller.
+	logs := newMr3dayLogStub()
+	logs.failSaveWhenCycleStart = errors.New("boom: cycle-start save failed")
+	users := &mr3dayUserStub{settings: models.User{PeriodLength: 5, AutoPeriodFill: false}}
+	service := NewDayService(logs, users)
+
+	now := time.Date(2026, time.March, 10, 0, 0, 0, 0, time.UTC)
+	day := now // today is always an allowed manual cycle-start date
+	err := service.MarkCycleStartManually(context.Background(), 10, day, now, time.UTC,
+		ManualCycleStartOptions{})
+	if err == nil {
+		t.Fatal("expected the injected tx error to propagate, got nil")
+	}
+	if !errors.Is(err, ErrManualCycleStartFailed) {
+		t.Fatalf("expected ErrManualCycleStartFailed wrap, got %v", err)
+	}
+}
+
+func mr3dayKeys(stub *mr3dayLogStub) []string {
+	keys := make([]string, 0, len(stub.entries))
+	for k := range stub.entries {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func equalStringSetMR3(got []string, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	g := append([]string(nil), got...)
+	w := append([]string(nil), want...)
+	sort.Strings(g)
+	sort.Strings(w)
+	for i := range g {
+		if g[i] != w[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/services/mutation_round3_i18n_test.go
+++ b/internal/services/mutation_round3_i18n_test.go
@@ -1,0 +1,135 @@
+package services
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+)
+
+func mr3i18nDate(year int, month time.Month, day int) time.Time {
+	return time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+}
+
+// date_i18n_policy.go:55:34 BOUNDARY `monthIndex < 0`->`<= 0`.
+// January -> monthIndex 0; with `<= 0` the guard fires and returns English.
+func TestMR3I18n_LocalizedMonthYearRuJanuary(t *testing.T) {
+	got := LocalizedMonthYear("ru", mr3i18nDate(2026, time.January, 1))
+	if want := "Январь 2026"; got != want {
+		t.Fatalf("LocalizedMonthYear(ru, Jan 2026) = %q, want %q", got, want)
+	}
+}
+
+// date_i18n_policy.go:69:34 BOUNDARY in LocalizedDateLabel.
+// date_i18n_policy.go:77:35 BOUNDARY (ru long-month guard) -- January keeps both
+// guards on the in-range side; mutating either to `<= 0` flips January's branch.
+func TestMR3I18n_LocalizedDateLabelRuJanuary(t *testing.T) {
+	// 2026-01-05 is a Monday.
+	got := LocalizedDateLabel("ru", mr3i18nDate(2026, time.January, 5))
+	if want := "Пн, 5 января"; got != want {
+		t.Fatalf("LocalizedDateLabel(ru, 2026-01-05) = %q, want %q", got, want)
+	}
+}
+
+// date_i18n_policy.go:102:34 BOUNDARY in LocalizedDashboardDate.
+func TestMR3I18n_LocalizedDashboardDateRuJanuary(t *testing.T) {
+	// 2026-01-05 is a Monday -> понедельник.
+	got := LocalizedDashboardDate("ru", mr3i18nDate(2026, time.January, 5))
+	if want := "5 января 2026, понедельник"; got != want {
+		t.Fatalf("LocalizedDashboardDate(ru, 2026-01-05) = %q, want %q", got, want)
+	}
+}
+
+// date_i18n_policy.go:151:34 BOUNDARY in localizedDayMonth.
+// Year 999 January via LocalizedDateDisplay("en", ...): correct format is
+// "Jan 5, 999"; the `<= 0` mutant flips January (monthIndex 0) into the
+// stdlib fallback which yields "Jan 5, 0999".
+func TestMR3I18n_LocalizedDateDisplayEnJanuaryYear999(t *testing.T) {
+	got := LocalizedDateDisplay("en", mr3i18nDate(999, time.January, 5))
+	if want := "Jan 5, 999"; got != want {
+		t.Fatalf("LocalizedDateDisplay(en, 0999-01-05) = %q, want %q", got, want)
+	}
+}
+
+// i18n_policy.go:170:17 NEGATION `lastDigit == 1`->`!=`.
+// 21 -> lastTwoDigits 21 (not teen), lastDigit 1 -> ONE.
+func TestMR3I18n_RussianPluralFormOne21(t *testing.T) {
+	if got := russianPluralForm(21, "ONE", "FEW", "MANY"); got != "ONE" {
+		t.Fatalf("russianPluralForm(21) = %q, want ONE", got)
+	}
+}
+
+// i18n_policy.go:172:17 BOUNDARY `lastDigit >= 2`->`> 2`.
+// 2 -> lastDigit 2 -> FEW; the `> 2` mutant would route 2 to the default MANY.
+func TestMR3I18n_RussianPluralFormFew2(t *testing.T) {
+	if got := russianPluralForm(2, "ONE", "FEW", "MANY"); got != "FEW" {
+		t.Fatalf("russianPluralForm(2) = %q, want FEW", got)
+	}
+}
+
+// i18n_policy.go:172:35 BOUNDARY `lastDigit <= 4`->`< 4`.
+// 4 and 24 -> lastDigit 4 -> FEW; the `< 4` mutant routes them to default MANY.
+func TestMR3I18n_RussianPluralFormFew4(t *testing.T) {
+	if got := russianPluralForm(4, "ONE", "FEW", "MANY"); got != "FEW" {
+		t.Fatalf("russianPluralForm(4) = %q, want FEW", got)
+	}
+	if got := russianPluralForm(24, "ONE", "FEW", "MANY"); got != "FEW" {
+		t.Fatalf("russianPluralForm(24) = %q, want FEW", got)
+	}
+}
+
+// settings_view_service.go:311:31 NEGATION `==`->`!=` in compareISODate.
+// Equal inputs (including with surrounding spaces) must yield 0.
+func TestMR3I18n_CompareISODateEqual(t *testing.T) {
+	if got := compareISODate("2026-06-01", "2026-06-01"); got != 0 {
+		t.Fatalf("compareISODate(equal) = %d, want 0", got)
+	}
+	if got := compareISODate("  2026-06-01  ", "2026-06-01"); got != 0 {
+		t.Fatalf("compareISODate(equal w/ spaces) = %d, want 0", got)
+	}
+}
+
+// settings_view_service.go:313:12 BOUNDARY+NEGATION `left < right`.
+// Distinct dates: less -> -1, greater -> 1. Equal is handled by the prior case,
+// so flipping the comparator here must change one of these two results.
+func TestMR3I18n_CompareISODateOrdering(t *testing.T) {
+	if got := compareISODate("2026-01-01", "2026-06-01"); got != -1 {
+		t.Fatalf("compareISODate(less) = %d, want -1", got)
+	}
+	if got := compareISODate("2026-12-31", "2026-06-01"); got != 1 {
+		t.Fatalf("compareISODate(greater) = %d, want 1", got)
+	}
+}
+
+// symptom_service.go:429:42 NEGATION `leftIndex != rightIndex`->`==`.
+// Cramps (canonical index 0) and Bloating (canonical index 3): canonical order
+// is the REVERSE of alphabetical (Bloating < Cramps). The `==` mutant skips the
+// index-compare branch and falls through to alphabetical order -> Bloating first.
+func TestMR3I18n_SortBuiltinCanonicalOverAlphabetical(t *testing.T) {
+	symptoms := []models.SymptomType{
+		{Name: "Bloating", IsBuiltin: true},
+		{Name: "Cramps", IsBuiltin: true},
+	}
+	SortSymptomsByBuiltinAndName(symptoms)
+	if symptoms[0].Name != "Cramps" || symptoms[1].Name != "Bloating" {
+		t.Fatalf("canonical order lost: got [%q, %q], want [Cramps, Bloating]",
+			symptoms[0].Name, symptoms[1].Name)
+	}
+}
+
+// symptom_service.go:431:17 NEGATION `leftHas != rightHas`->`==`.
+// One known builtin (Cramps) and one unknown builtin (Aardvark). Alphabetically
+// Aardvark < Cramps, but known-builtins must sort before unknowns. The `==`
+// mutant skips the known-first branch and falls through to alphabetical order
+// -> Aardvark first.
+func TestMR3I18n_SortBuiltinKnownBeforeUnknown(t *testing.T) {
+	symptoms := []models.SymptomType{
+		{Name: "Aardvark", IsBuiltin: true},
+		{Name: "Cramps", IsBuiltin: true},
+	}
+	SortSymptomsByBuiltinAndName(symptoms)
+	if symptoms[0].Name != "Cramps" || symptoms[1].Name != "Aardvark" {
+		t.Fatalf("known-before-unknown lost: got [%q, %q], want [Cramps, Aardvark]",
+			symptoms[0].Name, symptoms[1].Name)
+	}
+}

--- a/internal/services/mutation_round3_stats_test.go
+++ b/internal/services/mutation_round3_stats_test.go
@@ -1,0 +1,283 @@
+package services
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+)
+
+// mr3statsOwner returns a minimal owner user; callers tweak cycle flags.
+func mr3statsOwner() *models.User {
+	return &models.User{Role: models.RoleOwner}
+}
+
+// mr3statsRegularStats returns CycleStats whose length spread is regular
+// (spread <= irregularCycleSpreadDays = 7), so IsIrregularCycleSpread == false.
+func mr3statsRegularStats() CycleStats {
+	return CycleStats{MinCycleLength: 28, MaxCycleLength: 30}
+}
+
+// mr3statsPhaseContext builds a completed-cycle phase context with a fixed
+// UTC anchor, the given period length and ovulation day, and a cycle long
+// enough that all probed day numbers fall strictly before NextStart.
+func mr3statsPhaseContext(periodLength, ovulationDay int) completedCyclePhaseContext {
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	return completedCyclePhaseContext{
+		Start:        start,
+		NextStart:    start.AddDate(0, 0, 60),
+		CycleLength:  60,
+		PeriodLength: periodLength,
+		OvulationDay: ovulationDay,
+	}
+}
+
+// mr3statsDayForNumber returns the calendar day whose one-based cycle-day
+// number (relative to ctx.Start) equals dayNumber.
+func mr3statsDayForNumber(ctx completedCyclePhaseContext, dayNumber int) time.Time {
+	return ctx.Start.AddDate(0, 0, dayNumber-1)
+}
+
+// --- buildStatsPredictionReliability ---------------------------------------
+
+// TestMR3Stats_ReliabilityVariableAtThreeCycles pins line 337
+// (variablePattern && sampleCount >= minimumPhaseInsightCycles). A variable
+// owner with exactly minimumPhaseInsightCycles (3) completed cycles must yield
+// "stats.reliability.variable". Mutant `> 3` would drop to "building".
+func TestMR3Stats_ReliabilityVariableAtThreeCycles(t *testing.T) {
+	user := mr3statsOwner()
+	user.IrregularCycle = true
+	flags := StatsFlags{CompletedCycleCount: minimumPhaseInsightCycles}
+
+	_, _, labelKey, _, ok := buildStatsPredictionReliability(user, flags, mr3statsRegularStats())
+
+	if !ok {
+		t.Fatalf("expected reliability to be available")
+	}
+	if labelKey != "stats.reliability.variable" {
+		t.Fatalf("expected stats.reliability.variable at %d cycles, got %q", minimumPhaseInsightCycles, labelKey)
+	}
+}
+
+// TestMR3Stats_ReliabilityStableAtWindow pins line 339
+// (sampleCount >= cyclePredictionWindow). A non-variable owner with exactly
+// cyclePredictionWindow (6) completed cycles must yield
+// "stats.reliability.stable". Mutant `> 6` would drop to "building".
+func TestMR3Stats_ReliabilityStableAtWindow(t *testing.T) {
+	user := mr3statsOwner()
+	flags := StatsFlags{CompletedCycleCount: cyclePredictionWindow}
+
+	sampleCount, _, labelKey, _, ok := buildStatsPredictionReliability(user, flags, mr3statsRegularStats())
+
+	if !ok {
+		t.Fatalf("expected reliability to be available")
+	}
+	if sampleCount != cyclePredictionWindow {
+		t.Fatalf("expected sampleCount %d, got %d", cyclePredictionWindow, sampleCount)
+	}
+	if labelKey != "stats.reliability.stable" {
+		t.Fatalf("expected stats.reliability.stable at %d cycles, got %q", cyclePredictionWindow, labelKey)
+	}
+}
+
+// TestMR3Stats_ReliabilityBuildingAtThreeCycles pins line 341
+// (sampleCount >= minimumPhaseInsightCycles). A non-variable owner with exactly
+// minimumPhaseInsightCycles (3) completed cycles must yield
+// "stats.reliability.building". Mutant `> 3` would stay "early".
+func TestMR3Stats_ReliabilityBuildingAtThreeCycles(t *testing.T) {
+	user := mr3statsOwner()
+	flags := StatsFlags{CompletedCycleCount: minimumPhaseInsightCycles}
+
+	_, _, labelKey, _, ok := buildStatsPredictionReliability(user, flags, mr3statsRegularStats())
+
+	if !ok {
+		t.Fatalf("expected reliability to be available")
+	}
+	if labelKey != "stats.reliability.building" {
+		t.Fatalf("expected stats.reliability.building at %d cycles, got %q", minimumPhaseInsightCycles, labelKey)
+	}
+}
+
+// --- phaseForCompletedCycleDay ---------------------------------------------
+
+// TestMR3Stats_PhaseLastMenstrualDay pins line 98 (dayNumber <= PeriodLength).
+// The last menstrual day (dayNumber == PeriodLength) must classify as
+// "menstrual". Mutant `<` would misclassify it as "follicular".
+func TestMR3Stats_PhaseLastMenstrualDay(t *testing.T) {
+	ctx := mr3statsPhaseContext(5, 14)
+	day := mr3statsDayForNumber(ctx, ctx.PeriodLength) // dayNumber == 5
+
+	phase := phaseForCompletedCycleDay(day, ctx, time.UTC)
+
+	if phase != "menstrual" {
+		t.Fatalf("expected menstrual at day %d (PeriodLength), got %q", ctx.PeriodLength, phase)
+	}
+}
+
+// TestMR3Stats_PhaseOvulationDay pins line 100 (dayNumber == OvulationDay).
+// Day == OvulationDay must classify as "ovulation"; a contrast day (6, which
+// is after PeriodLength and before OvulationDay) must classify as
+// "follicular". Mutant `!=` flips both classifications.
+func TestMR3Stats_PhaseOvulationDay(t *testing.T) {
+	ctx := mr3statsPhaseContext(5, 14)
+
+	ovulationDay := mr3statsDayForNumber(ctx, ctx.OvulationDay) // dayNumber == 14
+	if phase := phaseForCompletedCycleDay(ovulationDay, ctx, time.UTC); phase != "ovulation" {
+		t.Fatalf("expected ovulation at day %d, got %q", ctx.OvulationDay, phase)
+	}
+
+	contrastDay := mr3statsDayForNumber(ctx, 6) // not ovulation, between menstrual and ovulation
+	if phase := phaseForCompletedCycleDay(contrastDay, ctx, time.UTC); phase != "follicular" {
+		t.Fatalf("expected follicular at day 6 (non-ovulation contrast), got %q", phase)
+	}
+}
+
+// TestMR3Stats_PhaseFollicularLutealBoundary pins line 102
+// (dayNumber < OvulationDay). The day immediately before ovulation must be
+// "follicular"; the day immediately after must be "luteal". Mutant `<=` would
+// make the post-ovulation day "follicular".
+func TestMR3Stats_PhaseFollicularLutealBoundary(t *testing.T) {
+	ctx := mr3statsPhaseContext(5, 14)
+
+	beforeOv := mr3statsDayForNumber(ctx, ctx.OvulationDay-1) // dayNumber == 13
+	if phase := phaseForCompletedCycleDay(beforeOv, ctx, time.UTC); phase != "follicular" {
+		t.Fatalf("expected follicular at day %d (ovulation-1), got %q", ctx.OvulationDay-1, phase)
+	}
+
+	afterOv := mr3statsDayForNumber(ctx, ctx.OvulationDay+1) // dayNumber == 15
+	if phase := phaseForCompletedCycleDay(afterOv, ctx, time.UTC); phase != "luteal" {
+		t.Fatalf("expected luteal at day %d (ovulation+1), got %q", ctx.OvulationDay+1, phase)
+	}
+}
+
+// --- classifyStatsCycleFactorComparison ------------------------------------
+
+// TestMR3Stats_FactorComparisonShorterBoundary pins line 146
+// (cycleLength <= baseline-delta) at the boundary. baseline 28, delta 2,
+// cycleLength == 26 must classify as "shorter". Mutant `<` would yield
+// "variable".
+func TestMR3Stats_FactorComparisonShorterBoundary(t *testing.T) {
+	stats := CycleStats{MedianCycleLength: 28}
+	cycleLength := 28 - statsCycleFactorComparisonDelta // 26
+
+	if got := classifyStatsCycleFactorComparison(stats, cycleLength); got != "shorter" {
+		t.Fatalf("expected shorter at cycleLength %d (baseline-delta), got %q", cycleLength, got)
+	}
+}
+
+// TestMR3Stats_FactorComparisonShorterArithmetic pins line 146 arithmetic
+// (baseline - delta). With baseline 28 and cycleLength == 28, the result must
+// be "variable": a `+` mutant (baseline+delta = 30) would make 28 <= 30 true
+// and misclassify it as "shorter".
+func TestMR3Stats_FactorComparisonShorterArithmetic(t *testing.T) {
+	stats := CycleStats{MedianCycleLength: 28}
+
+	if got := classifyStatsCycleFactorComparison(stats, 28); got != "variable" {
+		t.Fatalf("expected variable at cycleLength == baseline (28), got %q", got)
+	}
+}
+
+// TestMR3Stats_FactorComparisonLongerBoundary pins line 148
+// (cycleLength >= baseline+delta) at the boundary. baseline 28, delta 2,
+// cycleLength == 30 must classify as "longer". Mutant `>` would yield
+// "variable".
+func TestMR3Stats_FactorComparisonLongerBoundary(t *testing.T) {
+	stats := CycleStats{MedianCycleLength: 28}
+	cycleLength := 28 + statsCycleFactorComparisonDelta // 30
+
+	if got := classifyStatsCycleFactorComparison(stats, cycleLength); got != "longer" {
+		t.Fatalf("expected longer at cycleLength %d (baseline+delta), got %q", cycleLength, got)
+	}
+}
+
+// TestMR3Stats_FactorComparisonLongerArithmetic pins line 148 arithmetic
+// (baseline + delta). With baseline 28, cycleLength == 28 must be "variable"
+// (a `-` mutant of baseline+delta = 26 would make 28 >= 26 true and
+// misclassify it as "longer"), and cycleLength == 30 must be "longer".
+func TestMR3Stats_FactorComparisonLongerArithmetic(t *testing.T) {
+	stats := CycleStats{MedianCycleLength: 28}
+
+	if got := classifyStatsCycleFactorComparison(stats, 28); got != "variable" {
+		t.Fatalf("expected variable at cycleLength == baseline (28), got %q", got)
+	}
+	if got := classifyStatsCycleFactorComparison(stats, 30); got != "longer" {
+		t.Fatalf("expected longer at cycleLength 30 (baseline+delta), got %q", got)
+	}
+}
+
+// TestMR3Stats_FactorComparisonDegenerateBaseline pins both line 146 and 148
+// `baseline > 0` guards. With no median and zero average, baseline resolves to
+// 0; any cycleLength must classify as "variable". Without the guard, a very
+// negative cycleLength would satisfy `<= baseline-delta` ("shorter") and a
+// large cycleLength would satisfy `>= baseline+delta` ("longer").
+func TestMR3Stats_FactorComparisonDegenerateBaseline(t *testing.T) {
+	stats := CycleStats{MedianCycleLength: 0, AverageCycleLength: 0}
+
+	if got := classifyStatsCycleFactorComparison(stats, -5); got != "variable" {
+		t.Fatalf("expected variable for negative cycleLength with zero baseline, got %q", got)
+	}
+	if got := classifyStatsCycleFactorComparison(stats, 100); got != "variable" {
+		t.Fatalf("expected variable for large cycleLength with zero baseline, got %q", got)
+	}
+}
+
+// --- predictionExplanationPrimaryKey ---------------------------------------
+
+// TestMR3Stats_PrimaryKeyIrregularSparse pins line 28 (irregular &&
+// (NeedsData...)). An irregular owner with NextPeriod/Ovulation NeedsData must
+// yield "prediction.explainer.irregular_sparse"; an irregular owner with all
+// four display flags false must yield "". A negated mutant flips both.
+func TestMR3Stats_PrimaryKeyIrregularSparse(t *testing.T) {
+	user := mr3statsOwner()
+	user.IrregularCycle = true
+
+	positive := DashboardCycleContext{
+		DisplayNextPeriodNeedsData: true,
+		DisplayOvulationNeedsData:  true,
+	}
+	if got := predictionExplanationPrimaryKey(user, positive); got != "prediction.explainer.irregular_sparse" {
+		t.Fatalf("expected irregular_sparse, got %q", got)
+	}
+
+	contrast := DashboardCycleContext{}
+	if got := predictionExplanationPrimaryKey(user, contrast); got != "" {
+		t.Fatalf("expected empty primary key when no display flags set, got %q", got)
+	}
+}
+
+// TestMR3Stats_PrimaryKeyIrregularRanges pins line 30 (irregular &&
+// (UseRange...)). An irregular owner with NextPeriod UseRange (and no
+// NeedsData) must yield "prediction.explainer.irregular_ranges"; an irregular
+// owner with all flags false must yield "". A negated mutant flips both.
+func TestMR3Stats_PrimaryKeyIrregularRanges(t *testing.T) {
+	user := mr3statsOwner()
+	user.IrregularCycle = true
+
+	positive := DashboardCycleContext{DisplayNextPeriodUseRange: true}
+	if got := predictionExplanationPrimaryKey(user, positive); got != "prediction.explainer.irregular_ranges" {
+		t.Fatalf("expected irregular_ranges, got %q", got)
+	}
+
+	contrast := DashboardCycleContext{}
+	if got := predictionExplanationPrimaryKey(user, contrast); got != "" {
+		t.Fatalf("expected empty primary key when no display flags set, got %q", got)
+	}
+}
+
+// TestMR3Stats_PrimaryKeyVariableRanges pins line 32 (!irregular &&
+// DisplayNextPeriodUseRange). A regular owner with NextPeriod UseRange must
+// yield "prediction.explainer.variable_ranges"; a regular owner with UseRange
+// false must yield "". A negated mutant (`user.IrregularCycle`) flips both.
+func TestMR3Stats_PrimaryKeyVariableRanges(t *testing.T) {
+	user := mr3statsOwner() // IrregularCycle == false
+
+	positive := DashboardCycleContext{DisplayNextPeriodUseRange: true}
+	if got := predictionExplanationPrimaryKey(user, positive); got != "prediction.explainer.variable_ranges" {
+		t.Fatalf("expected variable_ranges, got %q", got)
+	}
+
+	contrast := DashboardCycleContext{}
+	if got := predictionExplanationPrimaryKey(user, contrast); got != "" {
+		t.Fatalf("expected empty primary key when UseRange false, got %q", got)
+	}
+}


### PR DESCRIPTION
## What

Six focused test files (~52 tests) for `internal/services` that kill mutation survivors introduced by the 10 commits since the `ac3a4af` mutation baseline (audit phases 2–3, robustness/auth hardening). **Test-only — no production code changed.**

## How each kill was verified

Every test was verified **per-mutant** in an isolated worktree: the exact gremlins mutation was applied to the source line, the targeted test confirmed to **fail**, then the source reverted. Spot-re-verified on the final tree across all clusters (cycles, dashboard, day, i18n, stats, auth) — each mutation produces `--- FAIL` under its test.

## Survivor classes now killed

| Cluster | Examples |
|---|---|
| cycle math | `BuildCycleStats` observed-vs-detected starts; nil-location guards (`cycle_anchor`, `cycle_baseline`); `CalcOvulationDay`/`PredictCycleWindow`/`CycleLengthSpread`/`ResolveLutealPhase` boundaries |
| dashboard | irregular range `Max==Min`; `dashboardCycleHeroCurrentPhase` menstrual/ovulation/luteal day boundaries |
| day/calendar | `DayHasData`/`IsAutoFilledPeriodCandidate` mood boundaries; upsert & cycle-start transaction-error propagation |
| i18n | `LocalizedMonthYear`/`LocalizedDateLabel`/`LocalizedDashboardDate` January boundary; `russianPluralForm` lastDigit 1/2/4 |
| stats | reliability thresholds (3/6 cycles); `phaseForCompletedCycleDay`; `classifyStatsCycleFactorComparison` ±delta; `predictionExplanationPrimaryKey`; `compareISODate`; builtin-symptom sort |
| auth | `AuthAttemptPolicy.Configure` window lower bound; `attempt_limiter` sweep counter/size-guard; CAS session-version bump (fixed an assertion that read the stub, not the mutated `userSnap`) |

## Documented equivalents (left, not chased)

Capacity hints to `make`, the dead luteal-default guard (`cycles.go:317`, caller sets 14), `CalendarDay`-invariant location swaps (`day_feedback_policy:62`, `day_service:366` — `CalendarDay` uses `value.Date()`, not `In(location)`), const window/TTL initializers, the `dashboard_view_service:129` dead-store duplicate of the live `:199` predicate, equal-value min/max, downstream re-guards. See `.mutation/internal-services.md` → "Round 3 hardening".

## Numbers

The headline mutation efficacy is re-measured by the weekly CI `mutation.yml` job (clean Linux, stable Docker for Postgres integration tests) and refreshes from there. Local Windows re-measurement was **not** used for the figure: the Docker-backed Postgres integration tests (`testdb.StartPostgresDSN`) perturb gremlins' single coverage pass when Docker is cold/slow, and gremlins' parallel-worker runs were not reproducible on the host. The per-mutant verification above is the authoritative evidence the mutants are killed.

## Validation

`go vet ./...` clean; `go test ./...` green. No e2e impact (pure Go test additions, no runtime/template/JS change).