### PR TITLE
test(api): kill settings/onboarding mutation survivors

### DIFF
--- a/internal/api/onboarding_mutation_helpers_test.go
+++ b/internal/api/onboarding_mutation_helpers_test.go
@@ -1,0 +1,263 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/ovumcy/ovumcy-web/internal/models"
+)
+
+// Behavior-asserting tests closing mutation survivors in the onboarding input
+// helpers (handlers_onboarding_input_helpers.go) and the auth-token TTL constants
+// declared in handler_types.go. The timezone-parse helpers take a fiber.Ctx, so
+// they are exercised through a minimal mounted route that echoes their result —
+// this pins the branch decisions directly without depending on the full
+// onboarding persistence flow (which masks these branches because its form body
+// parses identically via both PostArgs and url.ParseQuery).
+
+// mountTimezoneValueProbe returns a Fiber app whose POST /tz-probe echoes
+// onboardingFormTimezoneValue(c) wrapped in brackets so an empty result is
+// visible as "[]".
+func mountTimezoneValueProbe() *fiber.App {
+	app := fiber.New()
+	app.Post("/tz-probe", func(c fiber.Ctx) error {
+		return c.SendString("[" + onboardingFormTimezoneValue(c) + "]")
+	})
+	return app
+}
+
+func timezoneValueProbeResult(t *testing.T, app *fiber.App, contentType, body string) string {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/tz-probe", strings.NewReader(body))
+	req.Header.Set("Content-Type", contentType)
+	resp, err := app.Test(req, testConfigNoTimeout)
+	if err != nil {
+		t.Fatalf("tz-probe request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	return mustReadBodyString(t, resp.Body)
+}
+
+// TestOnboardingFormTimezoneValue_PostArgPresentShortCircuitsBodyReparse pins the
+// `raw != ""` decision (handlers_onboarding_input_helpers.go:18): when the
+// client_timezone field is present in the parsed POST args, it is returned
+// verbatim WITHOUT re-parsing the raw body. A body that url.ParseQuery cannot
+// round-trip (contains ';') proves the short-circuit: the whole PostArg value is
+// returned, whereas negating the guard to `== ""` drops into the body re-parse,
+// which errors on ';' and yields "".
+func TestOnboardingFormTimezoneValue_PostArgPresentShortCircuitsBodyReparse(t *testing.T) {
+	app := mountTimezoneValueProbe()
+
+	// application/x-www-form-urlencoded => fasthttp populates PostArgs; the ';'
+	// is preserved in the PostArg value but makes url.ParseQuery fail.
+	got := timezoneValueProbeResult(t, app, "application/x-www-form-urlencoded", "client_timezone=Zone-A;junk=1")
+	if got != "[Zone-A;junk=1]" {
+		t.Fatalf("present PostArg must be returned verbatim, got %q", got)
+	}
+}
+
+// TestOnboardingFormTimezoneValue_FallsBackToBodyQuery pins BOTH the empty-PostArg
+// fallthrough and the `err != nil` guard (handlers_onboarding_input_helpers.go:23).
+// A non-form Content-Type leaves PostArgs empty, so the function must parse the
+// raw body as a query string and return the field. Negating `err != nil` to
+// `== nil` would return "" on the success path.
+func TestOnboardingFormTimezoneValue_FallsBackToBodyQuery(t *testing.T) {
+	app := mountTimezoneValueProbe()
+
+	// text/plain => PostArgs empty => url.ParseQuery(body) path, which succeeds.
+	got := timezoneValueProbeResult(t, app, "text/plain", "client_timezone=Zone-Body")
+	if got != "[Zone-Body]" {
+		t.Fatalf("body-query fallback must return the parsed value, got %q", got)
+	}
+
+	// A body url.ParseQuery cannot decode (bad percent-escape) hits the error
+	// branch and yields "" — this is the true side of the `err != nil` guard.
+	gotBad := timezoneValueProbeResult(t, app, "text/plain", "client_timezone=%zzBad")
+	if gotBad != "[]" {
+		t.Fatalf("unparseable body must yield empty timezone, got %q", gotBad)
+	}
+}
+
+// mountOnboardingLocationProbe mounts a route that invokes
+// requestLocationFromOnboardingForm directly on a minimal handler (no
+// LanguageMiddleware). This isolates the handler's OWN timezone-cookie decision:
+// in the full request pipeline LanguageMiddleware also mirrors the header into the
+// cookie, which masks the handler-level branch, so a bare route is required to
+// observe handlers_onboarding_input_helpers.go:31.
+func mountOnboardingLocationProbe() *fiber.App {
+	handler := &Handler{location: time.UTC}
+	app := fiber.New()
+	app.Post("/loc-probe", func(c fiber.Ctx) error {
+		loc := handler.requestLocationFromOnboardingForm(c)
+		return c.SendString(loc.String())
+	})
+	return app
+}
+
+// TestRequestLocationFromOnboardingForm_RefreshesTimezoneCookieOnMismatch pins the
+// `strings.TrimSpace(c.Cookies(...)) != canonical` decision
+// (handlers_onboarding_input_helpers.go:31). With a valid header timezone whose
+// canonical form differs from the current cookie, the handler must (re)issue the
+// timezone cookie; when the cookie already matches, it must NOT. Negating to `==`
+// inverts both, which the two sub-cases below catch.
+func TestRequestLocationFromOnboardingForm_RefreshesTimezoneCookieOnMismatch(t *testing.T) {
+	app := mountOnboardingLocationProbe()
+
+	nowUTC := time.Now().UTC()
+	timezoneName, location := timezoneWithDifferentCalendarDay(t, nowUTC)
+
+	t.Run("mismatch sets cookie", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/loc-probe", strings.NewReader(""))
+		req.Header.Set(timezoneHeaderName, timezoneName) // valid header, NO tz cookie -> mismatch
+		resp, err := app.Test(req, testConfigNoTimeout)
+		if err != nil {
+			t.Fatalf("loc-probe request failed: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if body := mustReadBodyString(t, resp.Body); body != location.String() {
+			t.Fatalf("resolved location = %q, want %q", body, location.String())
+		}
+		cookie := responseCookie(resp.Cookies(), timezoneCookieName)
+		if cookie == nil {
+			t.Fatalf("expected %s cookie to be set on header/cookie mismatch", timezoneCookieName)
+		}
+		if strings.TrimSpace(cookie.Value) != timezoneName {
+			t.Fatalf("expected %s cookie value %q, got %q", timezoneCookieName, timezoneName, cookie.Value)
+		}
+	})
+
+	t.Run("already-matching cookie is not re-set", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/loc-probe", strings.NewReader(""))
+		req.Header.Set(timezoneHeaderName, timezoneName)
+		req.Header.Set("Cookie", timezoneCookieName+"="+timezoneName) // cookie already canonical
+		resp, err := app.Test(req, testConfigNoTimeout)
+		if err != nil {
+			t.Fatalf("loc-probe request failed: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if cookie := responseCookie(resp.Cookies(), timezoneCookieName); cookie != nil {
+			t.Fatalf("cookie already matched canonical %q; handler must not re-set it, got Set-Cookie %q", timezoneName, cookie.Value)
+		}
+	})
+}
+
+// TestOnboardingStep2_JSONBodyValidInputSucceeds pins the JSON-body error guard
+// in parseOnboardingStep2Input (handlers_onboarding_input_helpers.go:117). On the
+// JSON path the cycle/period ints are re-serialized with strconv.Itoa before
+// ParseAndNormalizeStep2Input re-parses them, so that call never errors for a
+// well-formed JSON body — meaning the `if err != nil` guard's false branch is the
+// only reachable one. A valid JSON step-2 submission must therefore be accepted
+// (200, not a validation error). Negating the guard to `== nil` makes every valid
+// JSON step-2 body wrongly return "invalid input". No existing test posts a JSON
+// step-2 body, so this branch was uncovered.
+func TestOnboardingStep2_JSONBodyValidInputSucceeds(t *testing.T) {
+	app, database := newOnboardingTestApp(t)
+	user := createOnboardingTestUser(t, database, "onboarding-step2-json@example.com", "StrongPass1", false)
+	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
+
+	// Seed step 1 so step 2 can fully complete onboarding on success.
+	start := time.Date(2026, 2, 10, 0, 0, 0, 0, time.UTC)
+	if err := database.Model(&models.User{}).Where("id = ?", user.ID).Update("last_period_start", start).Error; err != nil {
+		t.Fatalf("seed last_period_start: %v", err)
+	}
+
+	jsonBody := `{"cycle_length":28,"period_length":5,"auto_period_fill":true,"irregular_cycle":false}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/onboarding/steps/2", strings.NewReader(jsonBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Cookie", authCookie)
+	resp := mustAppResponse(t, app, req)
+	defer func() { _ = resp.Body.Close() }()
+
+	// A valid JSON body must not be rejected as "invalid input"; the JSON success
+	// arm returns 200. The negated guard would surface a 400 validation error.
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("valid JSON step2 status = %d, want 200 (body %q)", resp.StatusCode, mustReadBodyString(t, resp.Body))
+	}
+
+	var reloaded models.User
+	if err := database.First(&reloaded, user.ID).Error; err != nil {
+		t.Fatalf("reload user: %v", err)
+	}
+	if reloaded.CycleLength != 28 || reloaded.PeriodLength != 5 {
+		t.Fatalf("expected cycle/period settings persisted from JSON step2, got cycle=%d period=%d", reloaded.CycleLength, reloaded.PeriodLength)
+	}
+}
+
+// TestOnboardingComplete_EligibleUserRedirectsToDashboard drives the standalone
+// /api/v1/onboarding/complete happy path (handlers_onboarding_complete.go): an
+// eligible owner (onboarding not yet completed, last_period_start already set)
+// completes successfully and is redirected to /dashboard. This pins the
+// `if err != nil` guard at line 27 — negating it to `== nil` turns a successful
+// completion into an onboarding-finish error. Existing onboarding-complete tests
+// reach this endpoint only AFTER step 2 has already completed onboarding, so they
+// short-circuit at the eligibility check and never exercise this success arm.
+func TestOnboardingComplete_EligibleUserRedirectsToDashboard(t *testing.T) {
+	app, database := newOnboardingTestApp(t)
+	user := createOnboardingTestUser(t, database, "onboarding-complete-success@example.com", "StrongPass1", false)
+	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
+
+	// Make the user eligible: onboarding still pending but a last period start on
+	// record (step 1 already saved). This is the exact precondition under which
+	// CompleteOnboardingForUser succeeds.
+	start := time.Date(2026, 2, 10, 0, 0, 0, 0, time.UTC)
+	if err := database.Model(&models.User{}).Where("id = ?", user.ID).Update("last_period_start", start).Error; err != nil {
+		t.Fatalf("seed last_period_start: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/onboarding/complete", strings.NewReader(""))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("HX-Request", "true")
+	req.Header.Set("Cookie", authCookie)
+	resp := mustAppResponse(t, app, req)
+	defer func() { _ = resp.Body.Close() }()
+
+	// HTMX success arm returns 200 with HX-Redirect /dashboard; the negated guard
+	// would instead surface an onboarding-finish error status.
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("complete status = %d, want 200 (body %q)", resp.StatusCode, mustReadBodyString(t, resp.Body))
+	}
+	if redirect := resp.Header.Get("HX-Redirect"); redirect != "/dashboard" {
+		t.Fatalf("expected HX-Redirect /dashboard on successful completion, got %q", redirect)
+	}
+
+	var reloaded models.User
+	if err := database.First(&reloaded, user.ID).Error; err != nil {
+		t.Fatalf("reload user: %v", err)
+	}
+	if !reloaded.OnboardingCompleted {
+		t.Fatal("expected onboarding to be marked completed after success")
+	}
+}
+
+// TestAuthTokenTTLConstants pins the two auth-token TTL constants declared in
+// handler_types.go against their intended multiplied values. The ARITHMETIC_BASE
+// mutants replace the '*' operators (7*24, 30*24, and *time.Hour) with '/', which
+// collapses each Duration to ~0; asserting the exact multi-day durations kills all
+// four. (The constants power remember-me vs default auth-token lifetimes consumed
+// by handlers_auth_token_helpers.go.)
+func TestAuthTokenTTLConstants(t *testing.T) {
+	if defaultAuthTokenTTL != 7*24*time.Hour {
+		t.Fatalf("defaultAuthTokenTTL = %v, want %v", defaultAuthTokenTTL, 7*24*time.Hour)
+	}
+	if defaultAuthTokenTTL != 168*time.Hour {
+		t.Fatalf("defaultAuthTokenTTL = %v, want 168h", defaultAuthTokenTTL)
+	}
+	if rememberAuthTokenTTL != 30*24*time.Hour {
+		t.Fatalf("rememberAuthTokenTTL = %v, want %v", rememberAuthTokenTTL, 30*24*time.Hour)
+	}
+	if rememberAuthTokenTTL != 720*time.Hour {
+		t.Fatalf("rememberAuthTokenTTL = %v, want 720h", rememberAuthTokenTTL)
+	}
+	// Remember-me must outlast the default lifetime; a collapsed operator would
+	// break this ordering too.
+	if rememberAuthTokenTTL <= defaultAuthTokenTTL {
+		t.Fatalf("remember-me TTL (%v) must exceed default TTL (%v)", rememberAuthTokenTTL, defaultAuthTokenTTL)
+	}
+}

--- a/internal/api/settings_mutation_handlers_test.go
+++ b/internal/api/settings_mutation_handlers_test.go
@@ -1,0 +1,451 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/net/html"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/ovumcy/ovumcy-web/internal/db"
+	"github.com/ovumcy/ovumcy-web/internal/i18n"
+	"github.com/ovumcy/ovumcy-web/internal/models"
+	"github.com/ovumcy/ovumcy-web/internal/services"
+	"github.com/pquerna/otp/totp"
+	"gorm.io/gorm"
+)
+
+// HTTP-integration tests closing mutation survivors in the settings handlers.
+// They mirror the internal/api harness (Fiber + real migrated temp DB + real
+// services) and assert observable behavior that a surviving mutation would break.
+//
+// Documented EQUIVALENT mutant (intentionally NOT killed): the
+// CONDITIONALS_NEGATION mutant on handlers_settings_danger.go:75 negates the
+// `hasJSONBody(c)` operand of
+// `if err := c.Bind().Body(&input); err != nil && hasJSONBody(c)` in
+// parsePasswordProtectedSettingsAction. passwordProtectedSettingsInput has a
+// single string Password field, so a bind error is only reachable on malformed
+// JSON and always leaves Password empty; the very next check
+// (`if input.Password == ""`) emits the identical settingsMissingPasswordErrorSpec.
+// There is therefore no request where the guard's value changes the observable
+// spec/status — verified by running the full clear-data/delete/missing-password
+// suite green with the operand negated.
+
+// --- handlers_settings_2fa.go ---
+
+// authCookieAuthenticates returns whether the given auth cookie is accepted on a
+// protected page (200). Used to prove a re-issued session cookie carries the
+// correct auth_session_version.
+func authCookieAuthenticates(t *testing.T, app *fiber.App, authCookieValue string) bool {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/settings", nil)
+	req.Header.Set("Accept-Language", "en")
+	req.Header.Set("Cookie", authCookieName+"="+authCookieValue)
+	resp, err := app.Test(req, testConfigNoTimeout)
+	if err != nil {
+		t.Fatalf("protected probe failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	return resp.StatusCode == http.StatusOK
+}
+
+// TestVerifyTOTP2FAEnrollment_ReissuedCookieStaysValidAndReturnsSuccess pins two
+// enrollment mutants:
+//   - handlers_settings_2fa.go:107 (`NormalizeAuthSessionVersion(...) + 1`): the
+//     in-memory bump must match the atomically bumped DB row so the re-issued
+//     ovumcy_auth cookie authenticates. `- 1` mints a cookie with the wrong
+//     version, which the next request rejects.
+//   - handlers_settings_2fa.go:109 (`refreshCurrentSession(...); err != nil`):
+//     negating to `== nil` returns early before the HTMX success markup, so the
+//     success body disappears.
+func TestVerifyTOTP2FAEnrollment_ReissuedCookieStaysValidAndReturnsSuccess(t *testing.T) {
+	ctx := newTOTPSettingsContext(t, "totp-enroll-reissue@example.com")
+
+	key, err := getTOTPServiceForTest(ctx.database).GenerateSetupKey("Ovumcy", ctx.user.Email)
+	if err != nil {
+		t.Fatalf("GenerateSetupKey: %v", err)
+	}
+	setupCookie := sealTOTPSetupCookieForTest(t, []byte("test-secret-key"), key.Secret())
+	code, err := totp.GenerateCode(key.Secret(), time.Now())
+	if err != nil {
+		t.Fatalf("GenerateCode: %v", err)
+	}
+
+	form := url.Values{"code": {code}, "password": {"StrongPass1"}, "csrf_token": {ctx.csrfToken}}
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/users/current/2fa", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("HX-Request", "true")
+	req.Header.Set("Accept-Language", "en")
+	req.Header.Set("Cookie", joinCookieHeader(ctx.authCookie, cookiePair(ctx.csrfCookie), setupCookie))
+	resp, err := ctx.app.Test(req, testConfigNoTimeout)
+	if err != nil {
+		t.Fatalf("verify enroll: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("HTMX enroll status = %d, want 200", resp.StatusCode)
+	}
+
+	// L109: the HTMX success body must be present (skipped if refresh-branch flips).
+	body := mustReadBodyString(t, resp.Body)
+	if !strings.Contains(body, "toast-close") {
+		t.Fatalf("expected dismissible success markup after enrollment, got %q", body)
+	}
+
+	// L107: the freshly re-issued cookie must authenticate the originating device.
+	refreshed := responseCookie(resp.Cookies(), authCookieName)
+	if refreshed == nil || strings.TrimSpace(refreshed.Value) == "" {
+		t.Fatal("enrollment must re-issue ovumcy_auth")
+	}
+	if !authCookieAuthenticates(t, ctx.app, refreshed.Value) {
+		t.Fatal("re-issued auth cookie must authenticate; wrong session-version bump would reject it")
+	}
+}
+
+// TestDisableTOTP2FA_ReissuedCookieStaysValidAndReturnsSuccess pins the disable-side
+// twins of the above: handlers_settings_2fa.go:161 (`... + 1`) and :164
+// (`refreshCurrentSession(...); err != nil`).
+func TestDisableTOTP2FA_ReissuedCookieStaysValidAndReturnsSuccess(t *testing.T) {
+	ctx := newTOTPSettingsContext(t, "totp-disable-reissue@example.com")
+	if err := getTOTPServiceForTest(ctx.database).EnableTOTP(context.Background(), ctx.user.ID, "JBSWY3DPEHPK3PXP"); err != nil {
+		t.Fatalf("EnableTOTP setup: %v", err)
+	}
+	ctx.refreshAuthCookie(t)
+
+	form := url.Values{"password": {"StrongPass1"}}
+	resp := settingsFormRequestWithCSRF(t, ctx, http.MethodDelete, "/api/v1/users/current/2fa", form, map[string]string{
+		"Accept-Language": "en",
+		"HX-Request":      "true",
+	})
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("HTMX disable status = %d, want 200", resp.StatusCode)
+	}
+
+	// L164: HTMX success body present.
+	body := mustReadBodyString(t, resp.Body)
+	if !strings.Contains(body, "toast-close") {
+		t.Fatalf("expected dismissible success markup after disable, got %q", body)
+	}
+
+	// L161: re-issued cookie authenticates.
+	refreshed := responseCookie(resp.Cookies(), authCookieName)
+	if refreshed == nil || strings.TrimSpace(refreshed.Value) == "" {
+		t.Fatal("disable must re-issue ovumcy_auth")
+	}
+	if !authCookieAuthenticates(t, ctx.app, refreshed.Value) {
+		t.Fatal("re-issued auth cookie must authenticate after disable; wrong session-version bump would reject it")
+	}
+}
+
+// --- handlers_settings_symptoms.go ---
+
+// TestDefaultSymptomDraftIcon_EmptyFallsBackToDefault pins the `icon == ""`
+// decision in defaultSymptomDraftIcon (handlers_settings_symptoms.go:120): an
+// empty/whitespace icon yields the default sparkle; a provided icon is kept.
+// Negating to `!=` swaps the two branches.
+func TestDefaultSymptomDraftIcon_EmptyFallsBackToDefault(t *testing.T) {
+	if got := defaultSymptomDraftIcon(""); got != "✨" {
+		t.Fatalf("empty icon must default to ✨, got %q", got)
+	}
+	if got := defaultSymptomDraftIcon("   "); got != "✨" {
+		t.Fatalf("whitespace icon must default to ✨, got %q", got)
+	}
+	if got := defaultSymptomDraftIcon("🔥"); got != "🔥" {
+		t.Fatalf("provided icon must be kept, got %q", got)
+	}
+}
+
+// TestLocalizedSettingsSymptomStatus pins the two decisions in
+// localizedSettingsSymptomStatus (handlers_settings_symptoms.go:110 and :111):
+//   - :110 `SettingsStatusTranslationKey(status) != ""`: a mappable status is
+//     localized; an unmappable one is echoed verbatim.
+//   - :111 `translateMessage(...) != key`: when the catalog resolves the key to a
+//     real localized string it is used; when the key is missing the raw status is
+//     echoed instead of the bare key.
+func TestLocalizedSettingsSymptomStatus(t *testing.T) {
+	// "symptom_created" -> "settings.symptoms.success.created" -> localized copy.
+	localized := localizedSettingsSymptomStatusForTest(t, "symptom_created", map[string]string{
+		"settings.symptoms.success.created": "Created!",
+	})
+	if localized != "Created!" {
+		t.Fatalf("mappable+translated status must localize, got %q", localized)
+	}
+
+	// Mappable key but NO translation available -> echoes the raw status (:111).
+	echoed := localizedSettingsSymptomStatusForTest(t, "symptom_created", map[string]string{})
+	if echoed != "symptom_created" {
+		t.Fatalf("mappable-but-untranslated status must echo raw status, got %q", echoed)
+	}
+
+	// Unmappable status -> echoed verbatim (:110 false branch).
+	unmapped := localizedSettingsSymptomStatusForTest(t, "definitely_not_a_status", map[string]string{})
+	if unmapped != "definitely_not_a_status" {
+		t.Fatalf("unmappable status must echo verbatim, got %q", unmapped)
+	}
+}
+
+// TestSettingsSymptomsHTMXCreateTooLongClearsDraftName pins the
+// `spec.Key == "symptom name is too long"` decision
+// (handlers_settings_symptoms.go:43): on a too-long create, the re-rendered create
+// form must NOT echo the rejected (over-length) name back into the input.
+// Negating the equality keeps the over-length value in the form.
+func TestSettingsSymptomsHTMXCreateTooLongClearsDraftName(t *testing.T) {
+	app, database := newOnboardingTestAppWithCSRF(t)
+	user := createOnboardingTestUser(t, database, "settings-symptoms-htmx-draftclear@example.com", "StrongPass1", true)
+	authCookie := loginAndExtractAuthCookieWithCSRF(t, app, user.Email, "StrongPass1")
+	csrfCookie, csrfToken := loadSettingsCSRFContext(t, app, authCookie)
+
+	const tooLong = "12345678901234567890123456789012345678901" // 41 chars
+	createForm := url.Values{
+		"csrf_token": {csrfToken},
+		"name":       {tooLong},
+		"icon":       {"✨"},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/symptoms", strings.NewReader(createForm.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("HX-Request", "true")
+	req.Header.Set("Cookie", joinCookieHeader(authCookie, cookiePair(csrfCookie)))
+	resp, err := app.Test(req, testConfigNoTimeout)
+	if err != nil {
+		t.Fatalf("too-long create request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("too-long create status = %d, want 200", resp.StatusCode)
+	}
+
+	body := mustReadBodyString(t, resp.Body)
+	nameInput := htmlFindElement(mustParseHTMLDocument(t, body), func(node *html.Node) bool {
+		return node.Type == html.ElementNode && node.Data == "input" && htmlHasAttr(node, "data-symptom-name-input")
+	})
+	if nameInput == nil {
+		t.Fatal("expected the create-form name input to be re-rendered")
+	}
+	if value := htmlAttr(nameInput, "value"); strings.TrimSpace(value) != "" {
+		t.Fatalf("too-long name must be cleared from the re-rendered create form, got value %q", value)
+	}
+	// Sanity: the rejected value really is absent from the whole rendered form.
+	if strings.Contains(body, tooLong) {
+		t.Fatalf("rejected over-length name must not be echoed back into the form")
+	}
+}
+
+// --- handlers_settings_password.go ---
+
+// TestStepupReauthMaxAgeConstant pins stepupReauthMaxAge
+// (handlers_settings_password.go:18) against 5 minutes; the ARITHMETIC_BASE mutant
+// swaps '*' for '/', collapsing the OIDC step-up replay window to ~0.
+func TestStepupReauthMaxAgeConstant(t *testing.T) {
+	if stepupReauthMaxAge != 5*time.Minute {
+		t.Fatalf("stepupReauthMaxAge = %v, want 5m", stepupReauthMaxAge)
+	}
+	if stepupReauthMaxAge <= 0 {
+		t.Fatalf("stepupReauthMaxAge must be a positive replay window, got %v", stepupReauthMaxAge)
+	}
+}
+
+// --- handlers_settings_cycle_helpers.go ---
+
+// TestUpdateCycleSettings_JSONBodyPersistsLastPeriodStart pins the JSON-body
+// `input.LastPeriodStart != ""` decision (handlers_settings_cycle_helpers.go:22):
+// a non-empty last_period_start supplied via a JSON body must mark the field as
+// set so it is validated and persisted. Negating to `== ""` drops the flag for a
+// real date, so the start date is silently ignored. Uses a no-CSRF app to isolate
+// JSON body parsing/negotiation (per the testing rules).
+func TestUpdateCycleSettings_JSONBodyPersistsLastPeriodStart(t *testing.T) {
+	app, database := newOnboardingTestApp(t)
+	user := createOnboardingTestUser(t, database, "settings-cycle-json@example.com", "StrongPass1", true)
+	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
+
+	const startDate = "2026-02-10"
+	jsonBody := `{"cycle_length":28,"period_length":5,"auto_period_fill":true,"last_period_start":"` + startDate + `"}`
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/users/current/cycle", strings.NewReader(jsonBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Accept-Language", "en")
+	req.Header.Set("Cookie", authCookie)
+	resp, err := app.Test(req, testConfigNoTimeout)
+	if err != nil {
+		t.Fatalf("json cycle update failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("json cycle update status = %d, want 200 (body %q)", resp.StatusCode, mustReadBodyString(t, resp.Body))
+	}
+
+	var persisted models.User
+	if err := database.Select("cycle_length", "last_period_start").First(&persisted, user.ID).Error; err != nil {
+		t.Fatalf("reload user: %v", err)
+	}
+	if persisted.LastPeriodStart == nil {
+		t.Fatal("JSON-body last_period_start must be persisted (LastPeriodStartSet must be true for a non-empty date)")
+	}
+	if got := services.CalendarDayKey(*persisted.LastPeriodStart); got != startDate {
+		t.Fatalf("persisted last_period_start = %q, want %q", got, startDate)
+	}
+}
+
+// TestCompleteLocalPasswordSetupReauth_SuccessIssuesRecoveryCode drives the OIDC
+// step-up password-setup callback all the way through its happy path to pin
+// handlers_settings_password.go:193 (`refreshPasswordChangeSession(...); err !=
+// nil`). On success the handler must set the recovery-code issuance cookie and
+// redirect to /recovery-code. Negating the guard to `== nil` returns early right
+// after the (successful) session refresh, so neither the redirect nor the
+// recovery cookie is produced. Existing step-up coverage only exercises the error
+// arms (no session / already-local), leaving this success arm uncovered.
+func TestCompleteLocalPasswordSetupReauth_SuccessIssuesRecoveryCode(t *testing.T) {
+	stub := &stubOIDCWorkflowService{enabled: true, localPublicAuthEnabled: true} // ValidateReauthExchange -> nil
+	app, database, handler := newSettingsMutationStepupApp(t, stub)
+
+	// OIDC-only user: no local password yet, so the setup flow can complete.
+	oidcUser := models.User{
+		Email:               "settings-stepup-success@example.com",
+		LocalAuthEnabled:    false,
+		Role:                models.RoleOwner,
+		OnboardingCompleted: true,
+		AuthSessionVersion:  1,
+		CycleLength:         28,
+		PeriodLength:        5,
+		AutoPeriodFill:      true,
+		CreatedAt:           time.Now().UTC(),
+	}
+	if err := database.Create(&oidcUser).Error; err != nil {
+		t.Fatalf("create oidc-only user: %v", err)
+	}
+	authCookie := issueAuthCookieForUser(t, oidcUser)
+
+	// Seed a step-up cookie for this user and learn its sealed State value so the
+	// callback's state check passes.
+	stepupCookie, stateValue := seedStepupCookie(t, app, handler, oidcUser.ID)
+
+	form := url.Values{"state": {stateValue}, "code": {"stub-code"}}
+	req := httptest.NewRequest(http.MethodPost, "/auth/oidc/callback", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Cookie", joinCookieHeader(authCookie, stepupCookie))
+	resp, err := app.Test(req, testConfigNoTimeout)
+	if err != nil {
+		t.Fatalf("oidc stepup callback failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// Success path: 303 -> /recovery-code with the recovery-code issuance cookie.
+	if resp.StatusCode != http.StatusSeeOther {
+		t.Fatalf("stepup success status = %d, want 303 (body %q)", resp.StatusCode, mustReadBodyString(t, resp.Body))
+	}
+	if loc := resp.Header.Get("Location"); loc != "/recovery-code" {
+		t.Fatalf("stepup success redirect = %q, want /recovery-code", loc)
+	}
+	if cookie := responseCookie(resp.Cookies(), recoveryCodeCookieName); cookie == nil || strings.TrimSpace(cookie.Value) == "" {
+		t.Fatalf("stepup success must set the %s issuance cookie", recoveryCodeCookieName)
+	}
+
+	// The password setup must have committed (local auth now enabled).
+	var reloaded models.User
+	if err := database.First(&reloaded, oidcUser.ID).Error; err != nil {
+		t.Fatalf("reload user: %v", err)
+	}
+	if !reloaded.LocalAuthEnabled {
+		t.Fatal("expected local auth to be enabled after successful password setup reauth")
+	}
+}
+
+// newSettingsMutationStepupApp builds a self-contained app (real DB + real
+// services + stub OIDC) with cookie-secure transport and a seed route that mints a
+// step-up cookie and echoes its State. It intentionally does not reuse the shared
+// fullpage-fallback harness to avoid editing another area's aggregator test file.
+func newSettingsMutationStepupApp(t *testing.T, stub *stubOIDCWorkflowService) (*fiber.App, *gorm.DB, *Handler) {
+	t.Helper()
+
+	databasePath := filepath.Join(t.TempDir(), "ovumcy-settings-stepup-test.db")
+	database, err := db.OpenSQLite(databasePath)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	sqlDB, err := database.DB()
+	if err != nil {
+		t.Fatalf("open sql db: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+
+	i18nManager, err := i18n.NewManager("en")
+	if err != nil {
+		t.Fatalf("init i18n: %v", err)
+	}
+
+	handler, err := NewHandler("test-secret-key", time.UTC, i18nManager, true, newTestHandlerDependencies(database, i18nManager, onboardingTestAppOptions{oidcService: stub, cookieSecure: true}))
+	if err != nil {
+		t.Fatalf("init handler: %v", err)
+	}
+
+	app := fiber.New()
+	app.Use(handler.LanguageMiddleware)
+	app.Get("/__seed/stepup", func(c fiber.Ctx) error {
+		userID := uint(fiber.Query[int](c, "user_id", 0))
+		state, stateErr := newOIDCStepupState(time.Now(), oidcStepupPurposeLocalPasswordSetup, userID, "prepared-hash")
+		if stateErr != nil {
+			return c.Status(fiber.StatusInternalServerError).SendString(stateErr.Error())
+		}
+		if err := handler.setOIDCStepupCookie(c, state); err != nil {
+			return c.Status(fiber.StatusInternalServerError).SendString(err.Error())
+		}
+		return c.JSON(fiber.Map{"state": state.State})
+	})
+	RegisterRoutes(app, handler)
+	app.Use(handler.NotFound)
+	return app, database, handler
+}
+
+// seedStepupCookie hits the seed route and returns the step-up cookie header plus
+// the sealed State value that the callback must echo.
+func seedStepupCookie(t *testing.T, app *fiber.App, _ *Handler, userID uint) (string, string) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/__seed/stepup?user_id="+utoa(userID), nil)
+	resp, err := app.Test(req, testConfigNoTimeout)
+	if err != nil {
+		t.Fatalf("seed stepup failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("seed stepup status = %d, want 200", resp.StatusCode)
+	}
+
+	var seeded struct {
+		State string `json:"state"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&seeded); err != nil {
+		t.Fatalf("decode seeded stepup state: %v", err)
+	}
+
+	cookie := responseCookie(resp.Cookies(), oidcStepupCookieName)
+	if cookie == nil {
+		t.Fatal("seed route did not set the stepup cookie")
+	}
+	return cookiePair(cookie), seeded.State
+}
+
+// localizedSettingsSymptomStatusForTest drives localizedSettingsSymptomStatus with
+// an injected message catalog via a mounted route (the function reads
+// currentMessages(c) from the request Locals).
+func localizedSettingsSymptomStatusForTest(t *testing.T, status string, messages map[string]string) string {
+	t.Helper()
+	app := fiber.New()
+	app.Get("/localize", func(c fiber.Ctx) error {
+		c.Locals(contextMessagesKey, messages)
+		return c.SendString(localizedSettingsSymptomStatus(c, status))
+	})
+	req := httptest.NewRequest(http.MethodGet, "/localize", nil)
+	resp, err := app.Test(req, testConfigNoTimeout)
+	if err != nil {
+		t.Fatalf("localizer probe failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	return mustReadBodyString(t, resp.Body)
+}

--- a/internal/api/settings_mutation_view_models_test.go
+++ b/internal/api/settings_mutation_view_models_test.go
@@ -1,0 +1,284 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+)
+
+// These are behavior-asserting unit tests over the settings/onboarding view-model
+// helpers, added to close mutation-testing survivors in the SETTINGS/ONBOARDING
+// cluster (settings_symptom_view_models.go, language_switch_view_models.go). Each
+// test pins an observable output of a boolean/equality decision so that negating
+// the operator makes the assertion fail (kills the mutant).
+//
+// Documented EQUIVALENT mutant (intentionally NOT killed): the ARITHMETIC_BASE
+// mutant on settings_symptom_view_models.go:81 changes the slice-capacity hint
+// `make([]settingsSymptomIconOption, 0, len(settingsSymptomIconCatalog)+1)` from
+// `+1` to `-1`. Capacity is only a pre-allocation hint; `append` grows the slice
+// as needed, so the returned length and contents are identical either way. No
+// test can distinguish the two without asserting on cap(), which is not observable
+// behavior — killing it would be a brittle, meaningless test.
+
+// --- buildSettingsSymptomIconOptions ---
+
+// findIconOption returns the option carrying the given value, or nil.
+func findIconOption(options []settingsSymptomIconOption, value string) *settingsSymptomIconOption {
+	for i := range options {
+		if options[i].Value == value {
+			return &options[i]
+		}
+	}
+	return nil
+}
+
+// TestBuildSettingsSymptomIconOptions_CatalogIconSelectsExactlyThatOption pins the
+// `value == selected` decision (settings_symptom_view_models.go:92): only the icon
+// equal to the current selection is Selected; every other catalog icon is not.
+// Negating to `!=` would flip Selected on all the wrong options.
+func TestBuildSettingsSymptomIconOptions_CatalogIconSelectsExactlyThatOption(t *testing.T) {
+	options := buildSettingsSymptomIconOptions("🔥")
+
+	// No custom option is prepended for a catalog icon (settingsSymptomIconInCatalog
+	// must report true here), so the returned set is exactly the catalog.
+	if len(options) != len(settingsSymptomIconCatalog) {
+		t.Fatalf("expected %d options for a catalog icon, got %d", len(settingsSymptomIconCatalog), len(options))
+	}
+
+	selectedCount := 0
+	for _, option := range options {
+		if option.IsCustom {
+			t.Errorf("catalog icon %q must not produce a custom option, got value %q", "🔥", option.Value)
+		}
+		if option.Selected {
+			selectedCount++
+			if option.Value != "🔥" {
+				t.Errorf("only the current icon should be selected; got Selected on %q", option.Value)
+			}
+		}
+	}
+	if selectedCount != 1 {
+		t.Fatalf("exactly one option should be selected, got %d", selectedCount)
+	}
+
+	fire := findIconOption(options, "🔥")
+	if fire == nil || !fire.Selected {
+		t.Fatalf("current icon 🔥 must be marked Selected")
+	}
+	// A different catalog icon must NOT be selected — this is what dies if
+	// `value == selected` is negated.
+	if spark := findIconOption(options, "✨"); spark == nil || spark.Selected {
+		t.Fatalf("non-selected catalog icon ✨ must have Selected=false")
+	}
+}
+
+// TestBuildSettingsSymptomIconOptions_CustomIconIsPrependedAsCustom pins the
+// `option == value` membership decision inside settingsSymptomIconInCatalog
+// (settings_symptom_view_models.go:100). A non-catalog icon must be reported as
+// NOT in the catalog, so a custom option is prepended at index 0. Negating to
+// `!=` makes the first differing catalog entry match, so the icon is wrongly
+// treated as in-catalog and no custom option is emitted.
+func TestBuildSettingsSymptomIconOptions_CustomIconIsPrependedAsCustom(t *testing.T) {
+	const customIcon = "🦄" // deliberately absent from settingsSymptomIconCatalog
+
+	options := buildSettingsSymptomIconOptions(customIcon)
+
+	if len(options) != len(settingsSymptomIconCatalog)+1 {
+		t.Fatalf("custom icon should add exactly one option, want %d got %d",
+			len(settingsSymptomIconCatalog)+1, len(options))
+	}
+	if options[0].Value != customIcon {
+		t.Fatalf("custom icon must be the leading option, got %q", options[0].Value)
+	}
+	if !options[0].IsCustom {
+		t.Fatalf("leading custom option must have IsCustom=true")
+	}
+	if !options[0].Selected {
+		t.Fatalf("leading custom option must be Selected")
+	}
+	// No catalog icon should be selected when the selection is a custom icon.
+	for _, option := range options[1:] {
+		if option.Selected {
+			t.Errorf("catalog option %q must not be selected when a custom icon is active", option.Value)
+		}
+		if option.IsCustom {
+			t.Errorf("catalog option %q must not be flagged custom", option.Value)
+		}
+	}
+}
+
+// TestSettingsSymptomIconInCatalog_ReportsMembership guards the membership helper
+// directly on both branches so the equality check keeps its meaning.
+func TestSettingsSymptomIconInCatalog_ReportsMembership(t *testing.T) {
+	if !settingsSymptomIconInCatalog("💧") {
+		t.Errorf("💧 is a catalog icon and must be reported as present")
+	}
+	if settingsSymptomIconInCatalog("🦄") {
+		t.Errorf("🦄 is not a catalog icon and must be reported as absent")
+	}
+}
+
+// --- buildSettingsSymptomRows ---
+
+// TestBuildSettingsSymptomRows_DraftAppliesOnlyToTargetedSymptom pins the
+// `rowState.SymptomID == symptom.ID` decision (settings_symptom_view_models.go:53,
+// second operand). Draft form values must override only the row whose ID matches
+// rowState.SymptomID; every other row keeps its persisted values. Negating the
+// equality would apply the draft to the wrong rows.
+func TestBuildSettingsSymptomRows_DraftAppliesOnlyToTargetedSymptom(t *testing.T) {
+	symptoms := []models.SymptomType{
+		{ID: 11, Name: "Cramps", Icon: "🔥"},
+		{ID: 22, Name: "Bloating", Icon: "💧"},
+	}
+	rowState := settingsSymptomRowState{
+		SymptomID:      11,
+		UseDraftValues: true,
+		Draft:          symptomPayload{Name: "Edited draft", Icon: "⚡"},
+	}
+	identity := func(s string) string { return s }
+
+	rows := buildSettingsSymptomRows(symptoms, rowState, identity, identity)
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(rows))
+	}
+
+	// Targeted row (ID 11) reflects the draft.
+	if rows[0].FormName != "Edited draft" {
+		t.Errorf("targeted row FormName = %q, want draft %q", rows[0].FormName, "Edited draft")
+	}
+	if rows[0].FormIcon != "⚡" {
+		t.Errorf("targeted row FormIcon = %q, want draft %q", rows[0].FormIcon, "⚡")
+	}
+	// Untargeted row (ID 22) keeps its persisted values — dies if == is negated.
+	if rows[1].FormName != "Bloating" {
+		t.Errorf("untargeted row FormName = %q, want persisted %q", rows[1].FormName, "Bloating")
+	}
+	if rows[1].FormIcon != "💧" {
+		t.Errorf("untargeted row FormIcon = %q, want persisted %q", rows[1].FormIcon, "💧")
+	}
+}
+
+// TestBuildSettingsSymptomRows_ZeroRowStateIDNeverUsesDraft pins the
+// `rowState.SymptomID != 0` guard (settings_symptom_view_models.go:53, first
+// operand). A zero rowState.SymptomID means "no row is being edited", so even a
+// symptom whose ID is the zero value must render its persisted values, not the
+// draft. Negating the guard to `== 0` would make the draft leak onto a zero-ID
+// symptom.
+func TestBuildSettingsSymptomRows_ZeroRowStateIDNeverUsesDraft(t *testing.T) {
+	symptoms := []models.SymptomType{
+		{ID: 0, Name: "Persisted name", Icon: "🌙"},
+	}
+	rowState := settingsSymptomRowState{
+		SymptomID:      0,
+		UseDraftValues: true,
+		Draft:          symptomPayload{Name: "Draft name", Icon: "⚡"},
+	}
+	identity := func(s string) string { return s }
+
+	rows := buildSettingsSymptomRows(symptoms, rowState, identity, identity)
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+	if rows[0].FormName != "Persisted name" {
+		t.Errorf("zero-ID row FormName = %q, want persisted %q (draft must not apply)", rows[0].FormName, "Persisted name")
+	}
+	if rows[0].FormIcon != "🌙" {
+		t.Errorf("zero-ID row FormIcon = %q, want persisted %q (draft must not apply)", rows[0].FormIcon, "🌙")
+	}
+}
+
+// TestBuildSettingsSymptomRows_LocalizesMessagesOnlyForTargetedRow verifies the
+// localizers are applied to the matching row's messages, exercising the
+// row-match branch that populates Error/Success.
+func TestBuildSettingsSymptomRows_LocalizesMessagesOnlyForTargetedRow(t *testing.T) {
+	symptoms := []models.SymptomType{
+		{ID: 5, Name: "Headache", Icon: "🤕"},
+		{ID: 6, Name: "Fatigue", Icon: "🌀"},
+	}
+	rowState := settingsSymptomRowState{
+		SymptomID:     5,
+		ErrorMessage:  "boom",
+		SuccessStatus: "yay",
+	}
+	statusLoc := func(s string) string {
+		if s == "" {
+			return ""
+		}
+		return "status:" + s
+	}
+	errorLoc := func(s string) string {
+		if s == "" {
+			return ""
+		}
+		return "error:" + s
+	}
+
+	rows := buildSettingsSymptomRows(symptoms, rowState, statusLoc, errorLoc)
+	if rows[0].ErrorMessage != "error:boom" {
+		t.Errorf("matched row ErrorMessage = %q, want %q", rows[0].ErrorMessage, "error:boom")
+	}
+	if rows[0].SuccessMessage != "status:yay" {
+		t.Errorf("matched row SuccessMessage = %q, want %q", rows[0].SuccessMessage, "status:yay")
+	}
+	if rows[1].ErrorMessage != "" || rows[1].SuccessMessage != "" {
+		t.Errorf("non-matched row must have empty messages, got err=%q success=%q", rows[1].ErrorMessage, rows[1].SuccessMessage)
+	}
+}
+
+// --- language switch view models ---
+
+// TestBuildLanguageSwitchOptions_MarksOnlyCurrentActive pins the
+// `normalizedCode == currentLanguage` decision (language_switch_view_models.go:24):
+// exactly the current language option is Active. Negating to `!=` would mark every
+// other language active and the current one inactive.
+func TestBuildLanguageSwitchOptions_MarksOnlyCurrentActive(t *testing.T) {
+	messages := map[string]string{}
+	supported := []string{"en", "ru", "es"}
+
+	options := buildLanguageSwitchOptions(messages, "ru", supported)
+	if len(options) != 3 {
+		t.Fatalf("expected 3 options, got %d", len(options))
+	}
+
+	activeCodes := map[string]bool{}
+	for _, option := range options {
+		if option.Active {
+			activeCodes[option.Code] = true
+		}
+	}
+	if len(activeCodes) != 1 || !activeCodes["ru"] {
+		t.Fatalf("exactly the current language ru should be active, got active set %v", activeCodes)
+	}
+}
+
+// TestBuildLanguageSwitchOptions_SkipsBlankCodes covers the empty-code continue
+// (language_switch_view_models.go:18): blank/whitespace codes are dropped.
+func TestBuildLanguageSwitchOptions_SkipsBlankCodes(t *testing.T) {
+	options := buildLanguageSwitchOptions(map[string]string{}, "en", []string{"en", "  ", "", "es"})
+	if len(options) != 2 {
+		t.Fatalf("blank codes must be skipped, want 2 options got %d", len(options))
+	}
+	for _, option := range options {
+		if option.Code != "en" && option.Code != "es" {
+			t.Errorf("unexpected option code %q", option.Code)
+		}
+	}
+}
+
+// TestLocalizedLanguageSwitchLabel_UsesTranslationWhenPresent pins the
+// `localized == key` fallback decision (language_switch_view_models.go:33, first
+// operand): when the message catalog carries a real label for lang.<code>, that
+// label is returned verbatim; only a missing translation falls back to the
+// uppercased code. Negating `==` to `!=` would discard a present translation and
+// wrongly uppercase the code.
+func TestLocalizedLanguageSwitchLabel_UsesTranslationWhenPresent(t *testing.T) {
+	messages := map[string]string{"lang.ru": "Русский"}
+
+	if got := localizedLanguageSwitchLabel(messages, "ru"); got != "Русский" {
+		t.Fatalf("present translation must be used, got %q want %q", got, "Русский")
+	}
+	// Missing translation falls back to the uppercased code.
+	if got := localizedLanguageSwitchLabel(messages, "es"); got != "ES" {
+		t.Fatalf("missing translation must fall back to uppercased code, got %q want %q", got, "ES")
+	}
+}


### PR DESCRIPTION
## What

Mutation-hardening for the **settings/onboarding** cluster of `internal/api`,
continuing PR #177. Closes the gremlins baseline survivors from run
`28758365493` (merged `internal_api.json` shard map) for these files. **Test-only
— zero production-code changes.**

Each real survivor is closed by a behavior-asserting test that fails under the
mutation, and every kill was proven by **per-mutant faulting** (apply the exact
mutation → confirm the targeted test fails → revert), which is the canonical
method the repo's mutation rules prescribe over chasing the aggregate score.

## Mutants closed

**Killed — 27** (file : what the test pins)

| File | Mutants | Behaviour pinned |
|------|:------:|------------------|
| `handler_types.go` | 4 | `defaultAuthTokenTTL` (168h) & `rememberAuthTokenTTL` (720h) — arithmetic collapse of `7*24`/`30*24`/`*time.Hour` |
| `handlers_settings_2fa.go` | 4 | enable+disable session-version `+1` bump and the `refreshCurrentSession` guard: the re-issued `ovumcy_auth` cookie must authenticate, and the HTMX success markup must render |
| `handlers_settings_symptoms.go` | 4 | too-long create clears the draft name from the re-rendered form; status-localizer key/translation guards; `defaultSymptomDraftIcon` empty fallback |
| `handlers_settings_password.go` | 2 | `stepupReauthMaxAge` (5m) constant; the OIDC step-up password-setup **success arm** refresh guard (redirect to `/recovery-code` + issuance cookie), driven end-to-end through a self-contained stub-OIDC harness |
| `handlers_settings_cycle_helpers.go` | 1 | JSON-body `last_period_start` "set" flag so a real date persists |
| `handlers_onboarding_input_helpers.go` | 4 | form-timezone resolution (PostArg short-circuit vs body-query fallback, error guard) and the cookie refresh-on-mismatch decision |
| `handlers_onboarding_complete.go` | 1 | standalone `/onboarding/complete` **success arm** (`err != nil` guard) → `/dashboard` |
| `language_switch_view_models.go` | 3 | only the current language is Active; label uses the catalog translation, else uppercased code |
| `settings_symptom_view_models.go` | 5 | draft applies only to the targeted row (both operands of the guard); exact icon selection; catalog membership |

**Documented EQUIVALENT — 2** (intentionally not force-killed; a brittle test
would be required and would assert non-behavior):

- `settings_symptom_view_models.go:81` — ARITHMETIC_BASE on the slice **capacity
  hint** `make(..., len(catalog)+1)` (`+1`→`-1`). Capacity is a pre-allocation
  hint only; `append` grows as needed, so the returned length and contents are
  identical. Killing it would require asserting on `cap()`.
- `handlers_settings_danger.go:75` — CONDITIONALS_NEGATION on the `hasJSONBody(c)`
  operand of the bind-error guard in `parsePasswordProtectedSettingsAction`.
  `passwordProtectedSettingsInput` has a single string `Password`, so a bind error
  is only reachable on malformed JSON and always leaves `Password` empty; the very
  next check (`input.Password == ""`) emits the identical
  `settingsMissingPasswordErrorSpec`. Verified by running the full
  clear-data/delete/missing-password suite green with the operand negated.

Both are documented in-code at the head of the relevant new test file.

## Tests added

Three new cluster-scoped test files (no shared aggregator touched, to avoid
collisions with the concurrent auth-token and sealed-cookie cluster PRs):

- `internal/api/settings_mutation_view_models_test.go` — pure view-model unit tests.
- `internal/api/onboarding_mutation_helpers_test.go` — onboarding input-helper +
  TTL-constant tests (timezone helpers exercised via minimal mounted routes so the
  branch decisions are observable, since the full onboarding flow's form body
  parses identically through both paths and masks them).
- `internal/api/settings_mutation_handlers_test.go` — 2FA / symptoms / cycle /
  password step-up HTTP-integration tests (Fiber + real migrated temp DB + real
  services).

## Gates (all green locally)

- `go test ./internal/api/...` — green (full package).
- `go build ./...`, `go vet ./internal/api/...` — clean.
- `staticcheck` (v0.6.1, CI scope) — 0 issues; no deprecated `Header.VisitAll`
  (SA1019).
- `golangci-lint` (v2.12.2) — 0 issues; zero `//nolint`, no three-clause counting
  loops.
- `gofmt` — clean.
- `bash scripts/patch-coverage-local.sh` (fresh, cache-defeated) — **patch
  coverage gate OK**.

Advisory-only mutation CI is unaffected; this raises the settings/onboarding
efficacy toward the saturation point where only the two documented equivalents
remain.
