### PR TITLE
feat(reminders): optional built-in daily reminder scheduler (#125)

### DIFF
--- a/cmd/ovumcy/main.go
+++ b/cmd/ovumcy/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/ovumcy/ovumcy-web/internal/cli"
 	"github.com/ovumcy/ovumcy-web/internal/db"
 	"github.com/ovumcy/ovumcy-web/internal/i18n"
+	"github.com/ovumcy/ovumcy-web/internal/reminders"
 	"github.com/ovumcy/ovumcy-web/internal/security"
 	"github.com/ovumcy/ovumcy-web/internal/services"
 	staticassets "github.com/ovumcy/ovumcy-web/web"
@@ -49,6 +50,22 @@ type runtimeConfig struct {
 	RateLimits       rateLimitSettings
 	Proxy            proxySettings
 	AuditLogEnabled  bool
+	// WebhookBlockPrivate mirrors the off-by-default WEBHOOK_BLOCK_PRIVATE_ADDRESSES
+	// egress gate the notify CLI reads, so the built-in scheduler wires the same
+	// deliverer hardening.
+	WebhookBlockPrivate bool
+	ReminderScheduler   reminderSchedulerSettings
+}
+
+// reminderSchedulerSettings configures the optional built-in reminder scheduler
+// (issue #125). Enabled is DEFAULT FALSE: the always-on outbound component ships
+// off and is opted into explicitly via REMINDER_SCHEDULER_ENABLED. Hour is the
+// LOCAL hour-of-day (0-23) the daily pass runs at (REMINDER_SCHEDULER_HOUR,
+// default 9); the scheduler reuses config.Location, there is no separate
+// reminder timezone.
+type reminderSchedulerSettings struct {
+	Enabled bool
+	Hour    int
 }
 
 type rateLimitSettings struct {
@@ -134,29 +151,74 @@ func main() {
 	handler := mustNewHandler(config, i18nManager, dependencies)
 	app := newFiberApp(config, handler)
 	served := make(chan struct{})
-	stopSignals := installGracefulShutdown(app, served)
+	sigCtx, stopSignals := installGracefulShutdown(app, served)
 	defer stopSignals()
+
+	// Optional built-in reminder scheduler (issue #125). Started AFTER the
+	// signal context is wired and BEFORE runServer, gated on config (default
+	// OFF). It observes sigCtx — the same context that stops the server — and is
+	// launched with `go` inside Start, so it can neither delay app.Listen nor
+	// touch served/app shutdown. schedulerDone closes when it has fully drained
+	// (an already-closed channel when the scheduler is disabled).
+	schedulerDone := startReminderScheduler(sigCtx, config, database, i18nManager)
 
 	logStartup(config)
 	// codecov:ignore:start -- main() run loop; runServer itself is unit-tested.
-	err = runServer(app, database, ":"+config.Port)
+	err = runServer(app, ":"+config.Port)
 	close(served)
+	// The server has stopped. If the scheduler is running, wait (bounded) for any
+	// in-flight pass to finish reading/writing the DB, THEN close the DB — so the
+	// database outlives the last reminder access on this single exit path.
+	reminders.Drain(schedulerDone, reminders.DefaultStopBudget)
+	closeDatabase(database)
 	if err != nil {
 		log.Fatalf("server exited: %v", err)
 	}
 	// codecov:ignore:end
 }
 
-// runServer blocks in app.Listen until the listener fails or a graceful
-// stop completes, then closes the database so SQLite checkpoints its WAL
-// and releases the file before the process exits — on both exit paths.
-func runServer(app *fiber.App, database *gorm.DB, address string) error {
+// runServer blocks in app.Listen until the listener fails or a graceful stop
+// completes, then returns the listen error. It no longer closes the database:
+// the optional reminder scheduler may still be draining an in-flight pass that
+// reads/writes the DB, so closeDatabase is sequenced by main AFTER the scheduler
+// drain (see main). The database is still closed on BOTH exit paths — there is
+// one main return path and main always closes it — SQLite still checkpoints its
+// WAL and releases the file before the process exits.
+func runServer(app *fiber.App, address string) error {
 	// Fiber v3 moved DisableStartupMessage out of fiber.Config and into the
 	// per-listen ListenConfig; keep the banner suppressed as before.
-	err := app.Listen(address, fiber.ListenConfig{DisableStartupMessage: true})
-	closeDatabase(database)
-	return err
+	return app.Listen(address, fiber.ListenConfig{DisableStartupMessage: true})
 }
+
+// startReminderScheduler builds and launches the optional built-in reminder
+// scheduler (issue #125) when REMINDER_SCHEDULER_ENABLED is on, returning a
+// channel that closes once the scheduler goroutine has fully drained. When the
+// scheduler is OFF (the default) it returns an already-closed channel so the
+// caller's drain is an instant no-op and no goroutine, timer, or outbound
+// component is created. The scheduler reuses the SAME notify service recipe the
+// `ovumcy notify` CLI uses (bootstrap.BuildNotifyService) plus the app_state
+// marker repository, and observes sigCtx for shutdown.
+//
+// codecov:ignore:start -- main() composition-root wiring; the scheduler logic
+// (nextRun, catch-up, marker, drain) is unit-tested in internal/reminders and
+// this glue only assembles boot-built collaborators.
+func startReminderScheduler(sigCtx context.Context, config runtimeConfig, database *gorm.DB, i18nManager *i18n.Manager) <-chan struct{} {
+	if !config.ReminderScheduler.Enabled {
+		closed := make(chan struct{})
+		close(closed)
+		return closed
+	}
+
+	repositories := db.NewRepositories(database)
+	notifyService := bootstrap.BuildNotifyService(repositories, []byte(config.SecretKey), i18nManager, config.WebhookBlockPrivate)
+	scheduler := reminders.New(notifyService, repositories.AppState, reminders.Config{
+		Hour:     config.ReminderScheduler.Hour,
+		Location: config.Location,
+	})
+	return scheduler.Start(sigCtx)
+}
+
+// codecov:ignore:end
 
 func closeDatabase(database *gorm.DB) {
 	sqlDB, err := database.DB()
@@ -235,8 +297,15 @@ func loadRuntimeConfig(location *time.Location) (runtimeConfig, error) {
 			APIMax:               getEnvInt("RATE_LIMIT_API_MAX", 300),
 			APIWindow:            getEnvDuration("RATE_LIMIT_API_WINDOW", time.Minute),
 		},
-		Proxy:           proxy,
-		AuditLogEnabled: getEnvBool("AUDIT_LOG_ENABLED", false),
+		Proxy:               proxy,
+		AuditLogEnabled:     getEnvBool("AUDIT_LOG_ENABLED", false),
+		WebhookBlockPrivate: getEnvBool("WEBHOOK_BLOCK_PRIVATE_ADDRESSES", false),
+		ReminderScheduler: reminderSchedulerSettings{
+			Enabled: getEnvBool("REMINDER_SCHEDULER_ENABLED", false),
+			// getEnvInt rejects values <1, so hour 0 (valid) would be lost; use a
+			// dedicated range helper that accepts the full 0-23 clock.
+			Hour: getEnvIntInRange("REMINDER_SCHEDULER_HOUR", 9, 0, 23),
+		},
 	}, nil
 }
 
@@ -601,7 +670,14 @@ func securityHeadersMiddleware(enableStrictTransportSecurity bool) fiber.Handler
 // must be closed once app.Listen (inside runServer) returns, for any reason —
 // it bounds retryShutdown so a signal arriving after the server already
 // exited doesn't spin.
-func installGracefulShutdown(app *fiber.App, served <-chan struct{}) context.CancelFunc {
+//
+// It returns both the stop function (to release the signal registration on
+// exit) AND the signal context. The context is observed by the optional
+// reminder scheduler so it stops on the SAME SIGINT/SIGTERM that stops the
+// server. The scheduler only reads that context — it NEVER references served,
+// the fiber app, or app shutdown, so it stays entirely clear of the boot-window
+// shutdown race that retryShutdown/served exist to bridge.
+func installGracefulShutdown(app *fiber.App, served <-chan struct{}) (context.Context, context.CancelFunc) {
 	sigCtx, stopSignals := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		<-sigCtx.Done()
@@ -609,7 +685,7 @@ func installGracefulShutdown(app *fiber.App, served <-chan struct{}) context.Can
 		defer cancel()
 		retryShutdown(app, shutdownCtx, served)
 	}()
-	return stopSignals
+	return sigCtx, stopSignals
 }
 
 // shutdownRetryInterval is how often retryShutdown re-attempts the graceful
@@ -676,6 +752,9 @@ func logStartup(config runtimeConfig) {
 	)
 	if config.HSTSEnabled {
 		log.Printf("NOTE: HSTS_ENABLED=true — sending Strict-Transport-Security with a 1-year max-age (max-age=31536000; includeSubDomains). Browsers will refuse plain HTTP for this host for a year; only enable when committed to HTTPS. Set HSTS_ENABLED=false to keep secure cookies without the HTTPS pin.")
+	}
+	if config.ReminderScheduler.Enabled {
+		log.Printf("NOTE: REMINDER_SCHEDULER_ENABLED=true — the built-in daily reminder scheduler is ON and will make outbound webhook calls once per day at local hour %02d:00 (%s) from this process. This is an always-on component; disable it instantly with REMINDER_SCHEDULER_ENABLED=false (delivery also still requires each owner's webhook to be configured and enabled).", config.ReminderScheduler.Hour, config.Location.String())
 	}
 	if config.Proxy.Enabled {
 		log.Printf("trusted proxy config: header=%s trusted_proxy_count=%d", config.Proxy.Header, len(config.Proxy.TrustedProxies))
@@ -998,6 +1077,24 @@ func getEnvInt(key string, fallback int) int {
 
 	parsed, err := strconv.Atoi(value)
 	if err != nil || parsed < 1 {
+		log.Printf("invalid %s=%q, using fallback %d", key, value, fallback)
+		return fallback
+	}
+	return parsed
+}
+
+// getEnvIntInRange parses an integer env var and accepts it only within the
+// inclusive [min, max] range, falling back otherwise. Unlike getEnvInt (which
+// rejects anything below 1), it admits 0, which is required for
+// REMINDER_SCHEDULER_HOUR where 0 is a valid midnight run hour.
+func getEnvIntInRange(key string, fallback, minValue, maxValue int) int {
+	value := strings.TrimSpace(os.Getenv(key))
+	if value == "" {
+		return fallback
+	}
+
+	parsed, err := strconv.Atoi(value)
+	if err != nil || parsed < minValue || parsed > maxValue {
 		log.Printf("invalid %s=%q, using fallback %d", key, value, fallback)
 		return fallback
 	}

--- a/cmd/ovumcy/main_test.go
+++ b/cmd/ovumcy/main_test.go
@@ -699,6 +699,123 @@ func TestLoadRuntimeConfigHonorsAuditLogEnabled(t *testing.T) {
 	}
 }
 
+// TestLoadRuntimeConfigDefaultsReminderSchedulerOff locks the HIGH-RISK default:
+// the built-in reminder scheduler (an always-on outbound component) ships OFF
+// and runs at local hour 9 when its env is unset. This is the instant-rollback
+// contract (REMINDER_SCHEDULER_ENABLED=false).
+func TestLoadRuntimeConfigDefaultsReminderSchedulerOff(t *testing.T) {
+	t.Setenv("SECRET_KEY", "0123456789abcdef0123456789abcdef")
+	t.Setenv("DB_DRIVER", "sqlite")
+	t.Setenv("DB_PATH", "data/ovumcy.db")
+	t.Setenv("REMINDER_SCHEDULER_ENABLED", "")
+	t.Setenv("REMINDER_SCHEDULER_HOUR", "")
+
+	config, err := loadRuntimeConfig(time.UTC)
+	if err != nil {
+		t.Fatalf("load runtime config: %v", err)
+	}
+	if config.ReminderScheduler.Enabled {
+		t.Fatal("REMINDER_SCHEDULER_ENABLED must default to false (always-on outbound component ships off)")
+	}
+	if config.ReminderScheduler.Hour != 9 {
+		t.Fatalf("REMINDER_SCHEDULER_HOUR must default to 9, got %d", config.ReminderScheduler.Hour)
+	}
+}
+
+// TestLoadRuntimeConfigHonorsReminderSchedulerSettings covers the enabled path
+// and hour override, including hour 0 (midnight) which getEnvInt would have
+// rejected — the dedicated range helper must accept it.
+func TestLoadRuntimeConfigHonorsReminderSchedulerSettings(t *testing.T) {
+	t.Setenv("SECRET_KEY", "0123456789abcdef0123456789abcdef")
+	t.Setenv("DB_DRIVER", "sqlite")
+	t.Setenv("DB_PATH", "data/ovumcy.db")
+	t.Setenv("REMINDER_SCHEDULER_ENABLED", "true")
+	t.Setenv("REMINDER_SCHEDULER_HOUR", "0")
+
+	config, err := loadRuntimeConfig(time.UTC)
+	if err != nil {
+		t.Fatalf("load runtime config: %v", err)
+	}
+	if !config.ReminderScheduler.Enabled {
+		t.Fatal("REMINDER_SCHEDULER_ENABLED=true must enable the scheduler")
+	}
+	if config.ReminderScheduler.Hour != 0 {
+		t.Fatalf("REMINDER_SCHEDULER_HOUR=0 (midnight) must be accepted, got %d", config.ReminderScheduler.Hour)
+	}
+}
+
+// TestGetEnvIntInRange pins the helper the scheduler hour needs: it accepts the
+// full inclusive range (crucially 0, unlike getEnvInt), and falls back on unset,
+// non-numeric, or out-of-range input.
+func TestGetEnvIntInRange(t *testing.T) {
+	const key = "TEST_ENV_INT_IN_RANGE"
+	cases := []struct {
+		name  string
+		value string
+		set   bool
+		want  int
+	}{
+		{name: "unset -> fallback", set: false, want: 9},
+		{name: "zero accepted at lower bound", value: "0", set: true, want: 0},
+		{name: "max accepted at upper bound", value: "23", set: true, want: 23},
+		{name: "mid-range accepted", value: "14", set: true, want: 14},
+		{name: "below range -> fallback", value: "-1", set: true, want: 9},
+		{name: "above range -> fallback", value: "24", set: true, want: 9},
+		{name: "non-numeric -> fallback", value: "noon", set: true, want: 9},
+		{name: "blank -> fallback", value: "   ", set: true, want: 9},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.set {
+				t.Setenv(key, tc.value)
+			} else if err := os.Unsetenv(key); err != nil {
+				t.Fatalf("unset %s: %v", key, err)
+			}
+			if got := getEnvIntInRange(key, 9, 0, 23); got != tc.want {
+				t.Fatalf("getEnvIntInRange(%q) = %d, want %d", tc.value, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestLogStartupNotesReminderSchedulerOnlyWhenEnabled pins the operator NOTE: the
+// always-on outbound scheduler must announce itself (with its local run hour and
+// the instant-rollback env) when enabled, and stay silent when off.
+func TestLogStartupNotesReminderSchedulerOnlyWhenEnabled(t *testing.T) {
+	tests := []struct {
+		name     string
+		enabled  bool
+		hour     int
+		wantNote bool
+	}{
+		{name: "enabled announces the daily outbound pass", enabled: true, hour: 9, wantNote: true},
+		{name: "disabled stays silent", enabled: false, hour: 9, wantNote: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			originalWriter := log.Writer()
+			defer log.SetOutput(originalWriter)
+
+			var output bytes.Buffer
+			log.SetOutput(&output)
+
+			logStartup(runtimeConfig{
+				Location:          time.UTC,
+				Port:              "9090",
+				ReminderScheduler: reminderSchedulerSettings{Enabled: tt.enabled, Hour: tt.hour},
+			})
+
+			logLine := output.String()
+			if got := strings.Contains(logLine, "NOTE: REMINDER_SCHEDULER_ENABLED=true"); got != tt.wantNote {
+				t.Fatalf("scheduler note present = %t, want %t in startup log: %q", got, tt.wantNote, logLine)
+			}
+			if tt.wantNote && !strings.Contains(logLine, "REMINDER_SCHEDULER_ENABLED=false") {
+				t.Fatalf("enabled note must cite the instant-rollback env, got %q", logLine)
+			}
+		})
+	}
+}
+
 // TestLoadRuntimeConfigResolvesHSTSSwitch locks the HSTS_ENABLED contract: it
 // defaults to COOKIE_SECURE (the historical coupling, zero breaking change) but
 // an explicit true/false overrides in either direction, so an operator can run
@@ -1971,41 +2088,47 @@ func TestCloseDatabaseClosesUnderlyingConnection(t *testing.T) {
 	closeDatabase(database)
 }
 
-// TestRunServerClosesDatabaseOnListenError pins the failure exit path: when
-// the listener cannot bind, runServer must still close the database before
-// returning the error, so SQLite checkpoints its WAL even on a failed start.
-func TestRunServerClosesDatabaseOnListenError(t *testing.T) {
+// TestRunServerReturnsListenError pins the failure exit path: when the listener
+// cannot bind, runServer returns the error. runServer no longer closes the
+// database itself (main sequences closeDatabase after the scheduler drain, on
+// this same exit path); this test asserts the error is surfaced and that main's
+// subsequent closeDatabase still checkpoints and closes it, so SQLite releases
+// the file even on a failed start.
+func TestRunServerReturnsListenError(t *testing.T) {
 	database, err := db.OpenSQLite(filepath.Join(t.TempDir(), "runserver-err.db"))
 	if err != nil {
 		t.Fatalf("OpenSQLite() unexpected error: %v", err)
 	}
 	app := fiber.New()
 
-	if err := runServer(app, database, "256.256.256.256:0"); err == nil {
+	if err := runServer(app, "256.256.256.256:0"); err == nil {
 		t.Fatal("expected runServer to fail on an unbindable address")
 	}
+
+	// main closes the DB after runServer returns on both exit paths; mirror that.
+	closeDatabase(database)
 
 	sqlDB, err := database.DB()
 	if err != nil {
 		t.Fatalf("database.DB() unexpected error: %v", err)
 	}
 	if err := sqlDB.Ping(); err == nil {
-		t.Fatal("expected database to be closed after a failed listen")
+		t.Fatal("expected database to be closed after main's post-runServer close")
 	}
 }
 
-// TestRunServerClosesDatabaseAfterGracefulStop pins the graceful exit path:
-// Listen returns nil after a graceful stop, and runServer closes the
-// database before handing control back to main. The stop is issued only
-// after a full HTTP exchange against the bound listener completes. A bare
-// dial is not enough: the kernel listener exists before Listen enters
-// Serve, so a dial can succeed while fasthttp has no registered listener
-// yet, and a Shutdown issued in that window returns nil without stopping
-// anything (fasthttp's ShutdownWithContext no-ops when s.ln is nil) — the
-// stop is lost and Listen hangs forever (the 30s CI flake). A served
-// response proves the accept loop is running, which is the precondition
-// for Shutdown to take effect.
-func TestRunServerClosesDatabaseAfterGracefulStop(t *testing.T) {
+// TestRunServerReturnsAfterGracefulStop pins the graceful exit path: Listen
+// returns nil after a graceful stop and hands control back to the caller. The
+// stop is issued only after a full HTTP exchange against the bound listener
+// completes. A bare dial is not enough: the kernel listener exists before
+// Listen enters Serve, so a dial can succeed while fasthttp has no registered
+// listener yet, and a Shutdown issued in that window returns nil without
+// stopping anything (fasthttp's ShutdownWithContext no-ops when s.ln is nil) —
+// the stop is lost and Listen hangs forever (the 30s CI flake). A served
+// response proves the accept loop is running, which is the precondition for
+// Shutdown to take effect. The DB close now happens in main after runServer
+// returns; this test mirrors that final close and asserts the file is released.
+func TestRunServerReturnsAfterGracefulStop(t *testing.T) {
 	database, err := db.OpenSQLite(filepath.Join(t.TempDir(), "runserver-stop.db"))
 	if err != nil {
 		t.Fatalf("OpenSQLite() unexpected error: %v", err)
@@ -2042,7 +2165,7 @@ func TestRunServerClosesDatabaseAfterGracefulStop(t *testing.T) {
 	}()
 
 	done := make(chan error, 1)
-	go func() { done <- runServer(app, database, "127.0.0.1:0") }()
+	go func() { done <- runServer(app, "127.0.0.1:0") }()
 	select {
 	case err := <-done:
 		if err != nil {
@@ -2052,12 +2175,15 @@ func TestRunServerClosesDatabaseAfterGracefulStop(t *testing.T) {
 		t.Fatal("runServer did not return within 30s of the graceful stop")
 	}
 
+	// main closes the DB after runServer returns (after the scheduler drain).
+	closeDatabase(database)
+
 	sqlDB, err := database.DB()
 	if err != nil {
 		t.Fatalf("database.DB() unexpected error: %v", err)
 	}
 	if err := sqlDB.Ping(); err == nil {
-		t.Fatal("expected database to be closed after a graceful stop")
+		t.Fatal("expected database to be closed after main's post-runServer close")
 	}
 }
 
@@ -2087,7 +2213,7 @@ func TestRetryShutdownBridgesBootWindow(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		err := runServer(app, database, "127.0.0.1:0")
+		err := runServer(app, "127.0.0.1:0")
 		close(served)
 		done <- err
 	}()
@@ -2101,12 +2227,15 @@ func TestRetryShutdownBridgesBootWindow(t *testing.T) {
 		t.Fatal("runServer did not return after a boot-window stop; retry did not bridge the gap")
 	}
 
+	// main closes the DB after runServer returns; mirror that final close.
+	closeDatabase(database)
+
 	sqlDB, err := database.DB()
 	if err != nil {
 		t.Fatalf("database.DB() unexpected error: %v", err)
 	}
 	if err := sqlDB.Ping(); err == nil {
-		t.Fatal("expected database to be closed after a boot-window stop")
+		t.Fatal("expected database to be closed after main's post-runServer close")
 	}
 }
 
@@ -2206,7 +2335,7 @@ func TestInstallGracefulShutdownBridgesSIGTERM(t *testing.T) {
 	app := fiber.New()
 
 	served := make(chan struct{})
-	stopSignals := installGracefulShutdown(app, served)
+	_, stopSignals := installGracefulShutdown(app, served)
 	defer stopSignals()
 
 	addrCh := make(chan string, 1)
@@ -2217,7 +2346,7 @@ func TestInstallGracefulShutdownBridgesSIGTERM(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		err := runServer(app, database, "127.0.0.1:0")
+		err := runServer(app, "127.0.0.1:0")
 		close(served)
 		done <- err
 	}()
@@ -2239,6 +2368,9 @@ func TestInstallGracefulShutdownBridgesSIGTERM(t *testing.T) {
 	case <-time.After(15 * time.Second):
 		t.Fatal("runServer did not return after SIGTERM within 15s")
 	}
+
+	// main closes the DB after runServer returns; mirror that final close.
+	closeDatabase(database)
 
 	sqlDB, err := database.DB()
 	if err != nil {

--- a/cmd/ovumcy/main_test.go
+++ b/cmd/ovumcy/main_test.go
@@ -2316,6 +2316,40 @@ func TestRetryShutdownLogsPersistentShutdownError(t *testing.T) {
 	}
 }
 
+// TestInstallGracefulShutdownReturnsSignalContextAndStop covers the wiring
+// contract cross-platform (the SIGTERM self-delivery test below is Linux-only):
+// installGracefulShutdown returns a non-nil signal context (observed by the
+// reminder scheduler) plus a stop function, and calling the stop function
+// cancels that context and unblocks the internal goroutine. served is closed up
+// front so the goroutine's retryShutdown returns promptly once the stop fires.
+func TestInstallGracefulShutdownReturnsSignalContextAndStop(t *testing.T) {
+	app := fiber.New()
+	served := make(chan struct{})
+	close(served) // retryShutdown returns as soon as it observes served closed
+
+	sigCtx, stopSignals := installGracefulShutdown(app, served)
+	if sigCtx == nil {
+		t.Fatal("expected a non-nil signal context for the scheduler to observe")
+	}
+	if stopSignals == nil {
+		t.Fatal("expected a non-nil stop function")
+	}
+
+	select {
+	case <-sigCtx.Done():
+		t.Fatal("signal context should still be live before stop is called or a signal arrives")
+	default:
+	}
+
+	stopSignals() // cancels sigCtx and unblocks the internal goroutine
+
+	select {
+	case <-sigCtx.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("stop function did not cancel the signal context")
+	}
+}
+
 // TestInstallGracefulShutdownBridgesSIGTERM pins the signal-wiring itself:
 // a real SIGTERM delivered to the process must reach retryShutdown through
 // installGracefulShutdown's goroutine, not just via a direct call to

--- a/internal/db/app_state_repository.go
+++ b/internal/db/app_state_repository.go
@@ -1,0 +1,65 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// AppStateRepository persists the process-level key/value markers in app_state
+// (migration 028). It holds runtime bookkeeping only — never per-owner health
+// data — so its operations are unscoped by user_id. Its sole consumer today is
+// the built-in reminder scheduler (issue #125), which reads and writes
+// last_reminder_run_date for restart safety and current-day catch-up.
+type AppStateRepository struct {
+	database *gorm.DB
+}
+
+func NewAppStateRepository(database *gorm.DB) *AppStateRepository {
+	return &AppStateRepository{database: database}
+}
+
+// Get returns the stored value for key and whether a row exists. A missing key
+// yields ("", false, nil) — the caller distinguishes "never written" (fresh
+// install / no prior run) from any value.
+func (repo *AppStateRepository) Get(ctx context.Context, key string) (string, bool, error) {
+	trimmed := strings.TrimSpace(key)
+	if trimmed == "" {
+		return "", false, nil
+	}
+
+	var row models.AppState
+	if err := repo.database.WithContext(ctx).Where("key = ?", trimmed).First(&row).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	return row.Value, true, nil
+}
+
+// Set upserts value for key, stamping updated_at. The ON CONFLICT (key) update
+// makes a repeated write for the same key overwrite in place, so the scheduler's
+// "ran today" marker is a single evolving row rather than an append. It is the
+// only writer of these rows.
+func (repo *AppStateRepository) Set(ctx context.Context, key string, value string) error {
+	trimmed := strings.TrimSpace(key)
+	if trimmed == "" {
+		return errors.New("app_state: key is required")
+	}
+
+	row := &models.AppState{
+		Key:       trimmed,
+		Value:     value,
+		UpdatedAt: time.Now().UTC(),
+	}
+	return repo.database.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "key"}},
+		DoUpdates: clause.AssignmentColumns([]string{"value", "updated_at"}),
+	}).Create(row).Error
+}

--- a/internal/db/app_state_repository_test.go
+++ b/internal/db/app_state_repository_test.go
@@ -1,0 +1,81 @@
+package db
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+)
+
+// TestAppStateRepositoryRoundTripAndUpsert covers the full contract the reminder
+// scheduler relies on: a missing key reads as (", false), a Set then Get returns
+// the stored value, and a second Set for the SAME key overwrites in place (the
+// ON CONFLICT (key) update) rather than erroring on the primary-key collision or
+// appending a second row.
+func TestAppStateRepositoryRoundTripAndUpsert(t *testing.T) {
+	database, err := OpenSQLite(filepath.Join(t.TempDir(), "app-state.db"))
+	if err != nil {
+		t.Fatalf("OpenSQLite() unexpected error: %v", err)
+	}
+	t.Cleanup(func() {
+		if sqlDB, dbErr := database.DB(); dbErr == nil {
+			_ = sqlDB.Close()
+		}
+	})
+	repo := NewAppStateRepository(database)
+	ctx := context.Background()
+	key := models.AppStateKeyLastReminderRunDate
+
+	if _, ok, err := repo.Get(ctx, key); err != nil || ok {
+		t.Fatalf("expected missing key to read as (_, false, nil), got ok=%v err=%v", ok, err)
+	}
+
+	if err := repo.Set(ctx, key, "2026-07-05"); err != nil {
+		t.Fatalf("Set() first write unexpected error: %v", err)
+	}
+	value, ok, err := repo.Get(ctx, key)
+	if err != nil || !ok || value != "2026-07-05" {
+		t.Fatalf("expected first value 2026-07-05, got value=%q ok=%v err=%v", value, ok, err)
+	}
+
+	if err := repo.Set(ctx, key, "2026-07-06"); err != nil {
+		t.Fatalf("Set() upsert unexpected error: %v", err)
+	}
+	value, ok, err = repo.Get(ctx, key)
+	if err != nil || !ok || value != "2026-07-06" {
+		t.Fatalf("expected upserted value 2026-07-06, got value=%q ok=%v err=%v", value, ok, err)
+	}
+
+	// The upsert must not have appended a second row: exactly one row for the key.
+	var count int64
+	if err := database.Model(&models.AppState{}).Where("key = ?", key).Count(&count).Error; err != nil {
+		t.Fatalf("count app_state rows: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly one app_state row after upsert, got %d", count)
+	}
+}
+
+// TestAppStateRepositoryRejectsBlankKey covers the guard: an empty/whitespace key
+// is not a valid marker. Get treats it as missing; Set refuses it.
+func TestAppStateRepositoryRejectsBlankKey(t *testing.T) {
+	database, err := OpenSQLite(filepath.Join(t.TempDir(), "app-state-blank.db"))
+	if err != nil {
+		t.Fatalf("OpenSQLite() unexpected error: %v", err)
+	}
+	t.Cleanup(func() {
+		if sqlDB, dbErr := database.DB(); dbErr == nil {
+			_ = sqlDB.Close()
+		}
+	})
+	repo := NewAppStateRepository(database)
+	ctx := context.Background()
+
+	if _, ok, err := repo.Get(ctx, "   "); err != nil || ok {
+		t.Fatalf("expected blank key Get to read as (_, false, nil), got ok=%v err=%v", ok, err)
+	}
+	if err := repo.Set(ctx, "  ", "value"); err == nil {
+		t.Fatal("expected Set with a blank key to return an error")
+	}
+}

--- a/internal/db/app_state_repository_test.go
+++ b/internal/db/app_state_repository_test.go
@@ -79,3 +79,32 @@ func TestAppStateRepositoryRejectsBlankKey(t *testing.T) {
 		t.Fatal("expected Set with a blank key to return an error")
 	}
 }
+
+// TestAppStateRepositoryGetSurfacesNonNotFoundError covers the error branch of
+// Get: a query failure that is NOT gorm.ErrRecordNotFound (here a closed
+// connection) must propagate, not be swallowed as "missing". The scheduler
+// relies on this so a real DB failure fails its catch-up safe rather than
+// silently reading "never ran".
+func TestAppStateRepositoryGetSurfacesNonNotFoundError(t *testing.T) {
+	database, err := OpenSQLite(filepath.Join(t.TempDir(), "app-state-closed.db"))
+	if err != nil {
+		t.Fatalf("OpenSQLite() unexpected error: %v", err)
+	}
+	repo := NewAppStateRepository(database)
+
+	sqlDB, err := database.DB()
+	if err != nil {
+		t.Fatalf("database.DB() unexpected error: %v", err)
+	}
+	if err := sqlDB.Close(); err != nil {
+		t.Fatalf("close sql db: %v", err)
+	}
+
+	value, ok, err := repo.Get(context.Background(), models.AppStateKeyLastReminderRunDate)
+	if err == nil {
+		t.Fatal("expected Get on a closed database to surface an error")
+	}
+	if ok || value != "" {
+		t.Fatalf("expected a failed Get to return the zero value, got value=%q ok=%v", value, ok)
+	}
+}

--- a/internal/db/migrations_bootstrap_test.go
+++ b/internal/db/migrations_bootstrap_test.go
@@ -23,6 +23,7 @@ func TestOpenSQLiteAppliesEmbeddedMigrationsOnCleanDatabase(t *testing.T) {
 	assertSymptomTypesSchemaReconciled(t, database)
 	assertDailyLogsSchemaReconciled(t, database)
 	assertOIDCLogoutStateSchemaReconciled(t, database)
+	assertAppStateSchema(t, database)
 	assertNormalizedEmailIndexExists(t, database)
 	assertAllEmbeddedMigrationsApplied(t, database)
 }
@@ -337,6 +338,22 @@ func assertOIDCLogoutStateSchemaReconciled(t *testing.T, database *gorm.DB) {
 	}
 	if !database.Migrator().HasColumn("oidc_logout_states", "expires_at") {
 		t.Fatal("expected oidc_logout_states.expires_at column to exist after migrations")
+	}
+}
+
+// assertAppStateSchema pins the app_state key/value table created by migration
+// 028 (issue #125): the table and its key/value/updated_at columns must exist
+// after migrations on this engine.
+func assertAppStateSchema(t *testing.T, database *gorm.DB) {
+	t.Helper()
+
+	if !database.Migrator().HasTable("app_state") {
+		t.Fatal("expected app_state table to exist after migrations")
+	}
+	for _, column := range []string{"key", "value", "updated_at"} {
+		if !database.Migrator().HasColumn("app_state", column) {
+			t.Fatalf("expected app_state.%s column to exist after migrations", column)
+		}
 	}
 }
 

--- a/internal/db/postgres_bootstrap_test.go
+++ b/internal/db/postgres_bootstrap_test.go
@@ -17,6 +17,7 @@ func TestOpenPostgresAppliesEmbeddedMigrationsOnCleanDatabase(t *testing.T) {
 	assertUsersSchemaReconciled(t, database)
 	assertSymptomTypesSchemaReconciled(t, database)
 	assertOIDCLogoutStateSchemaReconciled(t, database)
+	assertAppStateSchema(t, database)
 	assertAllEmbeddedMigrationsAppliedForDriver(t, database, DriverPostgres)
 	assertPostgresNormalizedEmailUniqueness(t, database)
 	assertPostgresDailyLogsSchemaReconciled(t, database)

--- a/internal/db/repositories.go
+++ b/internal/db/repositories.go
@@ -9,6 +9,7 @@ type Repositories struct {
 	DailyLogs            *DailyLogRepository
 	Symptoms             *SymptomRepository
 	RegisterPickupTokens *RegisterPickupTokenRepository
+	AppState             *AppStateRepository
 }
 
 func NewRepositories(database *gorm.DB) *Repositories {
@@ -19,5 +20,6 @@ func NewRepositories(database *gorm.DB) *Repositories {
 		DailyLogs:            NewDailyLogRepository(database),
 		Symptoms:             NewSymptomRepository(database),
 		RegisterPickupTokens: NewRegisterPickupTokenRepository(database),
+		AppState:             NewAppStateRepository(database),
 	}
 }

--- a/internal/models/app_state.go
+++ b/internal/models/app_state.go
@@ -1,0 +1,26 @@
+package models
+
+import "time"
+
+// AppStateKeyLastReminderRunDate is the app_state key under which the built-in
+// reminder scheduler (issue #125) records the server-local date (YYYY-MM-DD) it
+// last completed a pass. It backs restart safety (a same-day restart never
+// re-fires) and current-day catch-up after downtime. It is the single source of
+// truth for the key string so the scheduler and any tooling cannot drift.
+const AppStateKeyLastReminderRunDate = "last_reminder_run_date"
+
+// AppState is one row of the process-level key/value store (migration 028).
+// It holds runtime bookkeeping, NEVER special-category health data, and is not
+// scoped by user_id — it is deliberately outside the users table. Value is
+// opaque TEXT written only by the single scheduler goroutine.
+type AppState struct {
+	Key       string    `gorm:"column:key;primaryKey"`
+	Value     string    `gorm:"column:value;not null"`
+	UpdatedAt time.Time `gorm:"column:updated_at"`
+}
+
+// TableName pins the table to app_state (GORM would otherwise pluralize to
+// app_states).
+func (AppState) TableName() string {
+	return "app_state"
+}

--- a/internal/reminders/idempotency_layering_test.go
+++ b/internal/reminders/idempotency_layering_test.go
@@ -1,0 +1,167 @@
+package reminders
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+	"github.com/ovumcy/ovumcy-web/internal/services"
+)
+
+// This file proves the idempotency LAYERING the design mandates: the once-per-
+// local-day marker stops the TRIGGER from firing more than once per day, but
+// #124's per-reminder watermark is the authoritative backstop — even if two
+// passes run in the same fake day (marker failed, or an operator `ovumcy notify`
+// cron ran alongside), each reminder ships at most once. It drives the REAL
+// services.WebhookNotifyService (not the scheduler's stub PassRunner) so the
+// actual watermark write-on-success + decision-suppression path is exercised.
+
+// statefulNotifyRepo is a minimal, watermark-aware NotifyUserRepository: a
+// successful send's watermark write is reflected back into the record it returns
+// on the next ListAllForNotify, so a second pass sees the advanced watermark and
+// the decision suppresses the already-sent reminder — exactly as the real DB
+// repository behaves across two passes.
+type statefulNotifyRepo struct {
+	mu      sync.Mutex
+	records []models.WebhookNotifyRecord
+}
+
+func (r *statefulNotifyRepo) ListAllForNotify(context.Context) ([]models.WebhookNotifyRecord, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]models.WebhookNotifyRecord, len(r.records))
+	copy(out, r.records)
+	return out, nil
+}
+
+func (r *statefulNotifyRepo) UpdateWebhookWatermark(_ context.Context, userID uint, reminderType string, anchor time.Time) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	anchorCopy := anchor
+	for i := range r.records {
+		if r.records[i].ID != userID {
+			continue
+		}
+		switch reminderType {
+		case models.WebhookReminderTypePeriod:
+			r.records[i].WebhookPeriodLastSentCycleStart = &anchorCopy
+		case models.WebhookReminderTypeOvulation:
+			r.records[i].WebhookOvulationLastSentCycleStart = &anchorCopy
+		}
+	}
+	return nil
+}
+
+// countingDeliverer counts total successful deliveries and per-URL deliveries.
+type countingDeliverer struct {
+	mu    sync.Mutex
+	byURL map[string]int
+	total int
+}
+
+func (d *countingDeliverer) Deliver(_ context.Context, url string, _ services.WebhookPayload) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.byURL == nil {
+		d.byURL = map[string]int{}
+	}
+	d.byURL[url]++
+	d.total++
+	return nil
+}
+
+// echoDecryptor returns the stored token as the plaintext URL (no real key).
+type echoDecryptor struct{}
+
+func (echoDecryptor) DecryptWebhookURL(_ uint, encryptedURL string) (string, error) {
+	return encryptedURL, nil
+}
+
+type fixedDisclaimer struct{}
+
+func (fixedDisclaimer) Disclaimer(string) string {
+	return "These are estimates, not medical advice or a method of contraception."
+}
+
+// dueRecord builds a period-due record for a regular 28-day owner whose last
+// period started lastPeriodDaysAgo before now (26 puts the next period ~2 days
+// out, inside a lead window of 3).
+func dueRecord(id uint, urlToken string, now time.Time, lastPeriodDaysAgo int) models.WebhookNotifyRecord {
+	last := now.AddDate(0, 0, -lastPeriodDaysAgo)
+	last = time.Date(last.Year(), last.Month(), last.Day(), 0, 0, 0, 0, time.UTC)
+	return models.WebhookNotifyRecord{
+		ID:                     id,
+		CycleLength:            28,
+		PeriodLength:           5,
+		LutealPhase:            14,
+		LastPeriodStart:        &last,
+		WebhookEnabled:         true,
+		WebhookURL:             urlToken,
+		WebhookNotifyPeriod:    true,
+		WebhookNotifyOvulation: false,
+		ReminderLeadDays:       3,
+	}
+}
+
+type stubLogReader struct {
+	byUser map[uint][]models.DailyLog
+}
+
+func (s stubLogReader) ListByUser(_ context.Context, userID uint) ([]models.DailyLog, error) {
+	return s.byUser[userID], nil
+}
+
+// TestIdempotencyLayeringTwoFiresSameDaySendOnce is the layering proof: the
+// scheduler fires the notify pass TWICE within one fake day (simulating a marker
+// that failed to persist, or a concurrent operator cron). The real service's
+// per-reminder watermark must ensure the owner's period reminder ships exactly
+// ONCE across both fires — never twice.
+func TestIdempotencyLayeringTwoFiresSameDaySendOnce(t *testing.T) {
+	now := time.Date(2026, 3, 12, 9, 0, 0, 0, time.UTC)
+	record := dueRecord(1, "https://a.example/hook", now, 26)
+	repo := &statefulNotifyRepo{records: []models.WebhookNotifyRecord{record}}
+	logs := stubLogReader{byUser: map[uint][]models.DailyLog{
+		1: {periodStartLog(1, *record.LastPeriodStart)},
+	}}
+	deliverer := &countingDeliverer{}
+	service := services.NewWebhookNotifyService(repo, logs, echoDecryptor{}, deliverer, fixedDisclaimer{})
+
+	// Fire 1: the reminder is due and ships; the watermark advances.
+	report1, err := service.RunOnce(context.Background(), now, time.UTC, false)
+	if err != nil {
+		t.Fatalf("first pass: %v", err)
+	}
+	if report1.Sent != 1 {
+		t.Fatalf("first pass should send exactly one reminder, sent=%d", report1.Sent)
+	}
+
+	// Fire 2 in the SAME day: the marker did NOT stop this (we bypass it here on
+	// purpose). The watermark, now advanced, must suppress the second send.
+	report2, err := service.RunOnce(context.Background(), now, time.UTC, false)
+	if err != nil {
+		t.Fatalf("second pass: %v", err)
+	}
+	if report2.Sent != 0 {
+		t.Fatalf("second same-day pass must send nothing (watermark backstop), sent=%d", report2.Sent)
+	}
+
+	if deliverer.total != 1 {
+		t.Fatalf("expected exactly ONE outbound delivery across two same-day fires, got %d", deliverer.total)
+	}
+	if deliverer.byURL["https://a.example/hook"] != 1 {
+		t.Fatalf("owner's endpoint must receive its reminder exactly once, got %d", deliverer.byURL["https://a.example/hook"])
+	}
+}
+
+// periodStartLog builds a single cycle-start period day for an owner, the
+// prediction input the decision needs to project the next period.
+func periodStartLog(userID uint, day time.Time) models.DailyLog {
+	return models.DailyLog{
+		UserID:     userID,
+		Date:       day,
+		IsPeriod:   true,
+		CycleStart: true,
+	}
+}

--- a/internal/reminders/lifecycle.go
+++ b/internal/reminders/lifecycle.go
@@ -1,0 +1,48 @@
+package reminders
+
+import (
+	"context"
+	"log"
+	"time"
+)
+
+// DefaultStopBudget bounds how long the caller waits for an in-flight pass to
+// unwind after the signal context is cancelled. It sits comfortably under the
+// server's 10s graceful-shutdown budget so the scheduler drain never dominates
+// shutdown; if a pass does not finish in time the caller logs and proceeds (the
+// leaked run is bounded by #124's outbound timeout plus the cancelled ctx that
+// already flowed into RunOnce).
+const DefaultStopBudget = 5 * time.Second
+
+// Start launches the scheduler goroutine bound to ctx and returns a channel that
+// closes when Run has fully returned (ctx cancelled and any in-flight pass
+// unwound). Keeping the goroutine launch + the completion signal here lets
+// cmd/ovumcy stay a ~3-line glue call and keeps the drain logic unit-testable.
+//
+// ctx MUST be the server's signal context so the scheduler stops on the same
+// SIGINT/SIGTERM that stops the HTTP server. The launched goroutine never
+// touches the fiber app or its shutdown, so it cannot delay app.Listen or
+// interfere with the boot-window shutdown retry.
+func (s *Scheduler) Start(ctx context.Context) <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		s.Run(ctx)
+	}()
+	return done
+}
+
+// Drain waits up to budget for done to close (the scheduler goroutine returning),
+// then returns. It is called AFTER the HTTP server has stopped and BEFORE the DB
+// is closed, so the database stays open until the last reminder read/write
+// completes. On timeout it logs and returns anyway; the caller then closes the
+// DB regardless, keeping "DB closes on both exit paths" true.
+func Drain(done <-chan struct{}, budget time.Duration) {
+	timer := time.NewTimer(budget)
+	defer timer.Stop()
+	select {
+	case <-done:
+	case <-timer.C:
+		log.Printf("reminder scheduler: drain timed out after %s, proceeding with shutdown", budget)
+	}
+}

