### PR TITLE
test(api): kill auth-token/session mutation survivors

### DIFF
--- a/internal/api/auth_recovery_pickup_cookie_mutation_test.go
+++ b/internal/api/auth_recovery_pickup_cookie_mutation_test.go
@@ -1,0 +1,251 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/ovumcy/ovumcy-web/internal/models"
+)
+
+// This file hardens the register-pickup and recovery-code page cookie helpers
+// (register_pickup_cookie.go, recovery_code_page_cookie.go) and the recovery-code
+// render helpers (handlers_auth_session_helpers.go) against surviving mutants
+// from gremlins baseline run 28758365493.
+
+const recoveryCookieMutationSecret = "0123456789abcdef0123456789abcdef"
+
+// TestEncodePickupExpiryHexAcceptsUnixEpoch pins the lower boundary of
+// encodePickupExpiryHex's `if nanos < 0` guard (register_pickup_cookie.go L116).
+// The CONDITIONALS_BOUNDARY mutant widens it to `<= 0`, which would reject an
+// expiry that lands exactly on the unix epoch (nanos == 0) even though 0 is a
+// valid, representable timestamp. The epoch is the only value that separates the
+// two predicates.
+func TestEncodePickupExpiryHexAcceptsUnixEpoch(t *testing.T) {
+	t.Parallel()
+
+	encoded, err := encodePickupExpiryHex(time.Unix(0, 0).UTC())
+	if err != nil {
+		t.Fatalf("encodePickupExpiryHex(epoch) must succeed for nanos == 0, got error: %v", err)
+	}
+	if encoded != "0000000000000000" {
+		t.Fatalf("encodePickupExpiryHex(epoch) = %q, want the zero-padded hex of 0", encoded)
+	}
+}
+
+// TestDecodePickupExpiryAcceptsUnixEpoch pins the matching boundary on the
+// decode side (register_pickup_cookie.go L134). `if nanos < 0` widened to
+// `<= 0` would reject the encoded epoch ("0000000000000000") that
+// encodePickupExpiryHex legitimately produces, breaking the encode/decode
+// symmetry at the boundary value.
+func TestDecodePickupExpiryAcceptsUnixEpoch(t *testing.T) {
+	t.Parallel()
+
+	decoded, err := decodePickupExpiry("0000000000000000")
+	if err != nil {
+		t.Fatalf("decodePickupExpiry(epoch hex) must succeed for nanos == 0, got error: %v", err)
+	}
+	if !decoded.Equal(time.Unix(0, 0).UTC()) {
+		t.Fatalf("decodePickupExpiry(epoch hex) = %s, want the unix epoch", decoded)
+	}
+}
+
+// TestRecoveryCodeIssuanceCookieCarriesFutureExpiry pins the recovery-code
+// cookie lifetime (recovery_code_page_cookie.go L13, `20 * time.Minute`). The
+// ARITHMETIC_BASE mutant rewrites `*` to `/`, collapsing the const to 0, so the
+// cookie would be written with an Expires at (or before) now and the browser
+// would drop it immediately — the user could never read their recovery code.
+// Asserting the Set-Cookie expiry is comfortably in the future fails under the
+// collapsed TTL.
+func TestRecoveryCodeIssuanceCookieCarriesFutureExpiry(t *testing.T) {
+	t.Parallel()
+
+	handler := &Handler{
+		secretKey:    []byte(recoveryCookieMutationSecret),
+		cookieSecure: true,
+	}
+
+	app := fiber.New()
+	app.Get("/seal", func(c fiber.Ctx) error {
+		if err := handler.setRecoveryCodeIssuanceCookie(c, 42, "OVUM-EXPIRY-CODE0", "/dashboard", recoveryCodeSurfaceDedicated); err != nil {
+			t.Fatalf("seal recovery cookie: %v", err)
+		}
+		return c.SendStatus(fiber.StatusNoContent)
+	})
+
+	before := time.Now()
+	response, err := app.Test(httptest.NewRequest(http.MethodGet, "/seal", nil), testConfigNoTimeout)
+	if err != nil {
+		t.Fatalf("seal request: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+
+	cookie := responseCookie(response.Cookies(), recoveryCodeCookieName)
+	if cookie == nil {
+		t.Fatal("expected a recovery-code Set-Cookie in the response")
+	}
+	if cookie.Expires.IsZero() {
+		t.Fatal("recovery-code cookie must carry an explicit expiry, not a session cookie")
+	}
+	// A live 20-minute TTL lands well beyond a couple of minutes from now; a
+	// collapsed (zero) TTL lands at ~before, i.e. already in the past by the
+	// time the browser sees it.
+	if !cookie.Expires.After(before.Add(2 * time.Minute)) {
+		t.Fatalf("recovery-code cookie expiry %s is not meaningfully in the future (issued around %s); TTL collapsed", cookie.Expires, before)
+	}
+}
+
+// TestRecoveryCodeDisplayStateRejectsForeignUserID pins the ownership-scoping
+// guard in readRecoveryCodeDisplayState (recovery_code_page_cookie.go L145,
+// `payload.UserID != 0 && userID != 0 && payload.UserID != userID`). The
+// CONDITIONALS_NEGATION mutant on the first operand (`payload.UserID == 0`)
+// short-circuits the whole conjunction to false for any real (non-zero) cookie
+// owner, so the guard never clears the cookie and one owner's recovery code
+// leaks to a different authenticated owner. Sealing for owner A and reading as
+// owner B must yield the empty fallback.
+//
+// This also pins handlers_auth_session_helpers.go L73 (`if user != nil { userID
+// = user.ID }`): the render helper stamps the issuing owner's id into the
+// cookie via that branch. If it is skipped (userID left 0), the scoping check
+// above cannot bind the cookie to an owner, and the same cross-owner read
+// succeeds. The render-driven variant below exercises that path end to end.
+func TestRecoveryCodeDisplayStateRejectsForeignUserID(t *testing.T) {
+	t.Parallel()
+
+	const ownerA = uint(101)
+	const ownerB = uint(202)
+
+	handler := &Handler{
+		secretKey:    []byte(recoveryCookieMutationSecret),
+		cookieSecure: true,
+	}
+
+	app := fiber.New()
+	app.Get("/seal", func(c fiber.Ctx) error {
+		if err := handler.setRecoveryCodeIssuanceCookie(c, ownerA, "OVUM-SCOPE-CODE00", "/dashboard", recoveryCodeSurfaceDedicated); err != nil {
+			t.Fatalf("seal recovery cookie for owner A: %v", err)
+		}
+		return c.SendStatus(fiber.StatusNoContent)
+	})
+	app.Get("/open", func(c fiber.Ctx) error {
+		// Owner B reads the cookie owner A was issued.
+		state := handler.readRecoveryCodeDisplayState(c, ownerB, "/dashboard")
+		if state.RecoveryCode != "" {
+			t.Fatalf("owner B must not see owner A's recovery code; got %q", state.RecoveryCode)
+		}
+		return c.SendStatus(fiber.StatusNoContent)
+	})
+
+	sealResponse, err := app.Test(httptest.NewRequest(http.MethodGet, "/seal", nil), testConfigNoTimeout)
+	if err != nil {
+		t.Fatalf("seal request: %v", err)
+	}
+	defer func() { _ = sealResponse.Body.Close() }()
+
+	cookieValue := responseCookieValue(sealResponse.Cookies(), recoveryCodeCookieName)
+	if cookieValue == "" {
+		t.Fatal("expected sealed recovery cookie for owner A in response")
+	}
+
+	openRequest := httptest.NewRequest(http.MethodGet, "/open", nil)
+	openRequest.Header.Set("Cookie", recoveryCodeCookieName+"="+cookieValue)
+	openResponse, err := app.Test(openRequest, testConfigNoTimeout)
+	if err != nil {
+		t.Fatalf("open request: %v", err)
+	}
+	defer func() { _ = openResponse.Body.Close() }()
+}
+
+// TestRenderRecoveryCodeResponseStampsIssuingUser drives renderRecoveryCodeResponse
+// through a test route and asserts both render-helper branches in
+// handlers_auth_session_helpers.go:
+//
+//   - L61 `if user != nil { continuePath = services.PostLoginRedirectPath(user) }`:
+//     a not-yet-onboarded owner routes the recovery-code continue path to
+//     /onboarding rather than the /dashboard default. The CONDITIONALS_NEGATION
+//     mutant (`user == nil`) keeps the default, so the persisted ContinueTarget
+//     drops from onboarding to dashboard.
+//   - L73 `if user != nil { userID = user.ID }`: the issuing owner's id is
+//     stamped into the cookie, which the sibling scoping test relies on. Reading
+//     the cookie back as that same owner recovers the code; the ContinueTarget
+//     assertion below observes L61.
+func TestRenderRecoveryCodeResponseStampsIssuingUser(t *testing.T) {
+	t.Parallel()
+
+	handler := &Handler{
+		secretKey:    []byte(recoveryCookieMutationSecret),
+		cookieSecure: true,
+		location:     time.UTC,
+	}
+
+	const issuingOwner = uint(303)
+	const foreignOwner = uint(404)
+	// A not-yet-onboarded owner: PostLoginRedirectPath -> /onboarding.
+	pendingOwner := &models.User{
+		ID:                  issuingOwner,
+		Email:               "recovery-render-onboarding@example.com",
+		PasswordHash:        "test-hash",
+		LocalAuthEnabled:    true,
+		Role:                models.RoleOwner,
+		OnboardingCompleted: false,
+		CreatedAt:           time.Now().UTC(),
+	}
+
+	app := fiber.New()
+	app.Get("/render", func(c fiber.Ctx) error {
+		return handler.renderRecoveryCodeResponse(c, pendingOwner, "OVUM-RENDER-CODE0", fiber.StatusOK)
+	})
+	app.Get("/open", func(c fiber.Ctx) error {
+		// Read as the issuing owner: recovers the code, and reflects the
+		// onboarding continue target chosen at render time (L61).
+		state := handler.readRecoveryCodeDisplayState(c, issuingOwner, "/dashboard")
+		if state.RecoveryCode != "OVUM-RENDER-CODE0" {
+			t.Fatalf("issuing owner must recover the rendered code, got %q", state.RecoveryCode)
+		}
+		if state.ContinueTarget != recoveryCodeContinueTargetOnboarding {
+			t.Fatalf("expected onboarding continue target from PostLoginRedirectPath(pending owner), got %q", state.ContinueTarget)
+		}
+		if state.ContinuePath != "/onboarding" {
+			t.Fatalf("expected /onboarding continue path, got %q", state.ContinuePath)
+		}
+		return c.SendStatus(fiber.StatusNoContent)
+	})
+	app.Get("/open-foreign", func(c fiber.Ctx) error {
+		// A different owner must NOT recover the code the render helper stamped
+		// with the issuing owner's id (L73 stamps user.ID; L145 enforces it).
+		state := handler.readRecoveryCodeDisplayState(c, foreignOwner, "/dashboard")
+		if state.RecoveryCode != "" {
+			t.Fatalf("foreign owner must not recover the issuing owner's rendered code, got %q", state.RecoveryCode)
+		}
+		return c.SendStatus(fiber.StatusNoContent)
+	})
+
+	renderResponse, err := app.Test(httptest.NewRequest(http.MethodGet, "/render", nil), testConfigNoTimeout)
+	if err != nil {
+		t.Fatalf("render request: %v", err)
+	}
+	defer func() { _ = renderResponse.Body.Close() }()
+
+	cookieValue := responseCookieValue(renderResponse.Cookies(), recoveryCodeCookieName)
+	if cookieValue == "" {
+		t.Fatal("expected renderRecoveryCodeResponse to set the recovery-code cookie")
+	}
+
+	openRequest := httptest.NewRequest(http.MethodGet, "/open", nil)
+	openRequest.Header.Set("Cookie", recoveryCodeCookieName+"="+cookieValue)
+	openResponse, err := app.Test(openRequest, testConfigNoTimeout)
+	if err != nil {
+		t.Fatalf("open request: %v", err)
+	}
+	defer func() { _ = openResponse.Body.Close() }()
+
+	foreignRequest := httptest.NewRequest(http.MethodGet, "/open-foreign", nil)
+	foreignRequest.Header.Set("Cookie", recoveryCodeCookieName+"="+cookieValue)
+	foreignResponse, err := app.Test(foreignRequest, testConfigNoTimeout)
+	if err != nil {
+		t.Fatalf("open-foreign request: %v", err)
+	}
+	defer func() { _ = foreignResponse.Body.Close() }()
+}

--- a/internal/api/auth_reset_pickup_flow_mutation_test.go
+++ b/internal/api/auth_reset_pickup_flow_mutation_test.go
@@ -1,0 +1,103 @@
+package api
+
+import (
+	"bytes"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+// This file hardens two auth-flow decisions against surviving mutants from
+// gremlins baseline run 28758365493:
+//   - handlers_auth_session_recovery.go L98: clearing the reset cookie only on
+//     an invalid-reset-token completion error;
+//   - handlers_auth_session_register_pickup.go L161: emitting the
+//     redirect_signin security event with its reason on a failed pickup.
+
+// TestResetPasswordClearsCookieOnInvalidResetToken pins the L98 guard
+// `if spec.Key == "invalid reset token" { handler.clearResetPasswordCookie(c) }`.
+// A tampered reset token maps to the invalid-reset-token spec, so the stale
+// sealed cookie must be actively cleared (Set-Cookie with an empty value and a
+// past expiry) rather than left on the browser to be retried. The
+// CONDITIONALS_NEGATION mutant flips the comparison to `!=`, which skips the
+// clear for exactly the invalid-token case, leaving the dead cookie in place.
+func TestResetPasswordClearsCookieOnInvalidResetToken(t *testing.T) {
+	app, database := newOnboardingTestApp(t)
+	user := createOnboardingTestUser(t, database, "reset-invalid-clears-cookie@example.com", "StrongPass1", true)
+
+	validToken := mustSignResetTokenForTest(t, user.ID, user.PasswordHash, time.Now().Add(10*time.Minute), time.Now())
+	tamperedToken := mustTamperResetTokenSignatureForTest(t, validToken)
+	resetCookieValue := mustSealResetCookieValueForTest(t, []byte("test-secret-key"), tamperedToken, false)
+
+	request := httptest.NewRequest(http.MethodPost, "/api/v1/password-resets/redeem", strings.NewReader(url.Values{
+		"password":         {"EvenStronger2"},
+		"confirm_password": {"EvenStronger2"},
+	}.Encode()))
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	request.Header.Set("Cookie", resetPasswordCookieName+"="+resetCookieValue)
+
+	response, err := app.Test(request, testConfigNoTimeout)
+	if err != nil {
+		t.Fatalf("reset-password request failed: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+
+	if response.StatusCode != http.StatusSeeOther {
+		t.Fatalf("expected status 303, got %d", response.StatusCode)
+	}
+
+	cleared := responseCookie(response.Cookies(), resetPasswordCookieName)
+	if cleared == nil {
+		t.Fatal("invalid reset token must clear the reset cookie; no Set-Cookie for it was emitted")
+	}
+	if strings.TrimSpace(cleared.Value) != "" {
+		t.Fatalf("cleared reset cookie must carry an empty value, got %q", cleared.Value)
+	}
+	if !cleared.Expires.IsZero() && cleared.Expires.After(time.Now()) {
+		t.Fatalf("cleared reset cookie must expire in the past, got expiry %s", cleared.Expires)
+	}
+}
+
+// TestRegisterPickupFailureLogsRedirectSigninReason pins the L161 guard
+// `if reason != "" { handler.logSecurityEvent(c, "auth.register_pickup",
+// "redirect_signin", ...reason) }`. A pickup attempt with no cookie routes
+// through redirectToPostRegisterSignin(c, "missing_or_expired"), which must emit
+// the redirect_signin security event carrying that reason so operators can see
+// why sessions bounce back to /login. The CONDITIONALS_NEGATION mutant flips the
+// guard to `reason == ""`, suppressing the event for every real (non-empty)
+// reason. Asserting the event is present fails under that mutation.
+func TestRegisterPickupFailureLogsRedirectSigninReason(t *testing.T) {
+	originalWriter := log.Writer()
+	defer log.SetOutput(originalWriter)
+	var output bytes.Buffer
+	log.SetOutput(&output)
+
+	app, _ := newOnboardingTestAppWithOptions(t, onboardingTestAppOptions{auditLogEnabled: true})
+
+	// No pickup cookie -> redirectToPostRegisterSignin(c, "missing_or_expired").
+	request := httptest.NewRequest(http.MethodGet, "/register/welcome", nil)
+	response, err := app.Test(request, testConfigNoTimeout)
+	if err != nil {
+		t.Fatalf("register-welcome request failed: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+
+	if response.StatusCode != http.StatusSeeOther {
+		t.Fatalf("expected status 303, got %d", response.StatusCode)
+	}
+	if location := response.Header.Get("Location"); location != "/login" {
+		t.Fatalf("expected redirect to /login, got %q", location)
+	}
+
+	logged := output.String()
+	if !strings.Contains(logged, `action="auth.register_pickup"`) || !strings.Contains(logged, `outcome="redirect_signin"`) {
+		t.Fatalf("expected a register_pickup redirect_signin security event, got %q", logged)
+	}
+	if !strings.Contains(logged, `reason="missing_or_expired"`) {
+		t.Fatalf("expected the redirect_signin event to carry its reason, got %q", logged)
+	}
+}

--- a/internal/api/handlers_auth_token_helpers_mutation_test.go
+++ b/internal/api/handlers_auth_token_helpers_mutation_test.go
@@ -1,0 +1,186 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"log"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/db"
+	"github.com/ovumcy/ovumcy-web/internal/services"
+)
+
+// This file hardens the auth-token / session helpers in
+// handlers_auth_token_helpers.go against the surviving mutants reported by the
+// weekly gremlins run (baseline run 28758365493, internal_api shard map).
+//
+// The behavior under test is the OIDC logout-state rotation performed when a
+// credential change re-issues the auth cookie (refreshCurrentSession ->
+// setAuthCookie -> rotateOIDCLogoutState): the provider logout state keyed on
+// the retiring session id must move to the freshly minted session id so the
+// originating device can still complete provider logout, while every stale
+// session is invalidated by the auth_session_version bump. Each guard in
+// rotateOIDCLogoutState is a decision on that move, and the mutants flip those
+// decisions; the round-trip assertions below observe the move at the store.
+
+// validRotationLogoutState returns a fully-formed provider logout state that
+// passes validOIDCLogoutState, so rotateOIDCLogoutState follows the Save/Delete
+// arm rather than the invalid-state Delete-only arm.
+func validRotationLogoutState() services.OIDCLogoutState {
+	return services.OIDCLogoutState{
+		EndSessionEndpoint:    "https://idp.example.com/logout",
+		IDTokenHint:           "eyJhbGciOiJSUzI1NiJ9.header.signature",
+		PostLogoutRedirectURL: "https://app.example.com/",
+	}
+}
+
+// TestRotateOIDCLogoutStateMovesStateToNewSessionOnPasswordChange drives a real
+// password change on a session that owns a stored provider logout state and
+// asserts the state is re-keyed from the retiring session id to the new one.
+//
+// Kills the rotation-decision mutants in rotateOIDCLogoutState:
+//   - L63 `handler == nil` / `oidcLogoutStateSvc == nil` negation (both would
+//     early-return nil and skip the move),
+//   - L68 `newSessionID == ""` negation,
+//   - L73 `!ok || currentSession == nil` negation,
+//   - L78 `oldSessionID == "" || oldSessionID == newSessionID` negation (both
+//     operands),
+//   - L83 `err != nil || !found` negation on the Load result.
+//
+// Under any of those negations the Save at the new session id never happens, so
+// Load(newSessionID) comes back not-found and the assertion fails.
+func TestRotateOIDCLogoutStateMovesStateToNewSessionOnPasswordChange(t *testing.T) {
+	ctx := newSettingsSecurityTestContext(t, "token-rotate-move@example.com")
+
+	oldSessionID := mustExtractAuthSessionIDFromCookieHeader(t, ctx.authCookie)
+	stateService := services.NewOIDCLogoutStateService(db.NewRepositories(ctx.database).OIDCLogout)
+	if err := stateService.Save(context.Background(), oldSessionID, validRotationLogoutState(), time.Now().UTC()); err != nil {
+		t.Fatalf("seed logout state for old session: %v", err)
+	}
+
+	response := settingsFormRequestWithCSRF(t, ctx, http.MethodPut, "/api/v1/users/current/password", url.Values{
+		"current_password": {"StrongPass1"},
+		"new_password":     {"EvenStronger2"},
+		"confirm_password": {"EvenStronger2"},
+	}, map[string]string{"Accept": "application/json"})
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK && response.StatusCode != http.StatusSeeOther {
+		t.Fatalf("change-password status = %d, want 200 or 303", response.StatusCode)
+	}
+
+	refreshed := responseCookie(response.Cookies(), authCookieName)
+	if refreshed == nil || strings.TrimSpace(refreshed.Value) == "" {
+		t.Fatal("change-password must reissue ovumcy_auth so the originating session survives")
+	}
+	newSessionID := mustExtractAuthSessionIDFromCookieHeader(t, refreshed.Name+"="+refreshed.Value)
+	if newSessionID == oldSessionID {
+		t.Fatalf("expected a fresh session id after refresh, got the retiring id %q", newSessionID)
+	}
+
+	movedState, found, err := stateService.Load(context.Background(), newSessionID, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("load logout state for new session: %v", err)
+	}
+	if !found {
+		t.Fatal("logout state was not rotated onto the new session id; rotateOIDCLogoutState did not move it")
+	}
+	if movedState.EndSessionEndpoint != validRotationLogoutState().EndSessionEndpoint {
+		t.Fatalf("rotated logout state end_session_endpoint = %q, want %q", movedState.EndSessionEndpoint, validRotationLogoutState().EndSessionEndpoint)
+	}
+
+	staleState, staleFound, err := stateService.Load(context.Background(), oldSessionID, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("load logout state for old session: %v", err)
+	}
+	if staleFound {
+		t.Fatalf("retiring session id must not keep a logout state after rotation, got %#v", staleState)
+	}
+}
+
+// TestRefreshCurrentSessionDoesNotLogRotationFailureOnSuccess pins the L110
+// contract: a successful refresh whose rotation succeeds must NOT emit the
+// `provider_logout_state_rotation_failed` security event. The mutant negates
+// `if err := rotateOIDCLogoutState(...); err != nil` to `== nil`, which would
+// log the failure on every successful rotation. Asserting the log's absence on
+// the happy path fails under that mutation.
+func TestRefreshCurrentSessionDoesNotLogRotationFailureOnSuccess(t *testing.T) {
+	originalWriter := log.Writer()
+	defer log.SetOutput(originalWriter)
+	var output bytes.Buffer
+	log.SetOutput(&output)
+
+	ctx := newSettingsSecurityTestContextWithOptions(t, "token-rotate-nolog@example.com", onboardingTestAppOptions{enableCSRF: true, auditLogEnabled: true})
+
+	oldSessionID := mustExtractAuthSessionIDFromCookieHeader(t, ctx.authCookie)
+	stateService := services.NewOIDCLogoutStateService(db.NewRepositories(ctx.database).OIDCLogout)
+	if err := stateService.Save(context.Background(), oldSessionID, validRotationLogoutState(), time.Now().UTC()); err != nil {
+		t.Fatalf("seed logout state for old session: %v", err)
+	}
+
+	response := settingsFormRequestWithCSRF(t, ctx, http.MethodPut, "/api/v1/users/current/password", url.Values{
+		"current_password": {"StrongPass1"},
+		"new_password":     {"EvenStronger2"},
+		"confirm_password": {"EvenStronger2"},
+	}, map[string]string{"Accept": "application/json"})
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK && response.StatusCode != http.StatusSeeOther {
+		t.Fatalf("change-password status = %d, want 200 or 303", response.StatusCode)
+	}
+
+	// Rotation succeeded (asserted structurally by the sibling test); on this
+	// success path the failure event must be absent.
+	if strings.Contains(output.String(), "provider_logout_state_rotation_failed") {
+		t.Fatalf("successful refresh must not log a rotation failure, got %q", output.String())
+	}
+	// Guard: the audit stream is actually flowing, so the assertion above is a
+	// real observation and not a silently-empty buffer.
+	if !strings.Contains(output.String(), `action="auth.password_change"`) {
+		t.Fatalf("expected the password-change audit event to be emitted, got %q", output.String())
+	}
+}
+
+// TestBuildTokenWithSessionIDKeepsCallerTTL pins the positive-TTL contract of
+// buildTokenWithSessionID's `if ttl <= 0` clamp (L56). The CONDITIONALS_NEGATION
+// mutant turns it into `if ttl > 0`, which overrides a caller's explicit
+// positive TTL with defaultAuthTokenTTL (7d). Building a token with a 1h TTL and
+// asserting the parsed expiry stays ~1h (well under a day) fails under that
+// mutation.
+//
+// The paired BOUNDARY mutant (`<=` -> `<`) is documented as equivalent in the
+// PR body: it only changes behavior at ttl == 0, and there the inner clamp in
+// services.BuildAuthSessionTokenWithVersionAndSessionID (also 7d) yields the
+// identical expiry whether or not the outer clamp fires.
+func TestBuildTokenWithSessionIDKeepsCallerTTL(t *testing.T) {
+	t.Parallel()
+
+	handler, database := newDataAccessTestHandler(t)
+	user := createDataAccessTestUser(t, database, "token-ttl-keep@example.com")
+
+	issuedAt := time.Now()
+	token, sessionID, err := handler.buildTokenWithSessionID(&user, time.Hour)
+	if err != nil {
+		t.Fatalf("buildTokenWithSessionID returned error: %v", err)
+	}
+	if strings.TrimSpace(sessionID) == "" {
+		t.Fatal("expected a non-empty session id")
+	}
+
+	claims, err := services.ParseAuthSessionToken(handler.secretKey, token, issuedAt)
+	if err != nil {
+		t.Fatalf("parse issued auth token: %v", err)
+	}
+	if claims.ExpiresAt == nil {
+		t.Fatal("expected an expiry claim on the issued token")
+	}
+
+	lifetime := claims.ExpiresAt.Sub(issuedAt)
+	// A caller TTL of 1h must be honored; anything at or beyond a day means the
+	// clamp overrode a positive TTL with the multi-day default.
+	if lifetime <= 0 || lifetime >= 24*time.Hour {
+		t.Fatalf("issued token lifetime = %s, want ~1h (caller TTL honored, not clamped to the default)", lifetime)
+	}
+}


### PR DESCRIPTION
## What

Mutation-hardening for the **auth-token / session** cluster of `internal/api`, continuing the
saturation work from #177. Test-only: three new `*_mutation_test.go` files, **zero production
changes**. Targets the surviving/not-covered mutants for this cluster from the weekly gremlins
baseline (run 28758365493, `internal_api` shard map).

Cluster files (auth-token/session/login handlers + the session-pickup/recovery-code cookies).
The sealed-cookie **codec** files (`oidc_*_cookie.go`, `totp_cookies.go`, `reset_password_cookie.go`,
`flash.go`) are a separate cluster and are untouched here.

## Distinct survivors in this cluster: 28 (23 LIVED + 5 NOT-COVERED)

**19 killed** (behavior tests, each proven by per-mutant faulting: apply mutation -> the new
assertion fails -> revert):

| File | Line | Mutant | Killed by |
|---|---|---|---|
| handlers_auth_token_helpers.go | 56 | `ttl <= 0` NEGATION (`> 0`) | `TestBuildTokenWithSessionIDKeepsCallerTTL` |
| handlers_auth_token_helpers.go | 63 | `handler == nil` NEGATION | `TestRotateOIDCLogoutStateMovesStateToNewSessionOnPasswordChange` |
| handlers_auth_token_helpers.go | 63 | `oidcLogoutStateSvc == nil` NEGATION | (same) |
| handlers_auth_token_helpers.go | 68 | `newSessionID == ""` NEGATION | (same) |
| handlers_auth_token_helpers.go | 73 | `currentSession == nil` NEGATION | (same) |
| handlers_auth_token_helpers.go | 78 | `oldSessionID == ""` NEGATION | (same) |
| handlers_auth_token_helpers.go | 78 | `oldSessionID == newSessionID` NEGATION | (same) |
| handlers_auth_token_helpers.go | 83 | `err != nil` NEGATION | (same) |
| handlers_auth_token_helpers.go | 110 | `err != nil` NEGATION (rotate result) | `TestRefreshCurrentSessionDoesNotLogRotationFailureOnSuccess` |
| register_pickup_cookie.go | 116 | `nanos < 0` BOUNDARY (`<= 0`) | `TestEncodePickupExpiryHexAcceptsUnixEpoch` |
| register_pickup_cookie.go | 134 | `nanos < 0` BOUNDARY (`<= 0`) | `TestDecodePickupExpiryAcceptsUnixEpoch` |
| recovery_code_page_cookie.go | 13 | `20 * time.Minute` ARITHMETIC (`/`) | `TestRecoveryCodeIssuanceCookieCarriesFutureExpiry` |
| recovery_code_page_cookie.go | 145 | `payload.UserID != 0` NEGATION (IDOR scope) | `TestRecoveryCodeDisplayStateRejectsForeignUserID` |
| handlers_auth_session_helpers.go | 61 | `user != nil` NEGATION (continue path) | `TestRenderRecoveryCodeResponseStampsIssuingUser` |
| handlers_auth_session_helpers.go | 73 | `user != nil` NEGATION (stamp userID) | (same, cross-owner arm) |
| handlers_auth_session_recovery.go | 98 | `spec.Key == "invalid reset token"` NEGATION | `TestResetPasswordClearsCookieOnInvalidResetToken` |
| handlers_auth_session_register_pickup.go | 161 | `reason != ""` NEGATION (audit event) | `TestRegisterPickupFailureLogsRedirectSigninReason` |
| handlers_auth_oidc.go | 13 | `10 * time.Second` ARITHMETIC (`/`), NOT-COVERED | already killed by existing `assertOIDCDeadline` |
| register_pickup_cookie.go | 20 | `5 * time.Minute` ARITHMETIC (`/`), NOT-COVERED | already killed by existing `TestNewRegisterPickupPayloadShape` |

Two NOT-COVERED mutants (`handlers_auth_oidc.go` L13, `register_pickup_cookie.go` L20) sit on
`const = N * time.Unit` declaration lines. Go's coverage profile never attributes const-declaration
lines to any test, so gremlins reports them NOT-COVERED and skips them — a coverage-attribution
artifact, not a test gap. Both are in fact killed by existing assertions (verified by faulting
`* -> /` and watching those suites fail): `assertOIDCDeadline` pins the OIDC context deadline to
`[5s,15s]`, and `TestNewRegisterPickupPayloadShape` asserts `validAt(now)` on a freshly-built pickup
payload. No new test added; documented here for the record.

**6 equivalent** (mutation cannot change observable behavior — documented, not force-killed):

- `handlers_auth_session_login.go` L84, `handlers_auth_oidc.go` L89,
  `handlers_auth_session_recovery.go` L50, `handlers_auth_oidc_link_confirm.go` L140 — all
  `30 * time.Minute` reset-token TTLs. ARITHMETIC `* -> /` collapses the value to 0, and the service
  clamps it right back: `services.BuildPasswordResetToken` starts with `if ttl <= 0 { ttl = 30 *
  time.Minute }` (auth_reset_policy.go). The issued token is byte-for-byte equally valid, so no
  observable difference. Verified by faulting L84 and running the full login suite green.
- `handlers_auth_token_helpers.go` L56 `ttl <= 0` BOUNDARY (`<= -> <`). Only differs at `ttl == 0`,
  where the outer clamp (`defaultAuthTokenTTL = 7d`) and the inner clamp in
  `services.BuildAuthSessionTokenWithVersionAndSessionID` (`7 * 24h`) land on the identical expiry
  whether or not the outer clamp fires. The paired NEGATION on the same line IS killed (positive
  caller TTL path).
- `handlers_auth_pages.go` L52 `redirectErr != nil` NEGATION. `c.Redirect().Status(303).To(path)`
  applies the redirect as a side-effect before the check and returns a nil error here; both the
  original (`!= nil` -> skip -> `return nil`) and the mutant (`== nil` -> `return redirectErr`,
  which is nil) return nil with the redirect already set. An error-check on an operation that cannot
  fail in this path.
- `handlers_auth_oidc.go` L145 `base == nil` NEGATION in `oidcRequestContext`. `c.Context()`
  (fasthttp `*RequestCtx`) is never nil on a served request, so the guarded `base =
  context.Background()` fallback is unreachable and both branches yield an equivalent usable context.

**3 deferred** (`// codecov:ignore`, covered by the e2e OIDC lanes, not the unit suite):

- `handlers_auth_token_helpers.go` L89 and `handlers_auth_oidc.go` L122 — the logout-state `Save`
  error arms; both already annotated `// codecov:ignore -- ... covered by the e2e OIDC lanes` in the
  source. Reaching them deterministically needs the logout-state store's `Save` to fail, which the
  real GORM repo does not do in-process. Left to the OIDC e2e lanes per the existing posture.

## Verification

- `gremlins unleash ./internal/api` scoped to `handlers_auth_token_helpers.go` (densest file):
  the previously-lived rotation/TTL mutants flip to KILLED, only the documented BOUNDARY equivalent
  remains.
- `go build ./...`, `go vet ./internal/api/...`: clean.
- `go test ./internal/api/...`: green.
- `staticcheck ./internal/api/...`: clean (no `Header.VisitAll` / SA1019 — uses no fasthttp header
  iteration).
- `golangci-lint` v2.12.2 `run ./internal/api/...`: 0 issues (zero `//nolint`, no `for i := range n`).
- `gofmt`: clean.
- `bash scripts/patch-coverage-local.sh` (fresh profile): gate OK.

Tests follow the repo's `internal/api` style: Fiber harness + real migrated temp DB + real services,
behavior-asserting, no snapshot/change-detectors. New files only; no shared aggregator touched.
