### PR TITLE
chore(release): v1.7.0 + CI runtime-image smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -430,3 +430,58 @@ jobs:
             test-results
             .tmp/e2e
           if-no-files-found: ignore
+
+  image-smoke:
+    # Boots the actual FROM-scratch runtime image and hits its public surfaces.
+    # The unit/e2e jobs exercise the app under `go run`; only this job proves the
+    # embedded templates/locales/web-static (go:embed) and the static.New asset
+    # middleware serve correctly from the shell-less scratch image, and that the
+    # in-container `ovumcy healthcheck` self-probe passes. Runs on code changes so
+    # an asset/embed/packaging regression cannot reach a release tag unnoticed.
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    needs:
+      - changes
+    if: needs.changes.outputs.run_e2e == 'true'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Build runtime image
+        run: docker build --tag ovumcy-image-smoke:${{ github.sha }} .
+
+      - name: Boot image and smoke public surfaces
+        run: |
+          set -euo pipefail
+          secret="$(openssl rand -hex 32)"
+          cid="$(docker run -d --rm -p 18080:8080 -e SECRET_KEY="$secret" ovumcy-image-smoke:${{ github.sha }})"
+          trap 'docker stop "$cid" >/dev/null 2>&1 || true' EXIT
+
+          # The scratch image has no shell/curl, so probe readiness from the host.
+          ready=0
+          for _ in $(seq 1 30); do
+            if curl -fsS http://localhost:18080/healthz >/dev/null 2>&1; then ready=1; break; fi
+            sleep 1
+          done
+          if [ "$ready" -ne 1 ]; then echo "app did not become healthy"; docker logs "$cid" || true; exit 1; fi
+
+          curl -fsS http://localhost:18080/healthz | grep -q '"status":"ok"'
+
+          # /login renders from embedded templates.
+          login="$(curl -fsS http://localhost:18080/login)"
+          printf '%s' "$login" | grep -q 'id="login-form"'
+
+          # A versioned /static asset serves via static.New from the embedded FS
+          # with the release cache header.
+          asset="$(printf '%s' "$login" | grep -oE '/static/[^"?]+\?v=[A-Za-z0-9]+' | head -1)"
+          if [ -z "$asset" ]; then echo "no versioned static asset found in /login"; exit 1; fi
+          curl -fsS -D - -o /dev/null "http://localhost:18080$asset" \
+            | tr -d '\r' | grep -iq '^cache-control: public, max-age=3600'
+
+          # The container's own HEALTHCHECK command (the binary self-probe).
+          docker exec "$cid" /app/ovumcy healthcheck
+
+          echo "image smoke OK: healthz + login + static ($asset) + in-container healthcheck"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0] - 2026-07-03
+
 ### Security
 
 - **Web framework upgraded to Fiber v3.** `gofiber/fiber` moves from v2.52.13 to v3.4.0, removing GHSA-gcfq-8gqf-4876 / CVE-2026-45045 (X-Real-IP spoofing in fiber's proxy middleware) from the dependency graph entirely — the vulnerable module was never compiled into Ovumcy, and `govulncheck` now reports no known vulnerabilities. Routes, JSON shapes, cookie attributes, security headers, and rate limiting are preserved; the CSRF token lifetime is pinned explicitly to the previous 1-hour value (Fiber v3's new default would otherwise shorten it to 30 minutes).
@@ -563,7 +565,8 @@ build-hardening work. No database migrations; no breaking API changes.
   - CSV/JSON export,
   - Russian/English localization.
 
-[Unreleased]: https://github.com/ovumcy/ovumcy-web/compare/v1.6.0...HEAD
+[Unreleased]: https://github.com/ovumcy/ovumcy-web/compare/v1.7.0...HEAD
+[1.7.0]: https://github.com/ovumcy/ovumcy-web/compare/v1.6.0...v1.7.0
 [1.6.0]: https://github.com/ovumcy/ovumcy-web/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/ovumcy/ovumcy-web/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/ovumcy/ovumcy-web/compare/v1.3.0...v1.4.0

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ It is built for people who want fast daily tracking, useful cycle insights, and 
 
 Ovumcy runs as a single Go service with a server-rendered web UI, can be installed on a phone home screen, and supports SQLite by default with Postgres as an advanced self-hosted path.
 
