### PR TITLE
ci: raise e2e app-readiness timeout for Postgres cold-start

### DIFF
--- a/scripts/run-e2e.mjs
+++ b/scripts/run-e2e.mjs
@@ -9,9 +9,36 @@ import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { startLocalHTTPSProxy, startLocalOIDCProvider } from "./e2e-runtime.mjs";
 
-const RUN_TIMEOUT_MS = 60_000;
+// Docker/container-level readiness (pg_isready, host port reachability). This
+// is a separate concern from app boot readiness below: Docker reporting the
+// Postgres container ready is normally fast even under load, so it keeps its
+// own fixed ceiling rather than sharing a knob with the app-boot timeout.
+const CONTAINER_READY_TIMEOUT_MS = 60_000;
 const SHUTDOWN_TIMEOUT_MS = 5_000;
 const REDACTED = "[REDACTED]";
+
+// How long to wait for the app (`go run ./cmd/ovumcy`) to answer its
+// readiness probe after spawn. On the Postgres lane this window covers the Go
+// compile, container-to-host handshake, app boot, AND schema migrations that
+// run on startup, which legitimately take longer than the SQLite lane under a
+// loaded shared CI runner. Configurable so operators/CI can tune it without a
+// code change; defaults differ per DB driver because Postgres cold-start is
+// the slow path.
+const DEFAULT_APP_READY_TIMEOUT_MS = { sqlite: 120_000, postgres: 180_000 };
+const APP_READY_POLL_INTERVAL_MS = 500;
+
+function resolveAppReadyTimeoutMs(dbDriver) {
+  const configured = String(process.env.E2E_READINESS_TIMEOUT_MS ?? "").trim();
+  if (configured) {
+    const parsed = Number.parseInt(configured, 10);
+    if (!Number.isInteger(parsed) || parsed <= 0) {
+      throw new Error(`Invalid E2E_READINESS_TIMEOUT_MS: ${configured}`);
+    }
+    return parsed;
+  }
+
+  return DEFAULT_APP_READY_TIMEOUT_MS[dbDriver] ?? DEFAULT_APP_READY_TIMEOUT_MS.sqlite;
+}
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -235,7 +262,7 @@ async function waitForServer(url, child, timeoutMs) {
       // Server is still booting.
     }
 
-    await delay(500);
+    await delay(APP_READY_POLL_INTERVAL_MS);
   }
 
   throw new Error(`App did not become ready within ${timeoutMs} ms`);
@@ -256,6 +283,7 @@ function printRunContext(context) {
     console.log(`[e2e] app_url=${context.appURL}`);
   }
   console.log(`[e2e] db_driver=${context.dbDriver}`);
