### PR TITLE
feat(auth): raise bcrypt cost to 12 and rehash stale hashes on login

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -366,6 +366,7 @@ Policy-level claims (threat model in/out-of-scope, design rationale, marketing-s
 | --- | --- |
 | `POST /api/v1/users` emits an identical-shape sealed pickup cookie for new and duplicate emails | `auth_register_regressions_test.go`, `auth_register_email_persistence_regressions_test.go` in `internal/api/` |
 | Duplicate-email branch runs equalized bcrypt timing | `TestAuthenticateCredentialsEqualizesTimingForMissingUser`, `TestAuthenticateCredentialsEqualizesTimingForDisabledLocalAuth` in [internal/services/auth_service_credentials_timing_test.go](internal/services/auth_service_credentials_timing_test.go) |
+| Timing-equalization placeholder hashes carry the production bcrypt cost (equalized paths are not measurably faster than a real compare) | `TestTimingEqualizationHashesMatchTargetCost` in [internal/services/auth_service_hash_cost_test.go](internal/services/auth_service_hash_cost_test.go) |
 | Pickup nonce is single-use via `register_pickup_tokens` (atomic UPDATE) | `register_pickup_handler_test.go` in `internal/api/` |
 | `GET /register/welcome` second consumption falls through to `/login` | `register_pickup_handler_test.go` in `internal/api/` |
 | Recovery code shape `OVUM-XXXX-XXXX-XXXX` | `TestValidateRecoveryCodeFormat`, `TestNormalizeRecoveryCode` in [internal/services/auth_input_policy_test.go](internal/services/auth_input_policy_test.go) |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -136,7 +136,7 @@ What Ovumcy persists per account and per record. All storage is in the operator'
 **`users`** — one row per account:
 
 - Identity: `id`, `email` (unique), `display_name`, `role` (default `owner`), `created_at`.
-- Credentials: `password_hash` (bcrypt cost 10), `recovery_code_hash` (bcrypt cost 10), `local_auth_enabled`, `auth_session_version`, `must_change_password`.
+- Credentials: `password_hash` (bcrypt cost 12), `recovery_code_hash` (bcrypt cost 12), `local_auth_enabled`, `auth_session_version`, `must_change_password`.
 - Onboarding: `onboarding_completed`.
 - Cycle preferences: `cycle_length`, `period_length`, `luteal_phase`, `auto_period_fill`, `irregular_cycle`, `unpredictable_cycle`, `age_group`, `usage_goal`, `last_period_start`, `long_period_warning_cycle_start`.
 - Tracking preferences: `track_bbt`, `temperature_unit`, `track_cervical_mucus`, `hide_sex_chip`, `hide_cycle_factors`, `hide_notes_field`, `show_historical_phases`, `shown_period_tip`.
@@ -187,7 +187,7 @@ Both operations require the current password through `validateSettingsActionPass
 - Minimum length: 8 Unicode code points.
 - Maximum length: 72 bytes — bcrypt's hard input limit. Longer submissions fail validation with the same stable weak-password error on every password-accepting flow instead of surfacing bcrypt's opaque hashing error.
 - Required character classes: at least one uppercase letter, one lowercase letter, and one digit (`ValidatePasswordStrength` in `internal/services/password_policy.go`).
-- Storage: bcrypt with `bcrypt.DefaultCost` (currently cost 10) via `golang.org/x/crypto/bcrypt`. Hashes live in `users.password_hash`.
+- Storage: bcrypt at cost 12 (the `passwordHashCost` constant in `internal/services`, above the library `bcrypt.DefaultCost` of 10) via `golang.org/x/crypto/bcrypt`. Hashes live in `users.password_hash`. A successful login whose stored hash predates this floor is opportunistically re-hashed at cost 12 in place (`UpdatePasswordHashOnly`), so the effective cost rises for existing accounts without forcing a reset; this transparent upgrade does **not** bump `auth_session_version` (the credential is unchanged).
 
 **Recovery codes:**
 
@@ -399,6 +399,7 @@ Policy-level claims (threat model in/out-of-scope, design rationale, marketing-s
 | TOTP enable bumps `auth_session_version` and refreshes originating session | `handlers_settings_2fa_session_revocation_test.go` in `internal/api/` |
 | TOTP disable bumps `auth_session_version` and refreshes originating session | `handlers_settings_2fa_session_revocation_test.go` in `internal/api/` |
 | `clear-data` bumps `auth_session_version` atomically with the wipe | `settings_clear_data_session_revocation_test.go` in `internal/api/` |
+| Opportunistic bcrypt-cost rehash on login rewrites `password_hash` without bumping `auth_session_version` (the authenticating session survives) | `TestUpdatePasswordHashOnlyPreservesSessionVersion` in [internal/db/user_repository_cas_test.go](internal/db/user_repository_cas_test.go), `TestAuthenticateCredentialsRehashesStaleCost` in [internal/services/auth_service_hash_cost_test.go](internal/services/auth_service_hash_cost_test.go) |
 | `ovumcy_auth` cookie verifies against current `auth_session_version`; revoked sessions are rejected | `TestAuthMiddlewareRejectsRevokedAuthSessionCookieForAPI`, `TestAuthMiddlewareRejectsRevokedAuthSessionCookieAfterForcedResetForHTML` in [internal/api/auth_cookie_compat_regression_test.go](internal/api/auth_cookie_compat_regression_test.go) |
 
 ### Cookies
@@ -435,6 +436,7 @@ Policy-level claims (threat model in/out-of-scope, design rationale, marketing-s
 | Strong password passes | `TestValidatePasswordStrength_AcceptsStrongPassword` in [internal/services/password_policy_test.go](internal/services/password_policy_test.go) |
 | Change-password rejects weak password and mismatch | `TestChangePasswordRejectsWeakNumericPassword`, `TestChangePasswordRejectsPasswordMismatch` in [internal/api/auth_change_password_validation_test.go](internal/api/auth_change_password_validation_test.go) |
 | Recovery code is bcrypt-hashed at rest | `TestGenerateRecoveryCodeHash` in [internal/services/auth_reset_policy_test.go](internal/services/auth_reset_policy_test.go) |
+| New password and recovery-code hashes are stamped at cost 12 (`passwordHashCost`, above `bcrypt.DefaultCost`) | `TestNewPasswordHashesUseConfiguredCost`, `TestPasswordHashCostIsAboveDefault` in [internal/services/auth_service_hash_cost_test.go](internal/services/auth_service_hash_cost_test.go) |
 | TOTP secret is encrypted under a key derived from `SECRET_KEY`; stored value not equal to plaintext | `internal/security/field_crypto_test.go` (see Field-Level Encryption above) |
 | TOTP code reuse within the same 30-second step is rejected | `totp_service_test.go`, `user_repository_totp_step_test.go`, `handlers_auth_2fa_test.go` |
 | TOTP enrollment rejects 6-digit codes that do not match | `handlers_settings_2fa_test.go` |

--- a/docs/SECURITY_INVARIANTS.md
+++ b/docs/SECURITY_INVARIANTS.md
@@ -44,7 +44,7 @@ Every entry has a corresponding test or set of tests in `SECURITY.md → Test En
 - AEAD: AES-256-GCM (sealed cookies, field encryption), implemented once in `internal/security/sealed_cipher.go`. Key derivation: HKDF-SHA256 with versioned, purpose-specific salt and info labels; the two purposes derive distinct keys, so cross-purpose opens fail (see `SECURITY.md → SECRET_KEY Usage Map`).
 - Randomness: `crypto/rand` for nonces, session IDs, OIDC state/nonce, PKCE verifiers, recovery codes. **Never `math/rand` for security-sensitive values.**
 - Comparisons: `crypto/subtle.ConstantTimeCompare` for OIDC state, recovery-code hashes (via `bcrypt.CompareHashAndPassword`), TOTP code validation, and password-state fingerprints.
-- Passwords are bcrypt cost 10. Minimum length 8 with at least one uppercase, one lowercase, and one digit.
+- Passwords are bcrypt cost 12 (a successful login re-hashes any older, lower-cost hash in place without invalidating the session). Minimum length 8 with at least one uppercase, one lowercase, and one digit.
 
 ## Content Security Policy
 

--- a/internal/api/auth_logout_rate_limit_regression_test.go
+++ b/internal/api/auth_logout_rate_limit_regression_test.go
@@ -54,6 +54,8 @@ func (stubLogoutAuthRepo) UpdatePasswordRecoveryCodeAndRevokeSessionsCAS(context
 	return nil
 }
 
+func (stubLogoutAuthRepo) UpdatePasswordHashOnly(context.Context, uint, string) error { return nil }
+
 func (stubLogoutAuthRepo) BumpAuthSessionVersion(context.Context, uint) error { return nil }
 
 // TestLogoutHandlerEnforcesPerAccountRateLimit asserts that Handler.Logout

--- a/internal/db/user_repository.go
+++ b/internal/db/user_repository.go
@@ -126,6 +126,17 @@ func (repo *UserRepository) UpdatePasswordAndRevokeSessions(ctx context.Context,
 	}).Error
 }
 