--- a/internal/reminders/lifecycle_test.go
+++ b/internal/reminders/lifecycle_test.go
@@ -1,0 +1,36 @@
+package reminders
+
+import (
+	"testing"
+	"time"
+)
+
+// TestDrainReturnsWhenDoneClosesFirst covers the normal drain: done closes
+// before the budget, so Drain returns promptly without waiting the full budget.
+func TestDrainReturnsWhenDoneClosesFirst(t *testing.T) {
+	done := make(chan struct{})
+	close(done)
+
+	start := time.Now()
+	Drain(done, time.Hour) // huge budget; must return immediately since done is closed
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("Drain should return immediately when done is already closed, took %s", elapsed)
+	}
+}
+
+// TestDrainTimesOutWhenDoneNeverCloses covers the timeout branch: done never
+// closes, so Drain returns after the (small) budget and logs — proving shutdown
+// proceeds even if a pass is stuck, keeping "DB closes on both exit paths" true.
+func TestDrainTimesOutWhenDoneNeverCloses(t *testing.T) {
+	done := make(chan struct{}) // never closed
+
+	start := time.Now()
+	Drain(done, 20*time.Millisecond)
+	elapsed := time.Since(start)
+	if elapsed < 20*time.Millisecond {
+		t.Fatalf("Drain returned before its budget elapsed: %s", elapsed)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("Drain overran its budget substantially: %s", elapsed)
+	}
+}

