### PR TITLE
ci(fuzz): add ClusterFuzzLite continuous fuzzing on GitHub Actions

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,10 @@
+# ClusterFuzzLite build sandbox — runs on GitHub Actions (not Google infra).
+# It compiles the native Go fuzz targets in internal/services into libFuzzer
+# binaries. base-builder-go is the rolling image ClusterFuzzLite requires for
+# the go-118-fuzz-build toolchain; it is an ephemeral build environment, never
+# a shipped or scanned runtime image, so it is intentionally not digest-pinned
+# (unlike the repo-root Dockerfile). See docs/SECURITY_INVARIANTS.md.
+FROM gcr.io/oss-fuzz-base/base-builder-go
+COPY . $SRC/ovumcy-web
+WORKDIR $SRC/ovumcy-web
+COPY .clusterfuzzlite/build.sh $SRC/

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,13 +1,15 @@
 #!/bin/bash -eu
 # Compile each fuzz target into a libFuzzer binary for ClusterFuzzLite.
 #
-# go-118-fuzz-build cannot pick up native testing.F fuzzers that live in _test.go
-# files, so the six targets are mirrored in internal/services/policy_fuzz_libfuzzer.go
-# under the `gofuzz` build tag (see that file). compile_go_fuzzer builds those shim
-# harnesses with -tags gofuzz. Keep this list in sync with .github/workflows/fuzz.yml
-# and policy_fuzz_libfuzzer.go.
+# The six targets are mirrored in internal/services/policy_fuzz_libfuzzer.go under
+# the `gofuzz` build tag (go-118-fuzz-build cannot read native testing.F fuzzers
+# that live in _test.go). GOFLAGS forces that tag on every `go build` so the shim
+# file is included, and compile_native_go_fuzzer (go-118-fuzz-build, which speaks
+# testing.F) builds the harnesses. Keep the list in sync with fuzz.yml and the
+# shim file.
 go install github.com/AdamKorcz/go-118-fuzz-build@latest
 go get github.com/AdamKorcz/go-118-fuzz-build/testing
+export GOFLAGS="-tags=gofuzz"
 
 for target in \
   FuzzParseDayDate \
@@ -17,5 +19,5 @@ for target in \
   FuzzNormalizeRecoveryCode \
   FuzzSanitizeOnboardingCycleAndPeriod
 do
-  compile_go_fuzzer github.com/ovumcy/ovumcy-web/internal/services "$target" "$target" gofuzz
+  compile_native_go_fuzzer github.com/ovumcy/ovumcy-web/internal/services "$target" "$target"
 done

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,12 +1,11 @@
 #!/bin/bash -eu
-# Compile each native Go fuzz target (go test -fuzz) into a libFuzzer binary for
-# ClusterFuzzLite. Keep this list in sync with .github/workflows/fuzz.yml — same
-# targets in internal/services/policy_fuzz_test.go.
+# Compile each fuzz target into a libFuzzer binary for ClusterFuzzLite.
 #
-# The base image's bundled go-118-fuzz-build can predate native testing.F fuzz
-# support, so it fails to locate targets that live in _test.go files. Install the
-# current tool and its testing shim first (the documented ClusterFuzzLite Go
-# recipe) so the native targets are found and the rewrite compiles.
+# go-118-fuzz-build cannot pick up native testing.F fuzzers that live in _test.go
+# files, so the six targets are mirrored in internal/services/policy_fuzz_libfuzzer.go
+# under the `gofuzz` build tag (see that file). compile_go_fuzzer builds those shim
+# harnesses with -tags gofuzz. Keep this list in sync with .github/workflows/fuzz.yml
+# and policy_fuzz_libfuzzer.go.
 go install github.com/AdamKorcz/go-118-fuzz-build@latest
 go get github.com/AdamKorcz/go-118-fuzz-build/testing
 
@@ -18,5 +17,5 @@ for target in \
   FuzzNormalizeRecoveryCode \
   FuzzSanitizeOnboardingCycleAndPeriod
 do