+// UpdatePasswordHashOnly rewrites only the password_hash column without bumping
+// auth_session_version and without touching must_change_password or
+// local_auth_enabled. It exists for the transparent bcrypt-cost upgrade the
+// auth service performs after a successful login (mirrors
+// UpdateTOTPSecretCiphertext for the TOTP secret): the account's security
+// posture is unchanged — same password, stronger hash — so no active session
+// should be revoked by what is an internal storage upgrade.
+func (repo *UserRepository) UpdatePasswordHashOnly(ctx context.Context, userID uint, passwordHash string) error {
+	return repo.database.WithContext(ctx).Model(&models.User{}).Where("id = ?", userID).Update("password_hash", passwordHash).Error
+}
+
 func (repo *UserRepository) UpdatePasswordRecoveryCodeAndRevokeSessions(ctx context.Context, userID uint, passwordHash string, recoveryHash string, mustChangePassword bool) error {
 	return repo.database.WithContext(ctx).Model(&models.User{}).Where("id = ?", userID).Updates(map[string]any{
 		"password_hash":        passwordHash,

--- a/internal/db/user_repository_cas_test.go
+++ b/internal/db/user_repository_cas_test.go
@@ -116,3 +116,61 @@ func TestOpenSQLiteConnectionPoolLimits(t *testing.T) {
 		t.Fatalf("expected MaxOpenConnections 4, got %d", stats.MaxOpenConnections)
 	}
 }
+
+// TestUpdatePasswordHashOnlyPreservesSessionVersion asserts the transparent
+// bcrypt-cost upgrade rewrites password_hash without bumping
+// auth_session_version and without disturbing the other credential columns —
+// the account's security posture is unchanged, so no active session may be
+// revoked by an internal storage upgrade.
+func TestUpdatePasswordHashOnlyPreservesSessionVersion(t *testing.T) {
+	dir := t.TempDir()
+	database, err := OpenSQLite(filepath.Join(dir, "rehash_test.db"))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() {
+		if sqlDB, err := database.DB(); err == nil {
+			_ = sqlDB.Close()
+		}
+	})
+
+	repo := NewUserRepository(database)
+
+	user := &models.User{
+		Email:              "rehash@example.com",
+		PasswordHash:       "legacy-hash",
+		RecoveryCodeHash:   "recovery-hash",
+		LocalAuthEnabled:   true,
+		MustChangePassword: false,
+		AuthSessionVersion: 4,
+		Role:               models.RoleOwner,
+		CycleLength:        models.DefaultCycleLength,
+		PeriodLength:       models.DefaultPeriodLength,
+		AutoPeriodFill:     true,
+		CreatedAt:          time.Now().UTC(),
+	}
+	if err := repo.Create(context.Background(), user); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	if err := repo.UpdatePasswordHashOnly(context.Background(), user.ID, "upgraded-hash"); err != nil {
+		t.Fatalf("UpdatePasswordHashOnly: %v", err)
+	}
+
+	got, err := repo.FindByID(context.Background(), user.ID)
+	if err != nil {
+		t.Fatalf("find after rehash: %v", err)
+	}
+	if got.PasswordHash != "upgraded-hash" {
+		t.Fatalf("expected password_hash 'upgraded-hash', got %q", got.PasswordHash)
+	}
+	if got.AuthSessionVersion != 4 {
+		t.Fatalf("expected auth_session_version to stay 4 (no revoke), got %d", got.AuthSessionVersion)
+	}
+	if got.RecoveryCodeHash != "recovery-hash" {
+		t.Fatalf("expected recovery_code_hash untouched, got %q", got.RecoveryCodeHash)
+	}
+	if !got.LocalAuthEnabled {
+		t.Fatal("expected local_auth_enabled untouched (true)")
+	}
+}

--- a/internal/services/auth_reset_policy.go
+++ b/internal/services/auth_reset_policy.go
@@ -130,7 +130,7 @@ func GenerateRecoveryCodeHash() (string, string, error) {
 	if err != nil {
 		return "", "", err
 	}
-	hash, err := bcrypt.GenerateFromPassword([]byte(code), bcrypt.DefaultCost)
+	hash, err := bcrypt.GenerateFromPassword([]byte(code), passwordHashCost)
 	if err != nil {
 		return "", "", err
 	}

--- a/internal/services/auth_service.go
+++ b/internal/services/auth_service.go
@@ -32,12 +32,15 @@ var (
 )
 
 // recoveryCodeTimingEqualizationHash and credentialsTimingEqualizationHash are
-// fixed bcrypt-cost-10 placeholder hashes used by the equalize* helpers below
-// to spend bcrypt compute time on the early-return paths in recovery and
-// login. They are never compared against a real credential — the result of
+// fixed placeholder hashes used by the equalize* helpers below to spend bcrypt
+// compute time on the early-return paths in recovery and login. They are never
+// compared against a real credential — the result of
 // bcrypt.CompareHashAndPassword is discarded — and never authenticate anyone.
-const recoveryCodeTimingEqualizationHash = "$2a$10$ReZgUuXu2GXtC.RZ/q2QyesBFX182a3ycbr78sbtgURmuOyc3ygtG" // #nosec G101 -- fixed placeholder bcrypt hash, see comment above; never authenticates a real user
-const credentialsTimingEqualizationHash = "$2a$10$h7pMPVpw/fZjbsXnbtpfD.UzmSCNk0FmbmMkP7wKDlO7IqhsBVX1m"  // #nosec G101 -- fixed placeholder bcrypt hash, see comment on recoveryCodeTimingEqualizationHash
+// Their embedded cost MUST stay equal to passwordHashCost (test-pinned): a
+// cheaper placeholder would make the equalized paths measurably faster than a
+// real comparison and reintroduce the account-enumeration timing oracle.
+const recoveryCodeTimingEqualizationHash = "$2a$12$KeFGg3nMPoiaOcsZpE9qUevfmpFV3VlY5cAQ.8FazuuHUIgnQrBwS" // #nosec G101 -- fixed placeholder bcrypt hash, see comment above; never authenticates a real user
+const credentialsTimingEqualizationHash = "$2a$12$pI5aDx1kby9ZEk9.2NzhBeq77y41xgUaCrP/vyyRCgdGnvaV.UxZm"  // #nosec G101 -- fixed placeholder bcrypt hash, see comment on recoveryCodeTimingEqualizationHash
 
 type AuthUserRepository interface {
 	ExistsByNormalizedEmail(ctx context.Context, email string) (bool, error)

--- a/internal/services/auth_service.go
+++ b/internal/services/auth_service.go
@@ -50,6 +50,11 @@ type AuthUserRepository interface {
 	UpdatePasswordAndRevokeSessions(ctx context.Context, userID uint, passwordHash string, mustChangePassword bool) error
 	UpdatePasswordRecoveryCodeAndRevokeSessions(ctx context.Context, userID uint, passwordHash string, recoveryHash string, mustChangePassword bool) error
 	UpdatePasswordRecoveryCodeAndRevokeSessionsCAS(ctx context.Context, userID uint, oldPasswordHash string, newPasswordHash string, recoveryHash string) error
+	// UpdatePasswordHashOnly rewrites password_hash WITHOUT bumping
+	// auth_session_version — a transparent storage-format upgrade (bcrypt cost
+	// rise), not a credential change. Used only by the opportunistic rehash on
+	// successful login; the caller has already proven the password.
+	UpdatePasswordHashOnly(ctx context.Context, userID uint, passwordHash string) error
 	BumpAuthSessionVersion(ctx context.Context, userID uint) error
 }
 
@@ -57,6 +62,15 @@ const (
 	DefaultLogoutAttemptsLimit  = 20
 	DefaultLogoutAttemptsWindow = 15 * time.Minute
 )
+
+// passwordHashCost is the bcrypt cost used for every password and recovery-code
+// hash written by this package. It is deliberately higher than
+// bcrypt.DefaultCost (10) to widen the offline-guessing margin if the database
+// and SECRET_KEY ever leak together. Successful logins opportunistically
+// rehash any stored password below this cost (see AuthenticateCredentials), so
+// the effective floor rises without forcing a reset. Raising this value is a
+// per-hash CPU trade-off: bcrypt work doubles per +1.
+const passwordHashCost = 12
 
 type AuthService struct {
 	users               AuthUserRepository
@@ -183,7 +197,7 @@ func (service *AuthService) ForceResetPasswordByEmail(ctx context.Context, email
 		return fmt.Errorf("%w: %v", ErrAuthUserLookupFailed, err)
 	}
 
-	passwordHash, err := bcrypt.GenerateFromPassword([]byte(newPassword), bcrypt.DefaultCost)
+	passwordHash, err := bcrypt.GenerateFromPassword([]byte(newPassword), passwordHashCost)
 	if err != nil {
 		return fmt.Errorf("%w: %v", ErrAuthPasswordHash, err)
 	}
@@ -196,7 +210,7 @@ func (service *AuthService) ForceResetPasswordByEmail(ctx context.Context, email
 }
 
 func (service *AuthService) BuildOwnerUserWithRecovery(email string, rawPassword string, createdAt time.Time) (models.User, string, error) {
-	passwordHash, err := bcrypt.GenerateFromPassword([]byte(rawPassword), bcrypt.DefaultCost)
+	passwordHash, err := bcrypt.GenerateFromPassword([]byte(rawPassword), passwordHashCost)
 	if err != nil {
 		return models.User{}, "", err
 	}
@@ -258,7 +272,37 @@ func (service *AuthService) AuthenticateCredentials(ctx context.Context, email s
 	if err := ValidateSupportedWebUser(&user); err != nil {
 		return models.User{}, err
 	}
+	service.rehashPasswordIfStale(ctx, &user, password)
 	return user, nil
+}
+
+// rehashPasswordIfStale opportunistically re-hashes a valid password whose
+// stored bcrypt cost is below passwordHashCost, so the effective cost floor
+// rises for pre-existing accounts without forcing a reset. It runs only after
+// a successful CompareHashAndPassword (the plaintext is proven), rewrites the
+// hash in place via UpdatePasswordHashOnly (no auth_session_version bump — the
+// credential itself is unchanged), and mutates user.PasswordHash so a caller
+// that persists the struct sees the upgraded hash.
+//
+// Best-effort by design: a costing/read error or a failed write is swallowed
+// so it can never turn a valid login into a failure. On the next login the
+// upgrade is simply retried.
+func (service *AuthService) rehashPasswordIfStale(ctx context.Context, user *models.User, password string) {
+	if user == nil || user.ID == 0 {
+		return
+	}
+	cost, err := bcrypt.Cost([]byte(user.PasswordHash))
+	if err != nil || cost >= passwordHashCost {
+		return
+	}
+	upgraded, err := bcrypt.GenerateFromPassword([]byte(password), passwordHashCost)
+	if err != nil {
+		return
+	}
+	if err := service.users.UpdatePasswordHashOnly(ctx, user.ID, string(upgraded)); err != nil {
+		return
+	}
+	user.PasswordHash = string(upgraded)
 }
 
 func (service *AuthService) FindUserByEmailAndRecoveryCode(ctx context.Context, email string, code string) (*models.User, error) {
@@ -406,7 +450,7 @@ func (service *AuthService) ResetPasswordAndRotateRecoveryCode(ctx context.Conte
 		return "", ErrAuthUserRequired
 	}
 
-	passwordHash, err := bcrypt.GenerateFromPassword([]byte(newPassword), bcrypt.DefaultCost)
+	passwordHash, err := bcrypt.GenerateFromPassword([]byte(newPassword), passwordHashCost)
 	if err != nil {
 		return "", err
 	}
@@ -441,7 +485,7 @@ func (service *AuthService) ResetPasswordAndRotateRecoveryCodeCAS(ctx context.Co
 		return "", ErrAuthUserRequired // codecov:ignore -- defensive; callers always pass a resolved user
 	}
 
-	passwordHash, err := bcrypt.GenerateFromPassword([]byte(newPassword), bcrypt.DefaultCost)
+	passwordHash, err := bcrypt.GenerateFromPassword([]byte(newPassword), passwordHashCost)
 	if err != nil {
 		return "", err // codecov:ignore -- bcrypt only errors on an out-of-range cost
 	}

--- a/internal/services/auth_service_hash_cost_test.go
+++ b/internal/services/auth_service_hash_cost_test.go
@@ -30,6 +30,23 @@ func TestPasswordHashCostIsAboveDefault(t *testing.T) {
 	}
 }
 
+// TestTimingEqualizationHashesMatchTargetCost pins the placeholder hashes used
+// by the timing equalizers to the production cost. A cheaper placeholder makes
+// the equalized early-return paths (missing account, OIDC-only account,
+// duplicate-email registration) measurably faster than a real bcrypt compare
+// at passwordHashCost, reintroducing the account-enumeration timing oracle the
+// equalizers exist to close.
+func TestTimingEqualizationHashesMatchTargetCost(t *testing.T) {
+	for name, hash := range map[string]string{
+		"recoveryCodeTimingEqualizationHash": recoveryCodeTimingEqualizationHash,
+		"credentialsTimingEqualizationHash":  credentialsTimingEqualizationHash,
+	} {
+		if got := mustBcryptCost(t, hash); got != passwordHashCost {
+			t.Fatalf("%s cost = %d, want passwordHashCost (%d)", name, got, passwordHashCost)
+		}
+	}
+}
+
 // TestNewPasswordHashesUseConfiguredCost asserts every service path that mints
 // a fresh password or recovery-code hash stamps it at passwordHashCost, not the
 // library default. Each sub-case reads the cost straight out of the produced

--- a/internal/services/auth_service_hash_cost_test.go
+++ b/internal/services/auth_service_hash_cost_test.go
@@ -1,0 +1,269 @@
+package services
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// mustBcryptCost fails the test if hash is not a parseable bcrypt hash and
+// returns its embedded cost otherwise.
+func mustBcryptCost(t *testing.T, hash string) int {
+	t.Helper()
+	cost, err := bcrypt.Cost([]byte(hash))
+	if err != nil {
+		t.Fatalf("bcrypt.Cost(%q): %v", hash, err)
+	}
+	return cost
+}
+
+// TestPasswordHashCostIsAboveDefault documents the intent behind the named
+// constant: production hashing must be stronger than bcrypt.DefaultCost, and
+// this test fails if someone lowers the constant to (or below) the default.
+func TestPasswordHashCostIsAboveDefault(t *testing.T) {
+	if passwordHashCost <= bcrypt.DefaultCost {
+		t.Fatalf("passwordHashCost (%d) must exceed bcrypt.DefaultCost (%d)", passwordHashCost, bcrypt.DefaultCost)
+	}
+}
+
+// TestNewPasswordHashesUseConfiguredCost asserts every service path that mints
+// a fresh password or recovery-code hash stamps it at passwordHashCost, not the
+// library default. Each sub-case reads the cost straight out of the produced
+// bcrypt hash.
+func TestNewPasswordHashesUseConfiguredCost(t *testing.T) {
+	t.Run("BuildOwnerUserWithRecovery hashes password and recovery code at target cost", func(t *testing.T) {
+		service := NewAuthService(&stubAuthUserRepo{})
+		user, recoveryCode, err := service.BuildOwnerUserWithRecovery("owner@example.com", "StrongPass1", time.Now())
+		if err != nil {
+			t.Fatalf("BuildOwnerUserWithRecovery: %v", err)
+		}
+		if got := mustBcryptCost(t, user.PasswordHash); got != passwordHashCost {
+			t.Fatalf("password hash cost = %d, want %d", got, passwordHashCost)
+		}
+		if recoveryCode == "" {
+			t.Fatal("expected a non-empty recovery code")
+		}
+		if got := mustBcryptCost(t, user.RecoveryCodeHash); got != passwordHashCost {
+			t.Fatalf("recovery code hash cost = %d, want %d", got, passwordHashCost)
+		}
+	})
+
+	t.Run("GenerateRecoveryCodeHash uses target cost", func(t *testing.T) {
+		_, hash, err := GenerateRecoveryCodeHash()
+		if err != nil {
+			t.Fatalf("GenerateRecoveryCodeHash: %v", err)
+		}
+		if got := mustBcryptCost(t, hash); got != passwordHashCost {
+			t.Fatalf("recovery code hash cost = %d, want %d", got, passwordHashCost)
+		}
+	})
+
+	t.Run("ForceResetPasswordByEmail writes hash at target cost", func(t *testing.T) {
+		repo := &stubAuthUserRepo{
+			existsByEmail:   true,
+			findByEmailUser: models.User{ID: 5, Email: "owner@example.com", Role: models.RoleOwner},
+		}
+		service := NewAuthService(repo)
+		if err := service.ForceResetPasswordByEmail(context.Background(), "owner@example.com", "StrongPass1"); err != nil {
+			t.Fatalf("ForceResetPasswordByEmail: %v", err)
+		}
+		if got := mustBcryptCost(t, repo.updatedPasswordHash); got != passwordHashCost {
+			t.Fatalf("force-reset hash cost = %d, want %d", got, passwordHashCost)
+		}
+	})
+
+	t.Run("ResetPasswordAndRotateRecoveryCode writes hash at target cost", func(t *testing.T) {
+		repo := &stubAuthUserRepo{}
+		service := NewAuthService(repo)
+		user := &models.User{ID: 9, Email: "owner@example.com"}
+		if _, err := service.ResetPasswordAndRotateRecoveryCode(context.Background(), user, "StrongPass1"); err != nil {
+			t.Fatalf("ResetPasswordAndRotateRecoveryCode: %v", err)
+		}
+		if got := mustBcryptCost(t, user.PasswordHash); got != passwordHashCost {
+			t.Fatalf("reset+rotate hash cost = %d, want %d", got, passwordHashCost)
+		}
+	})
+}
+
+// TestAuthenticateCredentialsRehashesStaleCost is the opportunistic-rehash
+// contract: a valid login against a below-target (legacy cost-10) hash upgrades
+// the stored hash to passwordHashCost via UpdatePasswordHashOnly (which does NOT
+// bump auth_session_version — the session that just authenticated must survive).
+func TestAuthenticateCredentialsRehashesStaleCost(t *testing.T) {
+	legacyHash, err := bcrypt.GenerateFromPassword([]byte("StrongPass1"), bcrypt.DefaultCost)
+	if err != nil {
+		t.Fatalf("hash password: %v", err)
+	}
+	repo := &stubAuthUserRepo{
+		findByEmailUser: models.User{
+			ID:                 77,
+			Email:              "login@example.com",
+			PasswordHash:       string(legacyHash),
+			LocalAuthEnabled:   true,
+			Role:               models.RoleOwner,
+			AuthSessionVersion: 3,
+		},
+	}
+	service := NewAuthService(repo)
+
+	user, err := service.AuthenticateCredentials(context.Background(), "login@example.com", "StrongPass1")
+	if err != nil {
+		t.Fatalf("AuthenticateCredentials: %v", err)
+	}
+	if repo.updateHashOnlyCalls != 1 {
+		t.Fatalf("expected exactly 1 opportunistic rehash write, got %d", repo.updateHashOnlyCalls)
+	}
+	if repo.updateHashOnlyUserID != 77 {
+		t.Fatalf("rehash targeted user %d, want 77", repo.updateHashOnlyUserID)
+	}
+	if got := mustBcryptCost(t, repo.updateHashOnlyHash); got != passwordHashCost {
+		t.Fatalf("rehash wrote cost %d, want %d", got, passwordHashCost)
+	}
+	// The returned user reflects the upgraded hash so a caller that reissues a
+	// cookie / persists the struct carries it forward.
+	if got := mustBcryptCost(t, user.PasswordHash); got != passwordHashCost {
+		t.Fatalf("returned user hash cost = %d, want %d", got, passwordHashCost)
+	}
+	// The upgraded hash still verifies the same password.
+	if bcrypt.CompareHashAndPassword([]byte(repo.updateHashOnlyHash), []byte("StrongPass1")) != nil {
+		t.Fatal("upgraded hash no longer verifies the original password")
+	}
+}
+
+// TestAuthenticateCredentialsSkipsRehashAtTargetCost proves the upgrade is a
+// no-op once the stored hash already meets the target cost — no needless write
+// on every subsequent login.
+func TestAuthenticateCredentialsSkipsRehashAtTargetCost(t *testing.T) {
+	currentHash, err := bcrypt.GenerateFromPassword([]byte("StrongPass1"), passwordHashCost)
+	if err != nil {
+		t.Fatalf("hash password: %v", err)
+	}
+	repo := &stubAuthUserRepo{
+		findByEmailUser: models.User{
+			ID:               77,
+			Email:            "login@example.com",
+			PasswordHash:     string(currentHash),
+			LocalAuthEnabled: true,
+			Role:             models.RoleOwner,
+		},
+	}
+	service := NewAuthService(repo)
+
+	if _, err := service.AuthenticateCredentials(context.Background(), "login@example.com", "StrongPass1"); err != nil {
+		t.Fatalf("AuthenticateCredentials: %v", err)
+	}
+	if repo.updateHashOnlyCalls != 0 {
+		t.Fatalf("expected no rehash write at target cost, got %d", repo.updateHashOnlyCalls)
+	}
+}
+
+// TestAuthenticateCredentialsWrongPasswordDoesNotRehash guards the ordering: a
+// failed CompareHashAndPassword must never trigger a rehash of a stale hash
+// (the plaintext was not proven).
+func TestAuthenticateCredentialsWrongPasswordDoesNotRehash(t *testing.T) {
+	legacyHash, err := bcrypt.GenerateFromPassword([]byte("StrongPass1"), bcrypt.DefaultCost)
+	if err != nil {
+		t.Fatalf("hash password: %v", err)
+	}
+	repo := &stubAuthUserRepo{
+		findByEmailUser: models.User{
+			ID:               77,
+			Email:            "login@example.com",
+			PasswordHash:     string(legacyHash),
+			LocalAuthEnabled: true,
+			Role:             models.RoleOwner,
+		},
+	}
+	service := NewAuthService(repo)
+
+	if _, err := service.AuthenticateCredentials(context.Background(), "login@example.com", "WrongPass2"); err == nil {
+		t.Fatal("expected error for wrong password")
+	}
+	if repo.updateHashOnlyCalls != 0 {
+		t.Fatalf("expected no rehash write on wrong password, got %d", repo.updateHashOnlyCalls)
+	}
+}
+
+// TestRehashPasswordIfStaleDefensiveBranches covers the guard clauses of the
+// rehash helper directly: a nil/unsaved user, an unparseable stored hash, and a
+// password bcrypt refuses to hash (>72 bytes) must all silently skip the write.
+func TestRehashPasswordIfStaleDefensiveBranches(t *testing.T) {
+	legacyHash, err := bcrypt.GenerateFromPassword([]byte("StrongPass1"), bcrypt.DefaultCost)
+	if err != nil {
+		t.Fatalf("hash password: %v", err)
+	}
+
+	t.Run("nil user is a no-op", func(t *testing.T) {
+		repo := &stubAuthUserRepo{}
+		NewAuthService(repo).rehashPasswordIfStale(context.Background(), nil, "StrongPass1")
+		if repo.updateHashOnlyCalls != 0 {
+			t.Fatalf("expected no write for nil user, got %d", repo.updateHashOnlyCalls)
+		}
+	})
+
+	t.Run("unsaved user (ID 0) is a no-op", func(t *testing.T) {
+		repo := &stubAuthUserRepo{}
+		user := &models.User{ID: 0, PasswordHash: string(legacyHash)}
+		NewAuthService(repo).rehashPasswordIfStale(context.Background(), user, "StrongPass1")
+		if repo.updateHashOnlyCalls != 0 {
+			t.Fatalf("expected no write for unsaved user, got %d", repo.updateHashOnlyCalls)
+		}
+	})
+
+	t.Run("unparseable stored hash is a no-op", func(t *testing.T) {
+		repo := &stubAuthUserRepo{}
+		user := &models.User{ID: 7, PasswordHash: "not-a-bcrypt-hash"}
+		NewAuthService(repo).rehashPasswordIfStale(context.Background(), user, "StrongPass1")
+		if repo.updateHashOnlyCalls != 0 {
+			t.Fatalf("expected no write for unparseable hash, got %d", repo.updateHashOnlyCalls)
+		}
+	})
+
+	t.Run("password bcrypt cannot hash is a no-op", func(t *testing.T) {
+		repo := &stubAuthUserRepo{}
+		user := &models.User{ID: 7, PasswordHash: string(legacyHash)}
+		tooLong := strings.Repeat("a", 80) // bcrypt hard-fails above 72 bytes
+		NewAuthService(repo).rehashPasswordIfStale(context.Background(), user, tooLong)
+		if repo.updateHashOnlyCalls != 0 {
+			t.Fatalf("expected no write when re-hashing fails, got %d", repo.updateHashOnlyCalls)
+		}
+	})
+}
+
+// TestAuthenticateCredentialsRehashFailureDoesNotFailLogin proves the rehash is
+// best-effort: a write error from UpdatePasswordHashOnly is swallowed and the
+// login still succeeds.
+func TestAuthenticateCredentialsRehashFailureDoesNotFailLogin(t *testing.T) {
+	legacyHash, err := bcrypt.GenerateFromPassword([]byte("StrongPass1"), bcrypt.DefaultCost)
+	if err != nil {
+		t.Fatalf("hash password: %v", err)
+	}
+	repo := &stubAuthUserRepo{
+		updateHashOnlyErr: context.DeadlineExceeded,
+		findByEmailUser: models.User{
+			ID:               77,
+			Email:            "login@example.com",
+			PasswordHash:     string(legacyHash),
+			LocalAuthEnabled: true,
+			Role:             models.RoleOwner,
+		},
+	}
+	service := NewAuthService(repo)
+
+	user, err := service.AuthenticateCredentials(context.Background(), "login@example.com", "StrongPass1")
+	if err != nil {
+		t.Fatalf("expected login to succeed despite rehash write error, got %v", err)
+	}
+	if repo.updateHashOnlyCalls != 1 {
+		t.Fatalf("expected the rehash write to be attempted once, got %d", repo.updateHashOnlyCalls)
+	}
+	// On write failure the returned struct keeps the legacy hash (no phantom
+	// in-memory upgrade that never hit the DB).
+	if got := mustBcryptCost(t, user.PasswordHash); got != bcrypt.DefaultCost {
+		t.Fatalf("returned hash cost = %d, want unchanged %d after failed write", got, bcrypt.DefaultCost)
+	}
+}

--- a/internal/services/auth_service_recovery_test.go
+++ b/internal/services/auth_service_recovery_test.go
@@ -36,6 +36,10 @@ type stubAuthUserRepo struct {
 	updatedRecoveryHash      string
 	updatedPasswordHash      string
 	updatedMustChange        bool
+	updateHashOnlyErr        error
+	updateHashOnlyCalls      int
+	updateHashOnlyUserID     uint
+	updateHashOnlyHash       string
 }
 
 func (stub *stubAuthUserRepo) ExistsByNormalizedEmail(context.Context, string) (bool, error) {
@@ -135,6 +139,17 @@ func (stub *stubAuthUserRepo) UpdatePasswordRecoveryCodeAndRevokeSessions(ctx co
 
 func (stub *stubAuthUserRepo) UpdatePasswordRecoveryCodeAndRevokeSessionsCAS(ctx context.Context, userID uint, oldPasswordHash string, newPasswordHash string, recoveryHash string) error {
 	return stub.UpdatePasswordRecoveryCodeAndRevokeSessions(ctx, userID, newPasswordHash, recoveryHash, false)
+}
+
+func (stub *stubAuthUserRepo) UpdatePasswordHashOnly(ctx context.Context, userID uint, passwordHash string) error {
+	stub.updateHashOnlyCalls++
+	if stub.updateHashOnlyErr != nil {
+		return stub.updateHashOnlyErr
+	}
+	stub.updateHashOnlyUserID = userID
+	stub.updateHashOnlyHash = passwordHash
+	stub.user.PasswordHash = passwordHash
+	return nil
 }
 
 func (stub *stubAuthUserRepo) BumpAuthSessionVersion(ctx context.Context, userID uint) error {

--- a/internal/services/settings_password_policy.go
+++ b/internal/services/settings_password_policy.go
@@ -56,7 +56,7 @@ func (service *SettingsService) ChangePassword(ctx context.Context, user *models
 	}
 
 	newPassword = strings.TrimSpace(newPassword)
-	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(newPassword), bcrypt.DefaultCost)
+	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(newPassword), passwordHashCost)
 	if err != nil {
 		return fmt.Errorf("%w: %v", ErrSettingsPasswordHashFailed, err)
 	}
@@ -96,7 +96,7 @@ func (service *SettingsService) PrepareLocalPasswordHash(user *models.User, newP
 		return "", ErrSettingsWeakPassword
 	}
 
-	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(newPassword), bcrypt.DefaultCost)
+	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(newPassword), passwordHashCost)
 	if err != nil {
 		return "", fmt.Errorf("%w: %v", ErrSettingsPasswordHashFailed, err)
 	}


### PR DESCRIPTION
## What

- Introduces a single named constant `passwordHashCost = 12` in `internal/services` and uses it at every production hashing site, replacing `bcrypt.DefaultCost` (10): registration, forced reset, reset+rotate (both CAS and legacy), settings password change, OIDC local-password setup, and recovery-code generation.
- Adds an opportunistic rehash on successful login: after bcrypt verification succeeds, a stored hash whose cost is below the target is re-hashed at cost 12 and written back via the new `UserRepository.UpdatePasswordHashOnly`.
- Regenerates the timing-equalization placeholder hashes at cost 12 and pins their cost by test (second commit): cost-10 placeholders would have made the equalized early-return paths ~4x faster than a real compare, reintroducing the account-enumeration timing oracle.

## Why

Cost 10 dates from bcrypt's defaults; cost 12 widens the offline-guessing margin if the DB and `SECRET_KEY` ever leak together (the scenario SECURITY.md names for recovery codes). The rehash raises the floor for existing accounts without forcing password resets.

## Security notes (reviewed against the constitution)

- **Session invalidation invariant:** the rehash intentionally does NOT bump `auth_session_version` — the credential itself is unchanged, so revoking sessions would log the user out on the very login that succeeded. This mirrors the existing `UpdateTOTPSecretCiphertext` transparent-storage-upgrade precedent (same file, same rationale). A repo-level test pins this.
- The rehash runs only after a successful `CompareHashAndPassword` (plaintext proven), writes only `password_hash` scoped by `user_id`, and is best-effort: any error is swallowed so it can never fail a valid login (test-pinned).
- `SECURITY.md` (Password & Auth Policy, data-model summary, and three new Test Enforcement Matrix rows) and `docs/SECURITY_INVARIANTS.md` updated in the same change.

## Validation

- `go test ./internal/services/` — ok (full suite re-run after each change; final pass 69.4s)
- `go test ./internal/db/` — ok (29.2s)
- `go test ./internal/api/` — ok (241.7s)
- `go vet ./internal/services/... ./internal/api/... ./internal/db/...` — clean
- `staticcheck` on the three packages — clean
- `go run ./scripts/patchcov` (coverage profile over services+db) — "patch coverage gate OK"

## Operational note

Login/registration CPU per bcrypt operation roughly quadruples (2 cost steps). The per-account rate limiters already bound the request rate; the timing-equalization paths spend the same (now larger) bcrypt budget by design.