### PR TITLE
feat(calendar): add read-only .ics feed endpoint

### DIFF
--- a/cmd/ovumcy/main.go
+++ b/cmd/ovumcy/main.go
@@ -623,6 +623,16 @@ func configureFiberMiddleware(app *fiber.App, config runtimeConfig, handler *api
 		KeyGenerator: keyGen,
 		LimitReached: newAPIRateLimitHandler(handler),
 	}))
+	// Per-IP limiter for the cookieless calendar-feed endpoint. It is not under
+	// /api, so the /api limiter does not cover it; a public, tokened polling
+	// surface must be independently capped so a leaked/guessed URL cannot be
+	// hammered. Reuses the same spoof-proof key generator and the API budget.
+	app.Use(api.CalendarFeedRateLimitPrefix, limiter.New(limiter.Config{
+		Max:          config.RateLimits.APIMax,
+		Expiration:   config.RateLimits.APIWindow,
+		KeyGenerator: keyGen,
+		LimitReached: newCalendarFeedRateLimitHandler(handler),
+	}))
 	app.Use(handler.LanguageMiddleware)
 	app.Use(csrf.New(csrfMiddlewareConfig(config.CookieSecure, handler)))
 }
@@ -1194,6 +1204,23 @@ func newAPIRateLimitHandler(handler *api.Handler) fiber.Handler {
 			api.SecurityEventField{Key: "reason", Value: "too many requests"},
 		)
 		return handler.RespondAPIRateLimited(c)
+	}
+}
+
+// newCalendarFeedRateLimitHandler is the LimitReached handler for the per-IP
+// calendar-feed limiter. The feed has no UI, so a 429 needs no HTML/JSON body:
+// it returns a bare 429 (preserving the limiter-set Retry-After header) after
+// logging the hit and a security event. logRateLimitHit masks the token in the
+// path via SafeRequestLogPath, so the rate-limit log line never carries the
+// token value.
+func newCalendarFeedRateLimitHandler(handler *api.Handler) fiber.Handler {
+	return func(c fiber.Ctx) error {
+		logRateLimitHit(c)
+		handler.LogSecurityEvent(c, "rate_limit", "blocked",
+			api.SecurityEventField{Key: "scope", Value: "calendar_feed"},
+			api.SecurityEventField{Key: "reason", Value: "too many requests"},
+		)
+		return c.SendStatus(fiber.StatusTooManyRequests)
 	}
 }
 

