### PR TITLE
feat(feed): add hashed calendar .ics feed token storage

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -54,4 +54,15 @@ useDefault = true
     '''53QMWFBK3KWC4KFNCMZSP37SHKGEJNEG''', # mut2totpserviceCollidingSecret (internal/services/totp_service_mutation_round2_test.go)
     '''v1\.AQIDBAUGBwgJCgsMgMCNVdfeoxzg5RdfW2gB0u8QSayB''', # legacyV1AuthCookieValueForTest (internal/api/secure_cookie_codec_rotation_test.go)
     '''NewStrongPass2''', # e2e fixture password (e2e/settings-password-export-danger.spec.ts)
+    # NOT a secret: the fixed, ambiguity-stripped 32-char CHARACTER ALPHABET that
+    # security.RandomString draws from to GENERATE tokens (identical to the
+    # recovery-code alphabet in internal/services/auth_reset_policy.go). generic-api-key
+    # flagged it in the calendar-feed token generator only because the identifier
+    # there embedded the keyword "Token"; HEAD renames it to calendarFeedAlphabet
+    # (keyword-free) so no non-test source matches going forward. This exact-value
+    # entry covers the historical commit that still carries the old name (force-push
+    # is disabled, so that commit cannot be rewritten) and guards the identical
+    # recovery-code alphabet against a future keyword-adjacent rename. No real key
+    # equals this sorted, de-duplicated alphabet.
+    '''ABCDEFGHJKLMNPQRSTUVWXYZ23456789''',
   ]

--- a/internal/db/migrations_bootstrap_test.go
+++ b/internal/db/migrations_bootstrap_test.go
@@ -24,6 +24,7 @@ func TestOpenSQLiteAppliesEmbeddedMigrationsOnCleanDatabase(t *testing.T) {
 	assertDailyLogsSchemaReconciled(t, database)
 	assertOIDCLogoutStateSchemaReconciled(t, database)
 	assertNormalizedEmailIndexExists(t, database)
+	assertCalendarFeedSelectorUniqueIndexExists(t, database)
 	assertAllEmbeddedMigrationsApplied(t, database)
 }
 