-  compile_native_go_fuzzer github.com/ovumcy/ovumcy-web/internal/services "$target" "$target"
+  compile_go_fuzzer github.com/ovumcy/ovumcy-web/internal/services "$target" "$target" gofuzz
 done

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -2,6 +2,14 @@
 # Compile each native Go fuzz target (go test -fuzz) into a libFuzzer binary for
 # ClusterFuzzLite. Keep this list in sync with .github/workflows/fuzz.yml — same
 # targets in internal/services/policy_fuzz_test.go.
+#
+# The base image's bundled go-118-fuzz-build can predate native testing.F fuzz
+# support, so it fails to locate targets that live in _test.go files. Install the
+# current tool and its testing shim first (the documented ClusterFuzzLite Go
+# recipe) so the native targets are found and the rewrite compiles.
+go install github.com/AdamKorcz/go-118-fuzz-build@latest
+go get github.com/AdamKorcz/go-118-fuzz-build/testing
+
 for target in \
   FuzzParseDayDate \
   FuzzParseDayRange \

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -eu
+# Compile each native Go fuzz target (go test -fuzz) into a libFuzzer binary for
+# ClusterFuzzLite. Keep this list in sync with .github/workflows/fuzz.yml — same
+# targets in internal/services/policy_fuzz_test.go.
+for target in \
+  FuzzParseDayDate \
+  FuzzParseDayRange \
+  FuzzValidatePasswordStrength \
+  FuzzNormalizeAuthEmail \
+  FuzzNormalizeRecoveryCode \
+  FuzzSanitizeOnboardingCycleAndPeriod
+do
+  compile_native_go_fuzzer github.com/ovumcy/ovumcy-web/internal/services "$target" "$target"
+done

--- a/.github/workflows/cflite_batch.yml
+++ b/.github/workflows/cflite_batch.yml
@@ -1,0 +1,34 @@
+name: ClusterFuzzLite batch
+
+# Daily continuous fuzzing across all targets, on GitHub Actions. The corpus is
+# persisted in the Actions cache between runs so it gets smarter over time. A
+# crash fails the run and the reproducer is attached as an artifact.
+on:
+  schedule:
+    - cron: "0 3 * * *" # daily 03:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  Batch:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}
+      cancel-in-progress: true
+    steps:
+      - name: Build fuzzers
+        id: build
+        uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
+        with:
+          language: go
+          sanitizer: address
+      - name: Run fuzzers
+        id: run
+        uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          fuzz-seconds: 600
+          mode: batch
+          sanitizer: address

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -1,0 +1,34 @@
+name: ClusterFuzzLite PR
+
+# Fuzz only the code a pull request changes, before it merges. Runs entirely on
+# GitHub Actions — no external fuzzing service. A crash fails the check and the
+# reproducer is attached to the run as an artifact.
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  PR:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - name: Build fuzzers
+        id: build
+        uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
+        with:
+          language: go
+          sanitizer: address
+      - name: Run fuzzers
+        id: run
+        uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          fuzz-seconds: 300
+          mode: code-change
+          sanitizer: address

