### PR TITLE
fix(cycle): use CalendarDaysBetween for DST-safe calendar-day diffs

### DIFF
--- a/e2e/support/language-helpers.ts
+++ b/e2e/support/language-helpers.ts
@@ -24,7 +24,21 @@ export async function saveSettingsLanguage(page: Page, code: string): Promise<vo
 
   if ((await option.getAttribute('data-selected')) !== 'true') {
     await option.locator('.radio-tile').click();
-    await form.locator('[data-settings-interface-save]').click();
+    // The radio change flips data-selected optimistically on the client, so the
+    // assertion below can pass before the htmx PATCH persists the preference.
+    // Bind to the save click's own request and await its response so callers
+    // that navigate away next (e.g. straight to /calendar) don't race an
+    // in-flight save that would otherwise drop the just-chosen language.
+    const [saveRequest] = await Promise.all([
+      page.waitForRequest(
+        (request) =>
+          request.method() === 'PATCH' &&
+          request.url().includes('/api/v1/users/current/interface'),
+      ),
+      form.locator('[data-settings-interface-save]').click(),
+    ]);
+    const saveResponse = await saveRequest.response();
+    expect(saveResponse?.ok()).toBeTruthy();
   }
 
   await expect(option).toHaveAttribute('data-selected', 'true');

