### PR TITLE
test(services): share cycle-prediction golden vectors with ovumcy-app

### DIFF
--- a/docs/cycle-prediction.md
+++ b/docs/cycle-prediction.md
@@ -136,8 +136,23 @@ estimate, nothing more.
 
 ## Verifying this document
 
-Every numeric claim above is enforced by `TestCyclePrediction_ReferenceVectors`
+Every numeric claim above is enforced by `TestCyclePrediction_GoldenVectors`
 and related tests in `internal/services/cycles_reference_test.go`. Property-based
 tests (`cycles_property_test.go`) additionally assert the invariants for
-thousands of generated inputs. If you change the math, these tests must be
-updated in lockstep with this document.
+thousands of generated inputs.
+
+### Shared golden-vector fixture (lockstep with ovumcy-app)
+
+The worked examples above are pinned to the code by a **shared golden-vector
+fixture**, [`internal/services/testdata/cycle-prediction-golden-vectors.json`](../internal/services/testdata/cycle-prediction-golden-vectors.json),
+consumed by `TestCyclePrediction_GoldenVectors`. That file is kept
+**byte-identical** with ovumcy-app's
+`src/services/__fixtures__/cycle-prediction-golden-vectors.json` (ovumcy-app
+PR #75), where it is consumed by `src/services/cycle-prediction-reference.test.ts`.
+
+The Go source of truth here (`internal/services/cycles.go`) and ovumcy-app's
+TypeScript port (`src/services/cycle-prediction-policy.ts`) are hand-parallel
+implementations; consuming one shared fixture makes any divergence between them
+fail CI on **both** sides instead of drifting silently. If you change the
+prediction math, update the fixture, **both** docs (this file and ovumcy-app's
+`docs/cycle-prediction.md`), and **both** reference tests in the same change.

--- a/internal/services/cycles_reference_test.go
+++ b/internal/services/cycles_reference_test.go
@@ -1,6 +1,9 @@
 package services
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -12,9 +15,81 @@ import (
 // These deterministic example-based tests complement the property tests
 // (cycles_property_test.go, invariants) and the fuzz tests (policy_fuzz_test.go,
 // robustness). Together: transparent and verifiable.
+//
+// The per-vector prediction cases (TestCyclePrediction_GoldenVectors) are driven
+// by a shared golden-vector fixture,
+// testdata/cycle-prediction-golden-vectors.json, that is kept byte-identical
+// with ovumcy-app's src/services/__fixtures__/cycle-prediction-golden-vectors.json
+// (ovumcy-app PR #75). The Go (cycles.go) and TypeScript
+// (cycle-prediction-policy.ts) prediction implementations are hand-parallel
+// ports; consuming one shared file makes any divergence between them fail CI on
+// both sides instead of silently drifting. If the prediction math changes,
+// update the fixture, docs/cycle-prediction.md, and BOTH reference tests
+// (this file and ovumcy-app's cycle-prediction-reference.test.ts) in the same
+// change.
 
 func refDate(year, month, day int) time.Time {
 	return time.Date(year, time.Month(month), day, 0, 0, 0, 0, time.UTC)
+}
+
+// goldenVectorsFile is the shared golden-vector fixture, vendored byte-identical
+// from ovumcy-app (see the package comment above).
+const goldenVectorsFile = "cycle-prediction-golden-vectors.json"
+
+// goldenVectorFixture is the parsed shape of the shared fixture. Field names
+// mirror the JSON (which uses the TypeScript port's vocabulary); the mapping
+// onto the Go CycleWindowPrediction struct happens in the test body. Nullable
+// dates are pointers so a JSON null (the non-calculable case) decodes to nil
+// rather than the zero date, and can be asserted as "absent".
+type goldenVectorFixture struct {
+	SchemaVersion int            `json:"schemaVersion"`
+	Vectors       []goldenVector `json:"vectors"`
+}
+
+type goldenVector struct {
+	Name  string `json:"name"`
+	Input struct {
+		CycleStartDate string `json:"cycleStartDate"`
+		CycleLength    int    `json:"cycleLength"`
+		LutealPhase    int    `json:"lutealPhase"`
+	} `json:"input"`
+	Expected struct {
+		Calculable      bool    `json:"calculable"`
+		FertilityStart  *string `json:"fertilityStart"`
+		FertilityEnd    *string `json:"fertilityEnd"`
+		OvulationDate   *string `json:"ovulationDate"`
+		IsExact         bool    `json:"isExact"`
+		NextPeriodStart string  `json:"nextPeriodStart"`
+	} `json:"expected"`
+}
+
+// loadGoldenVectors reads and parses the shared fixture, failing the test on any
+// read or decode error.
+func loadGoldenVectors(t *testing.T) goldenVectorFixture {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join("testdata", goldenVectorsFile))
+	if err != nil {
+		t.Fatalf("read golden vectors: %v", err)
+	}
+	var fixture goldenVectorFixture
+	if err := json.Unmarshal(raw, &fixture); err != nil {
+		t.Fatalf("parse golden vectors: %v", err)
+	}
+	if len(fixture.Vectors) == 0 {
+		t.Fatal("golden vectors fixture has no vectors")
+	}
+	return fixture
+}
+
+// goldenDate parses a fixture "YYYY-MM-DD" calendar date into a UTC-midnight
+// time.Time, matching the UTC-anchored dateOnly arithmetic in cycles.go.
+func goldenDate(t *testing.T, s string) time.Time {
+	t.Helper()
+	d, err := time.ParseInLocation("2006-01-02", s, time.UTC)
+	if err != nil {
+		t.Fatalf("parse golden date %q: %v", s, err)
+	}
+	return d
 }
 
 func TestResolveLutealPhase_ReferenceVectors(t *testing.T) {
@@ -68,87 +143,70 @@ func TestCalcOvulationDay_ReferenceVectors(t *testing.T) {
 	}
 }
 
-func TestCyclePrediction_ReferenceVectors(t *testing.T) {
-	cases := []struct {
-		name         string
-		periodStart  time.Time
-		cycleLen     int
-		luteal       int
-		wantCalc     bool
-		wantExact    bool
-		wantOvul     time.Time
-		wantFertFrom time.Time
-		wantFertTo   time.Time
-		wantNext     time.Time // model: periodStart + cycleLen
-	}{
-		{
-			name:        "standard 28-day cycle",
-			periodStart: refDate(2026, 3, 10), cycleLen: 28, luteal: 14,
-			wantCalc: true, wantExact: true,
-			wantOvul:     refDate(2026, 3, 23),
-			wantFertFrom: refDate(2026, 3, 18), wantFertTo: refDate(2026, 3, 23),
-			wantNext: refDate(2026, 4, 7),
-		},
-		{
-			name:        "30-day cycle, default luteal",
-			periodStart: refDate(2026, 6, 1), cycleLen: 30, luteal: 0,
-			wantCalc: true, wantExact: true,
-			wantOvul:     refDate(2026, 6, 16),
-			wantFertFrom: refDate(2026, 6, 11), wantFertTo: refDate(2026, 6, 16),
-			wantNext: refDate(2026, 7, 1),
-		},
-		{
-			name:        "short 21-day cycle",
-			periodStart: refDate(2026, 1, 1), cycleLen: 21, luteal: 14,
-			wantCalc: true, wantExact: true,
-			wantOvul:     refDate(2026, 1, 7),
-			wantFertFrom: refDate(2026, 1, 2), wantFertTo: refDate(2026, 1, 7),
-			wantNext: refDate(2026, 1, 22),
-		},
-		{
-			name:        "15-day cycle clamps luteal and fertile window",
-			periodStart: refDate(2026, 2, 1), cycleLen: 15, luteal: 14,
-			wantCalc: true, wantExact: false,
-			wantOvul:     refDate(2026, 2, 5),
-			wantFertFrom: refDate(2026, 2, 1), wantFertTo: refDate(2026, 2, 5),
-			wantNext: refDate(2026, 2, 16),
-		},
-		{
-			name:        "cycle too short for any prediction",
-			periodStart: refDate(2026, 5, 1), cycleLen: 14, luteal: 14,
-			wantCalc: false,
-		},
-	}
+// TestCyclePrediction_GoldenVectors asserts every vector in the shared fixture
+// against PredictCycleWindow (and the next-period formula), so the Go source of
+// truth and ovumcy-app's TypeScript port cannot drift apart without failing CI
+// on both sides. The fixture uses the TypeScript port's field vocabulary
+// (calculable / fertilityStart / fertilityEnd / ovulationDate / isExact /
+// nextPeriodStart); the mapping onto CycleWindowPrediction is spelled out below.
+func TestCyclePrediction_GoldenVectors(t *testing.T) {
+	fixture := loadGoldenVectors(t)
 
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			window := PredictCycleWindow(tc.periodStart, tc.cycleLen, tc.luteal)
-			ovul, fertFrom, fertTo, exact, calc := window.OvulationDate, window.FertilityWindowStart, window.FertilityWindowEnd, window.OvulationExact, window.Calculable
-			if calc != tc.wantCalc {
-				t.Fatalf("calculable = %t, want %t", calc, tc.wantCalc)
+	for _, vector := range fixture.Vectors {
+		t.Run(vector.Name, func(t *testing.T) {
+			periodStart := goldenDate(t, vector.Input.CycleStartDate)
+			window := PredictCycleWindow(periodStart, vector.Input.CycleLength, vector.Input.LutealPhase)
+
+			if window.Calculable != vector.Expected.Calculable {
+				t.Fatalf("calculable = %t, want %t", window.Calculable, vector.Expected.Calculable)
 			}
-			if !calc {
-				return
+
+			if vector.Expected.Calculable {
+				// fertilityStart -> FertilityWindowStart
+				wantFertFrom := goldenDate(t, *vector.Expected.FertilityStart)
+				if !window.FertilityWindowStart.Equal(wantFertFrom) {
+					t.Errorf("fertility start = %s, want %s",
+						window.FertilityWindowStart.Format("2006-01-02"), wantFertFrom.Format("2006-01-02"))
+				}
+				// fertilityEnd -> FertilityWindowEnd
+				wantFertTo := goldenDate(t, *vector.Expected.FertilityEnd)
+				if !window.FertilityWindowEnd.Equal(wantFertTo) {
+					t.Errorf("fertility end = %s, want %s",
+						window.FertilityWindowEnd.Format("2006-01-02"), wantFertTo.Format("2006-01-02"))
+				}
+				// ovulationDate -> OvulationDate
+				wantOvul := goldenDate(t, *vector.Expected.OvulationDate)
+				if !window.OvulationDate.Equal(wantOvul) {
+					t.Errorf("ovulation = %s, want %s",
+						window.OvulationDate.Format("2006-01-02"), wantOvul.Format("2006-01-02"))
+				}
+				// isExact -> OvulationExact
+				if window.OvulationExact != vector.Expected.IsExact {
+					t.Errorf("exact = %t, want %t", window.OvulationExact, vector.Expected.IsExact)
+				}
+			} else {
+				// A non-calculable prediction returns the zero struct: the
+				// fixture pins these to null, so assert the dates are absent
+				// rather than skipping the negative case.
+				if vector.Expected.OvulationDate != nil || vector.Expected.FertilityStart != nil || vector.Expected.FertilityEnd != nil {
+					t.Fatalf("fixture bug: non-calculable vector %q must have null date fields", vector.Name)
+				}
+				if !window.OvulationDate.IsZero() || !window.FertilityWindowStart.IsZero() || !window.FertilityWindowEnd.IsZero() {
+					t.Errorf("non-calculable window should have zero dates, got ovul=%v fertFrom=%v fertTo=%v",
+						window.OvulationDate, window.FertilityWindowStart, window.FertilityWindowEnd)
+				}
 			}
-			if !ovul.Equal(tc.wantOvul) {
-				t.Errorf("ovulation = %s, want %s", ovul.Format("2006-01-02"), tc.wantOvul.Format("2006-01-02"))
-			}
-			if !fertFrom.Equal(tc.wantFertFrom) {
-				t.Errorf("fertility start = %s, want %s", fertFrom.Format("2006-01-02"), tc.wantFertFrom.Format("2006-01-02"))
-			}
-			if !fertTo.Equal(tc.wantFertTo) {
-				t.Errorf("fertility end = %s, want %s", fertTo.Format("2006-01-02"), tc.wantFertTo.Format("2006-01-02"))
-			}
-			if exact != tc.wantExact {
-				t.Errorf("exact = %t, want %t", exact, tc.wantExact)
-			}
-			// Doc-only consistency check: this recomputes periodStart +
-			// cycleLength inline, so it can only catch a drifted "next
-			// period" column in docs/cycle-prediction.md — never a
-			// production bug. The production invariant is pinned by
-			// TestPipeline_NextPeriodMatchesFormula.
-			if next := tc.periodStart.AddDate(0, 0, tc.cycleLen); !next.Equal(tc.wantNext) {
-				t.Errorf("next period = %s, want %s", next.Format("2006-01-02"), tc.wantNext.Format("2006-01-02"))
+
+			// nextPeriodStart = cycleStartDate + cycleLength days. This is not
+			// part of PredictCycleWindow's output, so assert it against the same
+			// UTC-anchored formula the production pipeline uses
+			// (applyPredictedCycleStats / PredictCycleWindow, via dateOnly +
+			// AddDate). This mirrors ovumcy-app's cycle-prediction-reference.test.ts,
+			// which recomputes cycleStartDate + cycleLength the same way to lock
+			// the doc's "next period" column to the code on both sides.
+			wantNext := goldenDate(t, vector.Expected.NextPeriodStart)
+			if gotNext := dateOnly(periodStart.AddDate(0, 0, vector.Input.CycleLength)); !gotNext.Equal(wantNext) {
+				t.Errorf("next period = %s, want %s", gotNext.Format("2006-01-02"), wantNext.Format("2006-01-02"))
 			}
 		})
 	}

--- a/internal/services/cycles_reference_test.go
+++ b/internal/services/cycles_reference_test.go
@@ -28,10 +28,6 @@ import (
 // (this file and ovumcy-app's cycle-prediction-reference.test.ts) in the same
 // change.
 
-func refDate(year, month, day int) time.Time {
-	return time.Date(year, time.Month(month), day, 0, 0, 0, 0, time.UTC)
-}
-
 // goldenVectorsFile is the shared golden-vector fixture, vendored byte-identical
 // from ovumcy-app (see the package comment above).
 const goldenVectorsFile = "cycle-prediction-golden-vectors.json"

--- a/internal/services/testdata/cycle-prediction-golden-vectors.json
+++ b/internal/services/testdata/cycle-prediction-golden-vectors.json
@@ -1,0 +1,66 @@
+{
+  "$comment": "Shared golden vectors for cycle prediction. Single source of truth consumed by BOTH the TypeScript reference test (src/services/cycle-prediction-reference.test.ts) and, by design, ovumcy-web's Go reference test (internal/services/cycles_reference_test.go). The two prediction implementations — cycle-prediction-policy.ts and cycles.go — are hand-parallel ports; these vectors enforce parity so a change to either that diverges from the other fails CI. Any prediction-math change MUST update this file, docs/cycle-prediction.md, and both reference tests in the same change. Dates are calendar dates (YYYY-MM-DD), timezone-independent. See docs/cycle-prediction.md for the derivation of each case.",
+  "schemaVersion": 1,
+  "vectors": [
+    {
+      "name": "28-day cycle, luteal 14 -> ovulation day 14 (exact)",
+      "input": { "cycleStartDate": "2026-03-10", "cycleLength": 28, "lutealPhase": 14 },
+      "expected": {
+        "calculable": true,
+        "fertilityStart": "2026-03-18",
+        "fertilityEnd": "2026-03-23",
+        "ovulationDate": "2026-03-23",
+        "isExact": true,
+        "nextPeriodStart": "2026-04-07"
+      }
+    },
+    {
+      "name": "30-day cycle, luteal 0 defaults to 14 (exact)",
+      "input": { "cycleStartDate": "2026-06-01", "cycleLength": 30, "lutealPhase": 0 },
+      "expected": {
+        "calculable": true,
+        "fertilityStart": "2026-06-11",
+        "fertilityEnd": "2026-06-16",
+        "ovulationDate": "2026-06-16",
+        "isExact": true,
+        "nextPeriodStart": "2026-07-01"
+      }
+    },
+    {
+      "name": "21-day cycle, luteal 14 (exact)",
+      "input": { "cycleStartDate": "2026-01-01", "cycleLength": 21, "lutealPhase": 14 },
+      "expected": {
+        "calculable": true,
+        "fertilityStart": "2026-01-02",
+        "fertilityEnd": "2026-01-07",
+        "ovulationDate": "2026-01-07",
+        "isExact": true,
+        "nextPeriodStart": "2026-01-22"
+      }
+    },
+    {
+      "name": "15-day cycle, luteal 14 clamped to 10, window clamped to period start (non-exact)",
+      "input": { "cycleStartDate": "2026-02-01", "cycleLength": 15, "lutealPhase": 14 },
+      "expected": {
+        "calculable": true,
+        "fertilityStart": "2026-02-01",
+        "fertilityEnd": "2026-02-05",
+        "ovulationDate": "2026-02-05",
+        "isExact": false,
+        "nextPeriodStart": "2026-02-16"
+      }
+    },
+    {
+      "name": "14-day cycle -> below the 15-day floor, no prediction",
+      "input": { "cycleStartDate": "2026-02-01", "cycleLength": 14, "lutealPhase": 14 },
+      "expected": {
+        "calculable": false,
+        "fertilityStart": null,
+        "fertilityEnd": null,
+        "ovulationDate": null,
+        "isExact": false,
+        "nextPeriodStart": "2026-02-15"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Context

The cycle-prediction math exists in two hand-parallel implementations: the Go
source of truth here (`internal/services/cycles.go`) and ovumcy-app's TypeScript
port (`src/services/cycle-prediction-policy.ts`). They were pinned by two
*separate* sets of hand-written reference vectors — one per repo — so the two
could silently drift: a change on one side that diverged from the other would
pass both suites as long as each repo's own hand-copied numbers stayed
self-consistent.

ovumcy-app PR ovumcy/ovumcy-app#75 introduces a **shared golden-vector fixture**
(`src/services/__fixtures__/cycle-prediction-golden-vectors.json`) and rewrites
its TS reference test to consume it, with the explicit design intent that the
*same file* also drives this repo's Go reference test. This PR makes that
cross-repo claim true: it vendors the fixture byte-identical and reworks the Go
reference test to load and assert it, so prediction-math drift between `cycles.go`
and the TS port now fails CI on **both** sides.

## What changed

- **`internal/services/testdata/cycle-prediction-golden-vectors.json`** (new) —
  the shared fixture, vendored **byte-identical** from ovumcy-app PR #75 (git
  blob `637f6c1928f41ddc565e83787a0b08d8ff0d60e6`, verified by `cmp` against the
  app branch blob and by `git hash-object`). Placed under the Go-idiomatic
  `testdata/` directory (the `go` tool ignores it for builds); the repo had no
  `testdata/` dir before, so this establishes the pattern.
- **`internal/services/cycles_reference_test.go`** — replaced the hand-coded
  `TestCyclePrediction_ReferenceVectors` with table-driven
  `TestCyclePrediction_GoldenVectors`, which parses the fixture and asserts every
  vector against `PredictCycleWindow`. The fixture uses the TS port's field
  vocabulary (`calculable` / `fertilityStart` / `fertilityEnd` / `ovulationDate`
  / `isExact` / `nextPeriodStart`); the mapping onto `CycleWindowPrediction`
  (`OvulationDate` / `FertilityWindowStart` / `FertilityWindowEnd` /
  `OvulationExact` / `Calculable`) is spelled out in the test body. The
  `nextPeriodStart` column is asserted against the same UTC-anchored formula the
  production pipeline uses (`dateOnly(periodStart.AddDate(0, 0, cycleLength))`),
  mirroring the app-side test. `TestResolveLutealPhase_ReferenceVectors` and
  `TestCalcOvulationDay_ReferenceVectors` are unchanged.
- **`docs/cycle-prediction.md`** — added a "Shared golden-vector fixture
  (lockstep with ovumcy-app)" section documenting the same rule the app side
  documents: the fixture is byte-identical across both repos, and any
  prediction-math change must update the fixture, **both** docs, and **both**
  reference tests in the same change. Updated "Verifying this document" to name
  the new test.

**No production code changed.** All 5 vectors pass against `cycles.go` unchanged
— parity holds, no divergence found.

## Deviations

- **Fixture directory.** ovumcy-app stores the fixture under
  `src/services/__fixtures__/`; the byte-identical Go copy lives under
  `internal/services/testdata/` (the Go convention — `go test` runs with that as
  the working directory and the toolchain excludes `testdata/` from builds). The
  file *contents* are identical; only the path differs per each repo's idiom.
- **Kept the two non-prediction reference tables.** Only the per-vector
  prediction table was fixture-driven; `ResolveLutealPhase` and `CalcOvulationDay`
  reference tables have no app-side counterpart (they exercise Go-internal
  helpers), so they stay as hand-written tables rather than being forced into the
  shared fixture.
- **`nextPeriodStart` assertion mirrors the app's re-derivation.** Like
  ovumcy-app's `cycle-prediction-reference.test.ts`, the test recomputes
  `cycleStartDate + cycleLength` (here via the production `dateOnly` + `AddDate`)
  rather than reading it off a struct field — `nextPeriodStart` is not part of
  `PredictCycleWindow`'s output. The production next-period invariant remains
  additionally pinned by `TestPipeline_NextPeriodMatchesFormula`.

## Verification

Run inside an isolated worktree off `origin/main` (the primary checkout is on an
unrelated branch and was not touched):

- `go build ./...` — clean.
- `go vet ./...` — clean.
- `gofmt -l internal/services/cycles_reference_test.go` — empty (formatted).
- `go test ./internal/services/ -count=1` — **PASS** (full package, ~37–48s).
  `TestCyclePrediction_GoldenVectors` passes all 5 vectors against unchanged
  `cycles.go`.
- **Drift-detection proven, not assumed:** temporarily mutating one fixture value
  (`nextPeriodStart` 2026-04-07 → 2026-04-08) made the test **FAIL**
  (`next period = 2026-04-07, want 2026-04-08`); the vendored fixture was then
  restored to blob `637f6c1…`. So a real Go/TS divergence would fail this test,
  it is not vacuously green.
- **Byte-identity:** `cmp` against the app-branch blob reports no differences;
  `git hash-object` on the vendored file equals the `637f6c1…` blob declared by
  app PR #75.
- **Pre-push patch-coverage hook:** ran the full fresh suite and reported
  "patch coverage gate OK: every modified coverable line is covered by tests"
  (the gate skips `_test.go` and non-`.go` paths, so the test + JSON add nothing
  to gate). Not bypassed.
- **golangci-lint** is not installed in this environment (repo ships a
  `.golangci.yml`); `go vet` + `gofmt` stand in locally, and CI's lint job is the
  authoritative check.

## Review focus

- **Field-name mapping** (fixture TS vocabulary → `CycleWindowPrediction`) in
  `TestCyclePrediction_GoldenVectors` — confirm each JSON field lands on the
  intended Go struct field.
- **`testdata/` as the vendor location** — first `testdata/` dir in the repo;
  confirm that's the preferred home for shared fixtures vs. an `internal/services`
  embedded/const.
- **The lockstep documentation** — this PR asserts a cross-repo maintenance
  contract (any math change touches the fixture + both docs + both reference
  tests). Confirm you're comfortable owning the Go half of that contract.

Relates to ovumcy/ovumcy-app#75 (the shared fixture) and app issue
ovumcy/ovumcy-app#54. The issue lives in the sibling repo, so this PR only
references it — GitHub cannot auto-close a cross-repo issue and it is not the
sole deliverable of #54 anyway.