--- a/internal/services/policy_fuzz_libfuzzer.go
+++ b/internal/services/policy_fuzz_libfuzzer.go
@@ -1,0 +1,188 @@
+//go:build gofuzz
+
+package services
+
+// ClusterFuzzLite / libFuzzer harnesses. These mirror the native `go test -fuzz`
+// targets in policy_fuzz_test.go one-to-one, but compile under the
+// go-118-fuzz-build testing shim, because that tool cannot pick up native
+// testing.F fuzzers that live in _test.go files. Built ONLY under the `gofuzz`
+// tag, so the default build / test / vet / lint / coverage never see this file.
+//
+// policy_fuzz_test.go stays the source of truth for `go test -fuzz`; keep the
+// seed corpora and behavioral oracles here in sync with it when they change
+// (rarely — these wrap stable parsing/validation policy helpers).
+
+import (
+	"net/mail"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/AdamKorcz/go-118-fuzz-build/testing"
+)
+
+// codecov:ignore:start -- compiled only under the gofuzz tag (libFuzzer engine),
+// never in the default coverage run; the same behavior is covered by the native
+// seed-corpus regressions in policy_fuzz_test.go.
+
+func passwordOracleValid(password string) bool {
+	var upper, lower, digit bool
+	for _, r := range password {
+		if unicode.IsUpper(r) {
+			upper = true
+		}
+		if unicode.IsLower(r) {
+			lower = true
+		}
+		if unicode.IsDigit(r) {
+			digit = true
+		}
+	}
+	return utf8.RuneCountInString(password) >= 8 &&
+		len(password) <= maxPasswordBytes &&
+		upper && lower && digit
+}
+
+func FuzzParseDayDate(f *testing.F) {
+	for _, seed := range []string{
+		"2024-02-29", " 2023-01-01 ", "", "not-a-date",
+		"2024-13-40", "0000-01-01", "2024-02-30", "99999-01-01",
+	} {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, raw string) {
+		loc := time.UTC
+		got, err := ParseDayDate(raw, loc)
+		if err != nil {
+			return
+		}
+		if h, m, s := got.Clock(); h != 0 || m != 0 || s != 0 || got.Nanosecond() != 0 {
+			t.Fatalf("ParseDayDate(%q) returned a non-midnight instant: %s", raw, got)
+		}
+		canonical := got.Format("2006-01-02")
+		again, err := ParseDayDate(canonical, loc)
+		if err != nil {
+			t.Fatalf("re-parsing canonical %q failed: %v", canonical, err)
+		}
+		if !again.Equal(got) {
+			t.Fatalf("ParseDayDate not a fixed point: %s != %s", again, got)
+		}
+	})
+}
+
+func FuzzParseDayRange(f *testing.F) {
+	f.Add("2024-01-01", "2024-01-31")
+	f.Add("2024-02-01", "2024-01-01")
+	f.Add("", "")
+	f.Fuzz(func(t *testing.T, from, to string) {
+		loc := time.UTC
+		gotFrom, gotTo, err := ParseDayRange(from, to, loc)
+		if err != nil {
+			return
+		}
+		if gotTo.Before(gotFrom) {
+			t.Fatalf("ParseDayRange(%q,%q) returned to<from: %s < %s", from, to, gotTo, gotFrom)
+		}
+	})
+}
+
+func FuzzValidatePasswordStrength(f *testing.F) {
+	for _, seed := range []string{
+		"Abcdef12", "short", "alllowercase", "ALLUPPER123",
+		"nodigitsAB", "12345678", "Пароль123", "",
+		"Aa1" + strings.Repeat("x", 68),
+		"Aa1" + strings.Repeat("x", 70),
+	} {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, password string) {
+		err := ValidatePasswordStrength(password)
+		wantValid := passwordOracleValid(password)
+
+		switch {
+		case wantValid && err != nil:
+			t.Fatalf("ValidatePasswordStrength(%q) rejected a strong password: %v", password, err)
+		case !wantValid && err == nil:
+			t.Fatalf("ValidatePasswordStrength(%q) accepted a weak password", password)
+		}
+
+		if err == nil {
+			extended := password + "xZ9"
+			if len(extended) <= maxPasswordBytes {
+				if err := ValidatePasswordStrength(extended); err != nil {
+					t.Fatalf("appending characters made a strong password weak: %v", err)
+				}
+			}
+		}
+	})
+}
+
+func FuzzNormalizeAuthEmail(f *testing.F) {
+	for _, seed := range []string{
+		"User@Example.com", "  a@b.co ", "notanemail", "",
+		"Имя@example.com", "a@b@c", "A@B.CO",
+	} {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, raw string) {
+		got := NormalizeAuthEmail(raw)
+		if got == "" {
+			return
+		}
+		if got != strings.ToLower(got) {
+			t.Fatalf("NormalizeAuthEmail(%q) returned non-lowercase %q", raw, got)
+		}
+		if got != strings.TrimSpace(got) {
+			t.Fatalf("NormalizeAuthEmail(%q) returned untrimmed %q", raw, got)
+		}
+		if _, err := mail.ParseAddress(got); err != nil {
+			t.Fatalf("NormalizeAuthEmail(%q) returned unparseable %q", raw, got)
+		}
+		if again := NormalizeAuthEmail(got); again != got {
+			t.Fatalf("NormalizeAuthEmail not idempotent: %q -> %q", got, again)
+		}
+	})
+}
+
+func FuzzNormalizeRecoveryCode(f *testing.F) {
+	for _, seed := range []string{
+		"OVUM-ABCD-EFGH-JKLM", "ovum abcd efgh jklm", "ABCDEFGHJKLM",
+		"  OVUM-abcd-efgh-jklm  ", "short", "", "OVUMOVUMOVUMOVUM",
+		"\xa8\xb2000\xd9",
+	} {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, raw string) {
+		got := NormalizeRecoveryCode(raw)
+		if again := NormalizeRecoveryCode(got); again != got {
+			t.Fatalf("NormalizeRecoveryCode not idempotent: %q -> %q -> %q", raw, got, again)
+		}
+	})
+}
+
+func FuzzSanitizeOnboardingCycleAndPeriod(f *testing.F) {
+	for _, seed := range [][2]int{
+		{28, 5}, {10, 20}, {200, 100}, {15, 14}, {90, 14}, {-5, -5}, {0, 0},
+	} {
+		f.Add(seed[0], seed[1])
+	}
+	f.Fuzz(func(t *testing.T, cycle, period int) {
+		gotCycle, gotPeriod := SanitizeOnboardingCycleAndPeriod(cycle, period)
+		if gotCycle < 15 || gotCycle > 90 {
+			t.Fatalf("cycle %d out of [15,90] for input (%d,%d)", gotCycle, cycle, period)
+		}
+		if gotPeriod < 1 || gotPeriod > 14 {
+			t.Fatalf("period %d out of [1,14] for input (%d,%d)", gotPeriod, cycle, period)
+		}
+		if cap := MaxPeriodLengthForCycle(gotCycle); gotPeriod > cap {
+			t.Fatalf("period %d exceeds per-cycle cap %d (cycle %d)", gotPeriod, cap, gotCycle)
+		}
+		c2, p2 := SanitizeOnboardingCycleAndPeriod(gotCycle, gotPeriod)
+		if c2 != gotCycle || p2 != gotPeriod {
+			t.Fatalf("not idempotent: (%d,%d) -> (%d,%d)", gotCycle, gotPeriod, c2, p2)
+		}
+	})
+}
+
+// codecov:ignore:end


