### PR TITLE
chore(release): prepare v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-06-13
+
+### Security
+
+- **Auth and OIDC hardening (audit follow-up).** Per-IP/identity rate-limit key generation reworked, OIDC discovery/token endpoints origin-pinned against SSRF, the AEAD sealed-cookie path consolidated, request-scoped `context.Context` threaded through the data layer, and the reset-token compare-and-swap folded into `AuthUserRepository` with its dead fallback removed. Behavior-preserving where it counts; defense-in-depth elsewhere.
+- **CSRF tokens are kept out of GET request URLs.** Token transport moved off the query string so it cannot leak via history, logs, or referrers.
+- **Contract and privacy fixes.** Auth/settings validation errors stay in flash/session state rather than URL query parameters, and enumeration-safety wording was tightened across registration and recovery.
+
+### Changed
+
+- **Cycle predictions now use the median cycle length, not the mean**, and the current cycle day is counted on a DST-immune calendar basis. Medical docs and on-screen labeling were aligned to match.
+- **Localization pass across ru/es/de/fr.** Count-bearing stats strings use CLDR plural categories; Russian copy uses the consistent formal «Вы» register; terminology was unified (e.g. ru «панель»/«Аналитика»/«Базовая линия»/«БТТ»). Walkthrough findings also fixed an i18n gap, a settings toggle bug, a dashboard label, and a short-cycle note.
+- **Accessibility hardening.** Focus management for the confirm modal, `aria-live` status/toast regions, and a skip-to-content link.
+
+### Internal
+
+- Hermetic asset builds with a CI stale-bundle guard (committed `web/static` must match a fresh `npm run build`); shared dependency wiring extracted into `internal/bootstrap`; secure-cookie codec deduplicated.
+- Test quality: coverage quality pass (dead-symbol removal, vacuous-test fixes), and a round-3 mutation-hardening pass adding per-mutant-verified tests for service-layer survivors introduced by the audit work.
+- OpenSSF Scorecard fix: renamed `.mutation/security.md` so it no longer shadows `SECURITY.md` in the basename-matched Security-Policy check.
+- Dependencies: `golang.org/x/net` 0.55 → 0.56; npm dev-deps (`@tailwindcss/cli`/`tailwindcss` 4.3.0 → 4.3.1, `eslint` 10.4.1 → 10.5.0) with the CSS bundle rebuilt.
+
 ## [1.2.0] - 2026-06-09
 
 ### Added
@@ -468,7 +489,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - CSV/JSON export,
   - Russian/English localization.
 
-[Unreleased]: https://github.com/ovumcy/ovumcy-web/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/ovumcy/ovumcy-web/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/ovumcy/ovumcy-web/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/ovumcy/ovumcy-web/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/ovumcy/ovumcy-web/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/ovumcy/ovumcy-web/compare/v1.0.0...v1.1.0

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ It is built for people who want fast daily tracking, useful cycle insights, and 
 
 Ovumcy runs as a single Go service with a server-rendered web UI, can be installed on a phone home screen, and supports SQLite by default with Postgres as an advanced self-hosted path.
 
