### PR TITLE
test: reduce test cyclomatic complexity for Go Report Card

### DIFF
--- a/internal/db/daily_log_repository_test.go
+++ b/internal/db/daily_log_repository_test.go
@@ -34,6 +34,17 @@ func createDailyLogTestUser(t *testing.T, database *gorm.DB, email string) uint 
 // TestDailyLogRepositoryRangeQueriesAndWhitelist covers the daily-log read
 // paths (including the FindByUserAndDayRange column whitelist that carries
 // pregnancy_test), range/period filtering and ordering, save, and range delete.
+// requireNoErr fails the test immediately when err is non-nil. Extracting the
+// repeated `if err != nil { t.Fatalf }` blocks out of the long repository
+// integration scenarios keeps their cyclomatic complexity in range without
+// splitting a single coherent round-trip across many test functions.
+func requireNoErr(t *testing.T, err error, context string) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("%s: %v", context, err)
+	}
+}
+
 func TestDailyLogRepositoryRangeQueriesAndWhitelist(t *testing.T) {
 	database := openSQLiteForMigrationBootstrapTest(t, filepath.Join(t.TempDir(), "daily.db"))
 	userID := createDailyLogTestUser(t, database, "daily-log-repo@example.com")
@@ -57,21 +68,16 @@ func TestDailyLogRepositoryRangeQueriesAndWhitelist(t *testing.T) {
 		return entry
 	}
 
-	if err := repo.Create(context.Background(), mk(1, func(e *models.DailyLog) { e.IsPeriod = true })); err != nil {
-		t.Fatalf("create d1: %v", err)
-	}
-	if err := repo.Create(context.Background(), mk(5, func(e *models.DailyLog) { e.PregnancyTest = "positive" })); err != nil {
-		t.Fatalf("create d5: %v", err)
-	}
-	if err := repo.Create(context.Background(), mk(10, func(e *models.DailyLog) { e.IsPeriod = true; e.CycleStart = true })); err != nil {
-		t.Fatalf("create d10: %v", err)
-	}
+	requireNoErr(t, repo.Create(context.Background(), mk(1, func(e *models.DailyLog) { e.IsPeriod = true })), "create d1")
+	requireNoErr(t, repo.Create(context.Background(), mk(5, func(e *models.DailyLog) { e.PregnancyTest = "positive" })), "create d5")
+	requireNoErr(t, repo.Create(context.Background(), mk(10, func(e *models.DailyLog) { e.IsPeriod = true; e.CycleStart = true })), "create d10")
 
 	// FindByUserAndDayRange returns the pregnancy_test value via its column
 	// whitelist (regression guard: a missing column silently reads as empty).
 	entry, found, err := repo.FindByUserAndDayRange(context.Background(), userID, day(5), day(6))
-	if err != nil || !found {
-		t.Fatalf("find d5 = (found=%t, err=%v), want found", found, err)
+	requireNoErr(t, err, "find d5")
+	if !found {
+		t.Fatal("expected d5 to be found")
 	}
 	if entry.PregnancyTest != "positive" {
 		t.Fatalf("expected pregnancy_test=positive to round-trip via read whitelist, got %q", entry.PregnancyTest)
@@ -84,9 +90,7 @@ func TestDailyLogRepositoryRangeQueriesAndWhitelist(t *testing.T) {
 
 	// ListByUserDayRange returns the window in DESC order.
 	window, err := repo.ListByUserDayRange(context.Background(), userID, day(1), day(11))
-	if err != nil {
-		t.Fatalf("list day range: %v", err)
-	}
+	requireNoErr(t, err, "list day range")
 	if len(window) != 3 {
 		t.Fatalf("expected 3 logs in window, got %d", len(window))
 	}
@@ -97,39 +101,29 @@ func TestDailyLogRepositoryRangeQueriesAndWhitelist(t *testing.T) {
 	// ListByUserRange honors the lower bound only.
 	fromD5 := day(5)
 	ranged, err := repo.ListByUserRange(context.Background(), userID, &fromD5, nil)
-	if err != nil {
-		t.Fatalf("list range: %v", err)
-	}
+	requireNoErr(t, err, "list range")
 	if len(ranged) != 2 {
 		t.Fatalf("expected 2 logs from d5 onward, got %d", len(ranged))
 	}
 
 	// ListPeriodDays returns only period rows.
 	periods, err := repo.ListPeriodDays(context.Background(), userID)
-	if err != nil {
-		t.Fatalf("list period days: %v", err)
-	}
+	requireNoErr(t, err, "list period days")
 	if len(periods) != 2 {
 		t.Fatalf("expected 2 period days (d1, d10), got %d", len(periods))
 	}
 
 	// Save persists a mutation on an existing row.
 	entry.Notes = "updated note"
-	if err := repo.Save(context.Background(), &entry); err != nil {
-		t.Fatalf("save: %v", err)
-	}
+	requireNoErr(t, repo.Save(context.Background(), &entry), "save")
 	if updated, _, _ := repo.FindByUserAndDayRange(context.Background(), userID, day(5), day(6)); updated.Notes != "updated note" {
 		t.Fatalf("expected Save to persist note, got %q", updated.Notes)
 	}
 
 	// DeleteByUserAndDayRange removes the [d1, d5) window (only d1).
-	if err := repo.DeleteByUserAndDayRange(context.Background(), userID, day(1), day(5)); err != nil {
-		t.Fatalf("delete range: %v", err)
-	}
+	requireNoErr(t, repo.DeleteByUserAndDayRange(context.Background(), userID, day(1), day(5)), "delete range")
 	remaining, err := repo.ListByUser(context.Background(), userID)
-	if err != nil {
-		t.Fatalf("list by user: %v", err)
-	}
+	requireNoErr(t, err, "list by user")
 	if len(remaining) != 2 {
 		t.Fatalf("expected 2 logs after deleting d1, got %d", len(remaining))
 	}

--- a/internal/db/delete_account_completeness_test.go
+++ b/internal/db/delete_account_completeness_test.go
@@ -7,7 +7,18 @@ import (
 	"time"
 
 	"github.com/ovumcy/ovumcy-web/internal/models"
+	"gorm.io/gorm"
 )
+
+// countWhere returns the row count for model matching query, failing the test
+// on a query error — folding the repeated count-and-check-err blocks out of the
+// erasure scenarios.
+func countWhere(t *testing.T, database *gorm.DB, model any, query string, args ...any) int64 {
+	t.Helper()
+	var count int64
+	requireNoErr(t, database.Model(model).Where(query, args...).Count(&count).Error, "count")
+	return count
+}
 
 // TestDeleteAccountAndRelatedDataRemovesAllUserRows proves account erasure is
 // complete across every user-scoped table — including register_pickup_tokens
@@ -17,9 +28,7 @@ import (
 func TestDeleteAccountAndRelatedDataRemovesAllUserRows(t *testing.T) {
 	dir := t.TempDir()
 	database, err := OpenSQLite(filepath.Join(dir, "erasure.db"))
-	if err != nil {
-		t.Fatalf("open sqlite: %v", err)
-	}
+	requireNoErr(t, err, "open sqlite")
 	t.Cleanup(func() {
 		if sqlDB, err := database.DB(); err == nil {
 			_ = sqlDB.Close()
@@ -37,9 +46,7 @@ func TestDeleteAccountAndRelatedDataRemovesAllUserRows(t *testing.T) {
 		AutoPeriodFill:   true,
 		CreatedAt:        time.Now().UTC(),
 	}
-	if err := repos.Users.Create(context.Background(), user); err != nil {
-		t.Fatalf("create user: %v", err)
-	}
+	requireNoErr(t, repos.Users.Create(context.Background(), user), "create user")
 
 	seed := []any{
 		&models.DailyLog{UserID: user.ID, Date: time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC), IsPeriod: true},
@@ -52,20 +59,12 @@ func TestDeleteAccountAndRelatedDataRemovesAllUserRows(t *testing.T) {
 		&models.OIDCLogoutState{SessionID: "sess-live", EndSessionEndpoint: "https://idp.example.com/logout", IDTokenHint: "hint", ExpiresAt: time.Now().Add(time.Hour).UTC()},
 	}
 	for _, row := range seed {
-		if err := database.Create(row).Error; err != nil {
-			t.Fatalf("seed %T: %v", row, err)
-		}
+		requireNoErr(t, database.Create(row).Error, "seed row")
 	}
 
-	if err := repos.Users.DeleteAccountAndRelatedData(context.Background(), user.ID); err != nil {
-		t.Fatalf("delete account: %v", err)
-	}
+	requireNoErr(t, repos.Users.DeleteAccountAndRelatedData(context.Background(), user.ID), "delete account")
 
-	var usersLeft int64
-	if err := database.Model(&models.User{}).Where("id = ?", user.ID).Count(&usersLeft).Error; err != nil {
-		t.Fatalf("count users: %v", err)
-	}
-	if usersLeft != 0 {
+	if usersLeft := countWhere(t, database, &models.User{}, "id = ?", user.ID); usersLeft != 0 {
 		t.Fatalf("users still has %d row(s) for the deleted account", usersLeft)
 	}
 
@@ -79,29 +78,17 @@ func TestDeleteAccountAndRelatedDataRemovesAllUserRows(t *testing.T) {
 		{"register_pickup_tokens", &models.RegisterPickupToken{}},
 		{"oidc_identities", &models.OIDCIdentity{}},
 	} {
-		var remaining int64
-		if err := database.Model(tc.model).Where("user_id = ?", user.ID).Count(&remaining).Error; err != nil {
-			t.Fatalf("count %s: %v", tc.label, err)
-		}
-		if remaining != 0 {
+		if remaining := countWhere(t, database, tc.model, "user_id = ?", user.ID); remaining != 0 {
 			t.Fatalf("%s still has %d row(s) for the deleted user — account erasure incomplete", tc.label, remaining)
 		}
 	}
 
-	// The post-commit housekeeping purge drops expired logout states and
-	// keeps unexpired ones (they age out via their own TTL).
-	var expiredLeft int64
-	if err := database.Model(&models.OIDCLogoutState{}).Where("session_id = ?", "sess-expired").Count(&expiredLeft).Error; err != nil {
-		t.Fatalf("count expired logout states: %v", err)
-	}
-	if expiredLeft != 0 {
+	// The post-commit housekeeping purge drops expired logout states and keeps
+	// unexpired ones (they age out via their own TTL).
+	if expiredLeft := countWhere(t, database, &models.OIDCLogoutState{}, "session_id = ?", "sess-expired"); expiredLeft != 0 {
 		t.Fatalf("expected expired oidc_logout_states row to be purged after erasure, found %d", expiredLeft)
 	}
-	var liveLeft int64
-	if err := database.Model(&models.OIDCLogoutState{}).Where("session_id = ?", "sess-live").Count(&liveLeft).Error; err != nil {
-		t.Fatalf("count live logout states: %v", err)
-	}
-	if liveLeft != 1 {
+	if liveLeft := countWhere(t, database, &models.OIDCLogoutState{}, "session_id = ?", "sess-live"); liveLeft != 1 {
 		t.Fatalf("expected unexpired oidc_logout_states row to survive erasure, found %d", liveLeft)
 	}
 }

--- a/internal/db/ttl_repositories_test.go
+++ b/internal/db/ttl_repositories_test.go
@@ -14,6 +14,18 @@ import (
 // row consumed in the same transaction (replay is indistinguishable from
 // missing), expired rows never consume, and DeleteExpired drops only the
 // expired ones.
+// assertPickupConsume consumes nonce at time `at` and asserts the returned
+// (userID, ok) pair, folding the repeated Consume-and-check blocks out of the
+// scenario so its cyclomatic complexity stays in range.
+func assertPickupConsume(t *testing.T, repo *RegisterPickupTokenRepository, nonce string, at time.Time, wantUserID uint, wantOK bool) {
+	t.Helper()
+	userID, ok, err := repo.Consume(context.Background(), nonce, at)
+	requireNoErr(t, err, "consume "+nonce)
+	if ok != wantOK || userID != wantUserID {
+		t.Fatalf("consume %q = (%d, %t), want (%d, %t)", nonce, userID, ok, wantUserID, wantOK)
+	}
+}
+
 func TestRegisterPickupTokenRepositoryIssueConsumeTTL(t *testing.T) {
 	database := openSQLiteForMigrationBootstrapTest(t, filepath.Join(t.TempDir(), "pickup.db"))
 	repo := NewRegisterPickupTokenRepository(database)
@@ -33,51 +45,26 @@ func TestRegisterPickupTokenRepositoryIssueConsumeTTL(t *testing.T) {
 		t.Fatal("expected zero expiry to be rejected")
 	}
 
-	// Issue + consume returns the original user id once.
-	if err := repo.Issue(context.Background(), "nonce-a", 42, base.Add(5*time.Minute)); err != nil {
-		t.Fatalf("issue: %v", err)
-	}
-	if userID, ok, err := repo.Consume(context.Background(), "nonce-a", base); err != nil || !ok || userID != 42 {
-		t.Fatalf("first consume = (%d, %t, %v), want (42, true, nil)", userID, ok, err)
-	}
-
-	// Single-use: replay returns the same indistinguishable (0,false,nil).
-	if userID, ok, err := repo.Consume(context.Background(), "nonce-a", base); err != nil || ok || userID != 0 {
-		t.Fatalf("replay consume = (%d, %t, %v), want (0, false, nil)", userID, ok, err)
-	}
+	// Issue + consume returns the original user id once; replay is an
+	// indistinguishable no-op (single-use).
+	requireNoErr(t, repo.Issue(context.Background(), "nonce-a", 42, base.Add(5*time.Minute)), "issue nonce-a")
+	assertPickupConsume(t, repo, "nonce-a", base, 42, true)
+	assertPickupConsume(t, repo, "nonce-a", base, 0, false)
 
 	// Expired token cannot be consumed.
-	if err := repo.Issue(context.Background(), "nonce-expired", 7, base.Add(-1*time.Minute)); err != nil {
-		t.Fatalf("issue expired: %v", err)
-	}
-	if userID, ok, err := repo.Consume(context.Background(), "nonce-expired", base); err != nil || ok || userID != 0 {
-		t.Fatalf("expired consume = (%d, %t, %v), want (0, false, nil)", userID, ok, err)
-	}
+	requireNoErr(t, repo.Issue(context.Background(), "nonce-expired", 7, base.Add(-1*time.Minute)), "issue expired")
+	assertPickupConsume(t, repo, "nonce-expired", base, 0, false)
 
 	// Missing / empty nonce never consume.
-	if _, ok, _ := repo.Consume(context.Background(), "does-not-exist", base); ok {
-		t.Fatal("expected missing nonce to not consume")
-	}
-	if _, ok, _ := repo.Consume(context.Background(), "", base); ok {
-		t.Fatal("expected empty nonce to not consume")
-	}
+	assertPickupConsume(t, repo, "does-not-exist", base, 0, false)
+	assertPickupConsume(t, repo, "", base, 0, false)
 
 	// DeleteExpired drops only expired rows.
-	if err := repo.Issue(context.Background(), "nonce-future", 9, base.Add(5*time.Minute)); err != nil {
-		t.Fatalf("issue future: %v", err)
-	}
-	if err := repo.Issue(context.Background(), "nonce-stale", 9, base.Add(-2*time.Minute)); err != nil {
-		t.Fatalf("issue stale: %v", err)
-	}
-	if err := repo.DeleteExpired(context.Background(), base); err != nil {
-		t.Fatalf("delete expired: %v", err)
-	}
-	if _, ok, _ := repo.Consume(context.Background(), "nonce-stale", base); ok {
-		t.Fatal("expected stale row to be deleted by DeleteExpired")
-	}
-	if _, ok, _ := repo.Consume(context.Background(), "nonce-future", base); !ok {
-		t.Fatal("expected future row to survive DeleteExpired")
-	}
+	requireNoErr(t, repo.Issue(context.Background(), "nonce-future", 9, base.Add(5*time.Minute)), "issue future")
+	requireNoErr(t, repo.Issue(context.Background(), "nonce-stale", 9, base.Add(-2*time.Minute)), "issue stale")
+	requireNoErr(t, repo.DeleteExpired(context.Background(), base), "delete expired")
+	assertPickupConsume(t, repo, "nonce-stale", base, 0, false)
+	assertPickupConsume(t, repo, "nonce-future", base, 9, true)
 }
 
 // TestRegisterPickupTokenRepositoryIssuePurgesExpiredRows pins the retention
@@ -147,6 +134,21 @@ func TestRegisterPickupTokenRepositoryIssuePurgesExpiredRows(t *testing.T) {
 // TestOIDCLogoutStateRepositorySaveFindTTL covers the OIDC logout-state
 // persistence: save/find round-trip, session_id upsert, not-found, targeted
 // delete, and TTL sweep.
+// assertLogoutState finds sessionID and asserts presence, plus — when present
+// and wantEndpoint is set — the mutable columns, collapsing the repeated
+// find-and-check blocks out of the scenario.
+func assertLogoutState(t *testing.T, repo *OIDCLogoutStateRepository, sessionID string, wantOK bool, wantEndpoint, wantHint string) {
+	t.Helper()
+	got, ok, err := repo.FindBySessionID(context.Background(), sessionID)
+	requireNoErr(t, err, "find "+sessionID)
+	if ok != wantOK {
+		t.Fatalf("find %q ok=%t, want %t", sessionID, ok, wantOK)
+	}
+	if wantOK && wantEndpoint != "" && (got.EndSessionEndpoint != wantEndpoint || got.IDTokenHint != wantHint) {
+		t.Fatalf("find %q returned %#v, want endpoint=%q hint=%q", sessionID, got, wantEndpoint, wantHint)
+	}
+}
+
 func TestOIDCLogoutStateRepositorySaveFindTTL(t *testing.T) {
 	database := openSQLiteForMigrationBootstrapTest(t, filepath.Join(t.TempDir(), "logout.db"))
 	repo := NewOIDCLogoutStateRepository(database)
@@ -163,57 +165,26 @@ func TestOIDCLogoutStateRepositorySaveFindTTL(t *testing.T) {
 	}
 
 	// nil is a no-op.
-	if err := repo.Save(context.Background(), nil); err != nil {
-		t.Fatalf("save nil: %v", err)
-	}
+	requireNoErr(t, repo.Save(context.Background(), nil), "save nil")
 
-	if err := repo.Save(context.Background(), newState("sess-1", "https://id.example.com/logout", "hint-1", base.Add(10*time.Minute))); err != nil {
-		t.Fatalf("save: %v", err)
-	}
-	got, ok, err := repo.FindBySessionID(context.Background(), "sess-1")
-	if err != nil || !ok {
-		t.Fatalf("find = (ok=%t, err=%v), want found", ok, err)
-	}
-	if got.EndSessionEndpoint != "https://id.example.com/logout" || got.IDTokenHint != "hint-1" {
-		t.Fatalf("find returned unexpected state: %#v", got)
-	}
+	requireNoErr(t, repo.Save(context.Background(), newState("sess-1", "https://id.example.com/logout", "hint-1", base.Add(10*time.Minute))), "save")
+	assertLogoutState(t, repo, "sess-1", true, "https://id.example.com/logout", "hint-1")
 
 	// Upsert on session_id conflict updates the mutable columns.
-	if err := repo.Save(context.Background(), newState("sess-1", "https://id.example.com/logout-v2", "hint-2", base.Add(10*time.Minute))); err != nil {
-		t.Fatalf("re-save: %v", err)
-	}
-	got, _, _ = repo.FindBySessionID(context.Background(), "sess-1")
-	if got.EndSessionEndpoint != "https://id.example.com/logout-v2" || got.IDTokenHint != "hint-2" {
-		t.Fatalf("expected upsert to update columns, got %#v", got)
-	}
+	requireNoErr(t, repo.Save(context.Background(), newState("sess-1", "https://id.example.com/logout-v2", "hint-2", base.Add(10*time.Minute))), "re-save")
+	assertLogoutState(t, repo, "sess-1", true, "https://id.example.com/logout-v2", "hint-2")
 
 	// Missing session.
-	if _, ok, _ := repo.FindBySessionID(context.Background(), "nope"); ok {
-		t.Fatal("expected missing session to return not-found")
-	}
+	assertLogoutState(t, repo, "nope", false, "", "")
 
 	// Targeted delete.
-	if err := repo.DeleteBySessionID(context.Background(), "sess-1"); err != nil {
-		t.Fatalf("delete: %v", err)
-	}
-	if _, ok, _ := repo.FindBySessionID(context.Background(), "sess-1"); ok {
-		t.Fatal("expected deleted session to be gone")
-	}
+	requireNoErr(t, repo.DeleteBySessionID(context.Background(), "sess-1"), "delete")
+	assertLogoutState(t, repo, "sess-1", false, "", "")
 
 	// TTL sweep drops only expired rows.
-	if err := repo.Save(context.Background(), newState("valid", "https://id.example.com/l", "h", base.Add(10*time.Minute))); err != nil {
-		t.Fatalf("save valid: %v", err)
-	}
-	if err := repo.Save(context.Background(), newState("stale", "https://id.example.com/l", "h", base.Add(-1*time.Minute))); err != nil {
-		t.Fatalf("save stale: %v", err)
-	}
-	if err := repo.DeleteExpired(context.Background(), base); err != nil {
-		t.Fatalf("delete expired: %v", err)
-	}
-	if _, ok, _ := repo.FindBySessionID(context.Background(), "stale"); ok {
-		t.Fatal("expected stale logout state to be deleted")
-	}
-	if _, ok, _ := repo.FindBySessionID(context.Background(), "valid"); !ok {
-		t.Fatal("expected valid logout state to survive")
-	}
+	requireNoErr(t, repo.Save(context.Background(), newState("valid", "https://id.example.com/l", "h", base.Add(10*time.Minute))), "save valid")
+	requireNoErr(t, repo.Save(context.Background(), newState("stale", "https://id.example.com/l", "h", base.Add(-1*time.Minute))), "save stale")
+	requireNoErr(t, repo.DeleteExpired(context.Background(), base), "delete expired")
+	assertLogoutState(t, repo, "stale", false, "", "")
+	assertLogoutState(t, repo, "valid", true, "", "")
 }

--- a/internal/services/domain_label_policy_test.go
+++ b/internal/services/domain_label_policy_test.go
@@ -3,54 +3,30 @@ package services
 import "testing"
 
 func TestDomainLabelPolicy(t *testing.T) {
-	if got := PhaseTranslationKey("ovulation"); got != "phases.ovulation" {
-		t.Fatalf("expected ovulation key, got %q", got)
+	cases := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"phase ovulation", PhaseTranslationKey("ovulation"), "phases.ovulation"},
+		{"phase unknown", PhaseTranslationKey("unknown-phase"), "phases.unknown"},
+		{"flow light", FlowTranslationKey("light"), "dashboard.flow.light"},
+		{"flow fallback", FlowTranslationKey("unexpected"), "dashboard.flow.none"},
+		{"pregnancy negative", PregnancyTestTranslationKey("negative"), "dashboard.pregnancy_test.negative"},
+		{"pregnancy positive", PregnancyTestTranslationKey("positive"), "dashboard.pregnancy_test.positive"},
+		{"pregnancy fallback", PregnancyTestTranslationKey("unexpected"), "dashboard.pregnancy_test.none"},
+		{"role owner", RoleTranslationKey("owner"), "role.owner"},
+		{"role passthrough", RoleTranslationKey("guest"), "guest"},
+		{"icon menstrual", PhaseIcon("menstrual"), "\U0001FA78"},
+		{"icon fertile", PhaseIcon("fertile"), "\U0001F33F"},
+		{"icon default", PhaseIcon("bad"), "\u2728"},
+		{"symptom pain", SymptomGroup("Cramps"), "pain"},
+		{"symptom digestion", SymptomGroup("Food cravings"), "digestion"},
+		{"symptom other", SymptomGroup("Custom symptom"), "other"},
 	}
-	if got := PhaseTranslationKey("unknown-phase"); got != "phases.unknown" {
-		t.Fatalf("expected unknown phase key, got %q", got)
-	}
-
-	if got := FlowTranslationKey("light"); got != "dashboard.flow.light" {
-		t.Fatalf("expected light flow key, got %q", got)
-	}
-	if got := FlowTranslationKey("unexpected"); got != "dashboard.flow.none" {
-		t.Fatalf("expected none flow key, got %q", got)
-	}
-
-	if got := PregnancyTestTranslationKey("negative"); got != "dashboard.pregnancy_test.negative" {
-		t.Fatalf("expected negative pregnancy test key, got %q", got)
-	}
-	if got := PregnancyTestTranslationKey("positive"); got != "dashboard.pregnancy_test.positive" {
-		t.Fatalf("expected positive pregnancy test key, got %q", got)
-	}
-	if got := PregnancyTestTranslationKey("unexpected"); got != "dashboard.pregnancy_test.none" {
-		t.Fatalf("expected none pregnancy test key, got %q", got)
-	}
-
-	if got := RoleTranslationKey("owner"); got != "role.owner" {
-		t.Fatalf("expected owner role key, got %q", got)
-	}
-	if got := RoleTranslationKey("guest"); got != "guest" {
-		t.Fatalf("expected passthrough role for unknown, got %q", got)
-	}
-
-	if got := PhaseIcon("menstrual"); got != "\U0001FA78" {
-		t.Fatalf("expected menstrual icon, got %q", got)
-	}
-	if got := PhaseIcon("fertile"); got != "\U0001F33F" {
-		t.Fatalf("expected fertile icon, got %q", got)
-	}
-	if got := PhaseIcon("bad"); got != "\u2728" {
-		t.Fatalf("expected default icon, got %q", got)
-	}
-
-	if got := SymptomGroup("Cramps"); got != "pain" {
-		t.Fatalf("expected pain group, got %q", got)
-	}
-	if got := SymptomGroup("Food cravings"); got != "digestion" {
-		t.Fatalf("expected digestion group, got %q", got)
-	}
-	if got := SymptomGroup("Custom symptom"); got != "other" {
-		t.Fatalf("expected other group, got %q", got)
+	for _, tc := range cases {
+		if tc.got != tc.want {
+			t.Fatalf("%s: got %q, want %q", tc.name, tc.got, tc.want)
+		}
 	}
 }

--- a/internal/services/policy_fuzz_test.go
+++ b/internal/services/policy_fuzz_test.go
@@ -64,6 +64,29 @@ func FuzzParseDayRange(f *testing.F) {
 
 // FuzzValidatePasswordStrength cross-checks the validator against an independent
 // reimplementation and a metamorphic property (appending never weakens).
+// passwordOracleValid is the independent fuzz oracle for
+// ValidatePasswordStrength — structured differently from the implementation and
+// kept as a standalone function so the fuzz body stays within complexity limits.
+// A password is strong iff it has at least 8 runes, at most maxPasswordBytes
+// bytes (bcrypt's hard input limit), and all three character classes.
+func passwordOracleValid(password string) bool {
+	var upper, lower, digit bool
+	for _, r := range password {
+		if unicode.IsUpper(r) {
+			upper = true
+		}
+		if unicode.IsLower(r) {
+			lower = true
+		}
+		if unicode.IsDigit(r) {
+			digit = true
+		}
+	}
+	return utf8.RuneCountInString(password) >= 8 &&
+		len(password) <= maxPasswordBytes &&
+		upper && lower && digit
+}
+
 func FuzzValidatePasswordStrength(f *testing.F) {
 	for _, seed := range []string{
 		"Abcdef12", "short", "alllowercase", "ALLUPPER123",
@@ -77,25 +100,7 @@ func FuzzValidatePasswordStrength(f *testing.F) {
 	}
 	f.Fuzz(func(t *testing.T, password string) {
 		err := ValidatePasswordStrength(password)
-
-		// Independent oracle, structured differently from the implementation.
-		var upper, lower, digit bool
-		for _, r := range password {
-			if unicode.IsUpper(r) {
-				upper = true
-			}
-			if unicode.IsLower(r) {
-				lower = true
-			}
-			if unicode.IsDigit(r) {
-				digit = true
-			}
-		}
-		// The validator enforces BOTH bounds: at least 8 runes and at most 72
-		// BYTES (bcrypt's hard input limit), plus the three character classes.
-		wantValid := utf8.RuneCountInString(password) >= 8 &&
-			len(password) <= maxPasswordBytes &&
-			upper && lower && digit
+		wantValid := passwordOracleValid(password)
 
 		switch {
 		case wantValid && err != nil:


### PR DESCRIPTION
## Summary
Bring the last 6 functions flagged by `gocyclo` (>15) under threshold for the [Go Report Card](https://goreportcard.com/report/github.com/ovumcy/ovumcy-web) badge. **All six are test functions — production code was already clean (0 functions >15).** No assertion is weakened and no coverage changes.

- **db repository scenarios** (`daily_log` range, register-pickup TTL, oidc-logout TTL, delete-account completeness): extract `requireNoErr` + small per-repository assert helpers (`assertPickupConsume`, `assertLogoutState`, `countWhere`) so each long round-trip stays one coherent test but sheds the repeated `if err != nil { t.Fatalf }` blocks.
- **domain-label policy**: table-drive the 15 key/icon/group checks.
- **password fuzz**: lift the independent oracle into a standalone `passwordOracleValid` function.

## Verification
- `gocyclo -over 15 ./...` → **0 functions** (was 6).
- `go test ./internal/db/ ./internal/services/` green; fuzz seeds pass.
- gofmt / go vet / ineffassign / misspell clean.

Net −67 lines. Independent of the JSON-import feature PR (#127).
