### PR TITLE
test(e2e): bind calendar day-editor open to its htmx request

### DIFF
--- a/e2e/bugs.spec.ts
+++ b/e2e/bugs.spec.ts
@@ -165,7 +165,25 @@ async function openCalendarDayEditor(page: Page, isoDate: string) {
 
   const editButton = page.locator(`[data-day-editor-open="${isoDate}"]`).first();
   await expect(editButton).toBeVisible();
-  await editButton.click();
+  // Bind the disclosure click to its own htmx GET /calendar/day/{date}?mode=edit
+  // (waitForRequest -> request.response()) so the network round-trip is awaited
+  // explicitly and the form's default 5s visibility check only covers the client
+  // htmx swap. See calendar-autofill-clear.spec.ts for the full rationale.
+  const [request] = await Promise.all([
+    page.waitForRequest(
+      (candidate) =>
+        candidate.method() === 'GET' &&
+        candidate.url().includes(`/calendar/day/${isoDate}`) &&
+        candidate.url().includes('mode=edit'),
+    ),
+    editButton.click(),
+  ]);
+  const response = await request.response();
+  expect(response, `expected a response for GET /calendar/day/${isoDate}?mode=edit`).not.toBeNull();
+  expect(
+    response!.ok(),
+    `GET /calendar/day/${isoDate}?mode=edit failed with ${response!.status()}`,
+  ).toBeTruthy();
 
   const form = page.locator(`[data-day-editor-form][data-day-editor-date="${isoDate}"]`);
   await expect(form).toBeVisible();

--- a/e2e/calendar-autofill-clear.spec.ts
+++ b/e2e/calendar-autofill-clear.spec.ts
@@ -50,7 +50,30 @@ async function openCalendarDayEditor(page: Page, isoDate: string) {
 
   const editButton = page.locator(`[data-day-editor-open="${isoDate}"]`).first();
   if (await editButton.count()) {
-    await editButton.click();
+    await expect(editButton).toBeVisible();
+    // The disclosure fires hx-get /calendar/day/{date}?mode=edit into #day-editor.
+    // Bind to this click's own request (waitForRequest fires only for requests
+    // issued after registration, so it captures exactly this GET) rather than
+    // waitForResponse on the URL, which could resolve on the still-in-flight
+    // hx-trigger="load" fetch page.goto already kicked off. Awaiting the response
+    // before the visibility check leaves the 5s window covering only the
+    // client-side htmx swap, not the network round-trip — the part that overran
+    // under full-suite serial CPU contention and flaked this helper.
+    const [request] = await Promise.all([
+      page.waitForRequest(
+        (candidate) =>
+          candidate.method() === 'GET' &&
+          candidate.url().includes(`/calendar/day/${isoDate}`) &&
+          candidate.url().includes('mode=edit'),
+      ),
+      editButton.click(),
+    ]);
+    const response = await request.response();
+    expect(response, `expected a response for GET /calendar/day/${isoDate}?mode=edit`).not.toBeNull();
+    expect(
+      response!.ok(),
+      `GET /calendar/day/${isoDate}?mode=edit failed with ${response!.status()}`,
+    ).toBeTruthy();
   }
 
   const form = page.locator(`[data-day-editor-form][data-day-editor-date="${isoDate}"]`);

--- a/e2e/calendar.spec.ts
+++ b/e2e/calendar.spec.ts
@@ -46,7 +46,25 @@ async function openCalendarDayEditor(page: Page, isoDate: string) {
 
   const editButton = page.locator(`[data-day-editor-open="${isoDate}"]`).first();
   await expect(editButton).toBeVisible();
-  await editButton.click();
+  // Bind the disclosure click to its own htmx GET /calendar/day/{date}?mode=edit
+  // (waitForRequest -> request.response()) so the network round-trip is awaited
+  // explicitly and the form's default 5s visibility check only covers the client
+  // htmx swap. See calendar-autofill-clear.spec.ts for the full rationale.
+  const [request] = await Promise.all([
+    page.waitForRequest(
+      (candidate) =>
+        candidate.method() === 'GET' &&
+        candidate.url().includes(`/calendar/day/${isoDate}`) &&
+        candidate.url().includes('mode=edit'),
+    ),
+    editButton.click(),
+  ]);
+  const response = await request.response();
+  expect(response, `expected a response for GET /calendar/day/${isoDate}?mode=edit`).not.toBeNull();
+  expect(
+    response!.ok(),
+    `GET /calendar/day/${isoDate}?mode=edit failed with ${response!.status()}`,
+  ).toBeTruthy();
 
   const form = page.locator(`[data-day-editor-form][data-day-editor-date="${isoDate}"]`);
   await expect(form).toBeVisible();

--- a/e2e/settings-password-export-danger.spec.ts
+++ b/e2e/settings-password-export-danger.spec.ts
@@ -82,7 +82,25 @@ async function openCalendarDayEditor(page: Page, isoDate: string): Promise<Locat
 
   const editButton = page.locator(`[data-day-editor-open="${isoDate}"]`).first();
   await expect(editButton).toBeVisible();
-  await editButton.click();
+  // Bind the disclosure click to its own htmx GET /calendar/day/{date}?mode=edit
+  // (waitForRequest -> request.response()) so the network round-trip is awaited
+  // explicitly and the form's default 5s visibility check only covers the client
+  // htmx swap. See calendar-autofill-clear.spec.ts for the full rationale.
+  const [request] = await Promise.all([
+    page.waitForRequest(
+      (candidate) =>
+        candidate.method() === 'GET' &&
+        candidate.url().includes(`/calendar/day/${isoDate}`) &&
+        candidate.url().includes('mode=edit'),
+    ),
+    editButton.click(),
+  ]);
+  const response = await request.response();
+  expect(response, `expected a response for GET /calendar/day/${isoDate}?mode=edit`).not.toBeNull();
+  expect(
+    response!.ok(),
+    `GET /calendar/day/${isoDate}?mode=edit failed with ${response!.status()}`,
+  ).toBeTruthy();
 
   const form = page.locator(`[data-day-editor-form][data-day-editor-date="${isoDate}"]`);
   await expect(form).toBeVisible();

--- a/e2e/settings-profile-cycle.spec.ts
+++ b/e2e/settings-profile-cycle.spec.ts
@@ -164,7 +164,25 @@ async function openCalendarDayEditor(page: Page, isoDate: string): Promise<Locat
 
   const editButton = page.locator(`[data-day-editor-open="${isoDate}"]`).first();
   await expect(editButton).toBeVisible();
-  await editButton.click();
+  // Bind the disclosure click to its own htmx GET /calendar/day/{date}?mode=edit
+  // (waitForRequest -> request.response()) so the network round-trip is awaited
+  // explicitly and the form's default 5s visibility check only covers the client
+  // htmx swap. See calendar-autofill-clear.spec.ts for the full rationale.
+  const [request] = await Promise.all([
+    page.waitForRequest(
+      (candidate) =>
+        candidate.method() === 'GET' &&
+        candidate.url().includes(`/calendar/day/${isoDate}`) &&
+        candidate.url().includes('mode=edit'),
+    ),
+    editButton.click(),
+  ]);
+  const response = await request.response();
+  expect(response, `expected a response for GET /calendar/day/${isoDate}?mode=edit`).not.toBeNull();
+  expect(
+    response!.ok(),
+    `GET /calendar/day/${isoDate}?mode=edit failed with ${response!.status()}`,
+  ).toBeTruthy();
 
   const form = page.locator(`[data-day-editor-form][data-day-editor-date="${isoDate}"]`);
   await expect(form).toBeVisible();

--- a/e2e/support/stats-helpers.ts
+++ b/e2e/support/stats-helpers.ts
@@ -97,11 +97,29 @@ export async function openCalendarDayEditor(page: Page, isoDate: string): Promis
 
   const editButton = page.locator(`[data-day-editor-open="${isoDate}"]`).first();
   await expect(editButton).toBeVisible();
-  await editButton.evaluate((node) => {
-    if (node instanceof HTMLButtonElement) {
-      node.click();
-    }
-  });
+  // Bind the disclosure click to its own htmx GET /calendar/day/{date}?mode=edit
+  // (waitForRequest -> request.response()) so the network round-trip is awaited
+  // explicitly and the form's default 5s visibility check only covers the client
+  // htmx swap. See calendar-autofill-clear.spec.ts for the full rationale.
+  const [request] = await Promise.all([
+    page.waitForRequest(
+      (candidate) =>
+        candidate.method() === 'GET' &&
+        candidate.url().includes(`/calendar/day/${isoDate}`) &&
+        candidate.url().includes('mode=edit'),
+    ),
+    editButton.evaluate((node) => {
+      if (node instanceof HTMLButtonElement) {
+        node.click();
+      }
+    }),
+  ]);
+  const response = await request.response();
+  expect(response, `expected a response for GET /calendar/day/${isoDate}?mode=edit`).not.toBeNull();
+  expect(
+    response!.ok(),
+    `GET /calendar/day/${isoDate}?mode=edit failed with ${response!.status()}`,
+  ).toBeTruthy();
 
   const form = page.locator(`[data-day-editor-form][data-day-editor-date="${isoDate}"]`);
   await expect(form).toBeVisible();


### PR DESCRIPTION
## Problem
`openCalendarDayEditor` clicked the "Add entry"/"Edit entry" disclosure, then waited for the lazy-loaded day-editor form with the default 5s `expect` timeout. That window had to cover the htmx `GET /calendar/day/{date}?mode=edit` round-trip, which under full-suite serial CPU contention overran 5s and flaked `calendar-autofill-clear.spec.ts` ("clears bare auto-filled neighbors when the anchor period day is toggled off").

## Fix
Bind the disclosure click to its own request (`waitForRequest` → `request.response()`, the pattern `saveDayEditorForm`/`markCycleStart` already use) so the network round-trip is awaited explicitly and the 5s visibility check only covers the client-side htmx swap. Propagated to every `openCalendarDayEditor` copy carrying the same latent race.

## Validation
- `calendar-autofill-clear.spec.ts` ×3 (ci mode): 6/6 green.
- Full chromium suite: **152 passed, 5 skipped, 0 failed** — the previously-flaky test green under full serial contention.