+  console.log(`[e2e] app_ready_timeout_ms=${context.appReadyTimeoutMs}`);
   console.log(`[e2e] log_file=${context.appLogPath}`);
   if (context.dbDriver === "sqlite") {
     console.log(`[e2e] db_path=${context.dbPath}`);
@@ -346,7 +374,7 @@ async function generateLocalTLSFixture(tmpDir, runID) {
 
 async function waitForDockerPostgres(containerID, user, databaseName) {
   const startedAt = Date.now();
-  while (Date.now() - startedAt < RUN_TIMEOUT_MS) {
+  while (Date.now() - startedAt < CONTAINER_READY_TIMEOUT_MS) {
     try {
       await runDockerCapture(["exec", containerID, "pg_isready", "-U", user, "-d", databaseName]);
       return;
@@ -375,7 +403,7 @@ async function loadDockerPort(containerID) {
 
 async function waitForHostPort(host, port) {
   const startedAt = Date.now();
-  while (Date.now() - startedAt < RUN_TIMEOUT_MS) {
+  while (Date.now() - startedAt < CONTAINER_READY_TIMEOUT_MS) {
     try {
       await onceConnect(host, port);
       return;
@@ -473,6 +501,8 @@ async function main() {
           : null
         : 1;
 
+  const appReadyTimeoutMs = resolveAppReadyTimeoutMs(db);
+
   const runContext = {
     mode,
     baseURL,
@@ -482,6 +512,7 @@ async function main() {
     dbDriver: db,
     localOIDCIssuer,
     workerOverride,
+    appReadyTimeoutMs,
   };
   printRunContext(runContext);
 
@@ -575,7 +606,7 @@ async function main() {
   appProcess.stderr.pipe(appLogStream);
 
   try {
-    await waitForServer(`${appURL}/login`, appProcess, RUN_TIMEOUT_MS);
+    await waitForServer(`${appURL}/login`, appProcess, appReadyTimeoutMs);
 
     const playwrightArgs = [playwrightCLIPath, "test"];
     if (workerOverride !== null && !hasWorkersArg(passthrough)) {


### PR DESCRIPTION
## Summary

- Fixes a recurring e2e CI flake: `App did not become ready within 60000 ms`. It flaked PR #159 and red-flagged `main`'s `e2e-postgres-smoke` job — the same commit passed cleanly on rerun, confirming this is a timing flake, not a real boot failure.
- `scripts/run-e2e.mjs` shared a single `RUN_TIMEOUT_MS = 60_000` constant across three unrelated waits: app-boot readiness (`waitForServer` polling `/login`), Postgres `pg_isready`, and host-port reachability. The Postgres lane's app-boot window stacks Go compile + Docker container handshake + app boot + **schema migrations that run on startup**, which can legitimately exceed 60s on a loaded shared runner.
- App-boot readiness now gets its own timeout: **60s -> 120s (SQLite) / 180s (Postgres)**, configurable via `E2E_READINESS_TIMEOUT_MS` (falls back to the per-driver default when unset). Poll interval is unchanged at 500ms, so a genuinely broken app still fails within the new ceiling — it stays bounded, it does not hang.
- Docker container-level waits (`pg_isready`, host port) keep their original 60s ceiling under a separately named constant (`CONTAINER_READY_TIMEOUT_MS`); that was never the observed flake, so it's left untouched.
- No application code touched — this is test-harness/CI-config only. `git diff --stat` against origin/main shows exactly one file: `scripts/run-e2e.mjs`.

## Why 60s was too tight (Postgres lane)

`waitForServer` starts counting from process spawn. On the Postgres lane that window has to cover, in sequence: `go run ./cmd/ovumcy` compiling, the app connecting to the freshly-started Docker Postgres container, Fiber/fasthttp binding the listener, **and migrations running on boot**. Under CI load (shared runner, concurrent jobs) any one of those steps can slip past 60s even though the app is healthy and still booting — hence the flake pattern (fails intermittently, passes clean on rerun with no code change).

## Bounded, not infinite

The fix raises the ceiling, it does not remove it or lengthen the poll interval:
- Poll interval stays 500ms.
- A truly broken app (crash-looped binary, bad migration, port conflict) still fails the job — just at the new ceiling (120s/180s) instead of masking the failure or waiting indefinitely.
- The resolved timeout is logged every run (`[e2e] app_ready_timeout_ms=...`) for quick triage without reading source.

## Test plan

- [x] `node --check scripts/run-e2e.mjs` - syntax OK.
- [x] `npm run build` then a real harness run against SQLite: `node ./scripts/run-e2e.mjs --mode=ci --project=chromium e2e/dashboard.spec.ts` - booted the app, detected readiness, ran all 14 specs, exited `[e2e] completed successfully`. Confirmed log line `app_ready_timeout_ms=120000` (new SQLite default).
- [x] Confirmed `E2E_READINESS_TIMEOUT_MS` override flows through end-to-end: setting it to `45000` printed `app_ready_timeout_ms=45000` on the next run.
- [x] Unit-checked the resolver's default/override/invalid-input paths in isolation (sqlite=120000, postgres=180000, override wins, non-numeric value throws instead of silently defaulting).
- [ ] Full Postgres e2e lane (`npm run e2e:ci:postgres`) - not run here (needs Docker + exceeds a quick local check); this is exactly the CI job (`e2e-postgres-smoke`) this PR targets, so the next CI run on this branch is the real-world confirmation.
