### PR TITLE
fix(cmd): retry graceful stop through the fiber/fasthttp boot window

### DIFF
--- a/cmd/ovumcy/main.go
+++ b/cmd/ovumcy/main.go
@@ -133,12 +133,15 @@ func main() {
 	// codecov:ignore:end
 	handler := mustNewHandler(config, i18nManager, dependencies)
 	app := newFiberApp(config, handler)
-	stopSignals := installGracefulShutdown(app)
+	served := make(chan struct{})
+	stopSignals := installGracefulShutdown(app, served)
 	defer stopSignals()
 
 	logStartup(config)
 	// codecov:ignore:start -- main() run loop; runServer itself is unit-tested.
-	if err := runServer(app, database, ":"+config.Port); err != nil {
+	err = runServer(app, database, ":"+config.Port)
+	close(served)
+	if err != nil {
 		log.Fatalf("server exited: %v", err)
 	}
 	// codecov:ignore:end
@@ -592,17 +595,46 @@ func securityHeadersMiddleware(enableStrictTransportSecurity bool) fiber.Handler
 	}
 }
 
-func installGracefulShutdown(app *fiber.App) context.CancelFunc {
+// installGracefulShutdown wires SIGINT/SIGTERM to a graceful stop. served
+// must be closed once app.Listen (inside runServer) returns, for any reason —
+// it bounds retryShutdown so a signal arriving after the server already
+// exited doesn't spin.
+func installGracefulShutdown(app *fiber.App, served <-chan struct{}) context.CancelFunc {
 	sigCtx, stopSignals := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		<-sigCtx.Done()
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
-		if err := app.ShutdownWithContext(shutdownCtx); err != nil {
-			log.Printf("server shutdown failed: %v", err)
-		}
+		retryShutdown(app, shutdownCtx, served)
 	}()
 	return stopSignals
+}
+
+// retryShutdown calls app.ShutdownWithContext until it takes effect.
+// fasthttp's ShutdownWithContext silently no-ops ("if s.ln == nil { return
+// nil }") when called before Serve has registered the listener — the boot
+// window between fiber's net.Listen and fasthttp registering it, which fiber
+// v3's own OnListen hook fires strictly *before* (listen.go: runOnListenHooks
+// precedes app.server.Serve(ln)). A single call can silently lose the stop
+// request in that window; retrying until served closes (Listen has returned,
+// so either the stop already landed or there's nothing left to stop) bridges
+// it without slowing down the common, non-racing case.
+func retryShutdown(app *fiber.App, ctx context.Context, served <-chan struct{}) {
+	ticker := time.NewTicker(20 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if err := app.ShutdownWithContext(ctx); err != nil {
+			log.Printf("server shutdown failed: %v", err)
+			return
+		}
+		select {
+		case <-served:
+			return
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
 }
 
 func logStartup(config runtimeConfig) {

--- a/cmd/ovumcy/main_test.go
+++ b/cmd/ovumcy/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1821,6 +1822,55 @@ func TestRunServerClosesDatabaseAfterGracefulStop(t *testing.T) {
 	}
 	if err := sqlDB.Ping(); err == nil {
 		t.Fatal("expected database to be closed after a graceful stop")
+	}
+}
+
+// TestRetryShutdownBridgesBootWindow pins the boot-window hardening: a single
+// app.ShutdownWithContext call is a silent no-op while fasthttp's s.ln is
+// still nil (the gap between fiber's net.Listen and fasthttp's Serve
+// registering the listener) — without a retry, Listen would serve forever
+// and runServer would never return. retryShutdown is started against an
+// app that has not been Listen'd yet, guaranteeing its first attempts land
+// in that gap deterministically (no reliance on real signal timing, unlike
+// the actual boot-window race), then Listen is started afterward; the retry
+// loop must still notice and bridge the gap once Serve registers the
+// listener.
+func TestRetryShutdownBridgesBootWindow(t *testing.T) {
+	database, err := db.OpenSQLite(filepath.Join(t.TempDir(), "boot-window-stop.db"))
+	if err != nil {
+		t.Fatalf("OpenSQLite() unexpected error: %v", err)
+	}
+	app := fiber.New()
+
+	served := make(chan struct{})
+	go retryShutdown(app, context.Background(), served)
+
+	// Give retryShutdown a few iterations against the not-yet-listening app,
+	// so its early attempts are guaranteed genuine no-ops (s.ln == nil).
+	time.Sleep(60 * time.Millisecond)
+
+	done := make(chan error, 1)
+	go func() {
+		err := runServer(app, database, "127.0.0.1:0")
+		close(served)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("runServer after boot-window stop: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("runServer did not return after a boot-window stop; retry did not bridge the gap")
+	}
+
+	sqlDB, err := database.DB()
+	if err != nil {
+		t.Fatalf("database.DB() unexpected error: %v", err)
+	}
+	if err := sqlDB.Ping(); err == nil {
+		t.Fatal("expected database to be closed after a boot-window stop")
 	}
 }
 

--- a/cmd/ovumcy/main_test.go
+++ b/cmd/ovumcy/main_test.go
@@ -12,8 +12,10 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -1871,6 +1873,139 @@ func TestRetryShutdownBridgesBootWindow(t *testing.T) {
 	}
 	if err := sqlDB.Ping(); err == nil {
 		t.Fatal("expected database to be closed after a boot-window stop")
+	}
+}
+
+// TestRetryShutdownReturnsOnContextDeadline pins the ctx.Done() exit: a
+// signal that arrives but never sees the server finish (served never
+// closes) must still let retryShutdown return once its bounding context
+// expires, rather than looping forever.
+func TestRetryShutdownReturnsOnContextDeadline(t *testing.T) {
+	app := fiber.New()
+	served := make(chan struct{}) // deliberately never closed
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		retryShutdown(app, ctx, served)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("retryShutdown did not return after its context deadline expired")
+	}
+}
+
+// TestRetryShutdownLogsPersistentShutdownError pins the error-return branch:
+// once app.ShutdownWithContext itself fails (its own bounding context expires
+// while a connection is still open), retryShutdown must log the failure and
+// stop retrying rather than spinning on a shutdown that will never succeed.
+func TestRetryShutdownLogsPersistentShutdownError(t *testing.T) {
+	database, err := db.OpenSQLite(filepath.Join(t.TempDir(), "shutdown-error.db"))
+	if err != nil {
+		t.Fatalf("OpenSQLite() unexpected error: %v", err)
+	}
+	app := fiber.New()
+
+	addrCh := make(chan string, 1)
+	app.Hooks().OnListen(func(listenData fiber.ListenData) error {
+		addrCh <- net.JoinHostPort(listenData.Host, listenData.Port)
+		return nil
+	})
+
+	listenDone := make(chan error, 1)
+	go func() { listenDone <- runServer(app, database, "127.0.0.1:0") }()
+
+	address := <-addrCh
+	// A raw connection that never sends a request stays counted as open
+	// (not idle), so fasthttp's own ShutdownWithContext can never drain it
+	// and is guaranteed to time out.
+	conn, err := net.Dial("tcp", address)
+	if err != nil {
+		t.Fatalf("net.Dial() unexpected error: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	var buffer bytes.Buffer
+	log.SetOutput(&buffer)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+
+	served := make(chan struct{})
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
+	defer shutdownCancel()
+	retryShutdown(app, shutdownCtx, served)
+
+	if !strings.Contains(buffer.String(), "server shutdown failed") {
+		t.Fatalf("expected a logged shutdown failure, got %q", buffer.String())
+	}
+
+	_ = conn.Close()
+	_ = app.Shutdown()
+	<-listenDone
+}
+
+// TestInstallGracefulShutdownBridgesSIGTERM pins the signal-wiring itself:
+// a real SIGTERM delivered to the process must reach retryShutdown through
+// installGracefulShutdown's goroutine, not just via a direct call to
+// retryShutdown (as the other regressions in this file exercise). os.Process
+// only supports delivering os.Kill on windows (any other signal, including
+// SIGTERM, returns "not supported by windows"), so this is validated on
+// Linux (dev container / CI) and skipped on windows.
+func TestInstallGracefulShutdownBridgesSIGTERM(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("SIGTERM self-delivery is not supported by the Go runtime on windows; validated in Linux CI")
+	}
+
+	database, err := db.OpenSQLite(filepath.Join(t.TempDir(), "sigterm-stop.db"))
+	if err != nil {
+		t.Fatalf("OpenSQLite() unexpected error: %v", err)
+	}
+	app := fiber.New()
+
+	served := make(chan struct{})
+	stopSignals := installGracefulShutdown(app, served)
+	defer stopSignals()
+
+	addrCh := make(chan string, 1)
+	app.Hooks().OnListen(func(listenData fiber.ListenData) error {
+		addrCh <- net.JoinHostPort(listenData.Host, listenData.Port)
+		return nil
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		err := runServer(app, database, "127.0.0.1:0")
+		close(served)
+		done <- err
+	}()
+	<-addrCh
+
+	proc, err := os.FindProcess(os.Getpid())
+	if err != nil {
+		t.Fatalf("os.FindProcess() unexpected error: %v", err)
+	}
+	if err := proc.Signal(syscall.SIGTERM); err != nil {
+		t.Fatalf("failed to deliver SIGTERM to self: %v", err)
+	}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("runServer after SIGTERM: %v", err)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("runServer did not return after SIGTERM within 15s")
+	}
+
+	sqlDB, err := database.DB()
+	if err != nil {
+		t.Fatalf("database.DB() unexpected error: %v", err)
+	}
+	if err := sqlDB.Ping(); err == nil {
+		t.Fatal("expected database to be closed after a SIGTERM-triggered stop")
 	}
 }
 


### PR DESCRIPTION
## Summary
- A SIGINT/SIGTERM arriving in the boot window between fiber's `net.Listen` (inside `app.Listen`) and fasthttp's `Serve` registering the listener hit fasthttp's `ShutdownWithContext` no-op guard (`if s.ln == nil { return nil }`, fasthttp v1.72.0 `server.go:2057-2066`) and was silently lost — the one-shot goroutine then exits, `signal.NotifyContext`'s registration stays active with no reader, and every further SIGTERM/SIGINT is swallowed until the process is SIGKILLed.
- `installGracefulShutdown` now retries the stop (new `retryShutdown`, `cmd/ovumcy/main.go`) every 20ms until it lands, bounded by the existing 10s stop timeout and a `served` channel that `main` closes once `runServer`'s `app.Listen` returns for any reason — so a signal after the server already exited doesn't spin.
- Common (non-racing) path is unaffected: the first stop attempt still lands immediately and the loop exits right after via `served` closing.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./cmd/...`
- [x] `go test ./cmd/...`
- [x] New regression `TestRetryShutdownBridgesBootWindow` deterministically reproduces the boot-window no-op (starts the retry against a not-yet-`Listen`'d app) and asserts `runServer` still returns and the DB still closes.
- [x] Verified the test actually catches the regression: temporarily reverted `retryShutdown` to a single-shot call — test failed with a timeout reproducing the reported hang; restored the fix — test passes again.