### PR TITLE
docs(mutation): fill internal_api score from run 28758365493

### DIFF
--- a/.mutation/internal-api.md
+++ b/.mutation/internal-api.md
@@ -4,33 +4,69 @@ Authoritative gremlins run for the transport/HTTP package. Reproduce with
 `scripts/mutation.sh baseline` (per-package JSON lands in `.tmp/mutation/`); this
 file is the reviewed summary committed alongside the code.
 
-## Score (pending first weekly CI run)
-
-`internal/api` joined the baseline scope in `scripts/mutation.sh` alongside
-`internal/services` and `internal/security`. It is the largest package
-(~8.5k source lines) and carries heavy integration tests against a real
-database, so no local number is authoritative for it: canonical efficacy comes
-only from the weekly `mutation.yml` CI job (clean Linux), never from a local
-Windows run. This file will be filled in — measuring commit, killed/lived/timed
-out/not-covered counts, efficacy, and any documented equivalent mutants — once
-that job has produced its first `internal/api` result.
+## Score (measured on `a6d7e41`)
 
 A single unsharded CI run exceeds the job's 3h timeout before finishing (issue
 #161), so `mutation.yml` runs `internal/api` as 5 file-subset shards
 (`internal_api_1`..`internal_api_5` matrix entries, each excluding every file
 not assigned to it — see `scripts/mutation.sh`'s `api_shard_*` functions) and a
-follow-up job merges the 5 shard JSON reports into one `internal_api.json` via
-`scripts/mutationmerge`, matching the single-file-per-target convention
-`internal_services.json`/`internal_security.json` already use. The numbers
-below, once filled in, are the combined total across all 5 shards — the same
-number a hypothetical single unsharded run would have produced.
+follow-up job (`mutation-api-merge`) merges the 5 shard JSON reports into one
+`internal_api.json` via `scripts/mutationmerge`, matching the single-file-per-target
+convention `internal_services.json`/`internal_security.json` already use (PR
+#163). The numbers below are the first complete run since sharding landed —
+**workflow_dispatch run [28758365493](https://github.com/ovumcy/ovumcy-web/actions/runs/28758365493)**,
+all 5 shards plus the merge job green — and are the combined total across all 5
+shards, the same figure a hypothetical single unsharded run would have produced.
 
 | Metric | Value |
 |--------|-------|
-| Killed | pending first weekly CI run |
-| Lived (survivors) | pending first weekly CI run |
-| Timed out | pending first weekly CI run |
-| Not covered | pending first weekly CI run |
-| Not viable | pending first weekly CI run |
-| **Test efficacy** | pending first weekly CI run |
-| Mutator coverage | pending first weekly CI run |
+| Killed | 488 |
+| Lived (survivors) | 128 |
+| Timed out | 0 |
+| Not covered | 98 |
+| Not viable | 0 |
+| **Test efficacy** | **79.22%** — killed / (killed + lived) = 488 / 616 |
+| Mutator coverage | 86.27% — (killed + lived) / (killed + lived + not covered) = 616 / 714 |
+
+Per-shard breakdown (gremlins' own summary line for each matrix job; sums to the
+combined row above):
+
+| Shard | Killed | Lived | Not covered | Test efficacy | Mutator coverage |
+|-------|--------|-------|-------------|----------------|-------------------|
+| internal_api_1 | 77 | 29 | 19 | 72.64% | 84.80% |
+| internal_api_2 | 111 | 21 | 6 | 84.09% | 95.65% |
+| internal_api_3 | 93 | 8 | 9 | 92.08% | 91.82% |
+| internal_api_4 | 115 | 52 | 46 | 68.86% | 78.40% |
+| internal_api_5 | 92 | 18 | 18 | 83.64% | 85.94% |
+
+## Survivors — not yet triaged
+
+Unlike `internal-services.md`/`internal-security.md`, the 128 survivors here are
+**not** individually triaged into "real gap" vs. "documented equivalent mutant"
+yet — that requires a source-level equivalence review per mutant (apply the
+mutation, confirm no test fails, judge whether it's reachable), which is a
+separate follow-up, not implied by getting real numbers out of CI for the first
+time. Do not read the raw 79.22% efficacy as "21% of behavior is untested" —
+some fraction of these are almost certainly equivalent mutants like the ones
+already documented for `internal/services`/`internal/security`.
+
+Survivor count by file, top entries (from the merged `internal_api.json`; full
+list has 40 files with at least one survivor):
+
+| File | Survivors |
+|------|-----------|
+| `stats_page_helpers.go` | 19 |
+| `handlers_auth_token_helpers.go` | 10 |
+| `request_logging.go` | 9 |
+| `handlers_days_status_helpers.go` | 8 |
+| `security_event_logging.go` | 7 |
+| `handlers_template_ui_helpers.go` | 6 |
+| `handlers_template_format_helpers.go` | 6 |
+| `settings_symptom_view_models.go` | 5 |
+| `i18n_helpers.go` | 5 |
+
+The 98 not-covered mutants concentrate similarly: `request_logging.go` (35),
+`request_timezone_policy.go` (16), and `asset_version.go` (15) account for two
+thirds of them — worth checking whether these are dead code, tested only at the
+integration/e2e layer (the `internal/security` OIDC precedent), or a genuine gap
+before the next triage pass.


### PR DESCRIPTION
## Summary

- `.mutation/internal-api.md` still read "pending first weekly CI run" even
  though issue #161 / PR #163 shipped 5-way sharding for `internal/api`'s
  mutation run. This fills in the real numbers now that a complete sharded
  run has finished.
- Source: workflow_dispatch run
  [28758365493](https://github.com/ovumcy/ovumcy-web/actions/runs/28758365493)
  on `mutation.yml` (measured on commit `a6d7e41`) — all 5
  `internal_api_1..5` shards plus `mutation-api-merge` green. This is the
  **first complete `internal/api` mutation run since sharding landed**.
- Downloaded the `mutation-api-merge` job's combined artifact
  (`mutation-baseline-results-internal_api` → `internal_api.json`) and cross-checked
  the aggregate two independent ways: (a) summing gremlins' own per-shard
  "Killed/Lived/Not covered" summary lines from each shard's job log, and
  (b) counting `"status"` values directly in the merged JSON. Both agree
  exactly.

## Real internal_api score

| Metric | Value |
|--------|-------|
| Killed | 488 |
| Lived (survivors) | 128 |
| Timed out | 0 |
| Not covered | 98 |
| Not viable | 0 |
| **Test efficacy** | **79.22%** (488 / 616) |
| Mutator coverage | 86.27% (616 / 714) |

The 128 survivors are **not yet individually triaged** into real-gap vs.
equivalent-mutant (unlike the 4/9 survivors already triaged for
`internal/services`/`internal/security`) — that's a separate follow-up
requiring per-mutant source review, called out explicitly in the file so the
raw 79.22% isn't misread as "21% of behavior untested."

## Test plan

- [x] `git status` shows only `.mutation/internal-api.md` changed (docs/data
      file, no code) — confirmed before and after commit.
- [x] Numbers cross-checked two independent ways (gremlins per-shard summary
      lines vs. raw JSON status counts) — both give Killed=488, Lived=128,
      Not covered=98.
- [x] Arithmetic sanity: 488 + 128 + 0 + 98 + 0 = 714 total mutants, matching
      both the merged JSON's mutation count and the sum of gremlins' own
      per-shard totals.
- [x] Downloaded artifact deleted from scratch dir after use; no artifact or
      temp file left in the repo tree.
- No `go build`/`go test` — no Go source changed.
