### PR TITLE
docs: refresh internal_services/security mutation scores

### DIFF
--- a/.mutation/internal-security.md
+++ b/.mutation/internal-security.md
@@ -3,16 +3,25 @@
 Authoritative gremlins run for the auth/crypto/OIDC package (reproduce with
 `scripts/mutation.sh baseline`); this file is the reviewed summary.
 
-## Score (measured on `54a29ad`)
+## Score (measured on `a6d7e41`)
+
+**Source: workflow_dispatch run
+[28758365493](https://github.com/ovumcy/ovumcy-web/actions/runs/28758365493)**
+on `mutation.yml` (`mutation-baseline (internal_security)` job, single
+unsharded run, green) — the same run that refreshed `internal-api.md` (PR
+#174) and `internal-services.md`. Numbers confirmed two independent ways:
+(a) gremlins' own end-of-run summary line in the job log, (b) counting
+`"status"` values directly in the downloaded `internal_security.json`. Both
+agree exactly.
 
 | Metric | Value |
 |--------|-------|
-| Killed | 99 |
+| Killed | 112 |
 | Lived (survivors) | 9 — documented below (equivalent or e2e/host-covered) |
-| Timed out | 6 |
+| Timed out | 0 |
 | Not covered | 17 |
-| **Test efficacy** | **91.67%** — killed / (killed + lived) = 99 / 108 |
-| Mutator coverage | 86.40% |
+| **Test efficacy** | **92.56%** — killed / (killed + lived) = 112 / 121 |
+| Mutator coverage | 87.68% — (killed + lived) / (killed + lived + not covered) = 121 / 138 |
 
 The OIDC client's provider-facing code (discovery, code exchange, token
 verification, TLS bootstrap) is exercised by the end-to-end OIDC lanes
@@ -21,6 +30,13 @@ verification, TLS bootstrap) is exercised by the end-to-end OIDC lanes
 at the e2e layer.
 
 ## Documented survivors
+
+Reconciled against the `28758365493` survivor set: all 9 mutants below are
+still present and still carry the same argument (equivalent, or covered by the
+e2e OIDC lanes) — only line numbers shifted, since commits since `54a29ad`
+(security hardening, robustness/auth follow-up, the v1.6.0 release) added code
+earlier in `oidc.go`. No previously-documented survivor was killed, and no new
+survivor appeared — this is a like-for-like refresh, not a re-triage.
 
 ### Equivalent mutants
 
@@ -37,13 +53,13 @@ lets the code proceed, but it extracts an empty domain that matches no allowed
 domain and returns `false` anyway. (The `atIndex < 0` half is a real boundary,
 killed by a test.)
 
-**`oidc.go:578:9` — CA-bundle read-error check (NEGATION).**
+**`oidc.go:613:9` — CA-bundle read-error check (NEGATION).**
 On a failed read the content is nil; the mutant skips the early `return err`,
 then `AppendCertsFromPEM(nil)` is false and it rejects with "must contain at
 least one PEM certificate". Both paths reject the unreadable bundle; only the
 error text differs.
 
-**`oidc.go:594:15` — defensive transport nil-check (NEGATION).**
+**`oidc.go:629:15` — defensive transport nil-check (NEGATION).**
 `http.DefaultTransport` is always a non-nil `*http.Transport`, so the guarded
 branch is unreachable in practice; both branches yield a functional client.
 
@@ -54,14 +70,24 @@ Reaching the cached branch needs a previously discovered provider (live issuer +
 JWKS). The e2e lanes drive repeated authorize/exchange calls that reuse it; a Go
 unit cannot build a real verifier without a provider.
 
-**`oidc.go:603:15`, `oidc.go:603:31` — system cert-pool fallback (NEGATION).**
+**`oidc.go:638:15`, `oidc.go:638:31` — system cert-pool fallback (NEGATION).**
 The `SystemCertPool` failure branch cannot be forced from a test on a normally
 configured host; the success path is taken and the mutants do not change the
 resulting (functional) client observably.
 
 ## Not covered
 