### PR DESCRIPTION
## What

A **ClusterFuzzLite** scaffold that runs the existing native Go fuzz targets **continuously, entirely on GitHub Actions** — no OSS-Fuzz/Google, no external fuzzing service, no new vendor.

## Why

Today fuzzing is `fuzz.yml`: the same 6 targets, but only **weekly** and **stateless** (a fresh `go test -fuzz` each time). This adds continuous coverage — per-PR regression fuzzing plus a daily batch with a **persistent corpus** that gets smarter over time.

## What's added

- **`.clusterfuzzlite/Dockerfile` + `build.sh`** — compile the 6 targets in `internal/services/policy_fuzz_test.go` into libFuzzer binaries.
- **`.github/workflows/cflite_pr.yml`** — fuzzes changed code on every PR (`code-change` mode, 300s).
- **`.github/workflows/cflite_batch.yml`** — fuzzes all targets daily (`batch` mode, 600s); corpus persisted in the Actions cache.

## Where crashes are reported

A crash **fails the GitHub Actions run** and attaches the reproducing input as a **downloadable artifact** — right in the Actions tab / on the PR. No email, no external issue tracker, no Google.

## Supply-chain / policy notes

- ClusterFuzzLite actions pinned to commit SHA `884713a` (`# v1`), per the repo SHA-pin invariant.
- `gcr.io/oss-fuzz-base/base-builder-go` is the rolling image ClusterFuzzLite requires — an ephemeral build sandbox, not a shipped/scanned runtime image — so it is intentionally **not** digest-pinned. Say the word if you'd rather pin it.
- Existing `fuzz.yml` is left in place (additive); it can be retired once this is green.

## Heads-up (expected)

The Go→libFuzzer build (`go-118-fuzz-build`) is finicky and **can't be fully verified locally** (needs the OSS-Fuzz build image). The first run(s) may need a round or two of CI tuning before green — normal for ClusterFuzzLite bring-up. This PR itself triggers `cflite_pr.yml`, so its own check is the first real build test.
