### PR TITLE
refactor(api): return plain string from templateToJSON, drop nosec G203

### DIFF
--- a/internal/api/handlers_template_format_helpers.go
+++ b/internal/api/handlers_template_format_helpers.go
@@ -3,7 +3,6 @@ package api
 import (
 	"encoding/json"
 	"fmt"
-	"html/template"
 	"math"
 	"time"
 
@@ -27,11 +26,20 @@ func formatTemplateFloat(value float64) string {
 	return fmt.Sprintf("%.1f", rounded)
 }
 
-func templateToJSON(value any) template.JS {
+// templateToJSON serializes a value for embedding in HTML data-* attributes
+// (base.html data-supported-languages, stats.html data-chart). It returns a
+// plain string — NOT template.JS/template.HTML — so html/template applies full
+// contextual escaping in the attribute context. Browser-side consumers read
+// the attribute via getAttribute/dataset (chart-lite.js), which entity-decodes
+// before JSON.parse, so the escaping round-trips transparently.
+//
+// Do not "optimize" this back to template.JS: a typed-string return would
+// bypass the attribute escaper and make safety depend solely on json.Marshal's
+// escaping behavior (the retired #nosec G203 pattern).
+func templateToJSON(value any) string {
 	serialized, err := json.Marshal(value)
 	if err != nil {
-		return template.JS("null")
+		return "null"
 	}
-	// #nosec G203 -- json.Marshal escapes script-breaking characters before embedding a JS literal in the template.
-	return template.JS(serialized)
+	return string(serialized)
 }

--- a/internal/api/template_tojson_attr_escaping_test.go
+++ b/internal/api/template_tojson_attr_escaping_test.go
@@ -1,0 +1,71 @@
+package api
+
+import (
+	"html/template"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// Compile-time pin: templateToJSON must return a plain string so html/template
+// applies full contextual escaping in the attribute context (base.html
+// data-supported-languages, stats.html data-chart). Reverting it to a typed
+// string (template.JS / template.HTML) would bypass the attribute escaper and
+// fail this assignment — update this test only together with a conscious
+// security review of every template call site.
+var _ func(any) string = templateToJSON
+
+// TestTemplateToJSONEscapesSafelyInSingleQuotedAttribute is the regression for
+// the retired `#nosec G203` templateToJSON: adversarial JSON content embedded
+// in a single-quoted data-* attribute must not be able to break out of the
+// attribute or introduce markup, and must survive the browser's
+// getAttribute/dataset entity-decoding + JSON.parse round trip unchanged
+// (chart-lite.js consumes data-chart exactly that way; the test mirrors it via
+// extractStatsChartPayload's html.UnescapeString + json.Unmarshal).
+func TestTemplateToJSONEscapesSafelyInSingleQuotedAttribute(t *testing.T) {
+	t.Parallel()
+
+	payload := statsChartPayload{
+		Labels: []string{
+			"a'b",
+			`</script><script>alert(1)</script>`,
+			`double " quote and backslash \`,
+			"amp & angle < >",
+		},
+		Values: []int{1, 2, 3, 4},
+	}
+
+	probe := template.Must(template.New("probe").Funcs(newTemplateFuncMap()).Parse(
+		`<div id="probe" data-chart='{{toJSON .}}'></div>`,
+	))
+	var rendered strings.Builder
+	if err := probe.Execute(&rendered, payload); err != nil {
+		t.Fatalf("execute probe template: %v", err)
+	}
+	output := rendered.String()
+
+	// Attribute breakout: the template contains exactly one single-quoted
+	// attribute, so exactly its two delimiter quotes may survive rendering. Any
+	// third raw single quote means the payload escaped the attribute value.
+	if got := strings.Count(output, "'"); got != 2 {
+		t.Fatalf("expected exactly 2 raw single quotes (attribute delimiters), got %d in: %q", got, output)
+	}
+
+	// Markup injection: no literal script terminator / opener may appear
+	// anywhere in the rendered document.
+	lowered := strings.ToLower(output)
+	if strings.Contains(lowered, "</script") || strings.Contains(lowered, "<script") {
+		t.Fatalf("rendered output contains literal script markup: %q", output)
+	}
+
+	// Browser-equivalent round trip: entity-decode the attribute value and
+	// JSON-parse it (what getAttribute + JSON.parse do in chart-lite.js). The
+	// payload must come back byte-identical.
+	roundTripped, err := extractStatsChartPayload(output)
+	if err != nil {
+		t.Fatalf("round-trip extraction failed: %v", err)
+	}
+	if !reflect.DeepEqual(roundTripped, payload) {
+		t.Fatalf("payload mutated in the escape round trip:\n  want %#v\n  got  %#v", payload, roundTripped)
+	}
+}

--- a/internal/api/template_tojson_attr_escaping_test.go
+++ b/internal/api/template_tojson_attr_escaping_test.go
@@ -69,3 +69,14 @@ func TestTemplateToJSONEscapesSafelyInSingleQuotedAttribute(t *testing.T) {
 		t.Fatalf("payload mutated in the escape round trip:\n  want %#v\n  got  %#v", payload, roundTripped)
 	}
 }
+
+// TestTemplateToJSONReturnsNullOnMarshalError pins the fail-safe branch: when a
+// value cannot be JSON-serialized (e.g. a channel), templateToJSON returns the
+// literal "null" rather than propagating an error or emitting a partial string.
+func TestTemplateToJSONReturnsNullOnMarshalError(t *testing.T) {
+	t.Parallel()
+
+	if got := templateToJSON(make(chan int)); got != "null" {
+		t.Fatalf("expected %q on marshal error, got %q", "null", got)
+	}
+}


### PR DESCRIPTION
## What

`templateToJSON` (`internal/api/handlers_template_format_helpers.go`) returned `template.JS` that landed inside single-quoted HTML attributes: `base.html` `data-supported-languages` and `stats.html` `data-chart` (2 sites). It now returns a plain `string` and the `#nosec G203` suppression is gone.

## Why

A `template.JS` typed string tells `html/template` to trust the value, weakening contextual escaping — safety rested entirely on `json.Marshal`'s escaping behavior plus a lint suppression. With a plain string the attribute-context escaper applies in full (`'` → `&#39;`, etc.), making the template layer safe by construction regardless of what the JSON contains.

## Consumer audit (no behavior change)

- `data-chart`: read by `web/static/js/chart-lite.js` via `container.getAttribute("data-chart")` → `JSON.parse` — `getAttribute` entity-decodes, so the escaping round-trips transparently. The existing stats tests (`extractStatsChartPayload`, which mirrors that decode) keep passing unchanged.
- `data-supported-languages`: grep over `web/src` and `web/static` finds **no JS reader** — the attribute is currently unused by scripts, so nothing to adjust.
- No `web/src` JS changed → no `npm run build`, bundles untouched (CI stale-bundle guard unaffected).

## Regression test

`template_tojson_attr_escaping_test.go` (single-purpose file per the narrow-security-invariant convention) renders `'`, `</script><script>…`, `\"`, `\`, `& < >` through the real `newTemplateFuncMap()` in the exact single-quoted attribute context and asserts: no attribute breakout (quote count), no literal script markup anywhere in the output, and a byte-identical `getAttribute`-equivalent round trip. A compile-time pin (`var _ func(any) string = templateToJSON`) makes a silent revert to `template.JS` fail the build of this test.

## Validation

- `go test ./internal/api/` — ok (102.4s)
- `go vet ./internal/api/...` — clean
- `gosec ./internal/api/...` — 0 issues (suppression no longer needed, no new findings)
- `golangci-lint run ./internal/api/...` — 0 issues
- `go run ./scripts/patchcov` — "patch coverage gate OK"