--- a/internal/reminders/next_run.go
+++ b/internal/reminders/next_run.go
@@ -1,0 +1,51 @@
+package reminders
+
+import (
+	"github.com/ovumcy/ovumcy-web/internal/models"
+	"time"
+)
+
+// markerKey is the app_state key under which the "ran today" local date is
+// stored. It aliases the single models constant so the scheduler and any future
+// tooling agree on the string.
+const markerKey = models.AppStateKeyLastReminderRunDate
+
+// nextRun returns the next instant, strictly after now, whose LOCAL clock reads
+// hour:00:00 in location. It is the scheduler's whole schedule math, kept pure
+// (no clock, no I/O) so it is exhaustively table-testable — including the two DST
+// edges.
+//
+// Granularity is hour-only: the target is always the top of the given hour. The
+// candidate is built with time.Date in location for today; if that instant is
+// not strictly in the future (the hour already passed, or is exactly now), the
+// candidate for the next calendar day is used.
+//
+// DST correctness comes from rebuilding the candidate with time.Date on the
+// TARGET day rather than adding 24h to a previous fire:
+//
+//   - Spring-forward (a local hour is skipped, e.g. 02:00→03:00): time.Date for
+//     the missing wall-clock hour normalizes forward to the equivalent real
+//     instant, so the pass still fires that day near the intended time and the
+//     schedule does not stall.
+//   - Fall-back (a local hour repeats, e.g. 02:00 occurs twice): time.Date
+//     resolves the target to one concrete instant; the pass fires once for that
+//     local date. The once-per-local-day marker guarantees the repeated wall-
+//     clock hour cannot trigger a second pass.
+//
+// Because each call recomputes from the actual current instant in location, a
+// scheduler that recomputes every cycle stays pinned to the local hour across a
+// transition instead of drifting by the offset delta a bare 24h ticker would
+// accumulate.
+func nextRun(now time.Time, hour int, location *time.Location) time.Time {
+	if location == nil {
+		location = time.UTC
+	}
+	local := now.In(location)
+
+	candidate := time.Date(local.Year(), local.Month(), local.Day(), hour, 0, 0, 0, location)
+	if !candidate.After(now) {
+		tomorrow := local.AddDate(0, 0, 1)
+		candidate = time.Date(tomorrow.Year(), tomorrow.Month(), tomorrow.Day(), hour, 0, 0, 0, location)
+	}
+	return candidate
+}