--- a/cmd/ovumcy/rate_limit_negotiation_test.go
+++ b/cmd/ovumcy/rate_limit_negotiation_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"io"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -321,5 +323,50 @@ func TestAPIRateLimitHandlerReturnsJSONForGenericBrowserRequests(t *testing.T) {
 	}
 	if got, ok := payload["error"].(string); !ok || got != "too many requests" {
 		t.Fatalf("expected generic rate-limit error key, got %#v", payload)
+	}
+}
+
+// TestCalendarFeedRateLimitHandlerReturnsBare429AndRedactsToken drives the
+// calendar-feed LimitReached handler (newCalendarFeedRateLimitHandler). The feed
+// has no UI, so the handler must return a bare 429; and because it logs the hit
+// via logRateLimitHit → SafeRequestLogPath, the log line must carry the masked
+// route template, never the token value.
+func TestCalendarFeedRateLimitHandlerReturnsBare429AndRedactsToken(t *testing.T) {
+	originalWriter := log.Writer()
+	defer log.SetOutput(originalWriter)
+	var output bytes.Buffer
+	log.SetOutput(&output)
+
+	handler := newRateLimitTestHandler(t)
+	app := fiber.New()
+	// Mount the production LimitReached handler directly on the feed route so a
+	// single request exercises its full body (log + security event + status).
+	app.Get(api.CalendarFeedRateLimitPrefix+"/:token.ics", newCalendarFeedRateLimitHandler(handler))
+
+	const feedToken = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789ABCDEFGHJKLMNP"
+	request := httptest.NewRequest(http.MethodGet, "/calendar/feed/"+feedToken+".ics", nil)
+	response, err := app.Test(request, testConfigNoTimeout)
+	if err != nil {
+		t.Fatalf("calendar-feed rate-limit request failed: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+
+	if response.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("expected bare 429 from the feed rate-limit handler, got %d", response.StatusCode)
+	}
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if strings.Contains(string(body), "BEGIN:VCALENDAR") {
+		t.Fatalf("429 must not carry a calendar body, got %q", string(body))
+	}
+
+	logLine := output.String()
+	if strings.Contains(logLine, feedToken) {
+		t.Fatalf("rate-limit log leaked the feed token: %q", logLine)
+	}
+	if !strings.Contains(logLine, ":token.ics") {
+		t.Fatalf("expected masked route template in rate-limit log, got %q", logLine)
 	}
 }

--- a/internal/api/calendar_feed_regressions_test.go
+++ b/internal/api/calendar_feed_regressions_test.go
@@ -1,0 +1,266 @@
+package api
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/gofiber/fiber/v3/middleware/limiter"
+	"github.com/gofiber/fiber/v3/middleware/logger"
+	"github.com/ovumcy/ovumcy-web/internal/db"
+	"github.com/ovumcy/ovumcy-web/internal/i18n"
+	"github.com/ovumcy/ovumcy-web/internal/models"
+	"github.com/ovumcy/ovumcy-web/internal/services"
+	"gorm.io/gorm"
+)
+
+// armCalendarFeedForUser mints a real feed token for the user, persists the
+// selector + verifier hash, and seeds a stable ~28d period cadence so the feed
+// emits prediction events. It returns the full shown-once token to present in
+// the URL.
+func armCalendarFeedForUser(t *testing.T, database *gorm.DB, userID uint) string {
+	t.Helper()
+	token, selector, verifierHash, err := services.GenerateCalendarFeedToken()
+	if err != nil {
+		t.Fatalf("GenerateCalendarFeedToken: %v", err)
+	}
+	repo := db.NewRepositories(database).Users
+	if err := repo.SaveCalendarFeedToken(t.Context(), userID, models.CalendarFeedTokenColumns{
+		Selector:     selector,
+		VerifierHash: verifierHash,
+	}); err != nil {
+		t.Fatalf("SaveCalendarFeedToken: %v", err)
+	}
+	for _, day := range []string{"2026-01-05", "2026-02-02", "2026-03-02"} {
+		parsed, _ := time.ParseInLocation("2006-01-02", day, time.UTC)
+		if err := database.Create(&models.DailyLog{UserID: userID, Date: parsed, IsPeriod: true}).Error; err != nil {
+			t.Fatalf("seed period log %s: %v", day, err)
+		}
+	}
+	// Anchor the current cycle to the most recent seeded start.
+	start, _ := time.ParseInLocation("2006-01-02", "2026-03-02", time.UTC)
+	if err := database.Model(&models.User{}).Where("id = ?", userID).Update("last_period_start", start).Error; err != nil {
+		t.Fatalf("set last_period_start: %v", err)
+	}
+	return token
+}
+
+func calendarFeedURL(token string) string {
+	return "/calendar/feed/" + token + ".ics"
+}
+
+// TestCalendarFeedServesOwnersICSWithHardenedHeaders is the happy-path contract:
+// a valid token returns 200 with text/calendar, a private 1h cache, the
+// noindex robots tag, structural .ics markers, and the medical-safety disclaimer
+// in a DESCRIPTION — and never a Set-Cookie.
+func TestCalendarFeedServesOwnersICSWithHardenedHeaders(t *testing.T) {
+	app, database := newOnboardingTestApp(t)
+	user := createOnboardingTestUser(t, database, "feed-ok@example.com", "StrongPass1", true)
+	token := armCalendarFeedForUser(t, database, user.ID)
+
+	request := httptest.NewRequest(http.MethodGet, calendarFeedURL(token), nil)
+	response := mustAppResponse(t, app, request)
+
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 for a valid feed token, got %d", response.StatusCode)
+	}
+	if ct := response.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/calendar") {
+		t.Fatalf("expected text/calendar content type, got %q", ct)
+	}
+	if cc := response.Header.Get("Cache-Control"); cc != "private, max-age=3600" {
+		t.Fatalf("expected private 1h cache, got %q", cc)
+	}
+	if robots := response.Header.Get("X-Robots-Tag"); robots != "noindex" {
+		t.Fatalf("expected X-Robots-Tag noindex, got %q", robots)
+	}
+	if len(response.Cookies()) != 0 {
+		t.Fatalf("feed must not set any cookie, got %#v", response.Cookies())
+	}
+
+	body := readBodyString(t, response)
+	for _, marker := range []string{"BEGIN:VCALENDAR", "BEGIN:VEVENT", "SUMMARY:", "DESCRIPTION:"} {
+		if !strings.Contains(body, marker) {
+			t.Fatalf("expected .ics marker %q, got:\n%s", marker, body)
+		}
+	}
+	// Medical-safety disclaimer (exact-wording invariant) present in a DESCRIPTION.
+	// Assert against the UNFOLDED body — RFC 5545 folds long lines with a CRLF +
+	// space, which a calendar client (and this check) must unfold before reading
+	// the value; the wording itself is unchanged.
+	if unfolded := unfoldICS(body); !strings.Contains(unfolded, "not medical advice or a method of contraception") {
+		t.Fatalf("expected medical-safety disclaimer in feed body, got:\n%s", body)
+	}
+	// Neutral-title invariant: SUMMARY carries no date/phase.
+	for _, line := range strings.Split(body, "\r\n") {
+		if strings.HasPrefix(line, "SUMMARY:") && line != "SUMMARY:Ovumcy: reminder (estimate)" {
+			t.Fatalf("SUMMARY must be the fixed neutral label, got %q", line)
+		}
+	}
+}
+
+// TestCalendarFeedReturnsBare404WithoutOracleForBadTokens proves the no-oracle
+// contract at the transport boundary: a bogus, malformed, and cleared-feed token
+// all return an identical bare 404 with no body and no Set-Cookie.
+func TestCalendarFeedReturnsBare404WithoutOracleForBadTokens(t *testing.T) {
+	app, database := newOnboardingTestApp(t)
+	user := createOnboardingTestUser(t, database, "feed-404@example.com", "StrongPass1", true)
+	validToken := armCalendarFeedForUser(t, database, user.ID)
+
+	// A token whose selector resolves no row, a too-short malformed token, and a
+	// correct-selector/wrong-verifier token.
+	bogus := "ZZZZZZZZZZZZZZZZ" + validToken[16:]
+	malformed := "SHORT"
+	wrongVerifier := validToken[:16] + strings.Repeat("2", len(validToken)-16)
+
+	// After clearing the feed, the previously-valid token must 404 too.
+	if err := db.NewRepositories(database).Users.ClearCalendarFeedToken(t.Context(), user.ID); err != nil {
+		t.Fatalf("ClearCalendarFeedToken: %v", err)
+	}
+
+	for name, token := range map[string]string{
+		"bogus":            bogus,
+		"malformed":        malformed,
+		"wrongVerifier":    wrongVerifier,
+		"clearedValidOnce": validToken,
+	} {
+		request := httptest.NewRequest(http.MethodGet, calendarFeedURL(token), nil)
+		response := mustAppResponse(t, app, request)
+		if response.StatusCode != http.StatusNotFound {
+			t.Fatalf("%s: expected bare 404, got %d", name, response.StatusCode)
+		}
+		if len(response.Cookies()) != 0 {
+			t.Fatalf("%s: 404 must not set a cookie, got %#v", name, response.Cookies())
+		}
+		if body := readBodyString(t, response); strings.Contains(body, "BEGIN:VCALENDAR") {
+			t.Fatalf("%s: 404 must not leak a calendar body, got:\n%s", name, body)
+		}
+	}
+}
+
+// TestCalendarFeedTokenIsRedactedFromRequestLog drives a real request through a
+// Fiber request logger wired to the SAME SafeRequestLogPath tag production uses,
+// and asserts the captured log line carries ":token.ics", never the token value.
+func TestCalendarFeedTokenIsRedactedFromRequestLog(t *testing.T) {
+	_, database := newOnboardingTestApp(t)
+	user := createOnboardingTestUser(t, database, "feed-log@example.com", "StrongPass1", true)
+	token := armCalendarFeedForUser(t, database, user.ID)
+
+	var logBuf bytes.Buffer
+	logged := fiber.New()
+	logged.Use(logger.New(logger.Config{
+		Stream: &logBuf,
+		Format: "${method} ${request_path}\n",
+		CustomTags: map[string]logger.LogFunc{
+			"request_path": func(buffer logger.Buffer, c fiber.Ctx, _ *logger.Data, _ string) (int, error) {
+				return buffer.WriteString(SafeRequestLogPath(c))
+			},
+		},
+	}))
+	// Register the feed route on the logging app so the matched-route template
+	// drives SafeRequestLogPath exactly as in production.
+	handler := mustFeedHandler(t, database)
+	logged.Get(calendarFeedRoutePath, handler.ServeCalendarFeed)
+
+	request := httptest.NewRequest(http.MethodGet, calendarFeedURL(token), nil)
+	if _, err := logged.Test(request); err != nil {
+		t.Fatalf("request: %v", err)
+	}
+
+	logLine := logBuf.String()
+	if strings.Contains(logLine, token) {
+		t.Fatalf("request log leaked the feed token: %q", logLine)
+	}
+	if !strings.Contains(logLine, ":token.ics") {
+		t.Fatalf("expected request log to mask the token as :token.ics, got %q", logLine)
+	}
+}
+
+// TestSanitizeRequestLogPathMasksRawTokenDotICSFallback pins the defense-in-depth
+// hardening: even the RAW-PATH fallback (when no matched-route template is
+// available) masks a "<token>.ics" segment, closing the flagged gap where the
+// trailing ".ics" would otherwise defeat the opaque-token redaction.
+func TestSanitizeRequestLogPathMasksRawTokenDotICSFallback(t *testing.T) {
+	rawToken := "ABCDEFGHJKLMNPQRSTUVWXYZ23456789ABCDEFGHJKLMNP"
+	got := sanitizeRequestLogPath("/calendar/feed/" + rawToken + ".ics")
+	if strings.Contains(got, rawToken) {
+		t.Fatalf("raw-path fallback leaked the token: %q", got)
+	}
+	if got != "/calendar/feed/:token.ics" {
+		t.Fatalf("expected raw fallback to mask as /calendar/feed/:token.ics, got %q", got)
+	}
+}
+
+// TestCalendarFeedIsRateLimitedPerIP drives a REAL limiter.New mounted on the
+// feed prefix and asserts the endpoint returns 429 once the per-IP budget is
+// exceeded, with an integer Retry-After no greater than the window.
+func TestCalendarFeedIsRateLimitedPerIP(t *testing.T) {
+	_, database := newOnboardingTestApp(t)
+	user := createOnboardingTestUser(t, database, "feed-rl@example.com", "StrongPass1", true)
+	token := armCalendarFeedForUser(t, database, user.ID)
+	handler := mustFeedHandler(t, database)
+
+	const maxRequests = 3
+	rlApp := fiber.New()
+	rlApp.Use(CalendarFeedRateLimitPrefix, limiter.New(limiter.Config{
+		Max:        maxRequests,
+		Expiration: time.Minute,
+		LimitReached: func(c fiber.Ctx) error {
+			return c.SendStatus(fiber.StatusTooManyRequests)
+		},
+	}))
+	rlApp.Get(calendarFeedRoutePath, handler.ServeCalendarFeed)
+
+	url := calendarFeedURL(token)
+	var lastStatus int
+	var retryAfter string
+	for range maxRequests + 1 {
+		request := httptest.NewRequest(http.MethodGet, url, nil)
+		response := mustAppResponse(t, rlApp, request)
+		lastStatus = response.StatusCode
+		retryAfter = response.Header.Get(fiber.HeaderRetryAfter)
+	}
+	if lastStatus != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 after exceeding the per-IP budget, got %d", lastStatus)
+	}
+	if retryAfter == "" {
+		t.Fatalf("expected a Retry-After header on the 429")
+	}
+}
+
+// mustFeedHandler builds a handler bound to the given database, for tests that
+// mount the feed route on a bespoke Fiber app (logger / rate-limit wiring).
+func mustFeedHandler(t *testing.T, database *gorm.DB) *Handler {
+	t.Helper()
+	i18nManager, err := i18n.NewManager("en")
+	if err != nil {
+		t.Fatalf("init i18n: %v", err)
+	}
+	handler, err := NewHandler("test-secret-key", time.UTC, i18nManager, false, newTestHandlerDependencies(database, i18nManager))
+	if err != nil {
+		t.Fatalf("init handler: %v", err)
+	}
+	return handler
+}
+
+// unfoldICS reverses RFC 5545 §3.1 line folding: a CRLF immediately followed by
+// a single space (or tab) is a fold and is removed, rejoining the split content
+// line. This is exactly what a conforming calendar client does before reading a
+// property value.
+func unfoldICS(body string) string {
+	unfolded := strings.ReplaceAll(body, "\r\n ", "")
+	return strings.ReplaceAll(unfolded, "\r\n\t", "")
+}
+
+func readBodyString(t *testing.T, response *http.Response) string {
+	t.Helper()
+	defer func() { _ = response.Body.Close() }()
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(response.Body); err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	return buf.String()
+}

--- a/internal/api/calendar_feed_regressions_test.go
+++ b/internal/api/calendar_feed_regressions_test.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -244,6 +246,59 @@ func mustFeedHandler(t *testing.T, database *gorm.DB) *Handler {
 		t.Fatalf("init handler: %v", err)
 	}
 	return handler
+}
+
+// failingFeedUserReader makes CalendarFeedService.ResolveFeed return an
+// infrastructure error, driving ServeCalendarFeed's err != nil branch.
+type failingFeedUserReader struct{}
+
+func (failingFeedUserReader) FindByCalendarFeedSelector(context.Context, string) (models.User, bool, error) {
+	return models.User{}, false, errors.New("simulated feed lookup failure")
+}
+
+// failingFeedDayReader satisfies the day-reader port; it is never reached
+// because the user lookup fails first, but ResolveFeed needs a non-nil reader.
+type failingFeedDayReader struct{}
+
+func (failingFeedDayReader) FetchLogsForUser(context.Context, uint, time.Time, time.Time, *time.Location) ([]models.DailyLog, error) {
+	return nil, nil
+}
+
+type constFeedDisclaimer struct{}
+
+func (constFeedDisclaimer) Disclaimer(string) string { return "d" }
+
+// TestCalendarFeedReturns500OnInfrastructureError drives the ServeCalendarFeed
+// err != nil branch: when the feed service reports an infrastructure failure
+// (e.g. a DB read error), the handler returns a generic 500 via the top-level
+// error handler — never the raw error, and never a calendar body.
+func TestCalendarFeedReturns500OnInfrastructureError(t *testing.T) {
+	_, database := newOnboardingTestApp(t)
+	i18nManager, err := i18n.NewManager("en")
+	if err != nil {
+		t.Fatalf("init i18n: %v", err)
+	}
+	deps := newTestHandlerDependencies(database, i18nManager)
+	// Swap in a feed service whose owner lookup always errors.
+	deps.CalendarFeedService = services.NewCalendarFeedService(failingFeedUserReader{}, failingFeedDayReader{}, constFeedDisclaimer{})
+	handler, err := NewHandler("test-secret-key", time.UTC, i18nManager, false, deps)
+	if err != nil {
+		t.Fatalf("init handler: %v", err)
+	}
+
+	app := fiber.New()
+	app.Get(calendarFeedRoutePath, handler.ServeCalendarFeed)
+
+	// A well-formed token so the handler reaches the service (which then errors);
+	// the concrete value is irrelevant because the lookup is stubbed to fail.
+	token := strings.Repeat("A", 48)
+	response := mustAppResponse(t, app, httptest.NewRequest(http.MethodGet, calendarFeedURL(token), nil))
+	if response.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500 on an infrastructure error, got %d", response.StatusCode)
+	}
+	if body := readBodyString(t, response); strings.Contains(body, "BEGIN:VCALENDAR") {
+		t.Fatalf("500 must not leak a calendar body, got:\n%s", body)
+	}
 }
 
 // unfoldICS reverses RFC 5545 §3.1 line folding: a CRLF immediately followed by