-This README describes the current `main` branch. The latest tagged release is `v1.2.0`.
+This README describes the current `main` branch. The latest tagged release is `v1.3.0`.
 The public project site is [ovumcy.com](https://ovumcy.com).
 
 ## Why Ovumcy Exists
@@ -227,7 +227,7 @@ SQLite (default) / PostgreSQL (advanced)
 
 ### Docker
 
-Uses the prebuilt image from GHCR pinned to the latest tagged release by default (`ghcr.io/ovumcy/ovumcy-web:v1.2.0`).
+Uses the prebuilt image from GHCR pinned to the latest tagged release by default (`ghcr.io/ovumcy/ovumcy-web:v1.3.0`).
 
 Tagged releases from `v0.7.1` onward publish under the GHCR namespace `ghcr.io/ovumcy/ovumcy-web`.
 
@@ -244,7 +244,7 @@ docker compose up -d
 Override the pinned default image tag if needed:
 
 ```bash
-OVUMCY_IMAGE=ghcr.io/ovumcy/ovumcy-web:v1.2.0 docker compose up -d
+OVUMCY_IMAGE=ghcr.io/ovumcy/ovumcy-web:v1.3.0 docker compose up -d
 ```
 
 Then open `http://127.0.0.1:8080`.
@@ -409,7 +409,7 @@ For bugs and feature requests, open a GitHub issue:
 
 ## Releases
 
-- Latest tagged release: `v1.2.0`.
+- Latest tagged release: `v1.3.0`.
 - Publish release notes via GitHub Releases and keep [CHANGELOG.md](CHANGELOG.md) updated.
 
 ## Roadmap

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   ovumcy:
-    image: ${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.2.0}
+    image: ${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.3.0}
     pull_policy: always
     container_name: ovumcy
     env_file:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   ovumcy:
-    image: ${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.2.0}
+    image: ${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.3.0}
     pull_policy: always
     container_name: ovumcy
     env_file:

--- a/docs/examples/postgres/docker-compose.yml
+++ b/docs/examples/postgres/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     restart: unless-stopped
 
   ovumcy:
-    image: ${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.2.0}
+    image: ${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.3.0}
     pull_policy: always
     depends_on:
       postgres:

--- a/docs/examples/reverse-proxy/caddy-postgres/docker-compose.yml
+++ b/docs/examples/reverse-proxy/caddy-postgres/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     restart: unless-stopped
 
   ovumcy:
-    image: ${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.2.0}
+    image: ${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.3.0}
     pull_policy: always
     depends_on:
       postgres:

--- a/docs/examples/reverse-proxy/caddy/docker-compose.yml
+++ b/docs/examples/reverse-proxy/caddy/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   ovumcy:
-    image: ${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.2.0}
+    image: ${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.3.0}
     pull_policy: always
     environment:
       TZ: ${TZ:-UTC}

--- a/docs/examples/reverse-proxy/nginx-postgres/docker-compose.yml
+++ b/docs/examples/reverse-proxy/nginx-postgres/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     restart: unless-stopped
 
   ovumcy:
-    image: ${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.2.0}
+    image: ${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.3.0}
     pull_policy: always
     depends_on:
       postgres:

--- a/docs/examples/reverse-proxy/nginx/docker-compose.yml
+++ b/docs/examples/reverse-proxy/nginx/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   ovumcy:
-    image: ${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.2.0}
+    image: ${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.3.0}
     pull_policy: always
     environment:
       TZ: ${TZ:-UTC}


### PR DESCRIPTION
Release-prep for **v1.3.0** (previous tag v1.2.0, ~30 commits). No new migrations since v1.2.0.

## Changes
- **CHANGELOG**: `[Unreleased]` → `[1.3.0] - 2026-06-13` + compare link. Sections: Security (audit-phase auth/OIDC/CSRF hardening), Changed (median-based predictions + DST-immune cycle day, ru/es/de/fr localization pass, a11y), Internal (hermetic asset builds + stale-bundle guard, round-3 mutation hardening, scorecard fix, deps).
- **Image tag** `v1.2.0` → `v1.3.0`: `docker-compose.yml`, `docker/docker-compose.yml`, `docs/examples/postgres` + all four reverse-proxy stacks.
- **README** version references refreshed (×4).

## Tag flow (after this merges)
`git tag -a v1.3.0` on the merge commit → push tag → `gh release create v1.3.0`. The tag must point at the merge commit, so it is created **after** merge — not in this PR.

## Notes / known
- `docs/releases/` does not exist in this repo, so no per-release notes file was created (not an established artifact here).
- Two stale `*.env.example` image overrides under `reverse-proxy/{caddy,nginx}-postgres/` pin `v0.8.4` (pre-existing inconsistency, not part of the v1.2.0→v1.3.0 default contract). Left untouched here to avoid scope creep / secret-path tooling; worth a separate cleanup.

## Validation
`go vet ./...` clean, `gofmt -s -l` clean, LICENSE present; full `go test ./...` green on main pre-branch. CI on this PR is the gate.