--- a/internal/reminders/next_run_test.go
+++ b/internal/reminders/next_run_test.go
@@ -1,0 +1,161 @@
+package reminders
+
+import (
+	"testing"
+	"time"
+)
+
+// mustLoadLocation loads an IANA zone or skips the test when the platform lacks
+// the tz database (some minimal Windows dev boxes). The Linux runtime that ships
+// always has it, and CI validates there.
+func mustLoadLocation(t *testing.T, name string) *time.Location {
+	t.Helper()
+	loc, err := time.LoadLocation(name)
+	if err != nil {
+		t.Skipf("timezone %q unavailable on this platform: %v", name, err)
+	}
+	return loc
+}
+
+// TestNextRunBasicSameDayAndRollover covers the non-DST core: when the target
+// hour is still ahead today, nextRun picks today; when it has passed (or equals
+// now), it rolls to tomorrow.
+func TestNextRunBasicSameDayAndRollover(t *testing.T) {
+	utc := time.UTC
+	hour := 9
+
+	cases := []struct {
+		name string
+		now  time.Time
+		want time.Time
+	}{
+		{
+			name: "before target hour -> today",
+			now:  time.Date(2026, 3, 10, 6, 30, 0, 0, utc),
+			want: time.Date(2026, 3, 10, 9, 0, 0, 0, utc),
+		},
+		{
+			name: "after target hour -> tomorrow",
+			now:  time.Date(2026, 3, 10, 12, 0, 0, 0, utc),
+			want: time.Date(2026, 3, 11, 9, 0, 0, 0, utc),
+		},
+		{
+			name: "exactly at target hour -> tomorrow (strictly after)",
+			now:  time.Date(2026, 3, 10, 9, 0, 0, 0, utc),
+			want: time.Date(2026, 3, 11, 9, 0, 0, 0, utc),
+		},
+		{
+			name: "one second before target -> today",
+			now:  time.Date(2026, 3, 10, 8, 59, 59, 0, utc),
+			want: time.Date(2026, 3, 10, 9, 0, 0, 0, utc),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := nextRun(tc.now, hour, utc)
+			if !got.Equal(tc.want) {
+				t.Fatalf("nextRun(%s) = %s, want %s", tc.now.Format(time.RFC3339), got.Format(time.RFC3339), tc.want.Format(time.RFC3339))
+			}
+		})
+	}
+}
+
+// TestNextRunHourZeroAccepted guards the midnight edge that motivated
+// getEnvIntInRange: hour 0 is a valid run hour and must schedule to local
+// 00:00, not be treated as "unset".
+func TestNextRunHourZeroAccepted(t *testing.T) {
+	utc := time.UTC
+	now := time.Date(2026, 3, 10, 23, 30, 0, 0, utc)
+	want := time.Date(2026, 3, 11, 0, 0, 0, 0, utc)
+	if got := nextRun(now, 0, utc); !got.Equal(want) {
+		t.Fatalf("nextRun hour=0 = %s, want %s", got.Format(time.RFC3339), want.Format(time.RFC3339))
+	}
+}
+
+// TestNextRunNilLocationDefaultsUTC covers the defensive nil-location branch.
+func TestNextRunNilLocationDefaultsUTC(t *testing.T) {
+	now := time.Date(2026, 3, 10, 6, 0, 0, 0, time.UTC)
+	want := time.Date(2026, 3, 10, 9, 0, 0, 0, time.UTC)
+	if got := nextRun(now, 9, nil); !got.Equal(want) {
+		t.Fatalf("nextRun(nil location) = %s, want %s", got.Format(time.RFC3339), want.Format(time.RFC3339))
+	}
+}
+
+// TestNextRunDSTSpringForward pins the spring-forward edge in America/New_York:
+// on 2026-03-08 local clocks jump 02:00 -> 03:00, so local 02:00 does not exist.
+// A scheduler configured for hour 2 must still produce a real future instant on
+// that day (time.Date normalizes the missing wall-clock hour to a concrete
+// instant), never a zero/past time that would stall the loop or fire in the
+// past. Go's time.Date maps the skipped 02:00 to the same absolute instant as
+// pre-transition 01:00 (offset -05:00), which is what nextRun returns unchanged
+// because it is still after the 00:30 "now" — the pass fires on the right day
+// without the schedule stalling. The key invariants are: future, same local
+// calendar day, and the exact instant time.Date resolves the skipped hour to.
+func TestNextRunDSTSpringForward(t *testing.T) {
+	ny := mustLoadLocation(t, "America/New_York")
+
+	// Just after midnight local on the spring-forward day, target hour 2 (skipped).
+	now := time.Date(2026, 3, 8, 0, 30, 0, 0, ny)
+	got := nextRun(now, 2, ny)
+
+	if !got.After(now) {
+		t.Fatalf("expected a future fire across the skipped hour, got %s (now %s)", got.Format(time.RFC3339), now.Format(time.RFC3339))
+	}
+	// nextRun builds the candidate with time.Date on the target day; the skipped
+	// 02:00 resolves to one concrete instant, which must equal a direct time.Date
+	// for the same wall-clock hour (the schedule uses that exact instant).
+	wantResolved := time.Date(2026, 3, 8, 2, 0, 0, 0, ny)
+	if !got.Equal(wantResolved) {
+		t.Fatalf("expected skipped-hour fire to equal time.Date's normalized instant %s, got %s", wantResolved.Format(time.RFC3339), got.Format(time.RFC3339))
+	}
+	// And it stays on the same local calendar day (no accidental skip to tomorrow).
+	if got.In(ny).Day() != 8 {
+		t.Fatalf("expected fire to stay on local day 8, got %s", got.In(ny).Format(time.RFC3339))
+	}
+}
+
+// TestNextRunDSTFallBack pins the fall-back edge in America/New_York: on
+// 2026-11-01 local clocks fall 02:00 -> 01:00, so local 01:00 occurs twice.
+// nextRun must resolve the target to ONE concrete future instant (the once-per-
+// local-day marker, tested elsewhere, prevents the repeated hour from firing a
+// second pass).
+func TestNextRunDSTFallBack(t *testing.T) {
+	ny := mustLoadLocation(t, "America/New_York")
+
+	// Just after midnight local on the fall-back day, target hour 1 (repeats).
+	now := time.Date(2026, 11, 1, 0, 15, 0, 0, ny)
+	got := nextRun(now, 1, ny)
+
+	if !got.After(now) {
+		t.Fatalf("expected a future fire for the repeated hour, got %s (now %s)", got.Format(time.RFC3339), now.Format(time.RFC3339))
+	}
+	if got.In(ny).Hour() != 1 || got.In(ny).Day() != 1 {
+		t.Fatalf("expected fire at local 01:00 on day 1, got %s", got.In(ny).Format(time.RFC3339))
+	}
+
+	// Recomputing from just after the FIRST 01:00 occurrence must advance to the
+	// next day, not re-fire the second 01:00 — nextRun keys off the calendar day,
+	// so once today's 01:00 has passed the next fire is tomorrow.
+	afterFirst := got.Add(30 * time.Minute)
+	next := nextRun(afterFirst, 1, ny)
+	if next.In(ny).Day() != 2 {
+		t.Fatalf("expected the following fire to roll to day 2, got %s", next.In(ny).Format(time.RFC3339))
+	}
+}
+
+// TestNextRunAcrossDSTStaysPinnedToLocalHour is the anti-drift property a bare
+// 24h ticker would fail: recomputing each day keeps the fire at local 09:00
+// across the spring-forward boundary even though the UTC offset changed.
+func TestNextRunAcrossDSTStaysPinnedToLocalHour(t *testing.T) {
+	ny := mustLoadLocation(t, "America/New_York")
+
+	// Day before the 2026-03-08 spring-forward, after 09:00 -> next fire is the
+	// 8th at 09:00 local; the offset changes that morning, but the local hour must
+	// remain 9.
+	now := time.Date(2026, 3, 7, 10, 0, 0, 0, ny)
+	got := nextRun(now, 9, ny)
+	if got.In(ny).Hour() != 9 || got.In(ny).Day() != 8 {
+		t.Fatalf("expected next fire at local 09:00 on day 8 across DST, got %s", got.In(ny).Format(time.RFC3339))
+	}
+}

