### PR TITLE
fix(calendar): open cycle-start confirm modal in summary view

### DIFF
--- a/e2e/calendar.spec.ts
+++ b/e2e/calendar.spec.ts
@@ -307,24 +307,80 @@ test.describe('Calendar page', () => {
     await page.goto(`/calendar?month=${month}&day=${tomorrowISO}`);
     await expect(page).toHaveURL(new RegExp(`/calendar\\?month=${month}&day=${tomorrowISO}`));
 
-    const manualStartButton = page.locator(`[data-day-cycle-start-form][data-day-cycle-start-date="${tomorrowISO}"] [data-day-cycle-start-button]`);
+    const manualStartForm = page.locator(`[data-day-cycle-start-form][data-day-cycle-start-date="${tomorrowISO}"]`);
+    const manualStartButton = manualStartForm.locator('[data-day-cycle-start-button]');
     await expect(manualStartButton).toBeVisible();
     await expect(page.locator('#day-editor')).toContainText(/recalculated|пересчитается|recalcular/i);
 
-    await Promise.all([
+    // The onboarding seed anchors last_period_start at today-3, so tomorrow is a
+    // 4-day short gap: the backend rejects the start with a 400 unless the owner
+    // explicitly confirms it as uncertain (ShortGapDays > 0). The confirm modal
+    // must open so accepting can flip mark_uncertain=true before the POST fires.
+    await manualStartButton.click();
+    await expect(page.locator('#confirm-modal')).toBeVisible();
+
+    const [cycleStartResponse] = await Promise.all([
       page.waitForResponse((response) => {
         return (
           response.request().method() === 'POST' &&
           response.url().includes(`/api/v1/days/${tomorrowISO}/cycle-start?source=calendar`)
         );
       }),
-      manualStartButton.click(),
+      page.locator('#confirm-modal-accept').click(),
     ]);
+    expect(cycleStartResponse.status()).toBeLessThan(400);
+    await page.waitForLoadState('networkidle');
 
     await page.locator(`[data-day-editor-open="${tomorrowISO}"]`).first().click();
     const dayEditorForm = page.locator(`[data-day-editor-form][data-day-editor-date="${tomorrowISO}"]`);
     await expect(dayEditorForm).toBeVisible();
     await expect(dayEditorForm.locator('input[name="is_period"]')).toBeChecked();
+  });
+
+  test('summary-view manual cycle start exposes its policy node so the confirm modal opens', async ({
+    page,
+  }) => {
+    // Regression for the calendar summary-view placement bug: the confirm script
+    // resolves the policy node via form.parentElement.querySelector(
+    // '[data-cycle-start-policy]'), so the hidden policy node MUST be a sibling of
+    // the cycle-start form inside the same wrapper. When it was placed outside the
+    // wrapper the lookup returned null, the short-gap confirm modal never opened,
+    // and the POST failed with a silent 400.
+    await registerOwnerOnCalendar(page, 'calendar-cycle-start-policy-scope');
+
+    const todayISO = await todayISOFromCalendar(page);
+    const tomorrowISO = shiftISODate(todayISO, 1);
+    const month = tomorrowISO.slice(0, 7);
+
+    await page.goto(`/calendar?month=${month}&day=${tomorrowISO}`);
+    await expect(page).toHaveURL(new RegExp(`/calendar\\?month=${month}&day=${tomorrowISO}`));
+
+    const manualStartForm = page.locator(`[data-day-cycle-start-form][data-day-cycle-start-date="${tomorrowISO}"]`);
+    await expect(manualStartForm).toBeVisible();
+
+    // Structural guard: the policy node must be reachable from the form's parent,
+    // exactly as the confirm script looks it up. This fails immediately if the
+    // template ever moves the policy node back outside the form's wrapper.
+    const policyReachableFromForm = await manualStartForm.evaluate((form) =>
+      Boolean(form.parentElement && form.parentElement.querySelector('[data-cycle-start-policy]')),
+    );
+    expect(policyReachableFromForm).toBe(true);
+
+    // End-to-end: clicking opens the confirm modal, and accepting completes the
+    // short-gap cycle start (HTTP < 400) instead of the silent 400.
+    await manualStartForm.locator('[data-day-cycle-start-button]').click();
+    await expect(page.locator('#confirm-modal')).toBeVisible();
+
+    const [cycleStartResponse] = await Promise.all([
+      page.waitForResponse((response) => {
+        return (
+          response.request().method() === 'POST' &&
+          response.url().includes(`/api/v1/days/${tomorrowISO}/cycle-start?source=calendar`)
+        );
+      }),
+      page.locator('#confirm-modal-accept').click(),
+    ]);
+    expect(cycleStartResponse.status()).toBeLessThan(400);
   });
 
   test('BBT tracking without a confirmed signal demotes the predicted ovulation day to a tentative dash', async ({

--- a/internal/templates/day_editor_partial.html
+++ b/internal/templates/day_editor_partial.html
@@ -193,23 +193,21 @@
         <input type="hidden" name="mark_uncertain" value="false" data-cycle-start-uncertain-input>
         <button type="submit" class="{{if .Log.CycleStart}}btn-primary{{else}}btn-secondary{{end}}" data-day-cycle-start-button>{{t .Messages "dashboard.manual_cycle_start"}}</button>
       </form>
+      <div
+        hidden
+        data-cycle-start-policy
+        data-cycle-start-conflict="{{if .ManualCycleStartConflict}}true{{else}}false{{end}}"
+        data-cycle-start-conflict-date="{{if .ManualCycleStartConflict}}{{formatLocalizedDate .Lang .ManualCycleStartConflictDate "display"}}{{end}}"
+        data-cycle-start-target-date="{{formatLocalizedDate .Lang .Date "display"}}"
+        data-cycle-start-short-gap="{{.ManualCycleStartShortGap}}"
+        data-cycle-start-previous-date="{{if gt .ManualCycleStartShortGap 0}}{{formatLocalizedDate .Lang .ManualCycleStartPreviousDate "display"}}{{end}}"
+        data-cycle-start-implantation="{{if .ManualCycleStartPotentialImplantation}}true{{else}}false{{end}}"
+        data-cycle-start-replace-message="{{t .Messages "dashboard.cycle_start_replace_message"}}"
+        data-cycle-start-replace-accept="{{t .Messages "dashboard.cycle_start_replace_accept"}}"
+        data-cycle-start-short-gap-message="{{t .Messages "dashboard.cycle_start_short_gap_message"}}"
+        data-cycle-start-short-gap-accept="{{t .Messages "dashboard.cycle_start_short_gap_accept"}}"></div>
       {{end}}
     </div>
-    {{if .AllowManualCycleStart}}
-    <div
-      hidden
-      data-cycle-start-policy
-      data-cycle-start-conflict="{{if .ManualCycleStartConflict}}true{{else}}false{{end}}"
-      data-cycle-start-conflict-date="{{if .ManualCycleStartConflict}}{{formatLocalizedDate .Lang .ManualCycleStartConflictDate "display"}}{{end}}"
-      data-cycle-start-target-date="{{formatLocalizedDate .Lang .Date "display"}}"
-      data-cycle-start-short-gap="{{.ManualCycleStartShortGap}}"
-      data-cycle-start-previous-date="{{if gt .ManualCycleStartShortGap 0}}{{formatLocalizedDate .Lang .ManualCycleStartPreviousDate "display"}}{{end}}"
-      data-cycle-start-implantation="{{if .ManualCycleStartPotentialImplantation}}true{{else}}false{{end}}"
-      data-cycle-start-replace-message="{{t .Messages "dashboard.cycle_start_replace_message"}}"
-      data-cycle-start-replace-accept="{{t .Messages "dashboard.cycle_start_replace_accept"}}"
-      data-cycle-start-short-gap-message="{{t .Messages "dashboard.cycle_start_short_gap_message"}}"
-      data-cycle-start-short-gap-accept="{{t .Messages "dashboard.cycle_start_short_gap_accept"}}"></div>
-    {{end}}
     {{if .ShowFutureCycleStartNotice}}
     <p class="journal-muted text-sm">{{t .Messages "warning.future_cycle_start"}}</p>
     {{end}}
@@ -238,23 +236,21 @@
           <input type="hidden" name="mark_uncertain" value="false" data-cycle-start-uncertain-input>
           <button type="submit" class="btn-secondary" data-day-cycle-start-button>{{t .Messages "dashboard.manual_cycle_start"}}</button>
         </form>
+        <div
+          hidden
+          data-cycle-start-policy
+          data-cycle-start-conflict="{{if .ManualCycleStartConflict}}true{{else}}false{{end}}"
+          data-cycle-start-conflict-date="{{if .ManualCycleStartConflict}}{{formatLocalizedDate .Lang .ManualCycleStartConflictDate "display"}}{{end}}"
+          data-cycle-start-target-date="{{formatLocalizedDate .Lang .Date "display"}}"
+          data-cycle-start-short-gap="{{.ManualCycleStartShortGap}}"
+          data-cycle-start-previous-date="{{if gt .ManualCycleStartShortGap 0}}{{formatLocalizedDate .Lang .ManualCycleStartPreviousDate "display"}}{{end}}"
+          data-cycle-start-implantation="{{if .ManualCycleStartPotentialImplantation}}true{{else}}false{{end}}"
+          data-cycle-start-replace-message="{{t .Messages "dashboard.cycle_start_replace_message"}}"
+          data-cycle-start-replace-accept="{{t .Messages "dashboard.cycle_start_replace_accept"}}"
+          data-cycle-start-short-gap-message="{{t .Messages "dashboard.cycle_start_short_gap_message"}}"
+          data-cycle-start-short-gap-accept="{{t .Messages "dashboard.cycle_start_short_gap_accept"}}"></div>
         {{end}}
       </div>
-      {{if .AllowManualCycleStart}}
-      <div
-        hidden
-        data-cycle-start-policy
-        data-cycle-start-conflict="{{if .ManualCycleStartConflict}}true{{else}}false{{end}}"
-        data-cycle-start-conflict-date="{{if .ManualCycleStartConflict}}{{formatLocalizedDate .Lang .ManualCycleStartConflictDate "display"}}{{end}}"
-        data-cycle-start-target-date="{{formatLocalizedDate .Lang .Date "display"}}"
-        data-cycle-start-short-gap="{{.ManualCycleStartShortGap}}"
-        data-cycle-start-previous-date="{{if gt .ManualCycleStartShortGap 0}}{{formatLocalizedDate .Lang .ManualCycleStartPreviousDate "display"}}{{end}}"
-        data-cycle-start-implantation="{{if .ManualCycleStartPotentialImplantation}}true{{else}}false{{end}}"
-        data-cycle-start-replace-message="{{t .Messages "dashboard.cycle_start_replace_message"}}"
-        data-cycle-start-replace-accept="{{t .Messages "dashboard.cycle_start_replace_accept"}}"
-        data-cycle-start-short-gap-message="{{t .Messages "dashboard.cycle_start_short_gap_message"}}"
-        data-cycle-start-short-gap-accept="{{t .Messages "dashboard.cycle_start_short_gap_accept"}}"></div>
-      {{end}}
       {{if .ShowFutureCycleStartNotice}}
       <p class="journal-muted text-sm">{{t .Messages "warning.future_cycle_start"}}</p>
       {{end}}


### PR DESCRIPTION
## Problem
In the calendar **summary view**, manually marking a cycle-start on a short-gap or conflicting date failed with a silent **HTTP 400** because the confirmation modal never opened.

## Root cause
The confirm script (`web/src/js/app/23-cycle-start-confirm.js`) resolves the policy node with `form.parentElement.querySelector("[data-cycle-start-policy]")`. In both summary-view branches of `internal/templates/day_editor_partial.html`, the `<form data-cycle-start-confirm-form>` lived inside `<div class="flex flex-wrap items-center gap-3">` while the `[data-cycle-start-policy]` node was placed **outside** that wrapper (a sibling of it). So `form.parentElement` was the flex wrapper, its `querySelector` couldn't find the policy node → `readCycleStartPolicy` returned `null` → the modal was skipped → the form submitted with `mark_uncertain=false` → the backend requires confirmation for a short gap (`ShortGapDays > 0`) and returned 400.

Edit-mode and the dashboard keep the form and policy node as siblings, so they worked — confirming this was a summary-view placement bug.

## Fix
Move each `[data-cycle-start-policy]` node **inside** the same flex wrapper as its form, in both summary branches. Template-only and layout-safe (the node is `hidden`). No JS/CSS bundle changes.

## Tests
- Updated `tomorrow keeps manual cycle start available with a warning` to drive the modal: click → accept the short-gap confirm modal → POST completes `< 400` → the day is marked (`is_period` checked). The onboarding seed anchors `last_period_start = today-3`, so tomorrow is always a 4-day short gap.
- Added a focused regression asserting the summary-view policy node stays reachable from `form.parentElement` and the modal opens + completes, so this placement bug can't silently return.

## Validation
- `npm run lint` — clean
- `node scripts/run-e2e.mjs --mode=stable --project=chromium -- e2e/calendar.spec.ts` — **14/14 passed**