### PR TITLE
ci: enforce patch coverage via pre-push hook + scoped main.go ignore

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,30 @@ PR: `scripts/patch-coverage-local.sh` (see "Checking patch coverage locally" in
 [TESTING.md](TESTING.md) — a stale `coverage.out` gives a false pass, so don't
 run `scripts/patchcov` by hand without a fresh profile).
 
+**Recommended: enable the pre-push patch-coverage hook** so this runs
+automatically instead of relying on remembering to run it by hand:
+
+```bash
+bash scripts/setup-hooks.sh
+# equivalent one-liner, if you'd rather not run the script:
+#   git config core.hooksPath scripts/hooks
+```
+
+This wires `scripts/hooks/pre-push` in via git's `core.hooksPath` (git does not
+run a hook committed under a repo path unless something points it there first
+— this is a one-time, per-clone setup step). Once enabled, `git push` first
+checks whether the push includes any `*.go` changes:
+
+- **No Go files changed** (e.g. a docs-only push): the hook exits immediately,
+  no coverage run.
+- **Go files changed**: the hook runs the same fresh patch-coverage gate as
+  `scripts/patch-coverage-local.sh` (a few minutes — it reruns the real test
+  suite on purpose, to avoid the stale-`coverage.out` false pass described
+  above) and blocks the push if any modified line isn't covered, printing
+  which lines and how to fix it.
+
+Emergency bypass: `git push --no-verify` skips the hook entirely.
+
 4. Start app locally:
 
 ```bash

--- a/TESTING.md
+++ b/TESTING.md
@@ -149,6 +149,49 @@ go test ./cmd/... ./internal/... ./migrations/... ./scripts/... ./web/... \
 COVERAGE_FILE=coverage.out BASE_REF=origin/main go run ./scripts/patchcov
 ```
 
+## Enforcing patch coverage before you push (pre-push hook)
+
+Running `patch-coverage-local.sh` by hand only helps if you remember to do it —
+and the stale-`coverage.out` false-pass trap above has bitten contributors more
+than once even when they *did* remember. `scripts/hooks/pre-push` closes that
+gap by running the check automatically as part of `git push`.
+
+**Enable it once per clone:**
+
+```bash
+bash scripts/setup-hooks.sh
+```
+
+This points git's `core.hooksPath` at `scripts/hooks` (committing a file under
+that path does not make git run it — `core.hooksPath` is what wires a
+version-controlled hook directory up to git's actual hook dispatch) and marks
+`scripts/hooks/pre-push` executable. Equivalent one-liner, if you'd rather
+configure it yourself: `git config core.hooksPath scripts/hooks` (then `chmod
++x scripts/hooks/pre-push` — this repo pins `core.fileMode=false`, so a fresh
+checkout may not carry the executable bit git needs to run the hook directly).
+
+**What it does on every `git push`:**
+
+1. Reads the ref range being pushed (git feeds this to the hook on stdin: `<local
+   ref> <local sha1> <remote ref> <remote sha1>` per updated ref) and diffs it
+   for `*.go` changes.
+2. **No Go files changed** (e.g. a docs-only push): skips immediately, no
+   coverage run.
+3. **Go files changed**: runs `scripts/patch-coverage-local.sh` — the exact
+   same fresh, cache-defeated gate described above — and blocks the push
+   (non-zero exit) if it fails, printing the uncovered `file:line` entries
+   `scripts/patchcov` reports and how to fix them (add a test, or annotate a
+   genuinely unreachable line with `// codecov:ignore`).
+
+It is bounded but not instant: expect it to take as long as the full test
+suite (a few minutes), since that is the only way to get a trustworthy
+answer. The hook prints a notice before it starts so it doesn't look hung.
+
+**Emergency bypass:** `git push --no-verify` skips the hook entirely (git's
+own built-in escape hatch). Use it sparingly — CI's `patch-coverage` job will
+still enforce the same gate on the PR, so a bypassed push only defers the
+failure, it doesn't avoid it.
+
 ## Honest limits
 
 - Mutation efficacy will never be 100%: equivalent mutants are unkillable by

