### PR TITLE
fix(e2e): repair oidc_only step-up lane and calendar save helper

### DIFF
--- a/e2e/auth-oidc.spec.ts
+++ b/e2e/auth-oidc.spec.ts
@@ -34,14 +34,14 @@ async function signInViaOIDCOnlyAndEnableLocalPassword(page: Page) {
 
   const localPasswordForm = page.locator('[data-settings-local-password-form]');
   if (await localPasswordForm.isVisible().catch(() => false)) {
-    // OIDC-only users now must complete a step-up re-auth before a local
-    // password is committed. Submitting the form posts to
-    // /api/v1/users/current/password/step-up, which redirects to the
-    // provider's authorize endpoint with prompt=login + max_age=0. The full
-    // round-trip back through /auth/oidc/callback into /recovery-code depends
-    // on the test provider honoring those parameters and cannot be exercised
-    // without a controllable IdP — assert the redirect to the provider as the
-    // closest end-to-end signal.
+    // OIDC-only users must complete a step-up re-auth before a local password
+    // is committed. Submitting the form posts to
+    // /api/v1/users/current/password/step-up, which hands back a same-origin
+    // interstitial that bounces to the provider's authorize endpoint with
+    // prompt=login + max_age=0. Against the controllable local IdP the round
+    // trip runs to completion — provider re-auth, /auth/oidc/callback, then the
+    // freshly-issued recovery code — so wait for that terminal /recovery-code
+    // page as the end-to-end signal.
     await expect(page.locator('[data-settings-recovery-code-unavailable]')).toBeVisible();
     await expect(page.locator('form[action="/api/v1/users/current/recovery-code"]')).toHaveCount(0);
     await expect(localPasswordForm).toHaveAttribute('action', '/api/v1/users/current/password/step-up');
@@ -49,8 +49,11 @@ async function signInViaOIDCOnlyAndEnableLocalPassword(page: Page) {
     const localPassword = 'LocalStrongPass2';
     await page.locator('#settings-new-password').fill(localPassword);
     await page.locator('#settings-confirm-password').fill(localPassword);
+    // Wait for the concrete terminal URL, not `(url) => !url.startsWith(page.url())`:
+    // page.url() is re-read on every predicate call and tracks the live location,
+    // so it always equals the URL under test and the predicate never fires.
     await Promise.all([
-      page.waitForURL((url) => !url.toString().startsWith(page.url())),
+      page.waitForURL(/\/recovery-code(?:\?.*)?$/),
       page.locator('[data-settings-local-password-form] button[type="submit"]').click(),
     ]);
     expect(page.url()).not.toMatch(/\/settings(?:\?.*)?$/);

--- a/e2e/calendar-autofill-clear.spec.ts
+++ b/e2e/calendar-autofill-clear.spec.ts
@@ -59,12 +59,33 @@ async function openCalendarDayEditor(page: Page, isoDate: string) {
 }
 
 async function saveDayEditorForm(page: Page, isoDate: string, form: import('@playwright/test').Locator): Promise<void> {
-  await Promise.all([
-    page.waitForResponse((response) => {
-      return response.request().method() === 'PUT' && response.url().includes(`/api/v1/days/${isoDate}`);
-    }),
+  // Bind the wait to the request this click issues, not to any PUT response for
+  // the date. waitForResponse would resolve on the first matching response to
+  // arrive after registration — under CPU contention a still-in-flight earlier
+  // PUT's response can land inside this window and satisfy the predicate before
+  // the actual save lands. The `request` event only fires for requests issued
+  // after registration, so this captures exactly the click's PUT; awaiting that
+  // request's own response then blocks until this save has truly committed.
+  const [request] = await Promise.all([
+    page.waitForRequest(
+      (candidate) =>
+        candidate.method() === 'PUT' && candidate.url().includes(`/api/v1/days/${isoDate}`),
+    ),
     form.locator('button[data-save-button]').click(),
   ]);
+  const response = await request.response();
+  expect(response, `expected a response for PUT /api/v1/days/${isoDate}`).not.toBeNull();
+  expect(response!.ok(), `PUT /api/v1/days/${isoDate} failed with ${response!.status()}`).toBeTruthy();
+
+  // The PUT response only means the write committed. Its htmx afterSwap then
+  // fires `calendar-day-updated`, which reloads the whole calendar grid
+  // (GET /calendar) and re-lazy-loads the day editor — a cascade that outlives
+  // this click. If the caller navigates (openCalendarDayEditor → page.goto)
+  // while that cascade is still hitting the server, the next page's own
+  // hx-trigger="load" editor fetch competes with it and, under CPU contention,
+  // can miss the 5s visibility window. Let the app go quiescent first so the
+  // save is fully settled — not just committed — before returning.
+  await page.waitForLoadState('networkidle');
 }
 
 test.describe('calendar auto-fill clear-on-toggle-off', () => {

--- a/internal/api/fullpage_fallback_regressions_test.go
+++ b/internal/api/fullpage_fallback_regressions_test.go
@@ -358,7 +358,7 @@ func TestFullPageFallbackStepupRedirects(t *testing.T) {
 		assertSeeOther(t, response, "/settings")
 	})
 
-	t.Run("stepup start for oidc-only user redirects to provider", func(t *testing.T) {
+	t.Run("stepup start for oidc-only user bridges to provider via interstitial", func(t *testing.T) {
 		oidcOnly := models.User{
 			Email:               "fullpage-stepup-oidc@example.com",
 			PasswordHash:        "",
@@ -388,7 +388,22 @@ func TestFullPageFallbackStepupRedirects(t *testing.T) {
 
 		form := url.Values{"new_password": {"FreshStrong2"}, "confirm_password": {"FreshStrong2"}}
 		response := fullPageRequest(t, app, http.MethodPost, "/api/v1/users/current/password/step-up", form, authCookieName+"="+sealed)
-		assertSeeOther(t, response, stub.reauthURL)
+		defer func() { _ = response.Body.Close() }()
+
+		// The browser form submit must not be answered with a cross-origin 3xx:
+		// CSP form-action 'self' would abort that redirect (net::ERR_ABORTED).
+		// It returns a same-origin 200 interstitial that meta-refreshes to the
+		// provider authorize URL instead.
+		if response.StatusCode != http.StatusOK {
+			t.Fatalf("expected 200 interstitial, got %d", response.StatusCode)
+		}
+		if location := response.Header.Get("Location"); location != "" {
+			t.Fatalf("browser step-up path must not emit a Location redirect, got %q", location)
+		}
+		body := mustReadBodyString(t, response.Body)
+		if !strings.Contains(body, `http-equiv="refresh"`) || !strings.Contains(body, stub.reauthURL) {
+			t.Fatalf("expected meta-refresh interstitial targeting %q, got %q", stub.reauthURL, body)
+		}
 	})
 
 	t.Run("logout bridge redirect with empty provider url redirects to login", func(t *testing.T) {

--- a/internal/api/handlers_auth_oidc.go
+++ b/internal/api/handlers_auth_oidc.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"errors"
+	"html"
 	"time"
 
 	"github.com/gofiber/fiber/v3"
@@ -152,6 +153,21 @@ func boolString(value bool) string {
 		return "true"
 	}
 	return "false"
+}
+
+// oidcSameOriginRedirectInterstitial returns a minimal same-origin HTML
+// document that bounces the browser to target via a meta-refresh. A browser
+// form submission cannot 3xx-redirect straight to the cross-origin IdP: the
+// page CSP pins form-action to 'self', and Chromium enforces that across the
+// whole redirect chain of a form navigation, so a cross-origin hop aborts as
+// net::ERR_ABORTED. Returning a same-origin 200 whose meta-refresh performs the
+// hop keeps the cross-origin navigation out of the form submission — where
+// form-action does not apply — the same technique the provider-logout bridge
+// uses. target is server-built (config + random OIDC state), never user input,
+// but is HTML-escaped as defense-in-depth for the attribute context.
+func oidcSameOriginRedirectInterstitial(target string) string {
+	return `<!doctype html><html><head><meta charset="utf-8"><meta http-equiv="refresh" content="0; url=` +
+		html.EscapeString(target) + `"></head><body></body></html>`
 }
 
 func (handler *Handler) ShowOIDCLogoutBridge(c fiber.Ctx) error {

--- a/internal/api/handlers_settings_password.go
+++ b/internal/api/handlers_settings_password.go
@@ -122,7 +122,13 @@ func (handler *Handler) StartLocalPasswordSetupReauth(c fiber.Ctx) error {
 	if acceptsJSON(c) {
 		return c.JSON(fiber.Map{"ok": true, "redirect_url": authURL})
 	}
-	return c.Redirect().Status(fiber.StatusSeeOther).To(authURL)
+	// A plain HTML form submit cannot 303 straight to the cross-origin provider
+	// authorize endpoint: the settings page CSP pins form-action to 'self' and
+	// Chromium enforces that across the form navigation's redirect chain, so the
+	// cross-origin hop aborts client-side (net::ERR_ABORTED). Hand back a
+	// same-origin interstitial whose meta-refresh performs the hop instead.
+	c.Type("html", "utf-8")
+	return c.SendString(oidcSameOriginRedirectInterstitial(authURL))
 }
 
 // completeLocalPasswordSetupReauth is dispatched from CompleteOIDCLogin when

--- a/internal/api/settings_oidc_local_password_setup_test.go
+++ b/internal/api/settings_oidc_local_password_setup_test.go
@@ -201,6 +201,50 @@ func TestOIDCStartLocalPasswordSetupIssuesRedirectAndStepupCookie(t *testing.T) 
 	}
 }
 
+// A real browser submits the local-password step-up form as an ordinary HTML
+// form POST (Accept: text/html), not via fetch. The settings page CSP pins
+// form-action to 'self', and Chromium enforces that across the whole redirect
+// chain of a form navigation — so answering the submit with a 303 to the
+// cross-origin provider authorize endpoint aborts client-side
+// (net::ERR_ABORTED, reproduced in the oidc_only e2e lane). The browser path
+// must instead return a same-origin 200 interstitial whose meta-refresh
+// performs the cross-origin hop, keeping it out of the form submission.
+func TestOIDCStartLocalPasswordSetupBrowserPathReturnsSameOriginInterstitial(t *testing.T) {
+	t.Parallel()
+
+	fixture := newOIDCStepupFixture(t, "settings-stepup-browser@example.com")
+
+	csrfCookie, csrfToken := fixture.settingsCSRF(t)
+	form := url.Values{
+		"new_password":     {"EvenStronger2"},
+		"confirm_password": {"EvenStronger2"},
+		"csrf_token":       {csrfToken},
+	}
+	request := httptest.NewRequest(http.MethodPost, "/api/v1/users/current/password/step-up", strings.NewReader(form.Encode()))
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	request.Header.Set("Accept", "text/html,application/xhtml+xml")
+	request.Header.Set("Cookie", settingsCookieHeader(fixture.authCookie, csrfCookie))
+	response := mustAppResponse(t, fixture.app, request)
+	defer func() { _ = response.Body.Close() }()
+
+	assertStatusCode(t, response, http.StatusOK)
+	if location := response.Header.Get("Location"); location != "" {
+		t.Fatalf("browser step-up path must not emit a redirect the form navigation would follow; got Location %q", location)
+	}
+	if ct := response.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+		t.Fatalf("expected an html interstitial, got content-type %q", ct)
+	}
+	body := mustReadBodyString(t, response.Body)
+	if !strings.Contains(body, `http-equiv="refresh"`) {
+		t.Fatalf("expected a meta-refresh interstitial, got %q", body)
+	}
+	if !strings.Contains(body, fixture.oidcStub.reauthURL) {
+		t.Fatalf("expected the interstitial to target the provider authorize URL %q, got %q", fixture.oidcStub.reauthURL, body)
+	}
+	// The sealed step-up cookie must still ride along so the callback can finalize.
+	_ = readStepupCookie(t, response)
+}
+
 func TestOIDCStartLocalPasswordSetupRejectsWeakPassword(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Fixes two e2e reliability defects (topic: e2e reliability).

### MEDIUM — oidc_only step-up lane fails deterministically (real transport bug)

The OIDC-only "enable local password" step-up form is a plain HTML `<form method=post>`. The browser submits it same-origin, but `StartLocalPasswordSetupReauth` answered the browser path with a **303 straight to the cross-origin OIDC provider `/authorize`**. Chromium enforces CSP `form-action 'self'` across the **entire redirect chain** of a form-initiated navigation, so the cross-origin hop is blocked → `net::ERR_ABORTED`. The server flow is healthy (proven independently); only the browser blocks the redirect. The normal SSO login is immune because it's an anchor `GET` (`/auth/oidc/start`), not a form submission.

**Fix:** mirror the existing provider-logout bridge — the HTML branch returns a same-origin `200` interstitial whose `<meta http-equiv="refresh">` performs the cross-origin hop as an ordinary navigation (not governed by `form-action`). No CSP relaxation, no new JS, works without JS. The JSON path is untouched.

The abort masked a **second, latent spec-helper bug**: `waitForURL((url) => !url.startsWith(page.url()))` is self-referential — `page.url()` is re-read on every check and always equals the URL under test, so it never fires. With the controllable local IdP the flow now completes, so the helper waits for the terminal `/recovery-code`.

### LOW — calendar save helper race

`saveDayEditorForm` waited on `waitForResponse` for *any* PUT to the date (a late earlier response could satisfy it), and returned at the PUT response while the post-save htmx cascade (`calendar-day-updated` → `GET /calendar` grid reload → re-lazy-load of the editor) was still hitting the server. The next `openCalendarDayEditor`'s own `hx-trigger="load"` editor fetch then competed with the busy server and missed its 5s visibility window under CPU contention (failure surfaced at `openCalendarDayEditor:57`). **Fix:** bind the wait to the click's specific request (`waitForRequest` → `request.response()` + assert ok), then `waitForLoadState('networkidle')` so the save is fully settled.

## Tests
- New `TestOIDCStartLocalPasswordSetupBrowserPathReturnsSameOriginInterstitial` (browser Accept → 200 interstitial, no `Location`, meta-refresh to provider).
- Updated `TestFullPageFallbackStepupRedirects` subtest from asserting a 303 to asserting the interstitial.

## Validation
- oidc_only lane (`E2E_OIDC_PROVIDER=local OIDC_LOGIN_MODE=oidc_only OIDC_AUTO_PROVISION=true REGISTRATION_MODE=open OIDC_LOGOUT_MODE=provider`): **3/3 consecutive green**
- full `npm run e2e`: **145 passed**
- `npm run e2e:postgres -- e2e/calendar-autofill-clear.spec.ts e2e/calendar.spec.ts`: **5/5 consecutive green** (was ~1-in-4 flaky)
- `internal/api` package + `go build`/`vet`/`gofmt`: green