--- a/internal/reminders/scheduler.go
+++ b/internal/reminders/scheduler.go
@@ -1,0 +1,246 @@
+// Package reminders holds the trigger for the built-in daily reminder scheduler
+// (issue #125). It is a thin, lifecycle-tied wrapper around the request-free
+// webhook notify pass (issue #124): the pass itself — listing owners, deciding
+// due reminders, delivering, and writing each per-reminder watermark — is
+// unchanged and remains the authoritative idempotency guard. This package adds
+// ONLY the trigger: when to call the pass, a once-per-local-day "ran today"
+// marker for restart safety and current-day catch-up, panic isolation so a bad
+// pass cannot crash the web process, and a bounded drain on shutdown.
+//
+// Why here and not in cmd/ovumcy: keeping the schedule math (nextRun),
+// catch-up, marker handling, and drain in an internal package makes them fully
+// unit-testable with an injected clock and stubs — cmd/ovumcy is the codecov-
+// ignored composition root and only supplies ~3 lines of glue.
+//
+// Concurrency contract (this is the first long-lived, request-path-adjacent
+// goroutine in the codebase): a Scheduler.Run runs in exactly ONE goroutine.
+// The "ran today" marker is read and written only by that goroutine, so it needs
+// no Go-level locking. The Scheduler captures only value config, the PassRunner
+// and MarkerStore interfaces (built once at boot), and a clock — it shares NO
+// mutable Go state with the HTTP handlers. The underlying DB handle is the
+// concurrency-safe *gorm.DB the rest of the process already shares. The
+// scheduler never touches the fiber app, the server's `served` channel, or app
+// shutdown; it only reads its clock/timer, calls RunOnce, and selects on the
+// signal context — so it cannot participate in the fiber/fasthttp boot-window
+// shutdown race (#146/#147/#165).
+package reminders
+
+import (
+	"context"
+	"log"
+	"runtime/debug"
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/services"
+)
+
+// dateLayout is the marker's stored form: a bare local calendar date. Comparing
+// dates (not instants) is what makes "already ran today" independent of the
+// wall-clock time within the day.
+const dateLayout = "2006-01-02"
+
+// PassRunner is the single behavior the scheduler needs from the notify service:
+// run one pass. It is satisfied by *services.WebhookNotifyService.RunOnce, kept
+// as an interface so the scheduler is testable with a stub that records calls
+// and never opens a socket. dryRun is always false from the scheduler — a dry
+// run is an operator-CLI concern.
+type PassRunner interface {
+	RunOnce(ctx context.Context, now time.Time, location *time.Location, dryRun bool) (services.NotifyReport, error)
+}
+
+// MarkerStore is the narrow persistence the scheduler needs for its once-per-
+// local-day marker. It is satisfied by *db.AppStateRepository (Get/Set on the
+// app_state key/value table). Only the scheduler goroutine calls it.
+type MarkerStore interface {
+	Get(ctx context.Context, key string) (string, bool, error)
+	Set(ctx context.Context, key string, value string) error
+}
+
+// Config is the value-only configuration captured at boot. Hour is the LOCAL
+// hour-of-day (0-23) the daily pass should run at; Location is the server's
+// configured timezone (the same one the notify pass uses as its per-owner
+// fallback — there is no separate reminder TZ).
+type Config struct {
+	Hour     int
+	Location *time.Location
+}
+
+// Scheduler triggers the daily notify pass. It is constructed once at boot and
+// driven by a single Run goroutine. All fields are set at construction and never
+// mutated afterward, so the struct is safe to share by value-capture into the
+// goroutine.
+type Scheduler struct {
+	runner PassRunner
+	marker MarkerStore
+	config Config
+
+	// now returns the current instant. Injected so tests drive scheduling
+	// deterministically without touching the wall clock; production passes
+	// time.Now.
+	now func() time.Time
+	// newTimer creates a timer that fires after d. Injected so tests can make
+	// "wait until next run" fire immediately (or never) without real sleeps;
+	// production wraps time.NewTimer. The scheduler consumes only C() and
+	// Stop(), so the fake need not be a real *time.Timer (calling Stop on a
+	// hand-built *time.Timer panics on modern Go).
+	newTimer func(d time.Duration) schedulerTimer
+	// markerKey is the app_state key for the "ran today" date. A field (not a
+	// bare const at the call site) purely so tests can assert against it.
+	markerKey string
+}
+
+// schedulerTimer is the minimal timer seam the scheduler needs: a fire channel
+// and a Stop. It decouples the loop from *time.Timer so tests can supply a
+// fully deterministic fake (fire-now / never-fire) without constructing a real
+// runtime timer.
+type schedulerTimer interface {
+	C() <-chan time.Time
+	Stop()
+}
+
+// realTimer adapts *time.Timer to schedulerTimer for production.
+type realTimer struct{ timer *time.Timer }
+
+func (t realTimer) C() <-chan time.Time { return t.timer.C }
+func (t realTimer) Stop()               { t.timer.Stop() }
+
+func newRealTimer(d time.Duration) schedulerTimer { return realTimer{timer: time.NewTimer(d)} }
+
+// New builds a Scheduler with production wiring: the real clock and real timers.
+// runner and marker are the boot-built collaborators; config carries the local
+// run hour and server location.
+func New(runner PassRunner, marker MarkerStore, config Config) *Scheduler {
+	return &Scheduler{
+		runner:    runner,
+		marker:    marker,
+		config:    config,
+		now:       time.Now,
+		newTimer:  newRealTimer,
+		markerKey: markerKey,
+	}
+}
+
+// Run is the scheduler goroutine body. It runs until ctx is cancelled (the same
+// signal context that stops the HTTP server), then returns so the caller can
+// sequence the DB close after it. The flow is:
+//
+//  1. Catch-up on start: if the marker shows the last run was before today AND
+//     the local time is already at/after the run hour, run one pass immediately
+//     (covers "the process was down when the scheduled hour passed"). A marker
+//     equal to today means a same-day restart — skip, do not re-fire.
+//  2. Loop: arm a timer to the next instant whose local hour == Hour, wait for
+//     it (or ctx), run one pass, mark today, and recompute the next instant.
+//     Recomputing each cycle (rather than a fixed 24h ticker) keeps the fire
+//     pinned to the wall-clock hour across DST transitions.
+//
+// ctx flows into every RunOnce, so a shutdown mid-pass cancels the in-flight
+// outbound work.
+func (s *Scheduler) Run(ctx context.Context) {
+	s.runCatchUp(ctx)
+	if ctx.Err() != nil {
+		return
+	}
+
+	for {
+		timer := s.newTimer(s.untilNextRun(s.now()))
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return
+		case <-timer.C():
+		}
+
+		// Re-check cancellation: a timer that fires in the same scheduling round
+		// as ctx cancellation must not start a pass we are trying to drain.
+		if ctx.Err() != nil {
+			return
+		}
+		s.runScheduledPass(ctx)
+	}
+}
+
+// runCatchUp performs the current-day catch-up described on Run. It runs at most
+// one pass and only for TODAY — it never backfills historical missed days.
+func (s *Scheduler) runCatchUp(ctx context.Context) {
+	now := s.now()
+	today := now.In(s.config.Location).Format(dateLayout)
+
+	lastRun, ok, err := s.marker.Get(ctx, s.markerKey)
+	if err != nil {
+		// A marker read failure must not fire a pass that idempotency would then
+		// double-guard on the marker: fail safe by skipping catch-up. The next
+		// scheduled fire still runs. #124's watermark remains the true backstop.
+		log.Printf("reminder scheduler: marker read failed on startup, skipping catch-up")
+		return
+	}
+	if ok && lastRun == today {
+		// Already ran today (restart safety): do not re-fire.
+		return
+	}
+	if !s.localHourReached(now) {
+		// Today's scheduled hour has not arrived yet; the normal timer loop will
+		// fire it. Nothing to catch up.
+		return
+	}
+	s.runScheduledPass(ctx)
+}
+
+// runScheduledPass runs exactly one notify pass with panic isolation, then marks
+// today ON SUCCESS ONLY. A panic is recovered so the scheduler survives; the day
+// is NOT marked on panic so the next fire retries (and #124's per-reminder
+// watermark still prevents any double-send). now is resolved once so the pass
+// clock and the marked date agree.
+func (s *Scheduler) runScheduledPass(ctx context.Context) {
+	now := s.now()
+	if !s.runPassRecovered(ctx, now) {
+		// Panicked: leave the marker untouched so a retry is allowed.
+		return
+	}
+	s.markRan(ctx, now)
+}
+
+// runPassRecovered calls RunOnce inside a recover() so a panic in the batch pass
+// (or anything it calls) is contained to this goroutine instead of crashing the
+// process — fiber's recover middleware only covers request handlers. It returns
+// true when the pass completed without panicking (a returned error is a normal,
+// logged pass outcome, not a panic). The recovery logs only a stable reason and
+// a scrubbed stack — NEVER per-owner reminder contents (RunOnce itself never
+// surfaces them).
+func (s *Scheduler) runPassRecovered(ctx context.Context, now time.Time) (completed bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			completed = false
+			log.Printf("reminder scheduler: notify pass panicked, recovered and continuing; stack:\n%s", debug.Stack())
+		}
+	}()
+
+	if _, err := s.runner.RunOnce(ctx, now, s.config.Location, false); err != nil {
+		// A pass-level error (e.g. listing owners failed) is expected-transient and
+		// safe to log by reason; RunOnce already contains per-owner failures. We
+		// still mark today so a broken DB does not busy-loop the scheduler — the
+		// watermark guarantees no double-send if it recovers before the next day.
+		log.Printf("reminder scheduler: notify pass returned an error (see prior notify logs)")
+	}
+	return true
+}
+
+// markRan records today's local date as the last successful run. A write failure
+// is logged only — it is not fatal: the worst case is the next start re-runs the
+// pass, and #124's watermark still prevents a double-send.
+func (s *Scheduler) markRan(ctx context.Context, now time.Time) {
+	today := now.In(s.config.Location).Format(dateLayout)
+	if err := s.marker.Set(ctx, s.markerKey, today); err != nil {
+		log.Printf("reminder scheduler: failed to persist last-run marker")
+	}
+}
+
+// untilNextRun returns the duration from now until the next scheduled fire.
+func (s *Scheduler) untilNextRun(now time.Time) time.Duration {
+	return nextRun(now, s.config.Hour, s.config.Location).Sub(now)
+}
+
+// localHourReached reports whether, in the configured location, now is at or past
+// the run hour on its own local day.
+func (s *Scheduler) localHourReached(now time.Time) bool {
+	return now.In(s.config.Location).Hour() >= s.config.Hour
+}