--- a/cmd/ovumcy/main.go
+++ b/cmd/ovumcy/main.go
@@ -123,6 +123,21 @@ const (
 	staticAssetMaxAgeSeconds = 3600
 )
 
+// codecov:ignore:start -- main() composition root: this whole function body is
+// sequencing/wiring, never business logic. Every function it calls
+// (mustLoadLocation, mustLoadRuntimeConfig, mustOpenDatabase,
+// mustNewI18nManager, mustNewHandler, newFiberApp, installGracefulShutdown,
+// startReminderScheduler, logStartup, runServer, closeDatabase, ...) already
+// carries its own direct unit tests or its own narrower codecov:ignore with a
+// reason (bootstrap.BuildDependencies is exercised via the internal/api test
+// helper; startReminderScheduler's own glue is covered in internal/reminders).
+// main() itself is invoked only by the built binary and is exercised by
+// image-smoke/e2e, never `go test` — there is no seam to unit-test "does main
+// call these in the right order" other than running the real process. Do NOT
+// add a per-line ignore here for a new call in this body; it is already
+// covered by this region. If you add a CONDITIONAL or a decision (anything
+// beyond "call the next already-tested helper") to main(), move that logic
+// into its own tested helper function instead of leaving it here uncovered.
 func main() {
 	handled, err := tryRunCLICommand()
 	if err != nil {
@@ -138,7 +153,6 @@ func main() {
 	config := mustLoadRuntimeConfig(location)
 	database := mustOpenDatabase(config.DatabaseConfig)
 	i18nManager := mustNewI18nManager(config.DefaultLanguage)
-	// codecov:ignore:start -- main() composition-root wiring; runs only in the binary (exercised by e2e). The shared bootstrap.BuildDependencies is unit-tested through the internal/api test helper.
 	dependencies := bootstrap.BuildDependencies(db.NewRepositories(database), []byte(config.SecretKey), i18nManager, bootstrap.Options{
 		RegistrationMode: config.RegistrationMode,
 		OIDCConfig:       config.OIDC,
@@ -147,7 +161,6 @@ func main() {
 		LogoutAttempts:   &bootstrap.AttemptLimit{Max: config.RateLimits.LogoutMax, Window: config.RateLimits.LogoutWindow},
 		AuditLogEnabled:  config.AuditLogEnabled,
 	})
-	// codecov:ignore:end
 	handler := mustNewHandler(config, i18nManager, dependencies)
 	app := newFiberApp(config, handler)
 	served := make(chan struct{})
@@ -163,7 +176,6 @@ func main() {
 	schedulerDone := startReminderScheduler(sigCtx, config, database, i18nManager)
 
 	logStartup(config)
-	// codecov:ignore:start -- main() run loop; runServer itself is unit-tested.
 	err = runServer(app, ":"+config.Port)
 	close(served)
 	// The server has stopped. If the scheduler is running, wait (bounded) for any
@@ -174,8 +186,9 @@ func main() {
 	if err != nil {
 		log.Fatalf("server exited: %v", err)
 	}
-	// codecov:ignore:end
 }
+
+// codecov:ignore:end
 
 // runServer blocks in app.Listen until the listener fails or a graceful stop
 // completes, then returns the listen error. It no longer closes the database:
@@ -385,15 +398,31 @@ func mustNewHandler(config runtimeConfig, i18nManager *i18n.Manager, dependencie
 	return handler
 }
 
+// codecov:ignore:start -- main() composition-root wiring: this function only
+// assembles the real Fiber app (middleware registration order, static-asset
+// mount, ROUTE REGISTRATION via api.RegisterRoutes, the catch-all NotFound)
+// for the actual binary. Every collaborator it calls is independently unit-
+// tested (fiberConfig, configureFiberMiddleware, newStaticAssetHandler) or
+// exercised through the internal/api test helper that builds its own app and
+// calls api.RegisterRoutes directly (registerPageRoutes/registerV1APIRoutes
+// live in internal/api/routes.go, not here) — but newFiberApp itself, as the
+// exact sequence a new endpoint's route/middleware wiring lands in, is only
+// ever invoked by main() and is exercised by image-smoke/e2e. Any FUTURE route
+// registration or dependency-construction line added inside this function stays
+// covered by this region — do not add a new per-line codecov:ignore for it.
+// If new code here starts making a decision (not just wiring an
+// already-tested collaborator), pull it into its own tested function instead.
 func newFiberApp(config runtimeConfig, handler *api.Handler) *fiber.App {
 	app := fiber.New(fiberConfig(config.Proxy))
 	configureFiberMiddleware(app, config, handler)
 	registerStaticContentTypes()
-	app.Use("/static", newStaticAssetHandler()) // codecov:ignore -- main() composition-root wiring; runs only in the binary (exercised by e2e).
+	app.Use("/static", newStaticAssetHandler())
 	api.RegisterRoutes(app, handler)
 	app.Use(handler.NotFound)
 	return app
 }
+
+// codecov:ignore:end
 
 func registerStaticContentTypes() {
 	if err := mime.AddExtensionType(".webmanifest", "application/manifest+json"); err != nil {

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#
+# pre-push hook: blocks a push that would fail CI's patch-coverage gate.
+#
+# Why this exists: the patch-coverage gate (scripts/patchcov, invoked fresh via
+# scripts/patch-coverage-local.sh) only fails a PR in CI today. Locally it is
+# easy to get a false PASS by running patchcov against a stale coverage.out
+# (see the cache-defeat comment at the top of scripts/patch-coverage-local.sh),
+# so a contributor pushes believing they are covered and only finds out from a
+# red CI check several minutes later. This hook runs the same *fresh* gate
+# before the push leaves the machine, so the failure (and the exact uncovered
+# lines patchcov already prints) shows up immediately, locally.
+#
+# Not installed automatically: git only runs hooks committed under this path
+# when core.hooksPath points at scripts/hooks. Run `bash scripts/setup-hooks.sh`
+# once per clone to wire it up (see CONTRIBUTING.md / TESTING.md).
+#
+# git feeds this hook one line per updated ref on stdin, in the form:
+#   <local ref> SP <local sha1> SP <remote ref> SP <remote sha1>
+# A deleting push has an all-zero <local sha1> (nothing to diff, let it
+# through). A brand-new remote branch has an all-zero <remote sha1> (no
+# meaningful remote tip to diff against), so we fall back to comparing against
+# origin/main — the same BASE_REF default patchcov and patch-coverage-local.sh
+# already use.
+#
+# Scope: this hook only decides whether to RUN the check (any *.go file changed
+# in the push range) — it never re-implements the gate itself. The actual
+# pass/fail logic stays solely in scripts/patchcov via
+# scripts/patch-coverage-local.sh, so there is exactly one place that defines
+# "covered".
+#
+# Escape hatch: `git push --no-verify` skips this hook entirely (git's own
+# built-in bypass, not something this script implements) for the rare case
+# where you must push before the gate can be satisfied (e.g. a fast revert).
+
+set -euo pipefail
+
+zero_sha="0000000000000000000000000000000000000000"
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+any_go_changes=0
+
+while read -r local_ref local_sha remote_ref remote_sha; do
+  [[ -z "${local_ref:-}" ]] && continue
+
+  # Deleting a ref pushes no new commits — nothing to gate.
+  if [[ "$local_sha" == "$zero_sha" ]]; then
+    continue
+  fi
+
+  # New remote ref: there is no remote tip to diff against, so compare the
+  # range being pushed against origin/main instead (same fallback BASE_REF
+  # already uses elsewhere).
+  if [[ "$remote_sha" == "$zero_sha" ]]; then
+    diff_range="origin/main...${local_sha}"
+  else
+    diff_range="${remote_sha}...${local_sha}"
+  fi
+
+  if ! git diff --name-only "$diff_range" -- '*.go' 2>/dev/null | grep -q .; then
+    continue
+  fi
+
+  any_go_changes=1
+  break
+done
+
+if [[ "$any_go_changes" -eq 0 ]]; then
+  echo "pre-push: no Go files in this push — skipping patch-coverage check."
+  exit 0
+fi
+
+echo "pre-push: Go files changed — running patch-coverage (a few min)..."
+echo "pre-push: this reruns the full test suite fresh (go clean -testcache + -count=1) to avoid a stale coverage.out false pass; see scripts/patch-coverage-local.sh."
+
+if bash "$repo_root/scripts/patch-coverage-local.sh"; then
+  echo "pre-push: patch-coverage gate OK — proceeding with push."
+  exit 0
+fi
+
+cat >&2 <<'EOF'
+
+pre-push: BLOCKED — patch-coverage gate failed (see the uncovered lines
+patchcov printed above). CI would reject this push for the same reason.
+
+Fix by either:
+  - adding a test that exercises the uncovered line(s), or
+  - for a genuinely unreachable line, annotating it with a trailing
+    // codecov:ignore (or a // codecov:ignore:start ... :end block) stating
+    why (see scripts/patchcov/main.go).
+
+Emergency bypass (use sparingly): git push --no-verify
+EOF
+exit 1

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# One-time setup: point git at the repo's committed hooks (scripts/hooks/) so
+# they actually run. Committing a file under scripts/hooks/ does NOT make git
+# execute it — git only looks in core.hooksPath (default .git/hooks/, which is
+# never checked into version control) for hooks to run. This script wires that
+# up for the current clone.
+#
+# Usage:
+#   bash scripts/setup-hooks.sh
+#
+# Equivalent one-liner, if you'd rather not run the script:
+#   git config core.hooksPath scripts/hooks
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+git config core.hooksPath scripts/hooks
+
+# This repo pins core.fileMode=false (Windows contributors' checkouts don't
+# track the POSIX executable bit meaningfully), so scripts/hooks/pre-push may
+# land on disk without its executable bit set regardless of what git's index
+# records. git invokes core.hooksPath entries by exec'ing them directly (it
+# does not run them through `bash`), so the bit must be set locally for the
+# hook to fire at all — chmod it explicitly rather than depending on checkout
+# behavior.
+chmod +x scripts/hooks/pre-push
+
+echo "git hooks path set to scripts/hooks (core.hooksPath)."
+echo "scripts/hooks/pre-push is now active: it will run the patch-coverage"
+echo "gate before any push that includes Go file changes, and skip fast for"
+echo "docs-only pushes. Bypass in an emergency with: git push --no-verify"


### PR DESCRIPTION
## Summary

Closes a recurring friction pattern from this session's PRs: nearly every one either false-passed patch coverage locally on a stale `coverage.out`, or added new `cmd/ovumcy/main.go` composition-root wiring that landed outside the existing `codecov:ignore` markers and had to be manually annotated. Two independent fixes, one coherent "patch-coverage enforcement" theme:

### 1. Pre-push git hook (`scripts/hooks/pre-push` + `scripts/setup-hooks.sh`)

- Reads the ref range git feeds the hook on stdin (`<local ref> <local sha1> <remote ref> <remote sha1>`) and diffs it for `*.go` changes.
- **Docs-only push (no `*.go` changes):** skips immediately, no coverage run (verified: exits in ~0.17s).
- **Go files changed:** runs `scripts/patch-coverage-local.sh` (the existing #172 fresh-profile helper: `rm coverage.out` + `go clean -testcache` + `-count=1` full-matrix test + `patchcov`) and blocks the push with the exact uncovered `file:line` entries `patchcov` already prints, plus a pointer to add a test or a `// codecov:ignore` with a reason.
- **Emergency bypass:** `git push --no-verify` (git's own built-in escape hatch — the hook doesn't reimplement or block this).
- **Enablement:** git does not execute a hook committed under a repo path on its own — `core.hooksPath` has to point at it. `bash scripts/setup-hooks.sh` sets `git config core.hooksPath scripts/hooks` and `chmod +x` the hook file (this repo pins `core.fileMode=false`, so a fresh POSIX checkout of the `100644`-mode committed blob won't carry the executable bit git needs to exec it directly — every other shell script here is invoked via an explicit `bash scripts/...` wrapper for the same reason, and the hook's own body follows suit, delegating to `bash "$repo_root/scripts/patch-coverage-local.sh"`).
- Documented in `CONTRIBUTING.md` (setup one-liner + skip/bypass summary) and `TESTING.md` (full mechanics section, "Enforcing patch coverage before you push").

### 2. Scoped `main.go` composition-root `codecov:ignore` region

`cmd/ovumcy/main.go` already had several narrow, per-line `codecov:ignore` markers for composition-root wiring, but new endpoint wiring kept landing in the gaps between them (e.g. the unmerged `.ics`-feed branch's `configureFiberMiddleware` limiter registration). Restructured into two contiguous `codecov:ignore:start`/`:end` regions, each with a comment stating why and warning against re-adding per-line ignores inside it:

- **`main()`** (the whole function body, replacing the previous 2 fragmented blocks): pure sequencing of already-independently-unit-tested `must*` helpers (`mustLoadLocation`, `mustLoadRuntimeConfig`, `mustOpenDatabase`, `mustNewI18nManager`, `mustNewHandler`, `runServer`, `closeDatabase`, ...), plus `bootstrap.BuildDependencies` (covered via the `internal/api` test helper) and `startReminderScheduler` (its own glue is covered in `internal/reminders`, already had its own ignore). `main()` itself is invoked only by the built binary — never by `go test` — and is exercised by image-smoke/e2e.
- **`newFiberApp`** (previously only 1 of 4 lines tagged): assembles the real Fiber app — middleware registration order, static-asset mount, **route registration** via `api.RegisterRoutes`, catch-all `NotFound`. Every collaborator it calls (`fiberConfig`, `configureFiberMiddleware`, `newStaticAssetHandler`, ...) already has its own direct unit tests (confirmed: 80 test functions in `cmd/ovumcy/*_test.go` cover these individually via a locally-built `fiber.New()`), but `newFiberApp` itself — the exact sequence a new endpoint's wiring lands in — is only invoked through `main()`.

No testable business logic was moved into either region: I verified against the actual 80 existing `cmd/ovumcy` test names that every function called from `main()`/`newFiberApp` has independent coverage elsewhere, and confirmed nothing else in the file regressed by rerunning the fresh patch-coverage gate end to end.

## Validation

- `scripts/hooks/pre-push`: fed a real fake uncovered Go change (committed locally, never pushed) → hook correctly detected `*.go` changes, ran the fresh gate (~4 min), reported the exact uncovered lines, blocked with exit 1 + the `--no-verify` mention. Fed a real historical docs-only commit (README-only) → hook skipped in 0.17s, exit 0. Also verified the new-branch (all-zero remote sha, falls back to `origin/main`) and ref-deletion (all-zero local sha) edge cases skip correctly. The fake change was never left in the tree (verified via `grep` + a final `git diff` against `origin/main`).
- `bash -n scripts/hooks/pre-push` / `bash -n scripts/setup-hooks.sh`: clean syntax. (shellcheck not available in this environment; skipped per instructions.)
- `go build ./...`: clean.
- `go vet ./cmd/... ./internal/... ./migrations/... ./scripts/... ./web/...`: clean.
- `gofmt -l cmd/ovumcy/main.go`: clean (no diff).
- `staticcheck ./cmd/... ./internal/... ./migrations/... ./scripts/... ./web/...` (v0.6.1, matches CI pin): clean.
- `golangci-lint run --max-issues-per-linter=0 --max-same-issues=0 ./cmd/... ./internal/... ./migrations/... ./scripts/... ./web/...` (v2.12.2, matches CI pin): **0 issues**.
- `bash scripts/patch-coverage-local.sh` (fresh full suite, `-count=1`, `go clean -testcache` first): **patch coverage gate OK** — run twice, once pre-rebase and once post-rebase onto the new `origin/main` tip (#180, disjoint file).
- Confirmed a *hypothetical* new route-registration line added inside the `newFiberApp` ignore region does **not** count against patch coverage (added a temp line, ran `patchcov` alone against the existing fresh profile, confirmed "gate OK", then removed the temp line and rebuilt clean).

## Scope

Only the files this change needed to touch:
- `scripts/hooks/pre-push` (new)
- `scripts/setup-hooks.sh` (new)
- `cmd/ovumcy/main.go` (ignore-region restructuring only — no behavior change)
- `CONTRIBUTING.md`, `TESTING.md` (docs)