--- a/internal/api/handler_dependencies.go
+++ b/internal/api/handler_dependencies.go
@@ -21,6 +21,7 @@ func (handler *Handler) withDependencies(dependencies Dependencies) *Handler {
 	handler.viewerService = dependencies.ViewerService
 	handler.statsService = dependencies.StatsService
 	handler.calendarViewService = dependencies.CalendarViewService
+	handler.calendarFeedService = dependencies.CalendarFeedService
 	handler.dashboardViewService = dependencies.DashboardViewService
 	handler.exportService = dependencies.ExportService
 	handler.importService = dependencies.ImportService

--- a/internal/api/handler_types.go
+++ b/internal/api/handler_types.go
@@ -40,6 +40,7 @@ type Handler struct {
 	viewerService        *services.ViewerService
 	statsService         *services.StatsService
 	calendarViewService  *services.CalendarViewService
+	calendarFeedService  *services.CalendarFeedService
 	dashboardViewService *services.DashboardViewService
 	exportService        *services.ExportService
 	importService        *services.ImportService

--- a/internal/api/handlers_calendar_feed.go
+++ b/internal/api/handlers_calendar_feed.go
@@ -1,0 +1,80 @@
+package api
+
+import (
+	"time"
+
+	"github.com/gofiber/fiber/v3"
+)
+
+// Calendar (.ics) feed endpoint (issue #126-replacement / .ics, slice 3).
+//
+// Route: GET /calendar/feed/:token.ics — a PAGE route (registerPageRoutes), NOT
+// under /api/v1 and NOT behind AuthRequired/OwnerOnly: a calendar client sends
+// no cookie, so the request is authenticated by the bearer TOKEN alone. The
+// route is shaped so the token is a clean :token parameter (Fiber treats '.' as
+// a parameter delimiter, so ":token.ics" binds param "token" with ".ics" as a
+// literal constant suffix). This matters for log redaction: SafeRequestLogPath
+// prefers the matched route template ("/calendar/feed/:token.ics"), whose last
+// segment already begins with ':' and is therefore emitted verbatim as
+// ":token.ics" — the token VALUE never reaches a log line. The raw-path
+// fallback is additionally hardened in request_logging.go to mask an
+// "<opaque-token>.ics" segment, closing the flagged gap even if the route
+// template were ever unavailable.
+//
+// Security envelope (all enforced here + in CalendarFeedService):
+//   - Token IS the authorization. CalendarFeedService.ResolveFeed splits it,
+//     resolves the owner by non-secret selector, constant-time-verifies the
+//     secret verifier, and scopes every read to the resolved user id.
+//   - 404-no-oracle: a malformed token, unknown selector, wrong verifier, and
+//     disabled feed ALL return an identical bare 404 with no body and no
+//     Set-Cookie, and are timing-equalized (a dummy bcrypt runs on the
+//     selector-miss path inside the service).
+//   - Rate-limited per-IP by the edge /api-style limiter wired in main.go for
+//     this exact path; a 429 returns the limiter's own response (no UI needed).
+//   - Response headers pin text/calendar, a private 1-hour cache, and
+//     X-Robots-Tag: noindex.
+
+const (
+	// calendarFeedRoutePath is the registered page route. Fiber treats '.' as a
+	// parameter delimiter, so ":token.ics" binds param "token" (without ".ics")
+	// and ".ics" is a literal constant suffix.
+	calendarFeedRoutePath = "/calendar/feed/:token.ics"
+
+	// CalendarFeedRateLimitPrefix is the path prefix the composition root
+	// (cmd/ovumcy/main.go) mounts the per-IP feed rate limiter on. It is
+	// exported so the limiter wiring and the route share one source of truth;
+	// every concrete feed URL (…/calendar/feed/<token>.ics) sits under it.
+	CalendarFeedRateLimitPrefix = "/calendar/feed"
+)
+
+// ServeCalendarFeed serves an owner's read-only .ics feed, authenticated by the
+// path token alone. It never sets a cookie and never renders an HTML error: the
+// only outcomes are 200 + calendar body, a bare 404 (every not-found/invalid
+// case, no oracle), or a generic 500 on an infrastructure failure.
+func (handler *Handler) ServeCalendarFeed(c fiber.Ctx) error {
+	token := c.Params("token")
+	location := handler.requestLocation(c)
+	now := time.Now().In(location)
+
+	body, ok, err := handler.calendarFeedService.ResolveFeed(c.Context(), token, now, location)
+	if err != nil {
+		// Infrastructure failure (DB / log read). Return a generic 500 via the
+		// top-level error handler — never the raw error, and never a body that
+		// distinguishes this from the 404 path in a token-revealing way.
+		return fiber.ErrInternalServerError
+	}
+	if !ok {
+		// Uniform bare 404 for malformed token / unknown selector / wrong
+		// verifier / disabled feed. No body, no Set-Cookie, timing-equalized in
+		// the service.
+		return c.SendStatus(fiber.StatusNotFound)
+	}
+
+	c.Set(fiber.HeaderContentType, "text/calendar; charset=utf-8")
+	// Overwrites the middleware's default no-store: the feed is a private,
+	// owner-scoped resource a calendar client may cache briefly (1h) but that
+	// must not be stored by shared/proxy caches beyond the owner.
+	c.Set(fiber.HeaderCacheControl, "private, max-age=3600")
+	c.Set("X-Robots-Tag", "noindex")
+	return c.Send(body)
+}

--- a/internal/api/owner_only_coverage_regression_test.go
+++ b/internal/api/owner_only_coverage_regression_test.go
@@ -45,6 +45,15 @@ func TestUnsupportedRoleRejectedAcrossEveryAuthedV1Route(t *testing.T) {
 		"GET " + oidcLinkConfirmPath:          {},
 		"POST " + oidcLinkConfirmPath:         {},
 		"GET /privacy":                        {},
+		// The calendar (.ics) feed authenticates by the PATH TOKEN alone — a
+		// calendar client sends no cookie — so it is intentionally NOT behind
+		// AuthRequired/OwnerOnly and never inspects the role. An unsupported-role
+		// cookie is simply ignored; every invalid/absent-credential case (here, a
+		// bogus token) returns the same bare 404-no-oracle, not a 403. Its owner
+		// scoping is proven by the token-resolution + cross-user isolation tests in
+		// internal/services (calendar_feed_service_test.go), not by this cookie-role
+		// matrix.
+		"GET " + calendarFeedRoutePath: {},
 	}
 
 	app, database := newOnboardingTestApp(t)

--- a/internal/api/request_logging.go
+++ b/internal/api/request_logging.go
@@ -67,6 +67,14 @@ func sanitizeRequestLogSegment(segment string) string {
 		return ":id"
 	case strings.Contains(segment, "@"):
 		return ":email"
+	case isOpaqueTokenDotICSSegment(segment):
+		// The calendar-feed URL carries its bearer token as "<token>.ics" in a
+		// single path segment. The matched-route template already logs this as
+		// ":token.ics" (its segment starts with ':'), but this raw-path fallback
+		// must mask it too: the trailing ".ics" contains a '.', which
+		// isOpaqueRequestLogSegment rejects, so without this case the token VALUE
+		// would leak verbatim on the (route-template-unavailable) fallback path.
+		return ":token.ics"
 	case isOpaqueRequestLogSegment(segment):
 		return ":token"
 	default:
@@ -122,6 +130,19 @@ func isUUIDRequestLogSegment(segment string) bool {
 		}
 	}
 	return true
+}
+
+// isOpaqueTokenDotICSSegment reports whether segment is an opaque bearer token
+// immediately followed by a ".ics" suffix — the shape a calendar-feed URL takes
+// in a single raw-path segment ("<token>.ics"). It strips the suffix and reuses
+// the same opaque-token test applied to a bare token segment, so the redaction
+// threshold is identical whether or not the ".ics" suffix is present.
+func isOpaqueTokenDotICSSegment(segment string) bool {
+	const suffix = ".ics"
+	if !strings.HasSuffix(segment, suffix) {
+		return false
+	}
+	return isOpaqueRequestLogSegment(strings.TrimSuffix(segment, suffix))
 }
 
 func isOpaqueRequestLogSegment(segment string) bool {

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -97,6 +97,11 @@ func registerPageRoutes(app *fiber.App, handler *Handler) {
 	app.Get("/dashboard", handler.AuthRequired, handler.ShowDashboard)
 	app.Get("/calendar", handler.AuthRequired, handler.ShowCalendar)
 	app.Get("/calendar/day/:date", handler.AuthRequired, handler.CalendarDayPanel)
+	// Calendar (.ics) feed: authenticated by the path token ALONE (no cookie),
+	// so it is deliberately NOT behind AuthRequired/OwnerOnly. Shaped as
+	// ":token.ics" so the token binds as a clean :token param that
+	// SafeRequestLogPath masks. Per-IP rate-limited in cmd/ovumcy/main.go.
+	app.Get(calendarFeedRoutePath, handler.ServeCalendarFeed)
 	app.Get("/stats", handler.AuthRequired, handler.ShowStats)
 	app.Get("/settings", handler.AuthRequired, handler.ShowSettings)
 	app.Get("/settings/2fa", handler.AuthRequired, handler.ShowTOTPSetupPage)

--- a/internal/apideps/dependencies.go
+++ b/internal/apideps/dependencies.go
@@ -22,6 +22,7 @@ type Dependencies struct {
 	ViewerService          *services.ViewerService
 	StatsService           *services.StatsService
 	CalendarViewService    *services.CalendarViewService
+	CalendarFeedService    *services.CalendarFeedService
 	DashboardViewService   *services.DashboardViewService
 	ExportService          *services.ExportService
 	ImportService          *services.ImportService
@@ -68,6 +69,7 @@ func (dependencies Dependencies) requirements() []dependencyRequirement {
 		{value: dependencies.ViewerService, message: "viewer service is required"},
 		{value: dependencies.StatsService, message: "stats service is required"},
 		{value: dependencies.CalendarViewService, message: "calendar view service is required"},
+		{value: dependencies.CalendarFeedService, message: "calendar feed service is required"},
 		{value: dependencies.DashboardViewService, message: "dashboard view service is required"},
 		{value: dependencies.ExportService, message: "export service is required"},
 		{value: dependencies.ImportService, message: "import service is required"},

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -112,6 +112,7 @@ func BuildDependencies(repositories *db.Repositories, secretKey []byte, i18nMana
 	viewerService := services.NewViewerService(dayService, symptomService)
 	statsService := services.NewStatsService(dayService, symptomService)
 	calendarViewService := services.NewCalendarViewService(dayService, statsService)
+	calendarFeedService := services.NewCalendarFeedService(repositories.Users, dayService, i18nDisclaimerProvider{manager: i18nManager})
 	dashboardViewService := services.NewDashboardViewService(statsService, viewerService, dayService)
 	exportService := services.NewExportService(dayService, symptomService)
 	importService := services.NewImportService(dailyLogs, repositories.Users, symptomService, dayLogTxRunner)
@@ -143,6 +144,7 @@ func BuildDependencies(repositories *db.Repositories, secretKey []byte, i18nMana
 		ViewerService:          viewerService,
 		StatsService:           statsService,
 		CalendarViewService:    calendarViewService,
+		CalendarFeedService:    calendarFeedService,
 		DashboardViewService:   dashboardViewService,
 		ExportService:          exportService,
 		ImportService:          importService,

--- a/internal/services/calendar_feed_ics.go
+++ b/internal/services/calendar_feed_ics.go
@@ -1,0 +1,250 @@
+package services
+
+import (
+	"fmt"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+)
+
+// Calendar (.ics) feed builder (issue #126-replacement / .ics, slice 3). This
+// file is the PURE, transport-free RFC 5545 builder: given an owner, their day
+// logs, an injected now/location, and the localized medical-safety disclaimer,
+// it renders a read-only text/calendar body of the owner's upcoming cycle
+// events. It performs NO transport, NO auth, and NO persistence — the api layer
+// owns token resolution, headers, and rate-limiting.
+//
+// Medical-safety invariant (same as the webhook reminder decision): it reuses
+// the EXACT prediction path the dashboard uses (BuildCycleStatsFromLogs →
+// DashboardUpcomingPredictions, gated by DashboardPredictionDisabled /
+// stats.PregnancyPaused). It NEVER fabricates a date the app itself refuses to
+// show — when in-app predictions are suppressed (unpredictable cycle, or a
+// pregnancy pause), it emits ZERO prediction events, so a "fertile window" is
+// never pushed into a pregnant owner's calendar.
+//
+// Data-minimization invariant: every VEVENT SUMMARY is the SAME neutral,
+// contentless title (calendarFeedNeutralSummary) — no cycle phase, no date, no
+// symptom appears in the SUMMARY, so a lock-screen preview or a shared calendar
+// reveals nothing about the owner's health. The concrete date lives only in the
+// DTSTART/DTEND all-day fields a calendar client needs to place the event; the
+// disclaimer lives in the DESCRIPTION. (A detailed-event opt-in is a later
+// slice; the default here is always neutral.)
+
+const (
+	// calendarFeedNeutralSummary is the single, contentless SUMMARY used for
+	// every event. It carries the estimate qualifier (medical-safety) but no
+	// health specifics (data minimization). It is intentionally NOT localized:
+	// keeping it a fixed ASCII string means the neutral-title guarantee does not
+	// depend on any locale file, and a shared-calendar viewer sees the same
+	// contentless label regardless of the owner's language.
+	calendarFeedNeutralSummary = "Ovumcy: reminder (estimate)"
+
+	// calendarFeedProductID is the PRODID identifying this generator, per RFC
+	// 5545 §3.7.3. It is a stable, non-secret product identifier.
+	calendarFeedProductID = "-//Ovumcy//Calendar Feed//EN"
+
+	// calendarFeedProjectionCycles bounds how many upcoming cycles the feed
+	// projects. Three cycles at a typical ~28-30 day length spans ~60-90 days —
+	// enough lead time for a calendar subscription without emitting far-future
+	// events whose estimate error grows with distance.
+	calendarFeedProjectionCycles = 3
+
+	// calendarFeedDateLayout is the RFC 5545 DATE value form (VALUE=DATE) for
+	// all-day events: YYYYMMDD with no time component.
+	calendarFeedDateLayout = "20060102"
+
+	// calendarFeedTimestampLayout is the RFC 5545 UTC DATE-TIME form used for
+	// DTSTAMP: YYYYMMDDTHHMMSSZ.
+	calendarFeedTimestampLayout = "20060102T150405Z"
+)
+
+// CalendarFeedICSInput is the transport-free input to BuildCalendarFeedICS. The
+// user carries the cycle settings + baseline; logs are the already-fetched day
+// history the prediction path consumes; now/location are injected (never
+// time.Now()); disclaimer is the localized medical-safety string the caller
+// resolved via the shared DisclaimerProvider seam (the same one the webhook
+// notify pass uses), placed in each event's DESCRIPTION.
+type CalendarFeedICSInput struct {
+	User       *models.User
+	Logs       []models.DailyLog
+	Now        time.Time
+	Location   *time.Location
+	Disclaimer string
+}
+
+// calendarFeedEvent is one resolved all-day prediction event before rendering.
+// kind is a stable, non-secret discriminator used only to build a deterministic
+// UID; it is NEVER placed in the SUMMARY (that stays neutral).
+type calendarFeedEvent struct {
+	kind string
+	date time.Time
+}
+
+// BuildCalendarFeedICS renders the owner's upcoming-cycle .ics body. It always
+// returns a well-formed VCALENDAR (even with zero events — a calendar client
+// expects a valid, possibly empty, feed), so the api layer can serve a 200 with
+// a stable structure whether or not predictions are currently available.
+//
+// The decision, in order (mirrors DecideDueReminders' medical-safety gate):
+//   - Build cycle stats from the owner's logs via the SAME path the dashboard
+//     uses (StatsService.BuildCycleStatsFromLogs, which needs no repositories).
+//   - If in-app predictions are suppressed (DashboardPredictionDisabled — the
+//     owner's unpredictable-cycle mode — or stats.PregnancyPaused), emit ZERO
+//     events. This is the hard medical-safety suppression gate.
+//   - Otherwise project the next calendarFeedProjectionCycles cycles forward from
+//     the owner's last period start, reusing the dashboard's own cycle-start
+//     projection + window helpers, and emit a predicted-next-period event and an
+//     ovulation event per projected cycle when each is calculable and not in the
+//     past.
+func BuildCalendarFeedICS(input CalendarFeedICSInput) []byte {
+	events := calendarFeedEvents(input)
+	return renderCalendarFeedICS(events, input.Disclaimer, input.Now)
+}
+
+// calendarFeedEvents resolves the neutral, all-day prediction events for the
+// feed. Returns nil when predictions are suppressed or no cycle can be
+// projected.
+func calendarFeedEvents(input CalendarFeedICSInput) []calendarFeedEvent {
+	user := input.User
+	if user == nil {
+		return nil
+	}
+
+	// Reuse the exact dashboard prediction path — a zero-dependency StatsService
+	// runs precisely the dashboard's stats derivation (baseline + pregnancy-pause
+	// resolution) without a store, exactly as DecideDueReminders does.
+	stats := NewStatsService(nil, nil).BuildCycleStatsFromLogs(user, input.Logs, input.Now, input.Location)
+
+	// Medical-safety suppression gate: if the app suppresses predictions, emit
+	// nothing. Pregnancy-pause OR unpredictable-cycle mode both suppress.
+	if DashboardPredictionDisabled(user) || stats.PregnancyPaused {
+		return nil
+	}
+
+	today := DateAtLocation(input.Now, input.Location)
+	cycleLength := DashboardCycleReferenceLength(user, stats)
+	if stats.LastPeriodStart.IsZero() || cycleLength <= 0 {
+		return nil
+	}
+
+	// Anchor the first projected cycle to the current/next cycle start exactly as
+	// DashboardUpcomingPredictions does, then step forward one cycle at a time.
+	cycleStart, _, ok := ProjectCycleStart(stats.LastPeriodStart, cycleLength, today)
+	if !ok {
+		// codecov:ignore -- defensive: ProjectCycleStart only reports !ok for a zero
+		// LastPeriodStart or non-positive cycleLength, both already returned above.
+		return nil
+	}
+
+	events := make([]calendarFeedEvent, 0, calendarFeedProjectionCycles*2)
+	for cycle := range calendarFeedProjectionCycles {
+		anchor := CalendarDay(cycleStart.AddDate(0, 0, cycle*cycleLength), input.Location)
+
+		nextPeriodStart := CalendarDay(anchor.AddDate(0, 0, cycleLength), input.Location)
+		if !nextPeriodStart.Before(today) {
+			events = append(events, calendarFeedEvent{kind: "period", date: nextPeriodStart})
+		}
+
+		window := PredictCycleWindow(anchor, cycleLength, stats.LutealPhase)
+		if window.Calculable && !window.OvulationDate.Before(today) {
+			events = append(events, calendarFeedEvent{
+				kind: "ovulation",
+				date: CalendarDay(window.OvulationDate, input.Location),
+			})
+		}
+	}
+	return events
+}
+
+// renderCalendarFeedICS assembles the RFC 5545 VCALENDAR text. Every line is
+// CRLF-terminated (RFC 5545 §3.1). DTSTAMP is the injected now in UTC. Each
+// VEVENT is an all-day event (VALUE=DATE DTSTART, exclusive next-day DTEND per
+// RFC 5545 §3.6.1), carries the fixed neutral SUMMARY, and puts the disclaimer
+// in DESCRIPTION.
+func renderCalendarFeedICS(events []calendarFeedEvent, disclaimer string, now time.Time) []byte {
+	stamp := now.UTC().Format(calendarFeedTimestampLayout)
+
+	var b strings.Builder
+	writeICSLine(&b, "BEGIN:VCALENDAR")
+	writeICSLine(&b, "VERSION:2.0")
+	writeICSLine(&b, "PRODID:"+calendarFeedProductID)
+	writeICSLine(&b, "CALSCALE:GREGORIAN")
+	writeICSLine(&b, "METHOD:PUBLISH")
+	for index, event := range events {
+		writeCalendarFeedEvent(&b, event, index, stamp, disclaimer)
+	}
+	writeICSLine(&b, "END:VCALENDAR")
+	return []byte(b.String())
+}
+
+func writeCalendarFeedEvent(b *strings.Builder, event calendarFeedEvent, index int, stamp string, disclaimer string) {
+	start := event.date.Format(calendarFeedDateLayout)
+	end := event.date.AddDate(0, 0, 1).Format(calendarFeedDateLayout)
+
+	writeICSLine(b, "BEGIN:VEVENT")
+	// UID is deterministic per (stamp, kind, index): stable within a render,
+	// unique across events, and free of any owner identifier or secret.
+	writeICSLine(b, fmt.Sprintf("UID:%s-%d-%s@ovumcy", event.kind, index, stamp))
+	writeICSLine(b, "DTSTAMP:"+stamp)
+	writeICSLine(b, "DTSTART;VALUE=DATE:"+start)
+	writeICSLine(b, "DTEND;VALUE=DATE:"+end)
+	writeICSLine(b, "SUMMARY:"+escapeICSText(calendarFeedNeutralSummary))
+	writeICSLine(b, "DESCRIPTION:"+escapeICSText(disclaimer))
+	writeICSLine(b, "TRANSP:TRANSPARENT")
+	writeICSLine(b, "END:VEVENT")
+}
+
+// writeICSLine appends one content line with RFC 5545's mandatory CRLF
+// terminator, folding lines longer than 75 octets per §3.1. Folding is applied
+// to the fully-escaped line so an escape sequence is never split.
+func writeICSLine(b *strings.Builder, line string) {
+	b.WriteString(foldICSLine(line))
+	b.WriteString("\r\n")
+}
+
+// foldICSLine folds a content line to <=75 octets per RFC 5545 §3.1: where a
+// fold is needed a CRLF followed by a single space is inserted and the octet
+// count restarts. Folding is done on RUNE boundaries, never mid-rune, so a
+// multi-byte UTF-8 sequence in a localized disclaimer is never split into
+// invalid bytes (a byte-boundary fold could corrupt non-ASCII copy). CR/LF have
+// already been stripped by escapeICSText, so no fold can be mistaken for a real
+// line break.
+func foldICSLine(line string) string {
+	const maxOctets = 75
+	if len(line) <= maxOctets {
+		return line
+	}
+	var b strings.Builder
+	segmentOctets := 0
+	for _, r := range line {
+		runeOctets := utf8.RuneLen(r)
+		if runeOctets < 0 {
+			runeOctets = 1 // codecov:ignore -- RuneLen only returns -1 for an invalid rune; ranging a Go string yields RuneError (valid, len 3), so this is unreachable here.
+		}
+		if segmentOctets > 0 && segmentOctets+runeOctets > maxOctets {
+			b.WriteString("\r\n ")
+			segmentOctets = 0
+		}
+		b.WriteRune(r)
+		segmentOctets += runeOctets
+	}
+	return b.String()
+}
+
+// escapeICSText escapes a TEXT value per RFC 5545 §3.3.11: backslash, semicolon,
+// comma are backslash-escaped; CR/LF are collapsed to the literal "\n" escape so
+// a value can never inject a new content line (defense against a stray newline
+// in translated copy breaking the calendar structure).
+func escapeICSText(value string) string {
+	replacer := strings.NewReplacer(
+		"\\", "\\\\",
+		";", "\\;",
+		",", "\\,",
+		"\r\n", "\\n",
+		"\r", "\\n",
+		"\n", "\\n",
+	)
+	return replacer.Replace(value)
+}

--- a/internal/services/calendar_feed_ics_test.go
+++ b/internal/services/calendar_feed_ics_test.go
@@ -158,6 +158,24 @@ func TestBuildCalendarFeedICSHandlesNoBaseline(t *testing.T) {
 	}
 }
 
+func TestBuildCalendarFeedICSHandlesNilUser(t *testing.T) {
+	// A nil user (defensive guard) must yield a well-formed, empty VCALENDAR —
+	// never a panic and never a fabricated event.
+	body := string(BuildCalendarFeedICS(CalendarFeedICSInput{
+		User:       nil,
+		Logs:       predictableFeedLogs(t),
+		Now:        mustParseDashboardDay(t, "2026-03-20"),
+		Location:   time.UTC,
+		Disclaimer: "disclaimer",
+	}))
+	if strings.Contains(body, "BEGIN:VEVENT") {
+		t.Fatalf("expected no events for a nil user, got:\n%s", body)
+	}
+	if !strings.Contains(body, "BEGIN:VCALENDAR") || !strings.Contains(body, "END:VCALENDAR") {
+		t.Fatalf("expected a well-formed empty VCALENDAR, got:\n%s", body)
+	}
+}
+
 func TestBuildCalendarFeedICSProjectsMultipleCyclesAndEscapesDescription(t *testing.T) {
 	user := predictableFeedUser(t, "2026-03-02")
 	now := mustParseDashboardDay(t, "2026-03-20")

--- a/internal/services/calendar_feed_ics_test.go
+++ b/internal/services/calendar_feed_ics_test.go
@@ -1,0 +1,185 @@
+package services
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+)
+
+// predictableFeedUser builds an owner with a stable, predictable cycle so the
+// builder emits prediction events. now is chosen so the last period start is in
+// the recent past and future cycles fall ahead.
+func predictableFeedUser(t *testing.T, lastPeriodStart string) *models.User {
+	t.Helper()
+	start := mustParseDashboardDay(t, lastPeriodStart)
+	return &models.User{
+		ID:              7,
+		CycleLength:     28,
+		PeriodLength:    5,
+		LutealPhase:     14,
+		LastPeriodStart: &start,
+	}
+}
+
+func predictableFeedLogs(t *testing.T) []models.DailyLog {
+	t.Helper()
+	// Three prior cycle starts ~28 days apart establish an observed, stable
+	// cadence so predictions are enabled (not sparse/unpredictable).
+	return []models.DailyLog{
+		{Date: mustParseDashboardDay(t, "2026-01-05"), IsPeriod: true},
+		{Date: mustParseDashboardDay(t, "2026-02-02"), IsPeriod: true},
+		{Date: mustParseDashboardDay(t, "2026-03-02"), IsPeriod: true},
+	}
+}
+
+func TestBuildCalendarFeedICSEmitsNeutralEventsWithDisclaimer(t *testing.T) {
+	user := predictableFeedUser(t, "2026-03-02")
+	now := mustParseDashboardDay(t, "2026-03-20")
+
+	body := string(BuildCalendarFeedICS(CalendarFeedICSInput{
+		User:       user,
+		Logs:       predictableFeedLogs(t),
+		Now:        now,
+		Location:   time.UTC,
+		Disclaimer: "These are estimates, not medical advice or a method of contraception.",
+	}))
+
+	// Structural RFC 5545 markers (never localized copy).
+	for _, marker := range []string{"BEGIN:VCALENDAR", "END:VCALENDAR", "BEGIN:VEVENT", "END:VEVENT", "SUMMARY:", "DESCRIPTION:", "DTSTART;VALUE=DATE:"} {
+		if !strings.Contains(body, marker) {
+			t.Fatalf("expected .ics to contain %q, got:\n%s", marker, body)
+		}
+	}
+
+	if !strings.Contains(body, "\r\n") {
+		t.Fatalf("expected CRLF line endings per RFC 5545")
+	}
+
+	// Neutral-title invariant: no phase word, no date digits, no symptom hint in
+	// any SUMMARY line. The concrete date must live only in DTSTART/DTEND.
+	assertNeutralSummaries(t, body)
+
+	// Disclaimer must be present in a DESCRIPTION line (medical-safety).
+	if !strings.Contains(body, "DESCRIPTION:These are estimates") {
+		t.Fatalf("expected medical-safety disclaimer in DESCRIPTION, got:\n%s", body)
+	}
+}
+
+// assertNeutralSummaries fails if any SUMMARY line leaks a cycle phase, a date,
+// or a symptom token. It asserts the fixed neutral label and the absence of
+// health specifics — the data-minimization invariant.
+func assertNeutralSummaries(t *testing.T, body string) {
+	t.Helper()
+	leakyTokens := []string{
+		"ovulation", "Ovulation", "fertile", "Fertile", "period", "Period",
+		"menstru", "luteal", "follicular", "2026", "03-", "symptom",
+	}
+	sawSummary := false
+	for _, line := range strings.Split(body, "\r\n") {
+		if !strings.HasPrefix(line, "SUMMARY:") {
+			continue
+		}
+		sawSummary = true
+		if line != "SUMMARY:Ovumcy: reminder (estimate)" {
+			t.Fatalf("SUMMARY is not the fixed neutral label: %q", line)
+		}
+		for _, token := range leakyTokens {
+			if strings.Contains(line, token) {
+				t.Fatalf("SUMMARY leaks health-specific token %q: %q", token, line)
+			}
+		}
+	}
+	if !sawSummary {
+		t.Fatalf("expected at least one SUMMARY line")
+	}
+}
+
+func TestBuildCalendarFeedICSSuppressesForPregnancyPause(t *testing.T) {
+	user := predictableFeedUser(t, "2026-03-02")
+	now := mustParseDashboardDay(t, "2026-03-20")
+
+	logs := append(predictableFeedLogs(t),
+		// A positive pregnancy test with no later cycle start pauses predictions.
+		models.DailyLog{Date: mustParseDashboardDay(t, "2026-03-10"), PregnancyTest: models.PregnancyTestPositive},
+	)
+
+	body := string(BuildCalendarFeedICS(CalendarFeedICSInput{
+		User:       user,
+		Logs:       logs,
+		Now:        now,
+		Location:   time.UTC,
+		Disclaimer: "disclaimer",
+	}))
+
+	if strings.Contains(body, "BEGIN:VEVENT") {
+		t.Fatalf("pregnancy-pause must suppress ALL prediction events, got:\n%s", body)
+	}
+	// The calendar shell must still be well-formed (a valid, empty feed).
+	if !strings.Contains(body, "BEGIN:VCALENDAR") || !strings.Contains(body, "END:VCALENDAR") {
+		t.Fatalf("expected a well-formed empty VCALENDAR, got:\n%s", body)
+	}
+}
+
+func TestBuildCalendarFeedICSSuppressesForUnpredictableCycle(t *testing.T) {
+	user := predictableFeedUser(t, "2026-03-02")
+	user.UnpredictableCycle = true
+	now := mustParseDashboardDay(t, "2026-03-20")
+
+	body := string(BuildCalendarFeedICS(CalendarFeedICSInput{
+		User:       user,
+		Logs:       predictableFeedLogs(t),
+		Now:        now,
+		Location:   time.UTC,
+		Disclaimer: "disclaimer",
+	}))
+
+	if strings.Contains(body, "BEGIN:VEVENT") {
+		t.Fatalf("unpredictable-cycle mode must suppress ALL prediction events, got:\n%s", body)
+	}
+}
+
+func TestBuildCalendarFeedICSHandlesNoBaseline(t *testing.T) {
+	// A user with no last period start and no logs yields a valid empty feed,
+	// never a panic or a fabricated event.
+	body := string(BuildCalendarFeedICS(CalendarFeedICSInput{
+		User:       &models.User{ID: 1, CycleLength: 28},
+		Logs:       nil,
+		Now:        mustParseDashboardDay(t, "2026-03-20"),
+		Location:   time.UTC,
+		Disclaimer: "disclaimer",
+	}))
+	if strings.Contains(body, "BEGIN:VEVENT") {
+		t.Fatalf("expected no events without a baseline, got:\n%s", body)
+	}
+	if !strings.Contains(body, "BEGIN:VCALENDAR") {
+		t.Fatalf("expected a well-formed VCALENDAR, got:\n%s", body)
+	}
+}
+
+func TestBuildCalendarFeedICSProjectsMultipleCyclesAndEscapesDescription(t *testing.T) {
+	user := predictableFeedUser(t, "2026-03-02")
+	now := mustParseDashboardDay(t, "2026-03-20")
+
+	body := string(BuildCalendarFeedICS(CalendarFeedICSInput{
+		User:     user,
+		Logs:     predictableFeedLogs(t),
+		Now:      now,
+		Location: time.UTC,
+		// Commas/semicolons/newlines must be escaped per RFC 5545 §3.3.11.
+		Disclaimer: "estimate; not advice, really\nsecond line",
+	}))
+
+	// At least two upcoming cycles => multiple VEVENTs across the ~60-90d horizon.
+	if got := strings.Count(body, "BEGIN:VEVENT"); got < 2 {
+		t.Fatalf("expected multiple projected events, got %d:\n%s", got, body)
+	}
+	// The raw newline must not create a new content line; it is escaped to \n.
+	if strings.Contains(body, "DESCRIPTION:estimate; not advice") {
+		t.Fatalf("expected ';' and ',' escaped in DESCRIPTION, got:\n%s", body)
+	}
+	if !strings.Contains(body, `DESCRIPTION:estimate\; not advice\, really\nsecond line`) {
+		t.Fatalf("expected escaped DESCRIPTION content, got:\n%s", body)
+	}
+}

--- a/internal/services/calendar_feed_service.go
+++ b/internal/services/calendar_feed_service.go
@@ -1,0 +1,146 @@
+package services
+
+import (
+	"context"
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// CalendarFeedService resolves a calendar-feed bearer token to its owner and
+// renders that owner's read-only .ics body (issue #126-replacement / .ics,
+// slice 3). It is the business-logic seam the api layer calls: the api layer
+// stays transport-only (it never touches a repository, bcrypt, or the token
+// split), and every security decision — constant-time verification,
+// timing-equalization against selector enumeration, owner scoping, and
+// prediction suppression — lives here.
+//
+// The token IS the authorization: there is no session, cookie, or user id in
+// the request. ResolveFeed splits the token, looks the row up by its non-secret
+// selector, constant-time-verifies the secret verifier, and — only on success —
+// loads that resolved owner's logs (scoped strictly to the resolved user id) and
+// builds the feed. A malformed token, an unknown selector, a wrong verifier, and
+// a disabled feed are ALL reported the same way (ok=false, no body), so a caller
+// (and thus the HTTP surface) gets no oracle distinguishing them.
+type CalendarFeedService struct {
+	users      CalendarFeedUserReader
+	days       CalendarFeedDayReader
+	disclaimer DisclaimerProvider
+}
+
+// CalendarFeedUserReader resolves the single owner whose calendar_feed_selector
+// equals selector. It returns (user, false, nil) for no match — the same shape
+// FindByCalendarFeedSelector uses — so the service keeps an unknown selector and
+// a wrong verifier observationally identical.
+type CalendarFeedUserReader interface {
+	FindByCalendarFeedSelector(ctx context.Context, selector string) (models.User, bool, error)
+}
+
+// CalendarFeedDayReader loads the resolved owner's day logs for the prediction
+// window. It is the same read the dashboard/stats path uses; the feed passes a
+// bounded recent range so the .ics reflects the owner's current cycle history.
+type CalendarFeedDayReader interface {
+	FetchLogsForUser(ctx context.Context, userID uint, from time.Time, to time.Time, location *time.Location) ([]models.DailyLog, error)
+}
+
+// calendarFeedStatsWindowYears bounds the log history loaded to compute the
+// feed's predictions. It mirrors the dashboard/stats 2-year window so the feed's
+// cycle baseline is derived from the same span the in-app surfaces use.
+const calendarFeedStatsWindowYears = 2
+
+// NewCalendarFeedService wires the feed service from the user + day readers and
+// the localized-disclaimer provider (the same seam the webhook notify pass
+// uses). All three are required in production; tests may pass stubs.
+func NewCalendarFeedService(users CalendarFeedUserReader, days CalendarFeedDayReader, disclaimer DisclaimerProvider) *CalendarFeedService {
+	return &CalendarFeedService{
+		users:      users,
+		days:       days,
+		disclaimer: disclaimer,
+	}
+}
+
+// ResolveFeed authenticates a feed token and returns the owner's rendered .ics
+// body. ok is false — with no body — for EVERY failure mode (malformed token,
+// unknown selector, wrong verifier, disabled feed); the caller maps that single
+// outcome to a bare 404, giving no oracle. err is non-nil only for an
+// infrastructure failure (a DB or log-read error), which the caller maps to a
+// generic 500 — never a body that distinguishes it from the 404 path in a way
+// that leaks token state.
+//
+// Timing-equalization (mirrors equalizeAuthCredentialsTiming): the happy path
+// pays exactly one bcrypt compare inside VerifyCalendarFeedToken. The
+// selector-miss path would otherwise short-circuit before any bcrypt work and
+// leak — through response latency — that no row bears the presented selector
+// (CWE-208). So on a selector miss the service performs one dummy bcrypt against
+// a fixed placeholder hash, matching the happy path's single compare and leaving
+// no timing signal that separates "unknown selector" from "known selector, wrong
+// verifier". A malformed token (wrong length) is rejected before any lookup and
+// is not timing-sensitive: it reveals nothing about which selectors exist.
+func (service *CalendarFeedService) ResolveFeed(ctx context.Context, token string, now time.Time, location *time.Location) (body []byte, ok bool, err error) {
+	selector, _, split := SplitCalendarFeedToken(token)
+	if !split {
+		return nil, false, nil
+	}
+
+	user, found, err := service.users.FindByCalendarFeedSelector(ctx, selector)
+	if err != nil {
+		return nil, false, err
+	}
+	if !found {
+		// Selector resolves no row: spend the same single bcrypt the happy path
+		// spends so an unknown selector is timing-indistinguishable from a known
+		// one with a bad verifier.
+		equalizeCalendarFeedTiming(token)
+		return nil, false, nil
+	}
+
+	if !VerifyCalendarFeedToken(token, user.CalendarFeedSelector, user.CalendarFeedVerifierHash) {
+		return nil, false, nil
+	}
+
+	// Verified. Every read below is scoped strictly to the resolved user.ID —
+	// the request carried no user id, only the token, so the owner boundary is
+	// exactly the row the token resolved to.
+	feedLocation := location
+	if feedLocation == nil {
+		feedLocation = time.UTC
+	}
+	today := DateAtLocation(now, feedLocation)
+	from := today.AddDate(-calendarFeedStatsWindowYears, 0, 0)
+	logs, err := service.days.FetchLogsForUser(ctx, user.ID, from, today, feedLocation)
+	if err != nil {
+		return nil, false, err
+	}
+
+	disclaimer := ""
+	if service.disclaimer != nil {
+		// No per-owner language is persisted (mirrors the webhook notify pass):
+		// resolve the disclaimer at the server-default language. Messages merges
+		// the default over an empty/unknown target, so "" yields the default copy.
+		disclaimer = service.disclaimer.Disclaimer("")
+	}
+
+	feedUser := user
+	feed := BuildCalendarFeedICS(CalendarFeedICSInput{
+		User:       &feedUser,
+		Logs:       logs,
+		Now:        now,
+		Location:   feedLocation,
+		Disclaimer: disclaimer,
+	})
+	return feed, true, nil
+}
+
+// equalizeCalendarFeedTiming performs the single dummy bcrypt compare that keeps
+// the selector-miss path's latency indistinguishable from a real verification.
+// It is declared as a var so tests can replace it with an invocation counter and
+// assert "a dummy bcrypt occurred on the selector-miss path" without measuring
+// wall-clock time — the same test-substitution idiom as
+// equalizeAuthCredentialsTiming. Production never reassigns it. It reuses the
+// fixed placeholder hash whose embedded cost is pinned to passwordHashCost, so
+// the equalized path is never cheaper than the real bcrypt in
+// VerifyCalendarFeedToken.
+var equalizeCalendarFeedTiming = func(token string) {
+	_ = bcrypt.CompareHashAndPassword([]byte(credentialsTimingEqualizationHash), []byte(token))
+}

--- a/internal/services/calendar_feed_service_test.go
+++ b/internal/services/calendar_feed_service_test.go
@@ -222,6 +222,55 @@ func TestResolveFeedPropagatesInfrastructureError(t *testing.T) {
 	}
 }
 
+// TestResolveFeedPropagatesDayReadErrorAfterVerification drives the day-read
+// error branch that sits AFTER a successful token verification: the token is
+// valid (so the user lookup + verifier pass), but the owner-scoped log read
+// fails. This is distinct from the user-lookup failure above, which returns
+// before any log read.
+func TestResolveFeedPropagatesDayReadErrorAfterVerification(t *testing.T) {
+	user, token := armedFeedUser(t, 7, "2026-03-02")
+	users := &stubFeedUserReader{selector: user.CalendarFeedSelector, user: user}
+	days := &stubFeedDayReader{err: errors.New("log read failed")}
+	svc := NewCalendarFeedService(users, days, stubFeedDisclaimer{text: "d"})
+
+	body, ok, err := svc.ResolveFeed(context.Background(), token, mustParseDashboardDay(t, "2026-03-20"), time.UTC)
+	if err == nil {
+		t.Fatalf("expected the day-read error to propagate after verification")
+	}
+	if ok {
+		t.Fatalf("expected ok=false when the owner-scoped log read fails")
+	}
+	if body != nil {
+		t.Fatalf("expected no body on a day-read failure, got %d bytes", len(body))
+	}
+	if days.requestedUser != 7 {
+		t.Fatalf("expected the failing log read to be scoped to the resolved owner 7, got %d", days.requestedUser)
+	}
+}
+
+// TestResolveFeedDefaultsToUTCWhenLocationNil drives the nil-location fallback:
+// a cookieless feed request can arrive with no resolved timezone, so ResolveFeed
+// must default to UTC rather than nil-deref. The valid token still resolves and
+// the feed still renders.
+func TestResolveFeedDefaultsToUTCWhenLocationNil(t *testing.T) {
+	user, token := armedFeedUser(t, 7, "2026-03-02")
+	svc, _, days := newFeedServiceForTest(user, predictableFeedLogs(t))
+
+	body, ok, err := svc.ResolveFeed(context.Background(), token, mustParseDashboardDay(t, "2026-03-20"), nil)
+	if err != nil {
+		t.Fatalf("unexpected error with nil location: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected ok for a valid token with nil location")
+	}
+	if days.requestedCount != 1 {
+		t.Fatalf("expected exactly one owner-scoped log read, got %d", days.requestedCount)
+	}
+	if !strings.Contains(string(body), "BEGIN:VCALENDAR") {
+		t.Fatalf("expected a well-formed feed with nil location, got:\n%s", string(body))
+	}
+}
+
 // TestGenerateCalendarFeedTokenVerifierIsRealBcrypt pairs the timing-equalization
 // call-counter test with a real bcrypt compatibility check: a freshly generated
 // token verifies against its stored hash, and a tampered verifier does not. This

--- a/internal/services/calendar_feed_service_test.go
+++ b/internal/services/calendar_feed_service_test.go
@@ -1,0 +1,242 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+)
+
+// stubFeedUserReader resolves a single armed owner by selector. Any other
+// selector (or the empty string) is a miss, mirroring FindByCalendarFeedSelector.
+type stubFeedUserReader struct {
+	selector string
+	user     models.User
+	err      error
+	calls    int
+}
+
+func (s *stubFeedUserReader) FindByCalendarFeedSelector(_ context.Context, selector string) (models.User, bool, error) {
+	s.calls++
+	if s.err != nil {
+		return models.User{}, false, s.err
+	}
+	if selector != "" && selector == s.selector {
+		return s.user, true, nil
+	}
+	return models.User{}, false, nil
+}
+
+// stubFeedDayReader records the userID it was asked for so a test can prove the
+// feed scopes its log read to the resolved owner.
+type stubFeedDayReader struct {
+	logs           []models.DailyLog
+	err            error
+	requestedUser  uint
+	requestedCount int
+}
+
+func (s *stubFeedDayReader) FetchLogsForUser(_ context.Context, userID uint, _ time.Time, _ time.Time, _ *time.Location) ([]models.DailyLog, error) {
+	s.requestedUser = userID
+	s.requestedCount++
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.logs, nil
+}
+
+type stubFeedDisclaimer struct{ text string }
+
+func (s stubFeedDisclaimer) Disclaimer(string) string { return s.text }
+
+// armedFeedUser mints a real token and returns the owner row that would resolve
+// it, plus the full token to present. A real GenerateCalendarFeedToken keeps the
+// verifier bcrypt path exercised end-to-end.
+func armedFeedUser(t *testing.T, id uint, lastPeriodStart string) (models.User, string) {
+	t.Helper()
+	token, selector, verifierHash, err := GenerateCalendarFeedToken()
+	if err != nil {
+		t.Fatalf("GenerateCalendarFeedToken: %v", err)
+	}
+	start := mustParseDashboardDay(t, lastPeriodStart)
+	user := models.User{
+		ID:                       id,
+		CycleLength:              28,
+		PeriodLength:             5,
+		LutealPhase:              14,
+		LastPeriodStart:          &start,
+		CalendarFeedSelector:     selector,
+		CalendarFeedVerifierHash: verifierHash,
+	}
+	return user, token
+}
+
+func newFeedServiceForTest(user models.User, logs []models.DailyLog) (*CalendarFeedService, *stubFeedUserReader, *stubFeedDayReader) {
+	users := &stubFeedUserReader{selector: user.CalendarFeedSelector, user: user}
+	days := &stubFeedDayReader{logs: logs}
+	svc := NewCalendarFeedService(users, days, stubFeedDisclaimer{text: "estimates disclaimer"})
+	return svc, users, days
+}
+
+func TestResolveFeedReturnsOwnersFeedForValidToken(t *testing.T) {
+	user, token := armedFeedUser(t, 42, "2026-03-02")
+	logs := predictableFeedLogs(t)
+	svc, _, days := newFeedServiceForTest(user, logs)
+
+	body, ok, err := svc.ResolveFeed(context.Background(), token, mustParseDashboardDay(t, "2026-03-20"), time.UTC)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected ok for a valid token")
+	}
+	if days.requestedUser != 42 {
+		t.Fatalf("expected log read scoped to resolved owner 42, got %d", days.requestedUser)
+	}
+	text := string(body)
+	if !strings.Contains(text, "BEGIN:VCALENDAR") || !strings.Contains(text, "BEGIN:VEVENT") {
+		t.Fatalf("expected a populated .ics for a predictable owner, got:\n%s", text)
+	}
+}
+
+// TestResolveFeedCrossUserIsolation is the headline test: user A's token must
+// NEVER return user B's events. Only A's selector is armed in the reader; A's
+// token resolves A, and the log read is scoped to A's id — B's id is never
+// requested.
+func TestResolveFeedCrossUserIsolation(t *testing.T) {
+	userA, tokenA := armedFeedUser(t, 100, "2026-03-02")
+	_, tokenB := armedFeedUser(t, 200, "2026-03-05")
+
+	// Reader knows only user A. B's marker logs would be a privacy breach if ever
+	// surfaced through A's feed.
+	days := &stubFeedDayReader{logs: predictableFeedLogs(t)}
+	users := &stubFeedUserReader{selector: userA.CalendarFeedSelector, user: userA}
+	svc := NewCalendarFeedService(users, days, stubFeedDisclaimer{text: "d"})
+
+	// A's token resolves A and reads A's logs only.
+	if _, ok, err := svc.ResolveFeed(context.Background(), tokenA, mustParseDashboardDay(t, "2026-03-20"), time.UTC); err != nil || !ok {
+		t.Fatalf("A's token should resolve A: ok=%v err=%v", ok, err)
+	}
+	if days.requestedUser != 100 {
+		t.Fatalf("A's feed must read only A's logs (id 100), got %d", days.requestedUser)
+	}
+
+	// B's token (B is NOT armed in this reader) must not resolve to A, and must
+	// not trigger a scoped read for A. It is an ordinary 404 (no oracle).
+	days.requestedCount = 0
+	_, ok, err := svc.ResolveFeed(context.Background(), tokenB, mustParseDashboardDay(t, "2026-03-20"), time.UTC)
+	if err != nil {
+		t.Fatalf("unexpected error for B's token: %v", err)
+	}
+	if ok {
+		t.Fatalf("B's token must NOT resolve to A's feed")
+	}
+	if days.requestedCount != 0 {
+		t.Fatalf("a non-resolving token must not trigger any owner-scoped log read, got %d reads", days.requestedCount)
+	}
+}
+
+// TestResolveFeedIdenticalNotFoundForEveryBadToken proves the no-oracle
+// contract: malformed token, unknown selector, and wrong verifier all yield the
+// identical (nil, false, nil) result — no body, no distinguishing error.
+func TestResolveFeedIdenticalNotFoundForEveryBadToken(t *testing.T) {
+	user, validToken := armedFeedUser(t, 7, "2026-03-02")
+	svc, _, _ := newFeedServiceForTest(user, predictableFeedLogs(t))
+	now := mustParseDashboardDay(t, "2026-03-20")
+
+	// Malformed: wrong length, rejected before any lookup.
+	malformed := "TOOSHORT"
+	// Unknown selector: right length shape, but selector not armed. Flip the
+	// selector half of the valid token so the length stays valid.
+	unknownSelector := "ZZZZZZZZZZZZZZZZ" + validToken[16:]
+	// Wrong verifier: correct selector, corrupted verifier half.
+	wrongVerifier := validToken[:16] + strings.Repeat("2", len(validToken)-16)
+
+	for name, bad := range map[string]string{
+		"malformed":       malformed,
+		"unknownSelector": unknownSelector,
+		"wrongVerifier":   wrongVerifier,
+	} {
+		body, ok, err := svc.ResolveFeed(context.Background(), bad, now, time.UTC)
+		if err != nil {
+			t.Fatalf("%s: expected nil error (no oracle), got %v", name, err)
+		}
+		if ok {
+			t.Fatalf("%s: expected ok=false", name)
+		}
+		if body != nil {
+			t.Fatalf("%s: expected no body, got %d bytes", name, len(body))
+		}
+	}
+}
+
+// TestResolveFeedEqualizesTimingOnSelectorMiss asserts (via a call-counter, not
+// wall-clock) that the selector-miss path performs a dummy bcrypt, so an unknown
+// selector is timing-indistinguishable from a known selector with a bad
+// verifier. Mirrors the equalizeAuthCredentialsTiming test idiom.
+func TestResolveFeedEqualizesTimingOnSelectorMiss(t *testing.T) {
+	original := equalizeCalendarFeedTiming
+	calls := 0
+	equalizeCalendarFeedTiming = func(string) { calls++ }
+	t.Cleanup(func() { equalizeCalendarFeedTiming = original })
+
+	user, validToken := armedFeedUser(t, 7, "2026-03-02")
+	svc, _, _ := newFeedServiceForTest(user, predictableFeedLogs(t))
+	now := mustParseDashboardDay(t, "2026-03-20")
+
+	// A well-formed token whose selector resolves no row (selector-miss path).
+	unknownSelector := "ZZZZZZZZZZZZZZZZ" + validToken[16:]
+	if _, ok, _ := svc.ResolveFeed(context.Background(), unknownSelector, now, time.UTC); ok {
+		t.Fatalf("expected selector miss to be ok=false")
+	}
+	if calls != 1 {
+		t.Fatalf("expected exactly one dummy bcrypt on the selector-miss path, got %d", calls)
+	}
+
+	// A malformed token is rejected before the lookup and must NOT spend the
+	// equalization bcrypt (it reveals nothing about selector existence).
+	calls = 0
+	if _, ok, _ := svc.ResolveFeed(context.Background(), "SHORT", now, time.UTC); ok {
+		t.Fatalf("expected malformed token to be ok=false")
+	}
+	if calls != 0 {
+		t.Fatalf("malformed token must not spend the equalization bcrypt, got %d", calls)
+	}
+}
+
+func TestResolveFeedPropagatesInfrastructureError(t *testing.T) {
+	user, token := armedFeedUser(t, 7, "2026-03-02")
+	users := &stubFeedUserReader{selector: user.CalendarFeedSelector, user: user, err: errors.New("db down")}
+	days := &stubFeedDayReader{}
+	svc := NewCalendarFeedService(users, days, stubFeedDisclaimer{text: "d"})
+
+	_, ok, err := svc.ResolveFeed(context.Background(), token, mustParseDashboardDay(t, "2026-03-20"), time.UTC)
+	if err == nil {
+		t.Fatalf("expected the infrastructure error to propagate")
+	}
+	if ok {
+		t.Fatalf("expected ok=false on infrastructure error")
+	}
+}
+
+// TestGenerateCalendarFeedTokenVerifierIsRealBcrypt pairs the timing-equalization
+// call-counter test with a real bcrypt compatibility check: a freshly generated
+// token verifies against its stored hash, and a tampered verifier does not. This
+// guards that the equalization placeholder stays cost-compatible with the real
+// verification path.
+func TestGenerateCalendarFeedTokenVerifierIsRealBcrypt(t *testing.T) {
+	token, selector, verifierHash, err := GenerateCalendarFeedToken()
+	if err != nil {
+		t.Fatalf("GenerateCalendarFeedToken: %v", err)
+	}
+	if !VerifyCalendarFeedToken(token, selector, verifierHash) {
+		t.Fatalf("a freshly minted token must verify against its stored hash")
+	}
+	tampered := token[:16] + strings.Repeat("2", len(token)-16)
+	if VerifyCalendarFeedToken(tampered, selector, verifierHash) {
+		t.Fatalf("a tampered verifier must not verify")
+	}
+}


### PR DESCRIPTION
## Slice 3 of the .ics calendar-feed subscription (#126-replacement / .ics)

Adds the GET endpoint, the RFC 5545 `.ics` builder, and the full security envelope. Slice 1 storage (token gen/verify + repo columns) merged in `main` as #176 and is the base; the settings UI to generate/rotate/revoke and the force-rotate hooks are slice 4; detailed-event opt-in and governance/docs/openapi are later slices.

### Endpoint & routing
- `GET /calendar/feed/:token.ics`, registered as a **page route**, **not** under `/api/v1` and **not** behind `AuthRequired`/`OwnerOnly` — a calendar client sends no cookie, so the request is authenticated by the **path token alone**.
- Fiber v3 treats `.` as a parameter delimiter, so `:token.ics` binds a clean `:token` param (verified empirically). `SafeRequestLogPath` prefers the matched route template `/calendar/feed/:token.ics`, whose last segment starts with `:` and is emitted verbatim — **the token value never reaches a log line**.
- The raw-path log fallback (`sanitizeRequestLogSegment`) is additionally hardened to mask a `<token>.ics` segment. Without this, the trailing `.ics` (a `.`) defeats the opaque-token check and would leak the token on the route-template-unavailable path — the exact gap flagged in review.

### Token → owner (the scoping) + no-oracle
- `CalendarFeedService` owns every security decision so `internal/api` stays transport-only: split token → resolve owner by non-secret **selector** → **constant-time** verify the secret verifier → scope every read to the resolved `user_id` (the request carries no user id).
- Malformed token, unknown selector, wrong verifier, and disabled feed **all** return an **identical bare 404** with no body and no `Set-Cookie`, **timing-equalized** with a dummy bcrypt on the selector-miss path (mirrors `equalize*Timing`, reusing the cost-pinned placeholder hash).
- Per-IP rate-limited via a `limiter.New` on the feed prefix (same spoof-proof key generator + API budget); a 429 returns a bare status (no UI).

### `.ics` builder (medical-safety + data-minimization)
- Transport-free; reuses the **exact** dashboard prediction path (`BuildCycleStatsFromLogs` → `DashboardUpcomingPredictions`) — never queries `daily_logs` directly. Projects the next ~3 cycles (~60-90d).
- **Suppression:** if `DashboardPredictionDisabled(user)` or `stats.PregnancyPaused`, emits **zero** prediction events — never pushes a fertile window into a pregnant owner's calendar.
- **Neutral titles:** every `SUMMARY` is the fixed `Ovumcy: reminder (estimate)` — no phase/date/symptom, so a lock screen / shared calendar reveals nothing. The localized medical-safety disclaimer lives in each VEVENT `DESCRIPTION`.
- Response headers: `Content-Type: text/calendar; charset=utf-8`, `Cache-Control: private, max-age=3600`, `X-Robots-Tag: noindex`.

### Tests (security core)
Right-owner resolution; **cross-user isolation** (A's token never returns B's events); identical-404 no-oracle across malformed/unknown/wrong/cleared; timing-equalization via **call-counter** (asserts a dummy bcrypt on selector-miss, not wall-clock); per-IP rate-limit (real `limiter.New`); neutral-SUMMARY default; disclaimer present in DESCRIPTION; suppression (pregnancy-pause + unpredictable → no VEVENTs); token redacted from a captured request log + raw-fallback regression. `.ics` asserts structural markers, not localized copy.

### Assumptions
- **No per-owner language is persisted** (same as the webhook notify pass), so the disclaimer resolves at the server-default language via the shared `DisclaimerProvider` seam.
- Feed uses **server-local time** (the cookieless request has no timezone hint; `requestLocation` falls back to the server zone).
- Reuses the **API rate-limit budget** (`RATE_LIMIT_API_*`) for the feed rather than adding a new env knob (kept in scope; can be split later if needed).

### Validation
`go build`/`vet` clean · full `go test ./internal/api/... ./internal/services/... ./cmd/...` green · **staticcheck** clean · **golangci-lint v2.12.2** 0 issues (`for i := range n`, zero `//nolint`) · gofmt clean · **patch-coverage gate OK** (fresh via `scripts/patch-coverage-local.sh`).