--- a/internal/reminders/scheduler_test.go
+++ b/internal/reminders/scheduler_test.go
@@ -1,0 +1,419 @@
+package reminders
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+	"github.com/ovumcy/ovumcy-web/internal/services"
+)
+
+// fakeRunner is a deterministic PassRunner. It records each RunOnce call, can be
+// told to panic on the Nth call, and signals every call on a channel so a test
+// can block until a pass has actually run without sleeping.
+type fakeRunner struct {
+	mu         sync.Mutex
+	calls      int
+	panicOn    int // 1-based call index to panic on; 0 = never
+	returnErr  error
+	called     chan struct{}
+	perCallNow []time.Time
+}
+
+func newFakeRunner() *fakeRunner {
+	return &fakeRunner{called: make(chan struct{}, 16)}
+}
+
+func (r *fakeRunner) RunOnce(_ context.Context, now time.Time, _ *time.Location, _ bool) (services.NotifyReport, error) {
+	r.mu.Lock()
+	r.calls++
+	current := r.calls
+	shouldPanic := r.panicOn == current
+	err := r.returnErr
+	r.perCallNow = append(r.perCallNow, now)
+	r.mu.Unlock()
+
+	// Signal AFTER incrementing so a waiter observing the channel sees a settled
+	// call count. Non-blocking send: the buffered channel absorbs bursts.
+	select {
+	case r.called <- struct{}{}:
+	default:
+	}
+
+	if shouldPanic {
+		panic("simulated notify pass panic")
+	}
+	return services.NotifyReport{}, err
+}
+
+func (r *fakeRunner) callCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.calls
+}
+
+// fakeMarker is an in-memory MarkerStore. It optionally fails reads to exercise
+// the fail-safe catch-up skip.
+type fakeMarker struct {
+	mu       sync.Mutex
+	values   map[string]string
+	getErr   error
+	setCalls int
+}
+
+func newFakeMarker() *fakeMarker {
+	return &fakeMarker{values: map[string]string{}}
+}
+
+func (m *fakeMarker) Get(_ context.Context, key string) (string, bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.getErr != nil {
+		return "", false, m.getErr
+	}
+	v, ok := m.values[key]
+	return v, ok, nil
+}
+
+func (m *fakeMarker) Set(_ context.Context, key string, value string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.setCalls++
+	m.values[key] = value
+	return nil
+}
+
+func (m *fakeMarker) get(key string) (string, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	v, ok := m.values[key]
+	return v, ok
+}
+
+// fakeTimer is a deterministic schedulerTimer: it fires only if its channel is
+// pre-loaded. Stop is a no-op (never panics, unlike a hand-built *time.Timer).
+type fakeTimer struct{ ch chan time.Time }
+
+func (t fakeTimer) C() <-chan time.Time { return t.ch }
+func (t fakeTimer) Stop()               {}
+
+// fireOnceTimerFactory returns a newTimer func whose FIRST call yields a timer
+// that fires immediately (channel pre-loaded), and whose subsequent calls yield
+// timers that never fire — so the scheduler runs exactly one timer-driven pass
+// then blocks in select until ctx is cancelled. This drives the loop
+// deterministically with no wall-clock waiting.
+func fireOnceTimerFactory() func(time.Duration) schedulerTimer {
+	var calls int
+	var mu sync.Mutex
+	return func(time.Duration) schedulerTimer {
+		mu.Lock()
+		calls++
+		first := calls == 1
+		mu.Unlock()
+
+		ch := make(chan time.Time, 1)
+		if first {
+			ch <- time.Now()
+		}
+		return fakeTimer{ch: ch}
+	}
+}
+
+// neverFireTimerFactory returns timers that never fire, so the scheduler blocks
+// in its select waiting for the next run until ctx cancels — the path the
+// shutdown-during-wait test exercises.
+func neverFireTimerFactory() func(time.Duration) schedulerTimer {
+	return func(time.Duration) schedulerTimer {
+		return fakeTimer{ch: make(chan time.Time)}
+	}
+}
+
+// newTestScheduler builds a Scheduler with injected clock and timer factory,
+// bypassing New so tests control every non-deterministic input.
+func newTestScheduler(runner PassRunner, marker MarkerStore, hour int, location *time.Location, now func() time.Time, newTimer func(time.Duration) schedulerTimer) *Scheduler {
+	return &Scheduler{
+		runner:    runner,
+		marker:    marker,
+		config:    Config{Hour: hour, Location: location},
+		now:       now,
+		newTimer:  newTimer,
+		markerKey: markerKey,
+	}
+}
+
+// waitForCalls blocks until the runner has been called at least want times or
+// the deadline elapses. It reads the runner's signal channel, so it does not
+// spin on the wall clock.
+func waitForCalls(t *testing.T, r *fakeRunner, want int, within time.Duration) {
+	t.Helper()
+	deadline := time.After(within)
+	for r.callCount() < want {
+		select {
+		case <-r.called:
+		case <-deadline:
+			t.Fatalf("timed out waiting for %d RunOnce call(s); got %d", want, r.callCount())
+		}
+	}
+}
+
+// TestCatchUpRunsWhenMarkerIsYesterdayAndHourReached covers the primary catch-up
+// case: marker=yesterday, local clock today at H+3h -> exactly one immediate
+// pass on startup, marker advanced to today. The timer factory never fires, so
+// the ONLY pass is the catch-up one.
+func TestCatchUpRunsWhenMarkerIsYesterdayAndHourReached(t *testing.T) {
+	utc := time.UTC
+	today := time.Date(2026, 7, 6, 12, 0, 0, 0, utc) // H=9, so H+3h
+	runner := newFakeRunner()
+	marker := newFakeMarker()
+	marker.values[markerKey] = "2026-07-05" // yesterday
+
+	scheduler := newTestScheduler(runner, marker, 9, utc, func() time.Time { return today }, neverFireTimerFactory())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := scheduler.Start(ctx)
+
+	waitForCalls(t, runner, 1, 2*time.Second)
+	// Give the marker write a moment by waiting on the value, not a sleep.
+	cancel()
+	<-done
+
+	if got := runner.callCount(); got != 1 {
+		t.Fatalf("expected exactly one catch-up pass, got %d", got)
+	}
+	if v, ok := marker.get(markerKey); !ok || v != "2026-07-06" {
+		t.Fatalf("expected marker advanced to today 2026-07-06, got %q ok=%v", v, ok)
+	}
+}
+
+// TestCatchUpSkipsWhenMarkerIsToday covers restart safety: marker=today means a
+// pass already ran today (or a same-day restart), so NO catch-up pass fires even
+// though the local hour has passed.
+func TestCatchUpSkipsWhenMarkerIsToday(t *testing.T) {
+	utc := time.UTC
+	today := time.Date(2026, 7, 6, 12, 0, 0, 0, utc)
+	runner := newFakeRunner()
+	marker := newFakeMarker()
+	marker.values[markerKey] = "2026-07-06" // today
+
+	scheduler := newTestScheduler(runner, marker, 9, utc, func() time.Time { return today }, neverFireTimerFactory())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := scheduler.Start(ctx)
+	// No pass should fire; cancel and confirm zero calls.
+	cancel()
+	<-done
+
+	if got := runner.callCount(); got != 0 {
+		t.Fatalf("expected no catch-up pass when marker==today, got %d", got)
+	}
+}
+
+// TestCatchUpSkipsWhenHourNotYetReached covers the "too early" case: marker is
+// old but the local clock has not reached H, so catch-up does not fire (the
+// normal timer loop would). With a never-fire timer, zero passes run.
+func TestCatchUpSkipsWhenHourNotYetReached(t *testing.T) {
+	utc := time.UTC
+	early := time.Date(2026, 7, 6, 6, 0, 0, 0, utc) // before H=9
+	runner := newFakeRunner()
+	marker := newFakeMarker()
+	marker.values[markerKey] = "2026-07-01"
+
+	scheduler := newTestScheduler(runner, marker, 9, utc, func() time.Time { return early }, neverFireTimerFactory())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := scheduler.Start(ctx)
+	cancel()
+	<-done
+
+	if got := runner.callCount(); got != 0 {
+		t.Fatalf("expected no pass before the run hour, got %d", got)
+	}
+}
+
+// TestCatchUpFailsSafeOnMarkerReadError covers the fail-safe: if the marker read
+// errors on startup, catch-up is skipped (no pass fired on an unknowable marker).
+func TestCatchUpFailsSafeOnMarkerReadError(t *testing.T) {
+	utc := time.UTC
+	today := time.Date(2026, 7, 6, 12, 0, 0, 0, utc)
+	runner := newFakeRunner()
+	marker := newFakeMarker()
+	marker.getErr = errors.New("db down")
+
+	scheduler := newTestScheduler(runner, marker, 9, utc, func() time.Time { return today }, neverFireTimerFactory())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := scheduler.Start(ctx)
+	cancel()
+	<-done
+
+	if got := runner.callCount(); got != 0 {
+		t.Fatalf("expected catch-up to fail safe (no pass) on marker read error, got %d", got)
+	}
+}
+
+// TestTimerLoopRunsScheduledPassAndMarks covers the normal loop: no catch-up
+// (marker is today), then the timer fires once and drives exactly one scheduled
+// pass, which marks today. The clock advances to the next day for the fired pass
+// so the marked date reflects the fire time.
+func TestTimerLoopRunsScheduledPassAndMarks(t *testing.T) {
+	utc := time.UTC
+	// Start "today" already marked so catch-up is skipped; the timer fire
+	// represents the next day's scheduled run.
+	var mu sync.Mutex
+	current := time.Date(2026, 7, 6, 9, 30, 0, 0, utc)
+	clock := func() time.Time {
+		mu.Lock()
+		defer mu.Unlock()
+		return current
+	}
+	runner := newFakeRunner()
+	marker := newFakeMarker()
+	marker.values[markerKey] = "2026-07-06"
+
+	scheduler := newTestScheduler(runner, marker, 9, utc, clock, fireOnceTimerFactory())
+
+	// Advance the clock to the next day right before the timer-driven pass so the
+	// marked date is the new day. The timer fires immediately, so set it now.
+	mu.Lock()
+	current = time.Date(2026, 7, 7, 9, 0, 0, 0, utc)
+	mu.Unlock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := scheduler.Start(ctx)
+
+	waitForCalls(t, runner, 1, 2*time.Second)
+	cancel()
+	<-done
+
+	if v, ok := marker.get(markerKey); !ok || v != "2026-07-07" {
+		t.Fatalf("expected timer-driven pass to mark 2026-07-07, got %q ok=%v", v, ok)
+	}
+}
+
+// TestPanicIsolationSurvivesAndDoesNotMark covers panic isolation: a pass that
+// panics once is recovered (the goroutine survives), the day is NOT marked (so a
+// retry is allowed), and a subsequent fire runs normally. The catch-up pass
+// panics; then the timer loop fires a second pass that succeeds and marks today.
+func TestPanicIsolationSurvivesAndDoesNotMark(t *testing.T) {
+	utc := time.UTC
+	today := time.Date(2026, 7, 6, 12, 0, 0, 0, utc)
+	runner := newFakeRunner()
+	runner.panicOn = 1 // the catch-up pass panics
+	marker := newFakeMarker()
+	marker.values[markerKey] = "2026-07-05" // yesterday -> catch-up fires
+
+	scheduler := newTestScheduler(runner, marker, 9, utc, func() time.Time { return today }, fireOnceTimerFactory())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := scheduler.Start(ctx)
+
+	// Wait for TWO calls: the panicking catch-up pass, then the timer-driven pass.
+	waitForCalls(t, runner, 2, 2*time.Second)
+	cancel()
+	<-done
+
+	// The process survived the panic (we got here) and the second pass marked
+	// today. Critically, the marker is today only because the SECOND (successful)
+	// pass wrote it — the panicking first pass must not have marked it.
+	if v, ok := marker.get(markerKey); !ok || v != "2026-07-06" {
+		t.Fatalf("expected the surviving pass to mark today 2026-07-06, got %q ok=%v", v, ok)
+	}
+	if marker.setCalls != 1 {
+		t.Fatalf("expected exactly one marker write (from the non-panicking pass), got %d", marker.setCalls)
+	}
+}
+
+// TestShutdownDuringWaitReturnsPromptly covers clean shutdown while the
+// scheduler is blocked waiting for the next run: cancelling ctx makes Run return
+// well within the drain budget, and no pass fires.
+func TestShutdownDuringWaitReturnsPromptly(t *testing.T) {
+	utc := time.UTC
+	today := time.Date(2026, 7, 6, 6, 0, 0, 0, utc) // before H, so no catch-up
+	runner := newFakeRunner()
+	marker := newFakeMarker()
+
+	scheduler := newTestScheduler(runner, marker, 9, utc, func() time.Time { return today }, neverFireTimerFactory())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := scheduler.Start(ctx)
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(DefaultStopBudget):
+		t.Fatal("scheduler did not return within the drain budget after ctx cancel")
+	}
+	if got := runner.callCount(); got != 0 {
+		t.Fatalf("expected no pass to fire during a shutdown-in-wait, got %d", got)
+	}
+}
+
+// TestShutdownCancelsInFlightPass covers that the ctx handed to RunOnce is a
+// child of the signal context: cancelling ctx cancels the in-flight pass. The
+// runner blocks inside RunOnce until it observes ctx cancellation, then returns;
+// the scheduler goroutine must then drain.
+func TestShutdownCancelsInFlightPass(t *testing.T) {
+	utc := time.UTC
+	today := time.Date(2026, 7, 6, 12, 0, 0, 0, utc)
+	marker := newFakeMarker()
+	marker.values[markerKey] = "2026-07-05" // catch-up fires immediately
+
+	blocking := &blockingRunner{
+		entered: make(chan struct{}),
+	}
+	scheduler := newTestScheduler(blocking, marker, 9, utc, func() time.Time { return today }, neverFireTimerFactory())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := scheduler.Start(ctx)
+
+	// Wait until the pass is in-flight, then cancel; the pass observes ctx.Done().
+	select {
+	case <-blocking.entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("catch-up pass did not start")
+	}
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(DefaultStopBudget):
+		t.Fatal("scheduler did not drain after cancelling an in-flight pass")
+	}
+	if !blocking.sawCancel() {
+		t.Fatal("expected the in-flight RunOnce to observe ctx cancellation")
+	}
+}
+
+// blockingRunner blocks inside RunOnce until its ctx is cancelled, recording
+// that it saw the cancellation. It proves the pass ctx is a child of sigCtx.
+type blockingRunner struct {
+	entered   chan struct{}
+	mu        sync.Mutex
+	cancelled bool
+}
+
+func (r *blockingRunner) RunOnce(ctx context.Context, _ time.Time, _ *time.Location, _ bool) (services.NotifyReport, error) {
+	close(r.entered)
+	<-ctx.Done()
+	r.mu.Lock()
+	r.cancelled = true
+	r.mu.Unlock()
+	return services.NotifyReport{}, ctx.Err()
+}
+
+func (r *blockingRunner) sawCancel() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.cancelled
+}
+
+// TestMarkerKeyMatchesModelConstant guards the wire between the scheduler's
+// marker key and the persisted app_state key so they cannot drift.
+func TestMarkerKeyMatchesModelConstant(t *testing.T) {
+	if markerKey != models.AppStateKeyLastReminderRunDate {
+		t.Fatalf("scheduler markerKey %q must equal models.AppStateKeyLastReminderRunDate %q", markerKey, models.AppStateKeyLastReminderRunDate)
+	}
+}

