### PR TITLE
fix(cycle): project dashboard/webhook/ics next-period from median, not mean

### DIFF
--- a/internal/services/calendar_feed_ics.go
+++ b/internal/services/calendar_feed_ics.go
@@ -124,7 +124,7 @@ func calendarFeedEvents(input CalendarFeedICSInput) []calendarFeedEvent {
 	}
 
 	today := DateAtLocation(input.Now, input.Location)
-	cycleLength := DashboardCycleReferenceLength(user, stats)
+	cycleLength := DashboardProjectionCycleLength(user, stats)
 	if stats.LastPeriodStart.IsZero() || cycleLength <= 0 {
 		return nil
 	}

--- a/internal/services/cycle_median_projection_test.go
+++ b/internal/services/cycle_median_projection_test.go
@@ -1,0 +1,158 @@
+package services
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+)
+
+// TestDashboardProjectionCycleLengthIsMedianFirst pins the projection length as
+// median-first, in deliberate contrast to the average-first
+// DashboardCycleReferenceLength. Both fall back to the user's configured cycle
+// length and then the default, but only when no observed statistic exists.
+func TestDashboardProjectionCycleLengthIsMedianFirst(t *testing.T) {
+	cases := []struct {
+		name string
+		user *models.User
+		stats CycleStats
+		want int
+	}{
+		{
+			name:  "prefers median over average",
+			user:  &models.User{CycleLength: 30},
+			stats: CycleStats{MedianCycleLength: 28, AverageCycleLength: 34},
+			want:  28,
+		},
+		{
+			name:  "rounds average when no median",
+			user:  &models.User{CycleLength: 30},
+			stats: CycleStats{MedianCycleLength: 0, AverageCycleLength: 29.6},
+			want:  30,
+		},
+		{
+			name:  "falls back to configured cycle length with no observed statistic",
+			user:  &models.User{CycleLength: 31},
+			stats: CycleStats{},
+			want:  31,
+		},
+		{
+			name:  "falls back to the default with no statistic and no valid configuration",
+			user:  nil,
+			stats: CycleStats{},
+			want:  models.DefaultCycleLength,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := DashboardProjectionCycleLength(tc.user, tc.stats); got != tc.want {
+				t.Fatalf("DashboardProjectionCycleLength = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestMedianProjectionAgreesAcrossSurfaces is the cross-surface regression for
+// the missed-log merge scenario: cycle lengths [28,28,28,28,60] give a median of
+// 28 but a mean of ~34. Before this fix the dashboard hero, webhook reminder, and
+// .ics feed projected from the mean (34) while stats and the calendar grid used
+// the median (28), so those surfaces drifted ~6 days late. This asserts all four
+// next-period surfaces now agree on the median-based date, and that it is NOT the
+// mean-based date.
+func TestMedianProjectionAgreesAcrossSurfaces(t *testing.T) {
+	loc := time.UTC
+	base := mustParseWebhookReminderDay(t, "2026-01-01", loc)
+
+	// Six explicit cycle starts spaced to yield lengths [28,28,28,28,60].
+	startOffsets := []int{0, 28, 56, 84, 112, 172}
+	logs := make([]models.DailyLog, 0, len(startOffsets))
+	for _, offset := range startOffsets {
+		logs = append(logs, models.DailyLog{
+			Date:       base.AddDate(0, 0, offset),
+			IsPeriod:   true,
+			CycleStart: true,
+		})
+	}
+
+	lastStart := base.AddDate(0, 0, 172)      // the most recent cycle start
+	today := lastStart.AddDate(0, 0, 18)      // still inside the first projected cycle
+	medianNext := lastStart.AddDate(0, 0, 28) // median projection (correct)
+	meanNext := lastStart.AddDate(0, 0, 34)   // mean projection (the old bug)
+
+	user := regularWebhookUser()
+	stats := NewStatsService(nil, nil).BuildCycleStatsFromLogs(user, logs, today, loc)
+
+	// Guard the scenario itself: median 28 must diverge from mean 34 here.
+	if stats.MedianCycleLength != 28 {
+		t.Fatalf("scenario setup: MedianCycleLength = %d, want 28", stats.MedianCycleLength)
+	}
+	if got := int(stats.AverageCycleLength + 0.5); got != 34 {
+		t.Fatalf("scenario setup: rounded AverageCycleLength = %d, want 34", got)
+	}
+	if DashboardProjectionCycleLength(user, stats) != 28 {
+		t.Fatalf("projection length = %d, want 28", DashboardProjectionCycleLength(user, stats))
+	}
+	if DashboardCycleReferenceLength(user, stats) != 34 {
+		t.Fatalf("reference length = %d, want 34 (average-first, retained for warnings)", DashboardCycleReferenceLength(user, stats))
+	}
+
+	assertDay := func(label string, got, want time.Time) {
+		t.Helper()
+		if got.Format("2006-01-02") != want.Format("2006-01-02") {
+			t.Fatalf("%s = %s, want %s", label, got.Format("2006-01-02"), want.Format("2006-01-02"))
+		}
+	}
+
+	// 1. stats / calendar authoritative next-period (median-based).
+	assertDay("stats.NextPeriodStart", stats.NextPeriodStart, medianNext)
+
+	// 2. Dashboard hero displayed next-period.
+	cycleContext := BuildDashboardCycleContext(user, stats, today, loc)
+	assertDay("DisplayNextPeriodStart", cycleContext.DisplayNextPeriodStart, medianNext)
+
+	// 3. Webhook period reminder anchor/event (lead wide enough to cover 28 days).
+	reminders := DecideDueReminders(user, enabledWebhookSettings(14), logs, today, loc)
+	period, ok := findDueReminder(reminders, DueReminderTypePeriod)
+	if !ok {
+		t.Fatalf("expected a period reminder within the lead window, got %#v", reminders)
+	}
+	assertDay("webhook period EventDate", period.EventDate, medianNext)
+
+	// 4. First .ics period event.
+	events := calendarFeedEvents(CalendarFeedICSInput{User: user, Logs: logs, Now: today, Location: loc})
+	firstPeriod, ok := firstEventOfKind(events, "period")
+	if !ok {
+		t.Fatalf("expected a period event in the .ics feed, got %#v", events)
+	}
+	assertDay("first .ics period event", firstPeriod, medianNext)
+
+	// And prove the surfaces are no longer on the mean-based date.
+	if cycleContext.DisplayNextPeriodStart.Format("2006-01-02") == meanNext.Format("2006-01-02") {
+		t.Fatalf("dashboard still projecting from the mean (%s)", meanNext.Format("2006-01-02"))
+	}
+}
+
+func firstEventOfKind(events []calendarFeedEvent, kind string) (time.Time, bool) {
+	for _, event := range events {
+		if event.kind == kind {
+			return event.date, true
+		}
+	}
+	return time.Time{}, false
+}
+
+// Guard against an accidental data-minimization regression alongside the date
+// change: the .ics SUMMARY must stay neutral even in this scenario.
+func TestMedianProjectionKeepsNeutralICSSummary(t *testing.T) {
+	loc := time.UTC
+	base := mustParseWebhookReminderDay(t, "2026-01-01", loc)
+	logs := []models.DailyLog{{Date: base, IsPeriod: true, CycleStart: true}}
+	body := string(BuildCalendarFeedICS(CalendarFeedICSInput{
+		User: regularWebhookUser(), Logs: logs, Now: base, Location: loc, Disclaimer: "estimate only",
+	}))
+	if !strings.Contains(body, "SUMMARY:"+calendarFeedNeutralSummary) {
+		t.Fatalf("expected neutral SUMMARY in feed body")
+	}
+}

--- a/internal/services/dashboard_cycle.go
+++ b/internal/services/dashboard_cycle.go
@@ -52,12 +52,41 @@ func DashboardPredictionDisabled(user *models.User) bool {
 	return user != nil && user.UnpredictableCycle
 }
 
+// DashboardCycleReferenceLength is the AVERAGE-first cycle length used only as a
+// REFERENCE for the cycle-day-long and data-stale warnings (and the hero phase
+// ring), where "how far past the owner's typical run are we" is best captured by
+// the mean. It must NOT feed a displayed next-period/ovulation DATE — use
+// DashboardProjectionCycleLength for that.
 func DashboardCycleReferenceLength(user *models.User, stats CycleStats) int {
 	if stats.AverageCycleLength > 0 {
 		return int(stats.AverageCycleLength + 0.5)
 	}
 	if stats.MedianCycleLength > 0 {
 		return stats.MedianCycleLength
+	}
+	if user != nil && IsValidOnboardingCycleLength(user.CycleLength) {
+		return user.CycleLength
+	}
+	return models.DefaultCycleLength
+}
+
+// DashboardProjectionCycleLength is the MEDIAN-first cycle length used to PROJECT
+// future next-period and ovulation DATES on the dashboard hero, the webhook
+// reminder decision, and the .ics feed. It delegates to predictedCycleLength —
+// the exact statistic stats.NextPeriodStart and the calendar grid already use —
+// so every next-period surface agrees on the date.
+//
+// The median is robust to a single outlier cycle: a missed period log merges two
+// real cycles into one ~60-90 day gap that drags the mean by ~10 days (pushing a
+// mean-based projection late) but leaves the median unmoved. That is why the
+// average-first DashboardCycleReferenceLength is deliberately NOT used here.
+//
+// The user's configured cycle length is the zero-fallback (mirroring
+// applyProjectedBaseline), used only in the degenerate case with no observed
+// statistic.
+func DashboardProjectionCycleLength(user *models.User, stats CycleStats) int {
+	if stats.MedianCycleLength > 0 || stats.AverageCycleLength > 0 {
+		return predictedCycleLength(stats.MedianCycleLength, stats.AverageCycleLength)
 	}
 	if user != nil && IsValidOnboardingCycleLength(user.CycleLength) {
 		return user.CycleLength
@@ -221,7 +250,7 @@ func BuildDashboardCycleContext(user *models.User, stats CycleStats, today time.
 	cycleDayWarning := DashboardCycleDayLooksLong(stats.CurrentCycleDay, cycleDayReference)
 	cycleStaleAnchor := DashboardCycleStaleAnchor(user, stats, location)
 	cycleDataStale := DashboardCycleDataLooksStale(cycleStaleAnchor, today, cycleDayReference)
-	display := buildDashboardPredictionDisplay(user, stats, today, location, cycleDayReference)
+	display := buildDashboardPredictionDisplay(user, stats, today, location)
 
 	return DashboardCycleContext{
 		CycleDayReference:           cycleDayReference,
@@ -247,12 +276,12 @@ func BuildDashboardCycleContext(user *models.User, stats CycleStats, today time.
 	}
 }
 
-func buildDashboardPredictionDisplay(user *models.User, stats CycleStats, today time.Time, location *time.Location, cycleDayReference int) dashboardPredictionDisplay {
+func buildDashboardPredictionDisplay(user *models.User, stats CycleStats, today time.Time, location *time.Location) dashboardPredictionDisplay {
 	prediction := DashboardUpcomingPredictions(
 		stats,
 		user,
 		today,
-		cycleDayReference,
+		DashboardProjectionCycleLength(user, stats),
 	)
 
 	display := dashboardPredictionDisplay{

--- a/internal/services/webhook_reminder.go
+++ b/internal/services/webhook_reminder.go
@@ -116,10 +116,11 @@ func WebhookReminderSettingsFromNotifyRecord(record models.WebhookNotifyRecord) 
 //     unpredictable-cycle mode — or stats.PregnancyPaused) ⇒ nothing. This is
 //     the medical-safety gate: never emit a date the app itself refuses to show.
 //   - Resolve "today" as the owner-local calendar day (DateAtLocation) and the
-//     reference cycle length the dashboard feeds to its predictions
-//     (DashboardCycleReferenceLength), then take the dashboard's own upcoming
-//     prediction (DashboardUpcomingPredictions) for the authoritative next-period
-//     and ovulation dates + flags.
+//     median-first projection cycle length the dashboard feeds to its predictions
+//     (DashboardProjectionCycleLength — the same statistic as stats.NextPeriodStart,
+//     NOT the average-first staleness reference), then take the dashboard's own
+//     upcoming prediction (DashboardUpcomingPredictions) for the authoritative
+//     next-period and ovulation dates + flags.
 //   - period-soon: emitted when NotifyPeriod is on, the next period start is
 //     known, and it falls within [today, today+leadDays] (inclusive) — i.e. not
 //     in the past and not beyond the window. Its cycle anchor is the next period
@@ -152,7 +153,7 @@ func DecideDueReminders(user *models.User, settings WebhookReminderSettings, log
 
 	today := DateAtLocation(now, location)
 	leadDays := NormalizeReminderLeadDays(settings.ReminderLeadDays)
-	cycleLength := DashboardCycleReferenceLength(user, stats)
+	cycleLength := DashboardProjectionCycleLength(user, stats)
 	prediction := DashboardUpcomingPredictions(stats, user, today, cycleLength)
 
 	reminders := make([]DueReminder, 0, 2)


### PR DESCRIPTION
## Problem

The dashboard hero, webhook reminders, and the `.ics` feed computed the next-period date from the **mean** cycle length (`DashboardCycleReferenceLength`, average-first), while `stats.NextPeriodStart`, the calendar grid, and all docs use the **median** (`predictedCycleLength`). A single outlier cycle drifts those surfaces late.

**Scenario** — history `[28,28,28,28,60]` (missed-log merge): median 28 vs mean 34. With last start 2026-06-22, hero/webhook/`.ics` showed the next period on **2026-07-26** while calendar/stats showed **2026-07-20** — a ~6-day drift on a user-visible health prediction.

## Fix

- Add `DashboardProjectionCycleLength` (median-first via `predictedCycleLength`, configured-length zero-fallback).
- Use it as the projection length in `buildDashboardPredictionDisplay`, `DecideDueReminders`, and `calendarFeedEvents`.
- Keep `DashboardCycleReferenceLength` (average-first) **only** as the cycle-day-long / staleness reference and hero phase-ring geometry. `cycle_start_policy` was already median-first.

After the fix all four next-period surfaces agree on **2026-07-20** (median).

## Tests

- New `cycle_median_projection_test.go`: helper-branch coverage + a four-surface agreement regression for `[28,28,28,28,60]` + an `.ics` neutral-SUMMARY guard.
- `go test ./internal/...` passes; `staticcheck ./...` clean.
- **Golden vectors untouched** — `internal/services/testdata/cycle-prediction-golden-vectors.json` is byte-identical (`predictedCycleLength` unchanged), so no two-repo coordination is required.

## Follow-up

`.claude/guides/services-cycle.md` gets a clarification (median projection vs average reference) via `/governance-update` in a separate change.