-The 17 not-covered mutants are the provider-facing OIDC methods `AuthCodeURL`
-and `ExchangeCode` (lines 295–356), which need a live provider and are driven by
-the e2e OIDC lanes, plus the package-level `const defaultOIDCHTTPTimeout =
-10 * time.Second`, which Go statement coverage never instruments.
+12 of the 17 not-covered mutants are the provider-facing OIDC methods
+`AuthCodeURL` (line 290) and `ExchangeCode` (line 313), spanning lines
+295–356, which need a live provider and are driven by the e2e OIDC lanes. 1 is
+the package-level `const defaultOIDCHTTPTimeout = 10 * time.Second` (line 21),
+which Go statement coverage never instruments — both as previously documented,
+just at a shifted line range.
+
+The remaining 4 are new since the last measurement: `OIDCConfig.validateRequiredFields`'s
+switch-case branches (`oidc.go:144,146,148,150`) that reject a missing
+`OIDC_ISSUER_URL`/`OIDC_CLIENT_ID`/`OIDC_CLIENT_SECRET`/`OIDC_REDIRECT_URL`.
+This validation runs once at bootstrap with a fixed, operator-supplied config —
+not exercised by a `go test` unit today. Whether that's an acceptable gap (config
+validation is arguably an integration/bootstrap concern) or worth a small
+table-driven unit test is a call for the next triage pass, not asserted here.

--- a/.mutation/internal-services.md
+++ b/.mutation/internal-services.md
@@ -4,20 +4,36 @@ Authoritative gremlins run for the core domain package. Reproduce with
 `scripts/mutation.sh baseline` (per-package JSON lands in `.tmp/mutation/`); this
 file is the reviewed summary committed alongside the code.
 