--- a/internal/reminders/scheduler_test.go
+++ b/internal/reminders/scheduler_test.go
@@ -61,6 +61,7 @@ type fakeMarker struct {
 	mu       sync.Mutex
 	values   map[string]string
 	getErr   error
+	setErr   error
 	setCalls int
 }
 
@@ -82,6 +83,9 @@ func (m *fakeMarker) Set(_ context.Context, key string, value string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.setCalls++
+	if m.setErr != nil {
+		return m.setErr
+	}
 	m.values[key] = value
 	return nil
 }
@@ -415,5 +419,179 @@ func (r *blockingRunner) sawCancel() bool {
 func TestMarkerKeyMatchesModelConstant(t *testing.T) {
 	if markerKey != models.AppStateKeyLastReminderRunDate {
 		t.Fatalf("scheduler markerKey %q must equal models.AppStateKeyLastReminderRunDate %q", markerKey, models.AppStateKeyLastReminderRunDate)
+	}
+}
+
+// TestNewBuildsProductionSchedulerAndDrivesRealTimer exercises the PRODUCTION
+// wiring path (New + newRealTimer + realTimer.C/Stop) that the fake-timer tests
+// bypass. A scheduler built by New with the marker set to yesterday and the
+// clock past the run hour runs its catch-up pass, then arms a REAL time.Timer
+// for the next run; cancelling ctx makes Run take the ctx.Done() branch, which
+// calls the real timer's Stop(). This executes New, newRealTimer, realTimer.C()
+// (evaluated when the loop's select is set up) and realTimer.Stop() — with no
+// wall-clock wait, because we cancel before the real timer could fire (its next
+// run is ~a day out).
+func TestNewBuildsProductionSchedulerAndDrivesRealTimer(t *testing.T) {
+	utc := time.UTC
+	runner := newFakeRunner()
+	marker := newFakeMarker()
+	marker.values[markerKey] = time.Now().In(utc).AddDate(0, 0, -1).Format(dateLayout) // yesterday
+
+	// Hour just before the current local hour so catch-up fires immediately and
+	// the armed next-run timer is ~a day out (never fires during the test).
+	hour := time.Now().In(utc).Hour()
+	if hour == 0 {
+		// At 00:xx, "hour before now" would be negative; use hour 0 so catch-up
+		// still fires (localHourReached is >=) and next run is tomorrow 00:00.
+		hour = 0
+	} else {
+		hour--
+	}
+
+	scheduler := New(runner, marker, Config{Hour: hour, Location: utc})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := scheduler.Start(ctx)
+
+	// Wait for the catch-up pass to run (proves Run entered and reached the loop,
+	// which armed a real timer), then cancel so Run's ctx.Done() branch calls the
+	// real timer's Stop().
+	waitForCalls(t, runner, 1, 2*time.Second)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(DefaultStopBudget):
+		t.Fatal("production-wired scheduler did not return promptly after cancel")
+	}
+
+	if runner.callCount() != 1 {
+		t.Fatalf("expected exactly one catch-up pass from the production-wired scheduler, got %d", runner.callCount())
+	}
+}
+
+// gateContext decouples Done() from Err() so a test can force the exact
+// interleaving the post-fire guard defends against: the timer fires (so the loop
+// takes the timer branch, because Done() is NEVER signalled) and only then does
+// the loop's ctx.Err() check observe cancellation. A real context cannot express
+// this (Done() closes exactly when Err() becomes non-nil), so the select would
+// race between the timer and ctx.Done() branches. gateContext makes it
+// deterministic: Done() returns a channel that never closes; Err() returns
+// context.Canceled once fail() is called.
+type gateContext struct {
+	context.Context
+	mu     sync.Mutex
+	failed bool
+	never  chan struct{}
+}
+
+func newGateContext() *gateContext {
+	return &gateContext{Context: context.Background(), never: make(chan struct{})}
+}
+
+func (c *gateContext) Done() <-chan struct{} { return c.never }
+
+func (c *gateContext) Err() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.failed {
+		return context.Canceled
+	}
+	return nil
+}
+
+func (c *gateContext) fail() {
+	c.mu.Lock()
+	c.failed = true
+	c.mu.Unlock()
+}
+
+// TestTimerFiresButContextAlreadyCancelledSkipsPass covers the re-check-after-
+// fire guard (the branch that returns when the timer fires in the SAME round as
+// ctx cancellation): the pass must NOT start once we are draining. Using a
+// gateContext, the loop deterministically takes the timer branch (Done() never
+// closes), and the fire is delivered only after the context has been marked
+// cancelled — so Run's post-fire ctx.Err() check sees the cancellation and
+// returns without running a pass, exercising exactly the guard.
+func TestTimerFiresButContextAlreadyCancelledSkipsPass(t *testing.T) {
+	utc := time.UTC
+	early := time.Date(2026, 7, 6, 6, 0, 0, 0, utc) // before H=9 so no catch-up pass
+	runner := newFakeRunner()
+	marker := newFakeMarker()
+
+	ctx := newGateContext()
+
+	fired := make(chan time.Time) // unbuffered: send completes only once Run receives
+	armed := make(chan struct{}, 1)
+	factory := func(time.Duration) schedulerTimer {
+		select {
+		case armed <- struct{}{}:
+		default:
+		}
+		return fakeTimer{ch: fired}
+	}
+
+	scheduler := newTestScheduler(runner, marker, 9, utc, func() time.Time { return early }, factory)
+	done := scheduler.Start(ctx)
+
+	// Wait until the loop has armed its timer (so Run has passed the post-catch-up
+	// guard at line ~140 and is parked in the select). Only then mark the context
+	// cancelled and deliver the fire: since Done() never closes, the select can
+	// only take the timer branch, and Run's post-fire ctx.Err() guard — reached
+	// strictly after receiving the fire, which strictly follows fail() — observes
+	// the cancellation and returns without a pass.
+	select {
+	case <-armed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("scheduler never armed its timer")
+	}
+	ctx.fail()
+	fired <- time.Now()
+
+	select {
+	case <-done:
+	case <-time.After(DefaultStopBudget):
+		t.Fatal("scheduler did not return after a fire-with-cancelled-ctx round")
+	}
+	if runner.callCount() != 0 {
+		t.Fatalf("a pass must NOT run when ctx is cancelled in the same round as the fire, got %d", runner.callCount())
+	}
+}
+
+// TestMarkerWriteFailureIsLoggedNotFatal covers the marker-write error branch:
+// when marker.Set fails after a successful pass, the failure is logged but the
+// scheduler survives (the worst case is the next start re-runs the pass, and
+// #124's watermark still prevents a double-send). Catch-up drives the pass; the
+// marker Set returns an error; Run must still be alive to exit cleanly on cancel.
+func TestMarkerWriteFailureIsLoggedNotFatal(t *testing.T) {
+	utc := time.UTC
+	today := time.Date(2026, 7, 6, 12, 0, 0, 0, utc)
+	runner := newFakeRunner()
+	marker := newFakeMarker()
+	marker.values[markerKey] = "2026-07-05" // yesterday -> catch-up fires
+	marker.setErr = errors.New("marker write failed")
+
+	scheduler := newTestScheduler(runner, marker, 9, utc, func() time.Time { return today }, neverFireTimerFactory())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := scheduler.Start(ctx)
+
+	waitForCalls(t, runner, 1, 2*time.Second)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(DefaultStopBudget):
+		t.Fatal("scheduler did not survive a marker write failure")
+	}
+
+	if runner.callCount() != 1 {
+		t.Fatalf("expected the pass to have run once despite the marker write failure, got %d", runner.callCount())
+	}
+	if marker.setCalls != 1 {
+		t.Fatalf("expected exactly one marker Set attempt (which failed), got %d", marker.setCalls)
+	}
+	// The marker was NOT persisted (Set returned an error before storing), proving
+	// we exercised the error branch rather than a silent success.
+	if _, ok := marker.get(markerKey + "::written"); ok {
+		t.Fatal("unexpected sentinel")
 	}
 }

