### PR TITLE
security(deps): bump Go toolchain to 1.26.5, clearing GO-2026-5856

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Go toolchain bumped to 1.26.5.** Clears GO-2026-5856 (Encrypted Client Hello privacy leak in `crypto/tls`, fixed upstream in go1.26.5), reachable via the outbound HTTP client used for webhook delivery and OIDC. The runtime image's builder stage moves to `golang:1.26.5-alpine3.24` (the `alpine3.22` variant of this patch release was not published); the final `alpine:3.24.1` runtime-assets stage is unchanged.
+
 ### Changed
 
 - **Breaking (export shape):** the built-in `swelling` symptom (added 2026-03-09) now has its own `swelling` boolean flag in the JSON `symptoms` object and its own `Swelling` CSV column, instead of falling through to `other_symptoms`/`Other` indistinguishably from an owner-created custom symptom. The `Swelling` CSV column is inserted after `Constipation` to stay adjacent to the other symptom columns, so every column from `Cycle factors` onward shifts one position to the right in files generated after this change; consumers reading CSV columns by position (not by header name) must account for the shift. `docs/export.md` and `docs/openapi.yaml` updated; import accepts both the new flag and legacy files that still carry `swelling` only via `other_symptoms`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.26.4-alpine3.22@sha256:727cfc3c40be55cd1bc9a4a059406b28a059857e3be752aa9d09531e12c20c56 AS builder
+FROM golang:1.26.5-alpine3.24@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS builder
 WORKDIR /src
 
 COPY go.mod go.sum ./

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ovumcy/ovumcy-web
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/coreos/go-oidc/v3 v3.19.0


### PR DESCRIPTION
## Summary

- `go.mod`: `go 1.26.4` → `go 1.26.5`.
- `Dockerfile`: builder base `golang:1.26.4-alpine3.22` → `golang:1.26.5-alpine3.24` (digest-pinned). The `alpine3.22` variant of the `1.26.5` patch release was never published to Docker Hub (only `3.23`/`3.24` exist for it), so this also brings the builder stage's Alpine minor version in line with the `alpine:3.24.1` runtime-assets stage, which already used 3.24.
- `CHANGELOG.md`: new `### Security` entry under `[Unreleased]`.

Split out from #202 (CI dedup/tiering) — that PR's `govulncheck` check failed on `GO-2026-5856` (Encrypted Client Hello privacy leak in `crypto/tls`, unrelated to the CI changes there), reachable through `internal/services/webhook_delivery.go` (outbound HTTP client) and OIDC discovery/token exchange. This is a standalone fix.

## Test plan

- [x] `go build ./...` — clean (auto-downloaded go1.26.5 toolchain).
- [x] `go test ./cmd/... ./internal/... ./migrations/... ./scripts/... ./web/...` — all pass.
- [x] `govulncheck ./...` — 0 vulnerabilities (was 1 reachable before the bump).
- [x] `docker build .` — succeeds with the new base image pin.

Not merging — for review only.