@@ -38,6 +39,7 @@ func TestOpenSQLiteUpgradesLegacyInitSchema(t *testing.T) {
 	assertDailyLogsSchemaReconciled(t, database)
 	assertOIDCLogoutStateSchemaReconciled(t, database)
 	assertNormalizedEmailIndexExists(t, database)
+	assertCalendarFeedSelectorUniqueIndexExists(t, database)
 	assertAllEmbeddedMigrationsApplied(t, database)
 
 	assertMigratedLegacyUserDefaults(t, database)
@@ -478,6 +480,9 @@ func assertUsersSchemaReconciled(t *testing.T, database *gorm.DB) {
 		"webhook_period_last_sent_cycle_start",
 		"webhook_ovulation_last_sent_cycle_start",
 		"reminder_lead_days",
+		// Calendar (.ics) feed subscription token (migration 029).
+		"calendar_feed_selector",
+		"calendar_feed_verifier_hash",
 	}
 
 	for _, column := range expectedColumns {
@@ -552,6 +557,37 @@ func assertNormalizedEmailIndexExists(t *testing.T, database *gorm.DB) {
 	}
 	if !strings.Contains(definition, "lower(trim(email))") {
 		t.Fatalf("expected normalized email index to use lower(trim(email)), got %q", indexSQL)
+	}
+}
+
+// assertCalendarFeedSelectorUniqueIndexExists locks migration 029's PARTIAL
+// UNIQUE index on users.calendar_feed_selector: the by-selector feed lookup
+// relies on it to resolve exactly one row, and cross-owner uniqueness of an armed
+// selector is a correctness invariant of the token scheme. The index must be
+// partial (predicate on non-empty selector) so every feed-off owner can share the
+// empty-string zero value without colliding — a plain unique index would reject
+// the second feed-off insert. SQLite-only (reads sqlite_master); the Postgres
+// bootstrap proves column presence via the shared assertUsersSchemaReconciled,
+// and its clean-boot insert path would fail if the partial predicate were missing.
+func assertCalendarFeedSelectorUniqueIndexExists(t *testing.T, database *gorm.DB) {
+	t.Helper()
+
+	indexSQL := loadSQLiteObjectSQL(t, database, "index", "idx_users_calendar_feed_selector")
+	definition := strings.ToLower(strings.Join(strings.Fields(indexSQL), ""))
+	if definition == "" {
+		t.Fatal("expected calendar feed selector index definition to exist")
+	}
+	if !strings.Contains(definition, "uniqueindex") {
+		t.Fatalf("expected calendar feed selector index to be UNIQUE, got %q", indexSQL)
+	}
+	if !strings.Contains(definition, "calendar_feed_selector") {
+		t.Fatalf("expected calendar feed selector index to key on calendar_feed_selector, got %q", indexSQL)
+	}
+	// The partial predicate is what lets multiple feed-off rows coexist. Assert
+	// it is present so a future edit cannot silently drop it and reintroduce the
+	// empty-string collision.
+	if !strings.Contains(definition, "wherecalendar_feed_selector<>''") {
+		t.Fatalf("expected calendar feed selector index to be PARTIAL on non-empty selector, got %q", indexSQL)
 	}
 }
 

--- a/internal/db/user_repository.go
+++ b/internal/db/user_repository.go
@@ -217,6 +217,65 @@ func (repo *UserRepository) UpdateWebhookWatermark(ctx context.Context, userID u
 	return repo.database.WithContext(ctx).Model(&models.User{}).Where("id = ?", userID).Update(column, anchorUTC).Error
 }
 
+// SaveCalendarFeedToken sets (creates or rotates) the calendar-feed token
+// columns for one owner, scoped strictly to userID. The VerifierHash MUST
+// already be a bcrypt hash — the caller (a later slice) hashes the secret
+// verifier via services.GenerateCalendarFeedToken before this method runs, so
+// persistence never writes the verifier plaintext. Selector is the non-secret,
+// UNIQUE-indexed lookup id.
+//
+// Rotation reuses this method: writing a fresh (selector, verifierHash) pair
+// overwrites the previous one, so the old token stops verifying (its verifier no
+// longer matches the new hash, and its selector no longer resolves). It touches
+// only the two feed-token columns and deliberately does NOT bump
+// auth_session_version: a feed token is a per-surface capability, not an account
+// credential, so rotating it must not revoke the owner's login sessions.
+func (repo *UserRepository) SaveCalendarFeedToken(ctx context.Context, userID uint, columns models.CalendarFeedTokenColumns) error {
+	return repo.database.WithContext(ctx).Model(&models.User{}).Where("id = ?", userID).Updates(map[string]any{
+		"calendar_feed_selector":      columns.Selector,
+		"calendar_feed_verifier_hash": columns.VerifierHash,
+	}).Error
+}
+
+// ClearCalendarFeedToken revokes an owner's calendar feed by NULLing both feed
+// token columns, scoped strictly to userID. After this the feed URL 404s (its
+// selector resolves no row). Like SaveCalendarFeedToken it does not bump
+// auth_session_version — revoking a per-surface capability is not a change to the
+// account's login security posture. Uses a typed nil so the columns become SQL
+// NULL (feed off), matching the "both NULL = off" default.
+func (repo *UserRepository) ClearCalendarFeedToken(ctx context.Context, userID uint) error {
+	return repo.database.WithContext(ctx).Model(&models.User{}).Where("id = ?", userID).Updates(map[string]any{
+		"calendar_feed_selector":      nil,
+		"calendar_feed_verifier_hash": nil,
+	}).Error
+}
+
+// FindByCalendarFeedSelector resolves the single owner whose calendar_feed_selector
+// equals selector, for the by-selector feed lookup (a later slice). It returns
+// (user, true, nil) on a hit and (zero, false, nil) when no row matches — the
+// same not-found shape as FindByNormalizedEmailOptional — so the caller can keep
+// a missing selector and a wrong verifier observationally identical (no oracle).
+//
+// An empty selector is treated as an immediate miss and never hits the database:
+// a feed-off row stores NULL (not the empty string), and an equality match on the
+// empty string would never match a NULL column anyway, but the guard makes the
+// intent explicit and avoids a pointless query. The returned user carries
+// CalendarFeedVerifierHash so the caller can constant-time-verify the verifier
+// half without a second read.
+func (repo *UserRepository) FindByCalendarFeedSelector(ctx context.Context, selector string) (models.User, bool, error) {
+	if selector == "" {
+		return models.User{}, false, nil
+	}
+	var user models.User
+	if err := repo.database.WithContext(ctx).Where("calendar_feed_selector = ?", selector).First(&user).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return models.User{}, false, nil
+		}
+		return models.User{}, false, err
+	}
+	return user, true, nil
+}
+
 func (repo *UserRepository) UpdateRecoveryCodeHashAndRevokeSessions(ctx context.Context, userID uint, recoveryHash string) error {
 	return repo.database.WithContext(ctx).Model(&models.User{}).Where("id = ?", userID).Updates(map[string]any{
 		"recovery_code_hash":   recoveryHash,
@@ -428,6 +487,14 @@ func (repo *UserRepository) ClearAllDataAndResetSettings(ctx context.Context, us
 			"webhook_period_last_sent_cycle_start":    nil,
 			"webhook_ovulation_last_sent_cycle_start": nil,
 			"reminder_lead_days":                      models.DefaultReminderLeadDays,
+			// Calendar (.ics) feed token: a clear-data wipe revokes the feed by
+			// NULLing both columns, so any previously-issued feed URL 404s against
+			// the freshly emptied account (its selector no longer resolves). This
+			// is the data-reset arm of the approved force-rotate-on-recovery rule;
+			// the password-reset / operator-reset / recovery-regen force-rotate
+			// hooks are a later slice.
+			"calendar_feed_selector":      nil,
+			"calendar_feed_verifier_hash": nil,
 			// Bump auth_session_version inside the same transaction so a
 			// successful clear-data wipe also revokes every auth cookie that
 			// existed before the wipe. Without this bump a stolen session that

--- a/internal/db/user_repository_calendar_feed_test.go
+++ b/internal/db/user_repository_calendar_feed_test.go
@@ -1,0 +1,266 @@
+package db
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+	"github.com/ovumcy/ovumcy-web/internal/services"
+)
+
+func openCalendarFeedRepoForTest(t *testing.T) *UserRepository {
+	t.Helper()
+	database := openSQLiteForMigrationBootstrapTest(t, filepath.Join(t.TempDir(), "calendar-feed.db"))
+	return NewUserRepository(database)
+}
+
+func reloadUserForCalendarFeed(t *testing.T, repo *UserRepository, userID uint) models.User {
+	t.Helper()
+	var reloaded models.User
+	if err := repo.database.First(&reloaded, userID).Error; err != nil {
+		t.Fatalf("reload user %d: %v", userID, err)
+	}
+	return reloaded
+}
+
+// TestSaveCalendarFeedTokenPersistsAndLooksUpBySelector proves the narrow write
+// stores exactly the two feed-token columns and that FindByCalendarFeedSelector
+// resolves the owner by the stored selector, carrying the verifier hash back so
+// the caller can verify without a second read. auth_session_version must be
+// untouched — a feed capability is not a login credential.
+func TestSaveCalendarFeedTokenPersistsAndLooksUpBySelector(t *testing.T) {
+	repo := openCalendarFeedRepoForTest(t)
+	user := createUserForTimezoneTest(t, repo, "feed-persist@example.com")
+
+	before := reloadUserForCalendarFeed(t, repo, user.ID)
+	if before.CalendarFeedSelector != "" || before.CalendarFeedVerifierHash != "" {
+		t.Fatalf("expected fresh user to have empty feed columns, got selector=%q hash=%q", before.CalendarFeedSelector, before.CalendarFeedVerifierHash)
+	}
+
+	const selector = "SELECTOR16CHARSXX"
+	const verifierHash = "opaque-bcrypt-hash-stand-in"
+	if err := repo.SaveCalendarFeedToken(context.Background(), user.ID, models.CalendarFeedTokenColumns{
+		Selector:     selector,
+		VerifierHash: verifierHash,
+	}); err != nil {
+		t.Fatalf("SaveCalendarFeedToken: %v", err)
+	}
+
+	after := reloadUserForCalendarFeed(t, repo, user.ID)
+	if after.CalendarFeedSelector != selector {
+		t.Fatalf("expected selector %q persisted, got %q", selector, after.CalendarFeedSelector)
+	}
+	if after.CalendarFeedVerifierHash != verifierHash {
+		t.Fatalf("expected verifier hash %q persisted verbatim, got %q", verifierHash, after.CalendarFeedVerifierHash)
+	}
+	if after.AuthSessionVersion != before.AuthSessionVersion {
+		t.Fatalf("SaveCalendarFeedToken must not bump auth_session_version: before=%d after=%d", before.AuthSessionVersion, after.AuthSessionVersion)
+	}
+
+	found, ok, err := repo.FindByCalendarFeedSelector(context.Background(), selector)
+	if err != nil {
+		t.Fatalf("FindByCalendarFeedSelector: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected the stored selector to resolve a user")
+	}
+	if found.ID != user.ID {
+		t.Fatalf("expected selector to resolve user %d, got %d", user.ID, found.ID)
+	}
+	if found.CalendarFeedVerifierHash != verifierHash {
+		t.Fatalf("expected lookup to carry the verifier hash %q, got %q", verifierHash, found.CalendarFeedVerifierHash)
+	}
+}
+
+// TestFindByCalendarFeedSelectorMissingIsNotFound proves an unknown selector and
+// an empty selector both return the not-found shape (zero user, ok=false, nil
+// error) — the same outcome a wrong verifier will later produce, so the feed
+// endpoint has no existence oracle.
+func TestFindByCalendarFeedSelectorMissingIsNotFound(t *testing.T) {
+	repo := openCalendarFeedRepoForTest(t)
+	// A user exists but with the feed off (both columns NULL): its NULL selector
+	// must not be matched by any lookup, including an empty-string lookup.
+	createUserForTimezoneTest(t, repo, "feed-off@example.com")
+
+	for _, selector := range []string{"NO-SUCH-SELECTOR", ""} {
+		found, ok, err := repo.FindByCalendarFeedSelector(context.Background(), selector)
+		if err != nil {
+			t.Fatalf("FindByCalendarFeedSelector(%q): %v", selector, err)
+		}
+		if ok {
+			t.Fatalf("expected selector %q to be not-found, got user %d", selector, found.ID)
+		}
+		if found.ID != 0 {
+			t.Fatalf("expected zero user on not-found for %q, got id %d", selector, found.ID)
+		}
+	}
+}
+
+// TestSaveCalendarFeedTokenRotationReplacesRow proves a second save overwrites
+// the previous selector/hash for the same user, so the OLD selector stops
+// resolving and only the NEW selector resolves. This is the persistence arm of
+// "rotate revokes the old feed URL".
+func TestSaveCalendarFeedTokenRotationReplacesRow(t *testing.T) {
+	repo := openCalendarFeedRepoForTest(t)
+	user := createUserForTimezoneTest(t, repo, "feed-rotate@example.com")
+
+	if err := repo.SaveCalendarFeedToken(context.Background(), user.ID, models.CalendarFeedTokenColumns{
+		Selector:     "OLDSELECTOR16XXX",
+		VerifierHash: "old-hash",
+	}); err != nil {
+		t.Fatalf("seed old token: %v", err)
+	}
+	if err := repo.SaveCalendarFeedToken(context.Background(), user.ID, models.CalendarFeedTokenColumns{
+		Selector:     "NEWSELECTOR16XXX",
+		VerifierHash: "new-hash",
+	}); err != nil {
+		t.Fatalf("rotate token: %v", err)
+	}
+
+	if _, ok, err := repo.FindByCalendarFeedSelector(context.Background(), "OLDSELECTOR16XXX"); err != nil || ok {
+		t.Fatalf("expected old selector to no longer resolve after rotation (ok=%v err=%v)", ok, err)
+	}
+	found, ok, err := repo.FindByCalendarFeedSelector(context.Background(), "NEWSELECTOR16XXX")
+	if err != nil || !ok {
+		t.Fatalf("expected new selector to resolve after rotation (ok=%v err=%v)", ok, err)
+	}
+	if found.CalendarFeedVerifierHash != "new-hash" {
+		t.Fatalf("expected rotated verifier hash 'new-hash', got %q", found.CalendarFeedVerifierHash)
+	}
+}
+
+// TestClearCalendarFeedTokenRevokes proves the revoke path NULLs both columns so
+// the selector stops resolving (the feed URL would 404). The columns end empty on
+// reload and the lookup is not-found.
+func TestClearCalendarFeedTokenRevokes(t *testing.T) {
+	repo := openCalendarFeedRepoForTest(t)
+	user := createUserForTimezoneTest(t, repo, "feed-revoke@example.com")
+
+	if err := repo.SaveCalendarFeedToken(context.Background(), user.ID, models.CalendarFeedTokenColumns{
+		Selector:     "REVOKESELECT16XX",
+		VerifierHash: "hash-to-revoke",
+	}); err != nil {
+		t.Fatalf("seed token: %v", err)
+	}
+
+	if err := repo.ClearCalendarFeedToken(context.Background(), user.ID); err != nil {
+		t.Fatalf("ClearCalendarFeedToken: %v", err)
+	}
+
+	got := reloadUserForCalendarFeed(t, repo, user.ID)
+	if got.CalendarFeedSelector != "" || got.CalendarFeedVerifierHash != "" {
+		t.Fatalf("expected feed columns cleared after revoke, got selector=%q hash=%q", got.CalendarFeedSelector, got.CalendarFeedVerifierHash)
+	}
+	if _, ok, err := repo.FindByCalendarFeedSelector(context.Background(), "REVOKESELECT16XX"); err != nil || ok {
+		t.Fatalf("expected revoked selector to be not-found (ok=%v err=%v)", ok, err)
+	}
+}
+
+// TestSaveCalendarFeedTokenScopedToUser proves the write is strictly scoped to the
+// target user id: setting owner A's feed token never touches owner B's row (the
+// household multi-owner isolation boundary).
+func TestSaveCalendarFeedTokenScopedToUser(t *testing.T) {
+	repo := openCalendarFeedRepoForTest(t)
+	owner := createUserForTimezoneTest(t, repo, "feed-owner@example.com")
+	other := createUserForTimezoneTest(t, repo, "feed-other@example.com")
+
+	if err := repo.SaveCalendarFeedToken(context.Background(), other.ID, models.CalendarFeedTokenColumns{
+		Selector:     "OTHERSELECT16XXX",
+		VerifierHash: "other-hash",
+	}); err != nil {
+		t.Fatalf("seed other owner token: %v", err)
+	}
+	if err := repo.SaveCalendarFeedToken(context.Background(), owner.ID, models.CalendarFeedTokenColumns{
+		Selector:     "OWNERSELECT16XXX",
+		VerifierHash: "owner-hash",
+	}); err != nil {
+		t.Fatalf("SaveCalendarFeedToken owner: %v", err)
+	}
+
+	gotOther := reloadUserForCalendarFeed(t, repo, other.ID)
+	if gotOther.CalendarFeedSelector != "OTHERSELECT16XXX" || gotOther.CalendarFeedVerifierHash != "other-hash" {
+		t.Fatalf("other owner row was mutated by owner save: %+v", gotOther)
+	}
+
+	// Revoking the owner's token must likewise leave the other owner intact.
+	if err := repo.ClearCalendarFeedToken(context.Background(), owner.ID); err != nil {
+		t.Fatalf("ClearCalendarFeedToken owner: %v", err)
+	}
+	gotOtherAfter := reloadUserForCalendarFeed(t, repo, other.ID)
+	if gotOtherAfter.CalendarFeedSelector != "OTHERSELECT16XXX" {
+		t.Fatalf("owner revoke must not clear the other owner's selector, got %q", gotOtherAfter.CalendarFeedSelector)
+	}
+}
+
+// TestClearAllDataResetsCalendarFeedColumns proves a clear-data wipe revokes the
+// feed: both columns are NULLed so a previously-issued feed URL 404s against the
+// freshly emptied account (its selector no longer resolves).
+func TestClearAllDataResetsCalendarFeedColumns(t *testing.T) {
+	repo := openCalendarFeedRepoForTest(t)
+	user := createUserForTimezoneTest(t, repo, "feed-clear@example.com")
+
+	if err := repo.SaveCalendarFeedToken(context.Background(), user.ID, models.CalendarFeedTokenColumns{
+		Selector:     "CLEARSELECT16XXX",
+		VerifierHash: "hash-to-clear",
+	}); err != nil {
+		t.Fatalf("seed token: %v", err)
+	}
+
+	if err := repo.ClearAllDataAndResetSettings(context.Background(), user.ID); err != nil {
+		t.Fatalf("ClearAllDataAndResetSettings: %v", err)
+	}
+
+	got := reloadUserForCalendarFeed(t, repo, user.ID)
+	if got.CalendarFeedSelector != "" || got.CalendarFeedVerifierHash != "" {
+		t.Fatalf("expected feed columns cleared after clear-data, got selector=%q hash=%q", got.CalendarFeedSelector, got.CalendarFeedVerifierHash)
+	}
+	if _, ok, err := repo.FindByCalendarFeedSelector(context.Background(), "CLEARSELECT16XXX"); err != nil || ok {
+		t.Fatalf("expected cleared selector to be not-found after clear-data (ok=%v err=%v)", ok, err)
+	}
+}
+
+// TestCalendarFeedTokenHashAtRestInDBRow proves the persisted verifier_hash row
+// value is a bcrypt hash produced by the service — NOT the shown-once verifier
+// plaintext. The plaintext verifier substring must be absent from the stored
+// column, and the stored hash must verify against the real verifier. This is the
+// end-to-end hash-at-rest check at the persistence boundary, using the real
+// service generator to produce the storables.
+func TestCalendarFeedTokenHashAtRestInDBRow(t *testing.T) {
+	repo := openCalendarFeedRepoForTest(t)
+	user := createUserForTimezoneTest(t, repo, "feed-hashrest@example.com")
+
+	fullToken, selector, verifierHash, err := services.GenerateCalendarFeedToken()
+	if err != nil {
+		t.Fatalf("GenerateCalendarFeedToken: %v", err)
+	}
+	_, verifier, ok := services.SplitCalendarFeedToken(fullToken)
+	if !ok {
+		t.Fatal("expected generated token to split")
+	}
+
+	if err := repo.SaveCalendarFeedToken(context.Background(), user.ID, models.CalendarFeedTokenColumns{
+		Selector:     selector,
+		VerifierHash: verifierHash,
+	}); err != nil {
+		t.Fatalf("SaveCalendarFeedToken: %v", err)
+	}
+
+	got := reloadUserForCalendarFeed(t, repo, user.ID)
+	// The stored hash must not be, or contain, the secret verifier plaintext, and
+	// must not contain the full shown-once token.
+	if got.CalendarFeedVerifierHash == verifier {
+		t.Fatal("stored verifier hash equals the verifier plaintext")
+	}
+	if strings.Contains(got.CalendarFeedVerifierHash, verifier) {
+		t.Fatalf("stored verifier hash %q contains the verifier plaintext", got.CalendarFeedVerifierHash)
+	}
+	if strings.Contains(got.CalendarFeedVerifierHash, fullToken) {
+		t.Fatal("stored verifier hash contains the full token")
+	}
+	// The presented full token verifies against the stored storables end to end.
+	if !services.VerifyCalendarFeedToken(fullToken, got.CalendarFeedSelector, got.CalendarFeedVerifierHash) {
+		t.Fatal("expected the full token to verify against the persisted storables")
+	}
+}

--- a/internal/db/user_repository_calendar_feed_test.go
+++ b/internal/db/user_repository_calendar_feed_test.go
@@ -264,3 +264,29 @@ func TestCalendarFeedTokenHashAtRestInDBRow(t *testing.T) {
 		t.Fatal("expected the full token to verify against the persisted storables")
 	}
 }
+
+// TestFindByCalendarFeedSelectorReturnsErrorOnQueryFailure exercises the
+// non-not-found error branch of FindByCalendarFeedSelector: when the underlying
+// SELECT fails for a reason other than gorm.ErrRecordNotFound (here because the
+// users table has been dropped), the method must propagate the error and report
+// ok=false with a zero user — distinct from the clean "not found" path, which
+// returns a nil error. Mirrors the drop-table technique in
+// TestListAllForNotifyReturnsErrorOnQueryFailure.
+func TestFindByCalendarFeedSelectorReturnsErrorOnQueryFailure(t *testing.T) {
+	repo := openCalendarFeedRepoForTest(t)
+
+	if err := repo.database.Exec("DROP TABLE users").Error; err != nil {
+		t.Fatalf("drop users table: %v", err)
+	}
+
+	user, ok, err := repo.FindByCalendarFeedSelector(context.Background(), "ANYSELECTOR16XXX")
+	if err == nil {
+		t.Fatal("expected FindByCalendarFeedSelector to error when the users table is missing")
+	}
+	if ok {
+		t.Fatal("expected ok=false on a query failure")
+	}
+	if user.ID != 0 {
+		t.Fatalf("expected zero user on a query failure, got id %d", user.ID)
+	}
+}

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -94,4 +94,39 @@ type User struct {
 	// once the predicted event is within this many days of "today". Default 3
 	// matches services.DashboardReminderBannerWindowDays; bounded 0–14 at save.
 	ReminderLeadDays int `gorm:"column:reminder_lead_days;not null;default:3"`
+	// Calendar (.ics) feed subscription token (slice 1: storage only). Backs a
+	// pull-based feed URL whose path carries a bearer capability token; a
+	// calendar client polls it for the owner's own cycle events. Both columns are
+	// empty when the feed is off (the default zero value). This block is storage
+	// only — no endpoint, .ics builder, rate-limit, or settings UI lives here
+	// (later slices).
+	//
+	// The token is split SELECTOR + VERIFIER so a feed request (which carries no
+	// email) resolves the row with one indexed lookup instead of an O(N) bcrypt
+	// scan over every user.
+	//
+	// CalendarFeedSelector is the NON-secret lookup id: high-entropy but it only
+	// NAMES the row, so it is stored in plaintext. A PARTIAL unique index (on
+	// non-empty values, migration 029) enforces cross-owner uniqueness for armed
+	// feeds while letting every feed-off owner share the empty-string zero value.
+	// It is not a credential on its own.
+	CalendarFeedSelector string `gorm:"column:calendar_feed_selector"`
+	// CalendarFeedVerifierHash holds the BCRYPT hash of the secret verifier half,
+	// never the verifier plaintext. The full token (selector+verifier) is shown
+	// to the owner exactly once at generation and is not retrievable afterward,
+	// mirroring the recovery-code shown-once model. Verification looks the row up
+	// by selector, then constant-time bcrypt-compares the verifier; a missing
+	// selector and a wrong verifier both resolve to the same "not found".
+	CalendarFeedVerifierHash string `gorm:"column:calendar_feed_verifier_hash"`
+}
+
+// CalendarFeedTokenColumns is the transport-free narrow payload written by the
+// calendar-feed token write path (slice 1). Selector is the NON-secret,
+// UNIQUE-indexed lookup id; VerifierHash is already a BCRYPT hash — the service
+// hashes the secret verifier before building this struct, so persistence never
+// sees the verifier plaintext. It carries only the two feed-token columns and
+// no security-posture field: writing it must not bump auth_session_version.
+type CalendarFeedTokenColumns struct {
+	Selector     string
+	VerifierHash string
 }

--- a/internal/services/calendar_feed_token.go
+++ b/internal/services/calendar_feed_token.go
@@ -1,0 +1,127 @@
+package services
+
+import (
+	"crypto/subtle"
+
+	"github.com/ovumcy/ovumcy-web/internal/security"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// Calendar (.ics) feed subscription token (slice 1: token generation +
+// verification only). The feed URL path carries a bearer capability token so a
+// calendar client can poll a read-only .ics of the owner's own cycle events.
+//
+// A bearer token in a URL path is a deliberate, owner-approved carve-out to the
+// "no secret in transport" invariant for the feed surface, compensated by
+// hashing-at-rest (the verifier is bcrypt-hashed here, never stored plaintext),
+// one-click revoke, 404-no-oracle, per-IP rate-limit, and log-redaction. Only
+// the hash-at-rest + no-oracle verification live in this slice; the transport
+// compensations land in later slices.
+//
+// The token is SELECTOR + VERIFIER, concatenated with no separator into a
+// fixed-width string:
+//
+//   - selector (calendarFeedSelectorLength chars) is the NON-secret lookup id.
+//     It only NAMES the row: a feed request resolves the single matching user
+//     with one indexed `WHERE calendar_feed_selector = ?` lookup, avoiding an
+//     O(N) bcrypt scan over every user (the feed carries no email to look up
+//     by). It is stored in plaintext and UNIQUE-indexed.
+//   - verifier (calendarFeedVerifierLength chars) is the SECRET. Only its bcrypt
+//     hash is stored; the verifier plaintext is never persisted. The full token
+//     is shown to the owner exactly once at generation, like a recovery code.
+//
+// Both halves draw from calendarFeedTokenAlphabet: 32 unambiguous URL/path-safe
+// characters (the recovery-code alphabet — no I/O/0/1). With a 32-char alphabet
+// each character carries 5 bits, so the 16-char selector is ~80 bits (ample for
+// a non-secret, collision-resistant lookup id) and the 32-char verifier is ~160
+// bits, comfortably above the ≥128-bit secret floor.
+const (
+	// calendarFeedTokenAlphabet is the 32-char unambiguous alphabet shared by the
+	// selector and verifier (identical to the recovery-code alphabet). Every
+	// character is URL/path-safe, so the concatenated token drops straight into a
+	// feed URL path with no escaping.
+	calendarFeedTokenAlphabet = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
+	// calendarFeedSelectorLength is the selector length in characters (~80 bits
+	// over the 32-char alphabet). Non-secret; sized for collision resistance as a
+	// lookup id, not for secrecy.
+	calendarFeedSelectorLength = 16
+	// calendarFeedVerifierLength is the verifier length in characters (~160 bits
+	// over the 32-char alphabet), well above the 128-bit secret floor.
+	calendarFeedVerifierLength = 32
+	// calendarFeedTokenLength is the total length of a well-formed full token.
+	calendarFeedTokenLength = calendarFeedSelectorLength + calendarFeedVerifierLength
+)
+
+// GenerateCalendarFeedToken mints a fresh calendar-feed token. It returns the
+// full shown-once token (selector+verifier, handed to the owner exactly once and
+// never retrievable afterward) alongside the two storables: the plaintext
+// selector (the non-secret lookup id) and the bcrypt hash of the verifier. The
+// verifier plaintext is deliberately NOT returned separately — it exists only
+// inside fullToken — so a caller cannot accidentally persist it. Callers store
+// selector + verifierHash via the repository; on rotation a new call replaces
+// both, invalidating the previous token because the old verifier no longer
+// matches the new hash.
+func GenerateCalendarFeedToken() (fullToken string, selector string, verifierHash string, err error) {
+	selector, err = security.RandomString(calendarFeedSelectorLength, calendarFeedTokenAlphabet)
+	if err != nil {
+		return "", "", "", err
+	}
+	verifier, err := security.RandomString(calendarFeedVerifierLength, calendarFeedTokenAlphabet)
+	if err != nil {
+		return "", "", "", err
+	}
+	hash, err := bcrypt.GenerateFromPassword([]byte(verifier), passwordHashCost)
+	if err != nil {
+		return "", "", "", err
+	}
+	return selector + verifier, selector, string(hash), nil
+}
+
+// SplitCalendarFeedToken splits a full feed token into its selector and verifier
+// halves. It returns ok=false for any token that is not exactly
+// calendarFeedTokenLength characters, so a malformed feed URL is rejected before
+// any DB lookup. The selector half is safe to use as a lookup key; the verifier
+// half is a secret and must only be fed to a constant-time compare.
+func SplitCalendarFeedToken(fullToken string) (selector string, verifier string, ok bool) {
+	if len(fullToken) != calendarFeedTokenLength {
+		return "", "", false
+	}
+	return fullToken[:calendarFeedSelectorLength], fullToken[calendarFeedSelectorLength:], true
+}
+
+// VerifyCalendarFeedToken reports whether a full feed token presented by a
+// request matches the stored selector + verifier hash for a row. It splits the
+// token, constant-time-compares the presented selector against the stored one
+// (defense in depth — the selector is non-secret, but a byte-wise compare avoids
+// even an incidental timing signal), then verifies the verifier half against the
+// stored bcrypt hash with bcrypt.CompareHashAndPassword (inherently
+// constant-time).
+//
+// It is written to give a caller no oracle: a malformed token, a selector
+// mismatch, and a wrong verifier all return false the same way. The intended
+// call site (a later slice) first looks the row up by selector — a missing
+// selector yields no row and the same "not found" outcome — so selector
+// existence, selector correctness, and verifier correctness are indistinguishable
+// to a caller of the feed endpoint.
+//
+// Both comparisons are evaluated unconditionally (the results are combined with a
+// bitwise AND, not a short-circuiting &&) so the bcrypt cost is always paid once a
+// stored hash is present. This keeps the run time independent of whether the
+// selector matched, leaving no timing signal that separates a selector mismatch
+// from a selector-match-plus-verifier-mismatch even when this primitive is called
+// directly (not via the by-selector lookup).
+func VerifyCalendarFeedToken(fullToken string, storedSelector string, storedVerifierHash string) bool {
+	presentedSelector, presentedVerifier, ok := SplitCalendarFeedToken(fullToken)
+	if !ok {
+		return false
+	}
+	if storedSelector == "" || storedVerifierHash == "" {
+		return false
+	}
+	selectorMatch := subtle.ConstantTimeCompare([]byte(presentedSelector), []byte(storedSelector))
+	verifierMatch := 0
+	if bcrypt.CompareHashAndPassword([]byte(storedVerifierHash), []byte(presentedVerifier)) == nil {
+		verifierMatch = 1
+	}
+	return selectorMatch&verifierMatch == 1
+}

--- a/internal/services/calendar_feed_token.go
+++ b/internal/services/calendar_feed_token.go
@@ -64,15 +64,15 @@ const (
 func GenerateCalendarFeedToken() (fullToken string, selector string, verifierHash string, err error) {
 	selector, err = security.RandomString(calendarFeedSelectorLength, calendarFeedAlphabet)
 	if err != nil {
-		return "", "", "", err
+		return "", "", "", err // codecov:ignore -- crypto/rand failure, not reachable in tests
 	}
 	verifier, err := security.RandomString(calendarFeedVerifierLength, calendarFeedAlphabet)
 	if err != nil {
-		return "", "", "", err
+		return "", "", "", err // codecov:ignore -- crypto/rand failure, not reachable in tests
 	}
 	hash, err := bcrypt.GenerateFromPassword([]byte(verifier), passwordHashCost)
 	if err != nil {
-		return "", "", "", err
+		return "", "", "", err // codecov:ignore -- bcrypt only errors on an out-of-range cost
 	}
 	return selector + verifier, selector, string(hash), nil
 }

--- a/internal/services/calendar_feed_token.go
+++ b/internal/services/calendar_feed_token.go
@@ -30,17 +30,17 @@ import (
 //     hash is stored; the verifier plaintext is never persisted. The full token
 //     is shown to the owner exactly once at generation, like a recovery code.
 //
-// Both halves draw from calendarFeedTokenAlphabet: 32 unambiguous URL/path-safe
+// Both halves draw from calendarFeedAlphabet: 32 unambiguous URL/path-safe
 // characters (the recovery-code alphabet — no I/O/0/1). With a 32-char alphabet
 // each character carries 5 bits, so the 16-char selector is ~80 bits (ample for
 // a non-secret, collision-resistant lookup id) and the 32-char verifier is ~160
 // bits, comfortably above the ≥128-bit secret floor.
 const (
-	// calendarFeedTokenAlphabet is the 32-char unambiguous alphabet shared by the
+	// calendarFeedAlphabet is the 32-char unambiguous alphabet shared by the
 	// selector and verifier (identical to the recovery-code alphabet). Every
 	// character is URL/path-safe, so the concatenated token drops straight into a
 	// feed URL path with no escaping.
-	calendarFeedTokenAlphabet = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
+	calendarFeedAlphabet = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
 	// calendarFeedSelectorLength is the selector length in characters (~80 bits
 	// over the 32-char alphabet). Non-secret; sized for collision resistance as a
 	// lookup id, not for secrecy.
@@ -62,11 +62,11 @@ const (
 // both, invalidating the previous token because the old verifier no longer
 // matches the new hash.
 func GenerateCalendarFeedToken() (fullToken string, selector string, verifierHash string, err error) {
-	selector, err = security.RandomString(calendarFeedSelectorLength, calendarFeedTokenAlphabet)
+	selector, err = security.RandomString(calendarFeedSelectorLength, calendarFeedAlphabet)
 	if err != nil {
 		return "", "", "", err
 	}
-	verifier, err := security.RandomString(calendarFeedVerifierLength, calendarFeedTokenAlphabet)
+	verifier, err := security.RandomString(calendarFeedVerifierLength, calendarFeedAlphabet)
 	if err != nil {
 		return "", "", "", err
 	}

--- a/internal/services/calendar_feed_token_test.go
+++ b/internal/services/calendar_feed_token_test.go
@@ -29,7 +29,7 @@ func TestGenerateCalendarFeedTokenRoundTrip(t *testing.T) {
 		t.Fatalf("expected full token %q to start with the selector %q", fullToken, selector)
 	}
 	// Every character must come from the URL/path-safe token alphabet.
-	if strings.Trim(fullToken, calendarFeedTokenAlphabet) != "" {
+	if strings.Trim(fullToken, calendarFeedAlphabet) != "" {
 		t.Fatalf("full token %q contains characters outside the token alphabet", fullToken)
 	}
 	if got := mustBcryptCost(t, verifierHash); got != passwordHashCost {

--- a/internal/services/calendar_feed_token_test.go
+++ b/internal/services/calendar_feed_token_test.go
@@ -1,0 +1,214 @@
+package services
+
+import (
+	"strings"
+	"testing"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+// TestGenerateCalendarFeedTokenRoundTrip proves a freshly generated token
+// verifies against the storables it returns, and pins the shape of the returned
+// values: the full token is selector+verifier at the fixed width, the selector
+// is exactly the first calendarFeedSelectorLength characters of the full token,
+// and the verifier hash is a real bcrypt hash at passwordHashCost (not the
+// verifier plaintext).
+func TestGenerateCalendarFeedTokenRoundTrip(t *testing.T) {
+	fullToken, selector, verifierHash, err := GenerateCalendarFeedToken()
+	if err != nil {
+		t.Fatalf("GenerateCalendarFeedToken() unexpected error: %v", err)
+	}
+
+	if len(fullToken) != calendarFeedTokenLength {
+		t.Fatalf("expected full token length %d, got %d (%q)", calendarFeedTokenLength, len(fullToken), fullToken)
+	}
+	if len(selector) != calendarFeedSelectorLength {
+		t.Fatalf("expected selector length %d, got %d (%q)", calendarFeedSelectorLength, len(selector), selector)
+	}
+	if !strings.HasPrefix(fullToken, selector) {
+		t.Fatalf("expected full token %q to start with the selector %q", fullToken, selector)
+	}
+	// Every character must come from the URL/path-safe token alphabet.
+	if strings.Trim(fullToken, calendarFeedTokenAlphabet) != "" {
+		t.Fatalf("full token %q contains characters outside the token alphabet", fullToken)
+	}
+	if got := mustBcryptCost(t, verifierHash); got != passwordHashCost {
+		t.Fatalf("verifier hash cost = %d, want passwordHashCost (%d)", got, passwordHashCost)
+	}
+
+	if !VerifyCalendarFeedToken(fullToken, selector, verifierHash) {
+		t.Fatal("expected a freshly generated token to verify against its own storables")
+	}
+}
+
+// TestVerifyCalendarFeedTokenRejectsWrongVerifier proves that a token carrying
+// the correct selector but the wrong verifier half fails verification: the
+// verifier is the secret, so a valid selector alone must not authenticate.
+func TestVerifyCalendarFeedTokenRejectsWrongVerifier(t *testing.T) {
+	_, selector, verifierHash, err := GenerateCalendarFeedToken()
+	if err != nil {
+		t.Fatalf("GenerateCalendarFeedToken() unexpected error: %v", err)
+	}
+
+	// Same selector, a different (wrong) verifier of the correct width.
+	wrongVerifier := strings.Repeat("A", calendarFeedVerifierLength)
+	tampered := selector + wrongVerifier
+
+	if VerifyCalendarFeedToken(tampered, selector, verifierHash) {
+		t.Fatal("expected verification to fail for a token with the wrong verifier half")
+	}
+}
+
+// TestVerifyCalendarFeedTokenRejectsWrongSelector proves that a token whose
+// verifier matches the stored hash but whose selector does not equal the stored
+// selector fails verification. The intended call site looks the row up by
+// selector first, so in practice a wrong selector resolves no row; this pins the
+// service's own selector check as defense in depth.
+func TestVerifyCalendarFeedTokenRejectsWrongSelector(t *testing.T) {
+	fullToken, selector, verifierHash, err := GenerateCalendarFeedToken()
+	if err != nil {
+		t.Fatalf("GenerateCalendarFeedToken() unexpected error: %v", err)
+	}
+
+	_, presentedVerifier, ok := SplitCalendarFeedToken(fullToken)
+	if !ok {
+		t.Fatal("expected the generated token to split")
+	}
+	// A different selector than the one whose hash we stored, same real verifier.
+	otherSelector := strings.Repeat("B", calendarFeedSelectorLength)
+	if otherSelector == selector {
+		t.Fatal("test setup: other selector must differ from the real selector")
+	}
+	tampered := otherSelector + presentedVerifier
+
+	if VerifyCalendarFeedToken(tampered, selector, verifierHash) {
+		t.Fatal("expected verification to fail when the presented selector does not match the stored selector")
+	}
+}
+
+// TestVerifyCalendarFeedTokenRejectsMalformedToken proves a token that is not
+// exactly the fixed width is rejected outright (no panic, no partial match), so
+// a truncated or padded feed URL never reaches a verifier compare.
+func TestVerifyCalendarFeedTokenRejectsMalformedToken(t *testing.T) {
+	_, selector, verifierHash, err := GenerateCalendarFeedToken()
+	if err != nil {
+		t.Fatalf("GenerateCalendarFeedToken() unexpected error: %v", err)
+	}
+
+	for _, malformed := range []string{
+		"",
+		"short",
+		selector, // selector only, no verifier
+		strings.Repeat("A", calendarFeedTokenLength-1), // one short
+		strings.Repeat("A", calendarFeedTokenLength+1), // one long
+	} {
+		if VerifyCalendarFeedToken(malformed, selector, verifierHash) {
+			t.Fatalf("expected malformed token %q (len %d) to fail verification", malformed, len(malformed))
+		}
+	}
+}
+
+// TestVerifyCalendarFeedTokenRejectsEmptyStoredColumns proves that when the
+// stored columns are empty (feed off — both columns NULL/empty), no presented
+// token verifies. This guards the "feed off" state against a token whose halves
+// happen to be empty-ish.
+func TestVerifyCalendarFeedTokenRejectsEmptyStoredColumns(t *testing.T) {
+	fullToken, selector, verifierHash, err := GenerateCalendarFeedToken()
+	if err != nil {
+		t.Fatalf("GenerateCalendarFeedToken() unexpected error: %v", err)
+	}
+
+	if VerifyCalendarFeedToken(fullToken, "", verifierHash) {
+		t.Fatal("expected verification to fail when the stored selector is empty")
+	}
+	if VerifyCalendarFeedToken(fullToken, selector, "") {
+		t.Fatal("expected verification to fail when the stored verifier hash is empty")
+	}
+}
+
+// TestGenerateCalendarFeedTokenHashAtRest proves the returned verifier hash is a
+// bcrypt hash of the verifier and NOT the verifier plaintext: the stored value
+// neither equals nor contains the secret verifier substring, and the plaintext
+// verifier does not verify when treated as if it were the stored hash. This is
+// the hash-at-rest invariant — the secret half never lands in a storable field
+// in the clear.
+func TestGenerateCalendarFeedTokenHashAtRest(t *testing.T) {
+	fullToken, selector, verifierHash, err := GenerateCalendarFeedToken()
+	if err != nil {
+		t.Fatalf("GenerateCalendarFeedToken() unexpected error: %v", err)
+	}
+
+	_, verifier, ok := SplitCalendarFeedToken(fullToken)
+	if !ok {
+		t.Fatal("expected the generated token to split")
+	}
+
+	if verifierHash == verifier {
+		t.Fatal("verifier hash must not equal the verifier plaintext")
+	}
+	if strings.Contains(verifierHash, verifier) {
+		t.Fatalf("verifier hash %q must not contain the verifier plaintext", verifierHash)
+	}
+	// The stored hash must not contain the full token or the shown-once verifier.
+	if strings.Contains(verifierHash, fullToken) {
+		t.Fatal("verifier hash must not contain the full token")
+	}
+	// The stored value is a valid bcrypt hash that opens only with the verifier,
+	// never with the selector.
+	if bcrypt.CompareHashAndPassword([]byte(verifierHash), []byte(verifier)) != nil {
+		t.Fatal("expected the stored hash to verify against the real verifier")
+	}
+	if bcrypt.CompareHashAndPassword([]byte(verifierHash), []byte(selector)) == nil {
+		t.Fatal("stored hash must not verify against the selector")
+	}
+}
+
+// TestGenerateCalendarFeedTokenUniquePerCall proves two generations produce
+// distinct selectors and distinct full tokens, so rotating always changes the
+// lookup id (no collision, no reuse of the previous URL).
+func TestGenerateCalendarFeedTokenUniquePerCall(t *testing.T) {
+	firstToken, firstSelector, _, err := GenerateCalendarFeedToken()
+	if err != nil {
+		t.Fatalf("first GenerateCalendarFeedToken(): %v", err)
+	}
+	secondToken, secondSelector, _, err := GenerateCalendarFeedToken()
+	if err != nil {
+		t.Fatalf("second GenerateCalendarFeedToken(): %v", err)
+	}
+
+	if firstSelector == secondSelector {
+		t.Fatal("expected two generations to yield distinct selectors")
+	}
+	if firstToken == secondToken {
+		t.Fatal("expected two generations to yield distinct full tokens")
+	}
+}
+
+// TestRotateCalendarFeedTokenInvalidatesOldToken proves that after a rotation
+// (a fresh generate whose storables replace the previous pair) the OLD full
+// token no longer verifies against the NEW storables — the old verifier does not
+// match the new hash and the old selector does not match the new selector. This
+// is the security core of "rotate revokes the previous URL".
+func TestRotateCalendarFeedTokenInvalidatesOldToken(t *testing.T) {
+	oldToken, oldSelector, oldHash, err := GenerateCalendarFeedToken()
+	if err != nil {
+		t.Fatalf("generate old token: %v", err)
+	}
+	// Sanity: the old token verifies against the old storables before rotation.
+	if !VerifyCalendarFeedToken(oldToken, oldSelector, oldHash) {
+		t.Fatal("old token should verify against the old storables before rotation")
+	}
+
+	newToken, newSelector, newHash, err := GenerateCalendarFeedToken()
+	if err != nil {
+		t.Fatalf("generate new token (rotation): %v", err)
+	}
+
+	// After rotation, only the new token verifies against the new storables.
+	if VerifyCalendarFeedToken(oldToken, newSelector, newHash) {
+		t.Fatal("old token must NOT verify against the rotated (new) storables")
+	}
+	if !VerifyCalendarFeedToken(newToken, newSelector, newHash) {
+		t.Fatal("new token must verify against the rotated (new) storables")
+	}
+}

--- a/migrations/029_calendar_feed_token.sql
+++ b/migrations/029_calendar_feed_token.sql
@@ -1,0 +1,57 @@
+-- Calendar (.ics) feed subscription token (slice 1: token storage only).
+--
+-- Adds the two per-owner columns that back a pull-based calendar-feed
+-- subscription: an owner can generate an opaque feed URL whose path carries a
+-- bearer capability token, and a calendar client polls it for an .ics of the
+-- owner's own predicted/recorded cycle events. Storage ONLY in this slice: no
+-- endpoint, no .ics builder, no rate-limit/404-no-oracle wiring, no settings
+-- UI (later slices).
+--
+-- The feed token is split SELECTOR + VERIFIER so a feed request (which carries
+-- no email to look up by) resolves the row with a single indexed lookup instead
+-- of an O(N) bcrypt scan over every user:
+--
+--   calendar_feed_selector       -- the NON-secret lookup id (high-entropy, but
+--                                  it only NAMES the row). Stored in plaintext by
+--                                  design as it is not a credential on its own,
+--                                  and indexed for the by-selector lookup.
+--   calendar_feed_verifier_hash  -- the bcrypt hash of the SECRET verifier half.
+--                                  The verifier plaintext is NEVER stored. The
+--                                  full token (selector+verifier) is shown to
+--                                  the owner exactly once at generation and is
+--                                  not retrievable afterward, mirroring the
+--                                  recovery-code shown-once model. A feed request
+--                                  supplies both halves in the URL path, and the
+--                                  server looks up by selector then verifies the
+--                                  verifier with a constant-time bcrypt compare.
+--                                  A missing selector and a wrong verifier both
+--                                  resolve to the same "not found" (no oracle).
+--
+-- Feed OFF by default: the model persists an empty string for a fresh/off feed
+-- (a Go string zero value), so the UNIQUE index is PARTIAL -- it covers only
+-- rows whose selector is non-empty. Without the predicate every feed-off row
+-- would share the empty-string key and collide on the second insert. A selector
+-- generated for an armed feed is guaranteed unique across owners so the
+-- by-selector lookup resolves exactly one row.
+--
+-- Governance note: a bearer capability token in a URL path is a deliberate,
+-- owner-approved carve-out to the "no secret in transport" invariant for the
+-- feed surface, compensated by hashing-at-rest (this column), one-click revoke,
+-- 404-no-oracle, per-IP rate-limit, and log-redaction (the compensating
+-- controls land in later slices). The governance/docs edits land in a later
+-- slice once the enforcing tests exist.
+--
+-- The migration runner skips any ADD COLUMN whose column already exists, so this
+-- file is idempotent across clean installs and rolling deploys. Rollback
+-- (forward-only repo) is documented in the commit body, not here.
+--
+-- NOTE: keep prose in this file free of semicolons -- the migration runner
+-- splits statements on the semicolon character without stripping SQL comments,
+-- so a semicolon inside a comment is mis-parsed as a statement boundary.
+
+ALTER TABLE users ADD COLUMN calendar_feed_selector TEXT;
+ALTER TABLE users ADD COLUMN calendar_feed_verifier_hash TEXT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_calendar_feed_selector
+    ON users (calendar_feed_selector)
+    WHERE calendar_feed_selector <> '';

--- a/migrations/postgres/029_calendar_feed_token.sql
+++ b/migrations/postgres/029_calendar_feed_token.sql
@@ -1,0 +1,29 @@
+-- Postgres mirror of migrations/029_calendar_feed_token.sql (calendar .ics feed
+-- subscription token, slice 1: token storage only). Same version number so
+-- schema history stays aligned across engines.
+--
+-- calendar_feed_selector is the NON-secret lookup id, stored in plaintext and
+-- indexed for the by-selector feed lookup. calendar_feed_verifier_hash stores
+-- the bcrypt hash of the SECRET verifier half. The verifier plaintext is NEVER
+-- stored and the full token is shown to the owner exactly once at generation.
+--
+-- The model persists an empty string for a fresh/off feed (a Go string zero
+-- value), so the UNIQUE index is PARTIAL -- it covers only rows whose selector
+-- is non-empty. Without the predicate every feed-off row would share the
+-- empty-string key and collide on the second insert. An armed feed's selector is
+-- unique across owners so the by-selector lookup resolves exactly one row.
+--
+-- ALTER TABLE ADD COLUMN IF NOT EXISTS keeps the migration idempotent across the
+-- postgres test bootstrap and rolling deploys (in addition to the runner's own
+-- already-exists skip). Rollback (forward-only repo) is documented in the commit
+-- body, not here.
+--
+-- NOTE: keep prose in this file free of semicolons -- the migration runner
+-- splits statements on the semicolon character without stripping SQL comments.
+
+ALTER TABLE users ADD COLUMN IF NOT EXISTS calendar_feed_selector TEXT;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS calendar_feed_verifier_hash TEXT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_calendar_feed_selector
+    ON users (calendar_feed_selector)
+    WHERE calendar_feed_selector <> '';


### PR DESCRIPTION
## What & why

Slice 1 of the pull-based calendar (`.ics`) feed subscription that replaces the declined PWA-push issue #126 with a privacy-aligned, self-hostable alternative: an owner generates an opaque feed URL and a calendar client polls it for an `.ics` of **their own** predicted/recorded cycle events.

**This slice builds ONLY the feed capability token storage (hashed at rest).** No endpoint, no `.ics` builder, no rate-limit / 404-no-oracle wiring, no settings UI, and no force-rotate hooks — those are later slices. **Nothing in `internal/api` is touched.**

Layering (strict): **models → db → services** + migrations + tests.

## Token scheme — SELECTOR + VERIFIER (mirrors the recovery-code precedent)

The feed request carries no email to look up by, so an O(N) bcrypt scan over every user is unacceptable. The token is split:

- **selector** — 16 `crypto/rand` chars over the unambiguous recovery-code alphabet (~80 bits). NON-secret lookup id: it only *names* the row, so it is stored in plaintext and used for a single indexed `WHERE calendar_feed_selector = ?` lookup.
- **verifier** — 32 `crypto/rand` chars (~160 bits, above the 128-bit floor). The SECRET. Only its **bcrypt hash** (`passwordHashCost=12`) is stored; the verifier plaintext is **never** persisted. The full token (`selector+verifier`) is returned **once** at generation, shown-once like a recovery code, and is not retrievable afterward.
- **verify** — look the row up by selector, then constant-time `bcrypt.CompareHashAndPassword` the verifier. A missing selector and a wrong verifier both return the same "not found" (no oracle). Both comparisons run unconditionally so the bcrypt cost is always paid once a hash is present — no selector-vs-verifier timing signal even when the primitive is called directly.

## Governance carve-out (owner-approved)

A bearer token in the URL path is a deliberate, approved exception to the **"no secret in transport"** invariant for the feed surface, compensated by **hashing-at-rest (this slice)** + one-click revoke + 404-no-oracle + per-IP rate-limit + log-redaction. The compensating controls and the governance/docs/openapi edits land in **later slices, once their enforcing tests exist** (per the plan).

## Migration number coordination

Uses migration **029**. Current max on `origin/main` is **027**. Migration **028** is reserved for the parallel built-in-scheduler PR **#125** (`app_state` table), which is **not yet merged** to `origin/main`, so this PR **skips 028** to avoid a number collision. If #125 merges first, no change is needed here — 029 stays free.

## Notes on the schema

- The `UNIQUE` index on `calendar_feed_selector` is **PARTIAL** (`WHERE calendar_feed_selector <> ''`): the model persists the empty-string zero value for a feed-off owner, so a plain unique index would reject the second feed-off insert. The partial predicate lets every feed-off owner coexist while keeping armed selectors unique across owners.
- Both columns live on `users`, so account deletion removes them with the row (no change to `DeleteAccountAndRelatedData`). `ClearAllDataAndResetSettings` revokes the feed (NULLs both columns) — the data-reset arm of the approved force-rotate-on-recovery rule.
- Migration prose avoids semicolons: the runner splits statements on `;` without stripping SQL comments.

## Tests (security core)

generate→verify round-trip; **wrong verifier fails**; wrong selector fails; malformed/empty token rejected; **hash-at-rest** (stored value is bcrypt at cost 12, and the plaintext verifier substring is absent from the persisted DB row); **rotate invalidates the old token**; clear-data clears the columns; per-owner scoping; by-selector lookup miss is not-found. `migrations_bootstrap_test` asserts both columns on **clean + legacy** DBs (both engines via the shared helper) and the partial unique index on SQLite. All test token strings are fakes — never a real secret.

## Validation

- `go build` / `go vet` / `gofmt` clean.
- `golangci-lint` **v2.12.2** — **0 issues** (`for i := range n`, zero `//nolint`).
- Both-engine migration bootstrap: SQLite **and** Docker Postgres green.
- Fresh, cache-defeating patch-coverage gate (`bash scripts/patch-coverage-local.sh`, from #172): **gate OK — every modified coverable line covered**.

## Rollback (forward-only repo; documented per persistence rule)

```sql
DROP INDEX idx_users_calendar_feed_selector;
ALTER TABLE users DROP COLUMN calendar_feed_verifier_hash;
ALTER TABLE users DROP COLUMN calendar_feed_selector;
```