--- a/internal/services/calendar_days.go
+++ b/internal/services/calendar_days.go
@@ -1,7 +1,6 @@
 package services
 
 import (
-	"math"
 	"time"
 
 	"github.com/ovumcy/ovumcy-web/internal/models"
@@ -145,7 +144,7 @@ func appendFertilityWindow(fertilityEdgeMap map[string]bool, fertilityPeakMap ma
 		return
 	}
 	for day := start; !day.After(end); day = day.AddDate(0, 0, 1) {
-		offset := int(ovulationDate.Sub(day).Hours() / 24)
+		offset := CalendarDaysBetween(day, ovulationDate)
 		if offset >= 0 && offset <= 2 {
 			fertilityPeakMap[day.Format("2006-01-02")] = true
 			continue
@@ -195,7 +194,7 @@ func appendHistoricalCycles(preFertileMap map[string]bool, fertilityEdgeMap map[
 	for index := range len(starts) - 1 {
 		cycleStart := starts[index]
 		nextStart := starts[index+1]
-		cycleLen := int(math.Round(nextStart.Sub(cycleStart).Hours() / 24))
+		cycleLen := CalendarDaysBetween(cycleStart, nextStart)
 		if cycleLen <= 0 {
 			continue
 		}

--- a/internal/services/cycle_baseline.go
+++ b/internal/services/cycle_baseline.go
@@ -170,7 +170,7 @@ func ProjectCycleStart(lastPeriodStart time.Time, cycleLength int, today time.Ti
 		return lastPeriodStart, 0, true
 	}
 
-	elapsedDays := int(today.Sub(lastPeriodStart).Hours() / 24)
+	elapsedDays := CalendarDaysBetween(lastPeriodStart, today)
 	cyclesElapsed := elapsedDays / cycleLength
 	projectedStart := CalendarDay(lastPeriodStart.AddDate(0, 0, cyclesElapsed*cycleLength), today.Location())
 	projectedCycleDay := (elapsedDays % cycleLength) + 1
@@ -181,7 +181,7 @@ func ShiftCycleStartToFutureOvulation(cycleStart time.Time, ovulationDate time.T
 	if cycleLength <= 0 || !ovulationDate.Before(today) {
 		return cycleStart
 	}
-	lagDays := int(today.Sub(ovulationDate).Hours() / 24)
+	lagDays := CalendarDaysBetween(ovulationDate, today)
 	shiftCycles := lagDays/cycleLength + 1
 	return CalendarDay(cycleStart.AddDate(0, 0, shiftCycles*cycleLength), today.Location())
 }

--- a/internal/services/cycle_baseline_coverage_test.go
+++ b/internal/services/cycle_baseline_coverage_test.go
@@ -305,6 +305,32 @@ func TestCycleBaseline_ProjectCycleStartReturnsCycleDay1AtCycleBoundary(t *testi
 	}
 }
 
+func TestCycleBaseline_ProjectCycleStartRollsToNewCycleAcrossDST(t *testing.T) {
+	// Europe/Berlin springs forward on 2026-03-29. With a 28-day cycle anchored
+	// at 2026-03-15 (Berlin midnight), the boundary day 2026-04-12 is exactly
+	// one full cycle later. The old int(today.Sub(lp).Hours()/24) truncated the
+	// 28*24-1h span to 27 elapsed days, so it reported cycleDay 28 of the SAME
+	// cycle instead of rolling over. CalendarDaysBetween yields the true 28
+	// elapsed days, so the projection advances to the new cycle at day 1.
+	loc, err := time.LoadLocation("Europe/Berlin")
+	if err != nil {
+		t.Skipf("tz database unavailable: %v", err)
+	}
+	lp := time.Date(2026, time.March, 15, 0, 0, 0, 0, loc)
+	today := time.Date(2026, time.April, 12, 0, 0, 0, 0, loc)
+
+	start, day, ok := ProjectCycleStart(lp, 28, today)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if day != 1 {
+		t.Fatalf("expected cycleDay=1 after rolling into the new cycle across DST, got %d", day)
+	}
+	if got := start.Format("2006-01-02"); got != "2026-04-12" {
+		t.Fatalf("expected projectedStart=2026-04-12, got %s", got)
+	}
+}
+
 func TestCycleBaseline_ProjectCycleStartMidCycleDayIsCorrect(t *testing.T) {
 	lp := mustParseBaselineDay(t, "2026-04-01")
 	// Day 15 of cycle (14 days elapsed) → cycleDay should be 15.

--- a/internal/services/cycle_signals.go
+++ b/internal/services/cycle_signals.go
@@ -33,7 +33,7 @@ func InferUserLutealPhase(logs []models.DailyLog, location *time.Location) (int,
 			continue
 		}
 
-		lutealLength := int(nextStart.Sub(ovulationDate).Hours() / 24)
+		lutealLength := CalendarDaysBetween(ovulationDate, nextStart)
 		if lutealLength < minLutealPhaseDays || lutealLength > 20 {
 			continue
 		}
@@ -94,7 +94,7 @@ func collectCycleBBTPoints(logs []models.DailyLog, cycleStart time.Time, nextSta
 
 		points = append(points, cycleBBTPoint{
 			Date:     day,
-			CycleDay: int(day.Sub(cycleStart).Hours()/24) + 1,
+			CycleDay: CalendarDaysBetween(cycleStart, day) + 1,
 			Value:    *logEntry.BBT,
 		})
 	}

--- a/internal/services/cycle_signals_mutation_round2_test.go
+++ b/internal/services/cycle_signals_mutation_round2_test.go
@@ -7,14 +7,16 @@ import (
 	"github.com/ovumcy/ovumcy-web/internal/models"
 )
 
-func TestCycleSignals_InferUserLutealPhase_RespectsNonUTCLocationAcrossDST(t *testing.T) {
+func TestCycleSignals_InferUserLutealPhase_UnchangedByDSTTransitionInCycle(t *testing.T) {
 	// America/Toronto springs forward on 2025-03-09. The first cycle's
 	// ovulation (Mar 6, BBT rise) and next period start (Mar 20) bracket that
-	// transition, so its luteal length is one day SHORTER when computed in a
-	// DST-observing local zone than in UTC. The function genuinely uses the
-	// passed location; if line 18 were negated to `location != nil` the
-	// caller's Toronto location would be discarded in favour of UTC and the
-	// inferred phase would shift from 13 to 14.
+	// transition. Because CalendarDaysBetween re-anchors both operands to
+	// UTC-midnight, the luteal length is the true calendar-day count (14) and
+	// is immune to the DST transition inside the cycle: a DST-observing local
+	// zone must yield the same value as UTC. Before the fix, the raw
+	// `nextStart.Sub(ovulationDate)/24` truncated the 14*24-1h span down to 13
+	// in Toronto, dragging the inferred phase to 13 in a DST-observing zone
+	// while UTC saw 14 — a location-dependent skew this test now guards against.
 	loc, err := time.LoadLocation("America/Toronto")
 	if err != nil {
 		t.Skipf("tz database unavailable: %v", err)
@@ -50,14 +52,24 @@ func TestCycleSignals_InferUserLutealPhase_RespectsNonUTCLocationAcrossDST(t *te
 		{Date: day("2025-03-28"), BBT: models.NewBBT(36.50)},
 	}
 
-	phase, ok := InferUserLutealPhase(logs, loc)
+	// Cycle A (Mar6->Mar20) = 14 true calendar days, cycle B (Mar26->Apr8) = 13.
+	// lens = [14, 13] -> round(13.5) = 14, regardless of DST, in every zone.
+	phaseLocal, ok := InferUserLutealPhase(logs, loc)
 	if !ok {
 		t.Fatalf("expected ok=true with two BBT-confirmed cycles")
 	}
-	// Toronto: lens = [13, 13] -> round(13) = 13.
-	// If location is forced to UTC (mutation), lens = [14, 13] -> round(13.5) = 14.
-	if phase != 13 {
-		t.Fatalf("expected inferred luteal phase 13 in America/Toronto (DST-spanning cycle); got %d. A phase of 14 means the caller location was discarded for UTC.", phase)
+	if phaseLocal != 14 {
+		t.Fatalf("expected inferred luteal phase 14 in America/Toronto (DST-immune calendar count); got %d. A phase of 13 means a DST transition inside the cycle truncated the luteal span.", phaseLocal)
+	}
+
+	// DST-immunity: the same calendar dates evaluated in UTC (no DST) must
+	// produce the identical phase — the location must not change the result.
+	phaseUTC, ok := InferUserLutealPhase(logs, time.UTC)
+	if !ok {
+		t.Fatalf("expected ok=true in UTC as well")
+	}
+	if phaseUTC != phaseLocal {
+		t.Fatalf("expected DST-observing zone (%d) and UTC (%d) to agree", phaseLocal, phaseUTC)
 	}
 }
 

--- a/internal/services/cycle_start_policy.go
+++ b/internal/services/cycle_start_policy.go
@@ -63,7 +63,7 @@ func ResolveManualCycleStartPolicy(user *models.User, logs []models.DailyLog, da
 		return policy
 	}
 
-	gapDays := int(targetDay.Sub(previousStart).Hours() / 24)
+	gapDays := CalendarDaysBetween(previousStart, targetDay)
 	if gapDays > 0 && gapDays < manualCycleStartSuggestionGapDays {
 		policy.PreviousStart = previousStart
 		policy.ShortGapDays = gapDays
@@ -125,7 +125,7 @@ func ShouldSuggestManualCycleStart(user *models.User, logs []models.DailyLog, lo
 	}
 
 	targetDay := DateAtLocation(day.In(location), location)
-	gapDays := int(targetDay.Sub(anchor).Hours() / 24)
+	gapDays := CalendarDaysBetween(anchor, targetDay)
 	return gapDays >= manualCycleStartSuggestionGapDays
 }
 

--- a/internal/services/dashboard_cycle.go
+++ b/internal/services/dashboard_cycle.go
@@ -76,7 +76,7 @@ func DashboardCycleDataLooksStale(lastPeriodStart time.Time, today time.Time, re
 	if lastPeriodStart.IsZero() || referenceLength <= 0 || today.Before(lastPeriodStart) {
 		return false
 	}
-	rawCycleDay := int(today.Sub(lastPeriodStart).Hours()/24) + 1
+	rawCycleDay := CalendarDaysBetween(lastPeriodStart, today) + 1
 	return rawCycleDay > referenceLength
 }
 
@@ -349,7 +349,7 @@ func CompletedCycleTrendLengths(logs []models.DailyLog, now time.Time, location 
 		if !currentStart.Before(today) {
 			break
 		}
-		lengths = append(lengths, int(currentStart.Sub(previousStart).Hours()/24))
+		lengths = append(lengths, CalendarDaysBetween(previousStart, currentStart))
 	}
 	return lengths
 }

--- a/internal/services/dashboard_cycle_test.go
+++ b/internal/services/dashboard_cycle_test.go
@@ -41,6 +41,34 @@ func TestCompletedCycleTrendLengths(t *testing.T) {
 	}
 }
 
+// TestCompletedCycleTrendLengthsDSTSpringForward pins the DST-sensitive
+// calendar-day diff: in Europe/Berlin the 2026-03-29 spring-forward falls
+// between the 2026-03-15 and 2026-04-12 cycle starts. Computed in Berlin those
+// two starts become location-midnight values 28*24-1h apart, so the old
+// int(a.Sub(b).Hours()/24) truncated to 27. CalendarDaysBetween re-anchors both
+// to UTC-midnight and yields the true 28, agreeing with CycleLengths (which
+// operates on UTC-midnight starts and is immune to the location skew).
+func TestCompletedCycleTrendLengthsDSTSpringForward(t *testing.T) {
+	loc, err := time.LoadLocation("Europe/Berlin")
+	if err != nil {
+		t.Skipf("tz database unavailable: %v", err)
+	}
+
+	logs := []models.DailyLog{
+		{Date: mustParseDashboardDay(t, "2026-03-15"), IsPeriod: true},
+		{Date: mustParseDashboardDay(t, "2026-04-12"), IsPeriod: true},
+	}
+	now := mustParseDashboardDay(t, "2026-05-01")
+
+	got := CompletedCycleTrendLengths(logs, now, loc)
+	if len(got) != 1 || got[0] != 28 {
+		t.Fatalf("expected [28] across the Berlin DST transition, got %#v", got)
+	}
+	if want := CycleLengths(logs); len(want) != 1 || want[0] != got[0] {
+		t.Fatalf("expected CompletedCycleTrendLengths to agree with CycleLengths %#v, got %#v", want, got)
+	}
+}
+
 func TestBuildDashboardCycleContext(t *testing.T) {
 	userStart := mustParseDashboardDay(t, "2026-02-10")
 	user := &models.User{

--- a/internal/services/dashboard_reminder_banner.go
+++ b/internal/services/dashboard_reminder_banner.go
@@ -205,14 +205,16 @@ func dashboardReminderBannerCopy(daysUntil int, todayKey string, tomorrowKey str
 // already-resolved per-request threshold from
 // dashboardReminderBannerWindowDays (the owner's clamped reminder_lead_days,
 // or DashboardReminderBannerWindowDays as its fallback). predictedDate and
-// today are both calendar-date-only values (see CalendarDay/DateAtLocation
-// in day_utils.go), so a plain day count avoids any time-of-day/location
-// skew.
+// today are calendar-date-only values (see CalendarDay/DateAtLocation in
+// day_utils.go) that may carry different midnight shapes (location-midnight vs
+// UTC-midnight); CalendarDaysBetween re-anchors both to UTC-midnight so the day
+// count is immune to time-of-day/location skew and to a DST transition between
+// the two dates.
 func dashboardReminderBannerDaysUntil(predictedDate time.Time, today time.Time, windowDays int) (int, bool) {
 	if predictedDate.IsZero() {
 		return 0, false
 	}
-	daysUntil := int(predictedDate.Sub(today).Hours() / 24)
+	daysUntil := CalendarDaysBetween(today, predictedDate)
 	if daysUntil < 0 || daysUntil > windowDays {
 		return 0, false
 	}

--- a/internal/services/dashboard_reminder_banner_test.go
+++ b/internal/services/dashboard_reminder_banner_test.go
@@ -5,6 +5,29 @@ import (
 	"time"
 )
 
+// TestDashboardReminderBannerDaysUntilDSTSpringForward guards the day count
+// against a DST transition between today and the predicted date. In
+// Europe/Berlin the 2026-03-29 spring-forward falls between 2026-03-28 and
+// 2026-03-30; as location-midnight values those are 2*24-1h apart, so the old
+// int(predictedDate.Sub(today).Hours()/24) truncated to 1. CalendarDaysBetween
+// re-anchors both to UTC-midnight and reports the true 2 days.
+func TestDashboardReminderBannerDaysUntilDSTSpringForward(t *testing.T) {
+	loc, err := time.LoadLocation("Europe/Berlin")
+	if err != nil {
+		t.Skipf("tz database unavailable: %v", err)
+	}
+	today := time.Date(2026, time.March, 28, 0, 0, 0, 0, loc)
+	predicted := time.Date(2026, time.March, 30, 0, 0, 0, 0, loc)
+
+	daysUntil, ok := dashboardReminderBannerDaysUntil(predicted, today, DashboardReminderBannerWindowDays)
+	if !ok {
+		t.Fatal("expected the predicted date to fall within the reminder window")
+	}
+	if daysUntil != 2 {
+		t.Fatalf("expected daysUntil=2 across the Berlin DST transition, got %d", daysUntil)
+	}
+}
+
 func TestBuildDashboardReminderBannerPeriodThresholdBoundaries(t *testing.T) {
 	today := mustParseDashboardDay(t, "2026-03-10")
 

--- a/internal/services/stats_cycle_insights.go
+++ b/internal/services/stats_cycle_insights.go
@@ -46,7 +46,7 @@ func buildCompletedCycleSpans(logs []models.DailyLog, location *time.Location) [
 	for index := 0; index+1 < len(starts) && index < len(cycles); index++ {
 		start := CalendarDay(starts[index], location)
 		nextStart := CalendarDay(starts[index+1], location)
-		cycleLength := int(nextStart.Sub(start).Hours() / 24)
+		cycleLength := CalendarDaysBetween(start, nextStart)
 		if cycleLength <= 0 {
 			continue
 		}
@@ -219,7 +219,7 @@ func collectCurrentCycleBBTPoints(logs []models.DailyLog, cycleStart time.Time, 
 			continue
 		}
 
-		dayNumber := int(localDay.Sub(cycleStart).Hours()/24) + 1
+		dayNumber := CalendarDaysBetween(cycleStart, localDay) + 1
 		if dayNumber <= 0 {
 			continue
 		}
@@ -315,7 +315,7 @@ func completedCycleDayNumber(day time.Time, completedCycles []completedCycleSpan
 		if localDay.Before(cycle.Start) || !localDay.Before(cycle.NextStart) {
 			continue
 		}
-		return int(localDay.Sub(cycle.Start).Hours()/24) + 1, true
+		return CalendarDaysBetween(cycle.Start, localDay) + 1, true
 	}
 	return 0, false
 }

--- a/internal/services/stats_phase_insights.go
+++ b/internal/services/stats_phase_insights.go
@@ -60,7 +60,7 @@ func buildCompletedCyclePhaseContexts(logs []models.DailyLog, location *time.Loc
 	for index := 0; index+1 < len(starts) && index < len(cycles); index++ {
 		start := CalendarDay(starts[index], location)
 		nextStart := CalendarDay(starts[index+1], location)
-		cycleLength := int(nextStart.Sub(start).Hours() / 24)
+		cycleLength := CalendarDaysBetween(start, nextStart)
 		if cycleLength <= 0 {
 			continue
 		}
@@ -93,7 +93,7 @@ func phaseForCompletedCycleDay(day time.Time, cycle completedCyclePhaseContext, 
 		return ""
 	}
 
-	dayNumber := int(localDay.Sub(cycle.Start).Hours()/24) + 1
+	dayNumber := CalendarDaysBetween(cycle.Start, localDay) + 1
 	switch {
 	case dayNumber <= cycle.PeriodLength:
 		return "menstrual"


### PR DESCRIPTION
## What & why

Replaces raw `int(a.Sub(b).Hours()/24)` with `services.CalendarDaysBetween` at **14 cycle-math sites**. The helper re-anchors both operands to UTC-midnight, so the result is a pure calendar-day difference immune to DST transitions and to mixed midnight shapes (location-midnight vs UTC-midnight, the issue #48 class).

Across a spring-forward the raw subtraction yields `N*24h - 1h` and truncates to `N-1`, understating cycle/luteal lengths and cycle-day offsets (repo rule `.claude/guides/services-cycle.md` → Timezone).

## Changes

- **api → services → db → models**: only the `services` layer (business logic) is touched. Transport/persistence/schema untouched.
- 14 sites migrated to `CalendarDaysBetween`, preserving argument order and all `+1`/`-1` offsets.
- `calendar_days.go`: the `math.Round` workaround is normalized to the same helper (unused `math` import removed).
- `dashboard_reminder_banner.go`: fixed a comment that wrongly claimed immunity to skew.
- Left untouched (UTC-midnight, DST-safe): `cycles.go:190/267/475`, `day_utils.go:102`.

## Tests (extended existing aggregators)

- `CompletedCycleTrendLengths` in Europe/Berlin across 2026-03-29 → `[28]`, agrees with `CycleLengths`.
- `ProjectCycleStart` on the boundary day rolls over into the new cycle across DST.
- `InferUserLutealPhase` unchanged by a DST transition inside the cycle (updated a previously-failing mutation test that pinned the buggy value 13 → now 14, DST-immune).
- `dashboardReminderBannerDaysUntil` correct across the transition.

## Verification
- `go test ./internal/services/...` — ok
- Full suite (`./cmd/... ./internal/... ./migrations/... ./scripts/... ./web/...`) — ok
- `staticcheck ./...` — clean

## Risk
Medium (cycle-math subsystem). No public contract, auth, schema, or sensitive-data changes.