### PR TITLE
test(api): drop reminder-banner UI-copy assertions from backend HTML tests

### DIFF
--- a/internal/api/dashboard_regressions_test.go
+++ b/internal/api/dashboard_regressions_test.go
@@ -344,9 +344,6 @@ func TestDashboardRendersReminderBannerWhenPeriodIsDueSoon(t *testing.T) {
 	if got := htmlAttr(banner, "data-reminder-banner-key"); got != "dashboard.reminder_banner_period" {
 		t.Fatalf("expected period reminder banner key, got %q", got)
 	}
-	if !strings.Contains(body, "Period likely in ~2 days") {
-		t.Fatalf("expected rendered period reminder copy for 2 days out, got body without it")
-	}
 
 	for _, fragment := range []string{
 		`data-dashboard-prediction-disclaimer`,
@@ -396,12 +393,6 @@ func TestDashboardRendersTomorrowReminderBannerCopy(t *testing.T) {
 	}
 	if got := htmlAttr(banner, "data-reminder-banner-key"); got != "dashboard.reminder_banner_period_tomorrow" {
 		t.Fatalf("expected period tomorrow reminder banner key, got %q", got)
-	}
-	if !strings.Contains(body, "Period likely tomorrow") {
-		t.Fatalf("expected rendered tomorrow reminder copy, got body without it")
-	}
-	if strings.Contains(body, "~1 day") {
-		t.Fatalf("did not expect the ~N days plural copy for the tomorrow branch")
 	}
 
 	for _, fragment := range []string{


### PR DESCRIPTION
## What

Remove exact UI-copy assertions from the two dashboard reminder-banner backend HTML regressions in `internal/api/dashboard_regressions_test.go`, leaving them to pin structural contracts only.

## Why

`.claude/rules/testing.md`: backend HTML tests in `internal/api` assert structural contracts — `data-*` hooks, `id=`, `aria-*` — and **never** `strings.Contains(body, "<localized phrase>")`; the sole exception is the medical-safety disclaimer. The two tests violated this by asserting `"Period likely in ~2 days"` and `"Period likely tomorrow"` (plus a negative `"~1 day"` scan).

Surfaced by the `test-suite-auditor` skill and confirmed by a repo-wide sweep: of 73 `Contains(body, …)` matches total, only these two positive copy assertions are genuine rule violations — the rest are CLI/service/`.ics` data contracts, helper-fallback unit tests (test-supplied default strings), and negative privacy checks.

## Change

`internal/templates/dashboard.html` renders both `data-reminder-banner-key` and the visible copy from the **same** `.ReminderBannerTitleKey`, so the `data-reminder-banner-key` assertions already own the plural-vs-tomorrow branch selection. All three copy scans (two positive + one negative) are therefore fully redundant and were removed — including the negative `"~1 day"` guard, since the copy cannot diverge from the key that the test already asserts. The day-count value is a service-layer concern covered there; visible reminder copy belongs in a Playwright spec via the same data hook.

Each test still pins: the banner element (`data-dashboard-reminder-banner`), its `data-reminder-banner-key` value, and the medical-safety disclaimer (hook + exact string, the sanctioned exception).

## Validation

- `go test ./internal/api -run 'TestDashboardRendersReminderBannerWhenPeriodIsDueSoon|TestDashboardRendersTomorrowReminderBannerCopy' -count=1` — both PASS.

Test-only change; no runtime impact.