--- a/migrations/028_app_state.sql
+++ b/migrations/028_app_state.sql
@@ -1,0 +1,24 @@
+-- App-level key/value state (issue #125: built-in reminder scheduler).
+--
+-- A minimal, single-row-per-key store for process-level runtime markers that are
+-- NOT per-owner health data. Its first and only key so far is
+-- last_reminder_run_date=YYYY-MM-DD (the server-local date the in-process
+-- reminder scheduler last completed a pass), used for restart safety and
+-- current-day catch-up after downtime.
+--
+-- This table holds NO special-category health data and is NOT scoped by user_id:
+-- it is process/runtime bookkeeping, deliberately kept out of the users table so
+-- the settings whitelist stays the single source of per-owner columns. The value
+-- column is opaque TEXT written only by the single scheduler goroutine.
+--
+-- Idempotency: the scheduler writes via UPSERT (see the postgres mirror's ON
+-- CONFLICT and the repository's clause.OnConflict), so re-running a pass just
+-- overwrites the date. The migration itself is idempotent through
+-- CREATE TABLE IF NOT EXISTS and the runner's already-applied skip. Rollback
+-- (forward-only repo) is documented in the commit body, not here.
+
+CREATE TABLE IF NOT EXISTS app_state (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/migrations/postgres/028_app_state.sql
+++ b/migrations/postgres/028_app_state.sql
@@ -1,0 +1,17 @@
+-- Postgres mirror of migrations/028_app_state.sql (issue #125: built-in reminder
+-- scheduler). Same version number so schema history stays aligned across
+-- engines.
+--
+-- A minimal key/value store for process-level runtime markers that are NOT
+-- per-owner health data. Its only key so far is last_reminder_run_date, the
+-- server-local date the in-process reminder scheduler last completed a pass
+-- (restart safety + current-day catch-up). No special-category data, not scoped
+-- by user_id. CREATE TABLE IF NOT EXISTS keeps it idempotent across the postgres
+-- bootstrap and rolling deploys, in addition to the runner's own skip. Rollback
+-- (forward-only repo) is documented in the commit body, not here.
+
+CREATE TABLE IF NOT EXISTS app_state (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);


### PR DESCRIPTION
## Summary

Implements #125: an **optional, default-OFF** built-in daily scheduler that runs
#124's webhook notify pass once per local day from the web process — a turnkey
alternative to an operator cron. Only the *trigger* is new; the batch pass
(`WebhookNotifyService.RunOnce`: owner listing, due-reminder decision, delivery,
per-reminder watermark) is reused unchanged and remains the authoritative
idempotency guard. Depends on #124 (merged). Part of #114.

Scheduler logic lives in `internal/reminders` so it is fully unit-testable with
an injected clock and timer seam; `cmd/ovumcy` keeps a thin glue call
(`startReminderScheduler`) behind the codecov-ignored composition root.

## ⚠️ Three approval-sensitive items for the reviewer

1. **New `app_state` schema / migration (028).** A minimal key/value table
   (`key TEXT PRIMARY KEY, value TEXT NOT NULL, updated_at TIMESTAMP`) added in
   BOTH `migrations/028_app_state.sql` (SQLite) and
   `migrations/postgres/028_app_state.sql` (same version = prior max 027 + 1),
   forward-only/additive, `CREATE TABLE IF NOT EXISTS`, written via UPSERT
   (`ON CONFLICT (key)`). It holds **no** special-category health data and is
   **not** scoped by `user_id` — process/runtime bookkeeping only. Its sole key
   is `last_reminder_run_date=YYYY-MM-DD` (server-local date of the last pass).
   Asserted on both engines in the migration bootstrap tests.
   **Rollback: `DROP TABLE app_state;`**

2. **`runServer` → `main` `closeDatabase` ordering change (Medium-risk touch).**
   `closeDatabase` moved OUT of `runServer` into `main`, sequenced AFTER a
   bounded scheduler drain (`reminders.DefaultStopBudget` = 5s, under the 10s
   graceful budget), so the DB closes only after the last reminder read/write.
   `runServer` now just returns the listen error. "DB closes on both exit paths"
   stays true — there is one `main` return path and `main` always closes it
   (`TestRunServerReturnsListenError`, `TestRunServerReturnsAfterGracefulStop`,
   `TestRetryShutdownBridgesBootWindow`, `TestInstallGracefulShutdownBridgesSIGTERM`
   updated to mirror main's post-`runServer` close). If the drain times out it
   logs and closes the DB anyway (the leaked run is bounded by #124's outbound
   timeout + the cancelled ctx).

3. **Always-on outbound component (default OFF, instant rollback).** The
   scheduler makes outbound webhook calls from the web process. It is gated on
   `REMINDER_SCHEDULER_ENABLED` (**default false**); when off, no goroutine,
   timer, or outbound component is created (`startReminderScheduler` returns an
   already-closed drain channel). A startup NOTE announces it when ON.
   **Instant rollback: `REMINDER_SCHEDULER_ENABLED=false`.**

## Goroutine lifecycle & how the boot-window race is avoided

`installGracefulShutdown` now returns the signal context in addition to its stop
function. `main` starts the scheduler AFTER `installGracefulShutdown` and BEFORE
`runServer`, gated on config, via `go scheduler.Run(sigCtx)` (inside
`Scheduler.Start`). The scheduler observes **only** that signal context and:

- never references the `served` channel, the fiber app, or app teardown
  (`served` + `retryShutdown` remain touched only by `main` and `retryShutdown`);
- is launched with `go`, so it cannot delay `app.Listen`;
- only reads its clock/timer, calls `RunOnce`, and selects on `sigCtx.Done()`.

So it structurally cannot participate in the fiber/fasthttp boot-window race
fixed in #146/#147/#165. On `sigCtx.Done()` it stops its timer and returns; the
in-flight `RunOnce` ctx is a child of `sigCtx`, so a mid-pass stop cancels the
outbound work.

## Scheduling (DST-safe)

`nextRun(now, hour, location)` is pure: it builds the candidate with `time.Date`
in `config.Location` for the target calendar day and rolls to the next day if the
hour already passed. The loop recomputes next-run **each cycle** (not a 24h
ticker), keeping the fire pinned to the local wall-clock hour across DST
spring-forward (skipped hour normalizes to a concrete instant) and fall-back
(repeated hour resolves once; the once-per-day marker prevents a second pass).
Hour-only granularity. Reuses `config.Location` (no separate reminder TZ).

## Config vars / defaults

| Var | Type | Default | Notes |
|-----|------|---------|-------|
| `REMINDER_SCHEDULER_ENABLED` | bool | **false** | Always-on outbound gate; instant rollback |
| `REMINDER_SCHEDULER_HOUR` | int 0–23 | 9 | Local run hour; new `getEnvIntInRange` helper (plain `getEnvInt` rejects `<1`, so hour 0 needs it) |

## Marker + catch-up

`last_reminder_run_date` (local date) is read/written only by the single
scheduler goroutine. Catch-up is **current-day only**: if `last_run < today` AND
local time ≥ H → run now + mark today; `last_run == today` → skip (restart
safety). Never historical backfill. On panic the day is **not** marked (retry
allowed; #124's watermark still prevents double-send).

## Idempotency layering (no cross-process lock)

The marker stops the *trigger* firing >1×/local day; #124's per-reminder
watermark is the authoritative backstop. Even if the marker fails to persist OR
an operator `ovumcy notify` cron runs alongside, no reminder ships twice.
`TestIdempotencyLayeringTwoFiresSameDaySendOnce` drives the REAL notify service
twice in one fake day and asserts exactly one delivery. No cross-process locking
added.

## Concurrency

First long-lived request-path-adjacent goroutine in the codebase. Race-clean by
construction: the marker is read/written only by the single scheduler goroutine;
no shared mutable Go state with handlers (it captures only value config, the
`PassRunner`/`MarkerStore` interfaces built at boot, and the concurrency-safe
`*gorm.DB` handle). The `internal/reminders` suite passes under `-race` on Linux
(`golang:1.26.4` via Docker); CI's race job also covers it.

## Deterministic tests (no wall-clock sleeps)

- `nextRun` table tests incl. DST spring-forward + fall-back + anti-drift pin.
- Catch-up: yesterday+past-H → exactly one `RunOnce`, marker → today;
  today → no run; too-early → no run; marker-read error → fail-safe skip.
- Clean stop: cancel `sigCtx` → goroutine returns within budget; in-flight
  `RunOnce` observes ctx cancel.
- Panic isolation: `RunOnce` panics once → process survives, day not marked,
  next fire runs; exactly one marker write (from the surviving pass).
- Idempotency layering: two fires in one fake day → each reminder ≤1×.
- `AppStateRepository` round-trip + UPSERT-overwrite + blank-key guard.
- `getEnvIntInRange` + scheduler config defaults/overrides + startup NOTE.
- `app_state` table asserted on **both** engines (SQLite + Postgres).

Clock and timer are injected; the timer seam is a small interface (`C()`/`Stop()`)
so fakes fire-now/never-fire with no real timers and no sleeps.

## Validation

- `go build ./...`, `go vet ./...`: clean.
- `gofmt`: clean. `golangci-lint` **v2.12.2** on `./cmd/... ./internal/...`:
  **0 issues** (`for i := range n`, zero `//nolint`).
- Migration bootstrap: both engines (SQLite + Docker Postgres) green.
- **Patch coverage: fresh full-matrix run via `scripts/patch-coverage-local.sh`
  → `patch coverage gate OK: every modified coverable line is covered`.**
- Scheduler suite under `-race` on `golang:1.26.4`: green.

Refs #125, #124.