-This README describes the current `main` branch. The latest tagged release is `v1.6.0`.
+This README describes the current `main` branch. The latest tagged release is `v1.7.0`.
 The public project site is [ovumcy.com](https://ovumcy.com).
 
 ## Why Ovumcy Exists
@@ -227,7 +227,7 @@ SQLite (default) / PostgreSQL (advanced)
 
 ### Docker
 
-Uses the prebuilt image from GHCR pinned to the latest tagged release by default (`ghcr.io/ovumcy/ovumcy-web:v1.6.0`).
+Uses the prebuilt image from GHCR pinned to the latest tagged release by default (`ghcr.io/ovumcy/ovumcy-web:v1.7.0`).
 
 Tagged releases from `v0.7.1` onward publish under the GHCR namespace `ghcr.io/ovumcy/ovumcy-web`.
 
@@ -244,7 +244,7 @@ docker compose up -d
 Override the pinned default image tag if needed:
 
 ```bash
-OVUMCY_IMAGE=ghcr.io/ovumcy/ovumcy-web:v1.6.0 docker compose up -d
+OVUMCY_IMAGE=ghcr.io/ovumcy/ovumcy-web:v1.7.0 docker compose up -d
 ```
 
 Then open `http://127.0.0.1:8080`.
@@ -413,7 +413,7 @@ For bugs and feature requests, open a GitHub issue:
 
 ## Releases
 
-- Latest tagged release: `v1.6.0`.
+- Latest tagged release: `v1.7.0`.
 - Publish release notes via GitHub Releases and keep [CHANGELOG.md](CHANGELOG.md) updated.
 
 ## Roadmap

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   ovumcy:
-    image: ${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.6.0}
+    image: ${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.7.0}
     pull_policy: always
     container_name: ovumcy
     env_file:

--- a/docs/examples/postgres/docker-compose.yml
+++ b/docs/examples/postgres/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     restart: unless-stopped
 
   ovumcy:
-    image: ${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.6.0}
+    image: ${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.7.0}
     pull_policy: always
     depends_on:
       postgres:

--- a/docs/examples/reverse-proxy/caddy-postgres/docker-compose.yml
+++ b/docs/examples/reverse-proxy/caddy-postgres/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     restart: unless-stopped
 
   ovumcy:
-    image: ${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.6.0}
+    image: ${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.7.0}
     pull_policy: always
     depends_on:
       postgres:

--- a/docs/examples/reverse-proxy/caddy/docker-compose.yml
+++ b/docs/examples/reverse-proxy/caddy/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   ovumcy:
-    image: ${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.6.0}
+    image: ${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.7.0}
     pull_policy: always
     environment:
       TZ: ${TZ:-UTC}

--- a/docs/examples/reverse-proxy/nginx-postgres/docker-compose.yml
+++ b/docs/examples/reverse-proxy/nginx-postgres/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     restart: unless-stopped
 
   ovumcy:
-    image: ${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.6.0}
+    image: ${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.7.0}
     pull_policy: always
     depends_on:
       postgres:

--- a/docs/examples/reverse-proxy/nginx/docker-compose.yml
+++ b/docs/examples/reverse-proxy/nginx/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   ovumcy:
-    image: ${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.6.0}
+    image: ${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.7.0}
     pull_policy: always
     environment:
       TZ: ${TZ:-UTC}


### PR DESCRIPTION
## Release v1.7.0 — Fiber v3 migration

Cuts **v1.7.0**, whose headline change (already merged to `main` via #132) is the framework move **Fiber v2.52.13 → v3.4.0**, removing GHSA-gcfq-8gqf-4876 / CVE-2026-45045 from the dependency graph (`govulncheck` clean). See the CHANGELOG `[1.7.0]` section for the operator upgrade note on HTTPS reverse-proxy CSRF `Origin` validation.

### Release artifacts
- `CHANGELOG.md`: `[Unreleased]` → `[1.7.0] - 2026-07-03` + compare-link footer.
- Image tag `v1.6.0` → `v1.7.0` in `README.md`, `docker-compose.yml`, and all `docs/examples/*` stacks (postgres, caddy, nginx, caddy-postgres, nginx-postgres).

### Durable CI fix (bundled here, not a standalone PR)
New **`image-smoke`** job in `ci.yml`: builds the `FROM scratch` runtime image, boots it, and asserts:
- `/healthz` → `{"status":"ok"}`
- `/login` renders from embedded templates
- a versioned `/static` asset serves via `static.New` from the embedded FS with `Cache-Control: public, max-age=3600`
- the in-container `ovumcy healthcheck` self-probe exits 0

This closes the gap where unit/e2e run under `go run` and Trivy only *scans* the image without booting it — an asset/embed/packaging regression can no longer reach a release tag unnoticed. `actionlint` clean.

### Pre-merge validation already done locally
- Full runtime smoke of the built binary from an empty directory **and** the literal scratch container: healthz + login + static + CSRF accept/reject + healthcheck all green.
- Chromium browser smoke (`e2e:fast`) green; full e2e + cross-browser + postgres + OIDC lanes green on #132.

After merge: tag `v1.7.0` on the merged `main` + `gh release`.