-## Score (measured on `ac3a4af`)
+## Score (measured on `a6d7e41`)
+
+**Source: workflow_dispatch run
+[28758365493](https://github.com/ovumcy/ovumcy-web/actions/runs/28758365493)**
+on `mutation.yml` (`mutation-baseline (internal_services)` job, single
+unsharded run, green) — the same run that refreshed `internal-api.md` (PR
+#174) and `internal-security.md`. Numbers confirmed two independent ways:
+(a) gremlins' own end-of-run summary line in the job log, (b) counting
+`"status"` values directly in the downloaded `internal_services.json`. Both
+agree exactly.
 
 | Metric | Value |
 |--------|-------|
-| Killed | 1462 |
-| Lived (survivors) | 4 — all documented equivalents (below) |
-| Timed out | 39 (property/fuzz runtime; not survivors, excluded from efficacy) |
-| Not covered | 59 |
+| Killed | 1478 |
+| Lived (survivors) | 62 — 4 reconciled equivalents (below) + 58 new/not yet triaged |
+| Timed out | 5 (property/fuzz runtime; not survivors, excluded from efficacy) |
+| Not covered | 62 |
 | Not viable | 0 |
-| **Test efficacy** | **99.73%** — killed / (killed + lived) = 1462 / 1466 |
-| Mutator coverage | 96.13% |
+| **Test efficacy** | **95.97%** — killed / (killed + lived) = 1478 / 1540 |
+| Mutator coverage | 96.13% — (killed + lived) / (killed + lived + not covered) = 1540 / 1602 |
 
-Efficacy over *killable* mutants is 100%: every survivor below is an equivalent
-mutant — a fault that cannot change any observable output — verified individually.
+The efficacy figure dropped from the previously-measured 99.73% (`ac3a4af`) to
+95.97% here — not a regression in test quality, but 43 feature commits
+(webhooks, `.ics` calendar feed, reminder banner/scheduler, per-user timezone
+persistence, JSON import/restore, prediction-struct refactor) landing between
+`ac3a4af` and `a6d7e41` that added real code whose mutants have not yet been
+individually triaged. See "Newly surfaced survivors" below — do not read the
+raw 95.97% as "4% of behavior is untested"; some fraction of the 58 new
+survivors are almost certainly equivalent mutants like the ones already
+documented for this package and for `internal/security`.
 
 ## Round 3 hardening (2026-06-13)
 
@@ -56,7 +72,12 @@ are killed.
 
 ## Documented equivalent mutants
 
-### 1–2. `cycles.go:315` — luteal-phase default guard (BOUNDARY, NEGATION)
+Reconciled against the `28758365493` survivor set: all 4 mutants below are
+still present and still equivalent under the same argument — only their line
+numbers shifted (intervening commits added code earlier in each file). None
+of the previously-documented equivalents were killed or disappeared.
+
+### 1–2. `cycles.go:337` — luteal-phase default guard (BOUNDARY, NEGATION)
 
 ```go
 if stats.LutealPhase <= 0 {            // mutated
@@ -101,3 +122,57 @@ already excludes everything after `targetDay - 1d`, the internal filter selects 
 same set either way. The only `today`-sensitive outputs — `CurrentCycleDay` and
 `CurrentPhase` — are never read by `potentialImplantationGapDays`. No observable
 change.
+
+## Newly surfaced survivors — not yet triaged
+
+The 43 commits between `ac3a4af` and `a6d7e41` (webhooks, `.ics` calendar feed
+token storage/lifecycle, reminder banner + scheduler, per-user timezone
+persistence, JSON import/restore, the prediction multi-bool→struct refactor,
+bcrypt cost raise) added real domain code whose mutants were never run against
+before. Unlike the 4 mutants above, these 58 are **not** individually triaged
+into "real gap" vs. "equivalent mutant" yet — that requires the same
+per-mutant source review (apply the mutation, confirm no test fails, judge
+reachability) applied to the legacy 4, which is a separate follow-up, not
+implied by getting real numbers out of CI. Do not read the delta from the
+prior 99.73% as "behavior regressed" — some fraction of these are almost
+certainly equivalent mutants like the ones already documented above and in
+`internal-security.md`.
+
+One adjacent guard is explicitly **not** folded into entries #3–4 above despite
+sitting one line below them: `cycle_start_policy.go:83` and `:86`
+(`if cycleLength <= 0 { cycleLength = DashboardCycleReferenceLength(...) }`,
+twice) are new fallback branches introduced by the same refactor that added
+`ResolveLutealPhase`/`DashboardCycleReferenceLength` — each has a `BOUNDARY`
+survivor and a killed `NEGATION` mutant. They were not part of the codebase at
+`ac3a4af` and need their own equivalence review, not inherited from #3–4's
+argument.
+
+Survivor count by file (from `internal_services.json`, all files with at least
+one survivor):
+
+| File | Survivors |
+|------|-----------|
+| `cycles.go` | 13 (2 reconciled equivalents above; 11 new) |
+| `dashboard_cycle.go` | 7 |
+| `cycle_start_policy.go` | 7 (2 reconciled equivalents above; 5 new) |
+| `import_service.go` | 7 |
+| `day_service.go` | 5 |
+| `date_i18n_policy.go` | 5 |
+| `cycle_signals.go` | 3 |
+| `dashboard_view_service.go` | 3 |
+| `dashboard_cycle_hero.go` | 3 |
+| `calendar_days.go` | 2 |
+| `i18n_policy.go` | 2 |
+| `attempt_limiter.go` | 1 |
+| `cycle_baseline.go` | 1 |
+| `day_input.go` | 1 |
+| `day_feedback_policy.go` | 1 |
+| `calendar_view_policy.go` | 1 |
+
+The 62 not-covered mutants concentrate in `dashboard_cycle_hero.go` (11) and
+`stats_cycle_factor_context.go` (11), followed by `stats_page_view_service.go`
+(6), `i18n_policy.go` (5), and `stats_phase_insights.go` (5) — worth checking
+whether these are dead code, tested only at the integration/e2e layer, or a
+genuine gap before the next triage pass. The 5 timed-out mutants are in
+`cycles.go` (4) and `day_service.go` (1) — property/fuzz runtime, not
+survivors, excluded from efficacy per the existing convention.


### PR DESCRIPTION
## Summary

- `.mutation/internal-services.md` and `.mutation/internal-security.md` still
  showed numbers measured on stale commits (`ac3a4af` / `54a29ad`), even
  though PR #174 already refreshed `internal-api.md` from the same completed
  sharded mutation run. This fills in the other two files consistently.
- Source: workflow_dispatch run
  [28758365493](https://github.com/ovumcy/ovumcy-web/actions/runs/28758365493)
  on `mutation.yml` (measured on commit `a6d7e41`, confirmed via the run's
  `head_sha`) — the `mutation-baseline (internal_services)` and
  `mutation-baseline (internal_security)` jobs, both green, single unsharded
  runs (unlike `internal_api`'s 5-way shard).
- Downloaded each job's artifact (`mutation-baseline-results-internal_services`
  -> `internal_services.json`, `mutation-baseline-results-internal_security`
  -> `internal_security.json`) and cross-checked both aggregates two
  independent ways: (a) gremlins' own end-of-run "Killed/Lived/Not
  covered/Timed out" summary line from each job's log, (b) counting
  `"status"` values directly in the JSON. Both agree exactly for both
  packages.

## Real scores

**`internal/services`**

| Metric | Value |
|--------|-------|
| Killed | 1478 |
| Lived (survivors) | 62 — 4 reconciled equivalents + 58 new/not yet triaged |
| Timed out | 5 |
| Not covered | 62 |
| **Test efficacy** | **95.97%** (1478 / 1540) |
| Mutator coverage | 96.13% (1540 / 1602) |

**`internal/security`**

| Metric | Value |
|--------|-------|
| Killed | 112 |
| Lived (survivors) | 9 — all reconciled, same as previously documented |
| Timed out | 0 |
| Not covered | 17 |
| **Test efficacy** | **92.56%** (112 / 121) |
| Mutator coverage | 87.68% (121 / 138) |

## Survivor reconciliation (not fabricated)

- **`internal-security.md`**: all 9 survivors from the new run map 1:1 onto
  the 6 previously-documented equivalence arguments (verified against current
  `oidc.go`/`sealed_cipher.go` source) — only line numbers shifted (+35 lines
  in most of `oidc.go`, from intervening hardening commits). No survivor was
  killed, none newly appeared. Pure line-number refresh, same narrative kept.
- **`internal-services.md`**: the previous 4 documented equivalents (luteal-
  phase default guard, implantation pre-filter, implantation "as-of" instant)
  are still present and still equivalent under the same argument, just at
  shifted lines (`cycles.go:315`->`:337`). The other 58 survivors are new:
  43 feature commits landed between `ac3a4af` and `a6d7e41` (webhooks, `.ics`
  calendar feed, reminder banner/scheduler, per-user timezone persistence,
  JSON import/restore, prediction-struct refactor) that were never mutation-
  tested before. Per the no-fabrication instruction, these are documented as
  **not yet individually triaged** (survivor-by-file breakdown included),
  mirroring exactly how `internal-api.md`'s 128 untriaged survivors are
  already handled — not force-fit into the old 4-item equivalence writeup.
- The efficacy drop (99.73% -> 95.97%) is explained inline as new-code
  volume, not a test-quality regression.

## Test plan

- [x] `git status` shows only `.mutation/internal-services.md` and
      `.mutation/internal-security.md` changed (docs/data, no code).
- [x] Numbers cross-checked two independent ways per package (gremlins'
      own summary line vs. raw JSON status counts) — both agree exactly.
- [x] Arithmetic sanity: killed + lived + not-covered + timed-out equals the
      raw mutation count in each JSON (1607 for services, 138 for security);
      efficacy = killed / (killed + lived) and coverage = (killed + lived) /
      (killed + lived + not covered) both recompute to the stated values.
- [x] Downloaded artifacts and job logs deleted from the scratch dir after
      use (explicit filenames); nothing left in the repo tree.
- No `go build`/`go test` — no Go source changed; pre-push confirmed
  "no Go files in this push — skipping patch-coverage check".
