### PR TITLE
test(e2e): consolidate openCalendarDayEditor onto the shared helper

### DIFF
--- a/e2e/bugs.spec.ts
+++ b/e2e/bugs.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test, type Page } from '@playwright/test';
 import { clearDateField, fillDateField } from './support/date-field-helpers';
+import { openCalendarDayEditor } from './support/stats-helpers';
 import {
   dashboardCurrentCycleDay,
   dashboardCurrentPhaseText,
@@ -156,38 +157,6 @@ async function formatEnglishDisplayDate(page: Page, iso: string): Promise<string
       year: 'numeric',
     }).format(date);
   }, iso);
-}
-
-async function openCalendarDayEditor(page: Page, isoDate: string) {
-  const month = isoDate.slice(0, 7);
-  await page.goto(`/calendar?month=${month}&day=${isoDate}`);
-  await expect(page).toHaveURL(new RegExp(`/calendar\\?month=${month}&day=${isoDate}`));
-
-  const editButton = page.locator(`[data-day-editor-open="${isoDate}"]`).first();
-  await expect(editButton).toBeVisible();
-  // Bind the disclosure click to its own htmx GET /calendar/day/{date}?mode=edit
-  // (waitForRequest -> request.response()) so the network round-trip is awaited
-  // explicitly and the form's default 5s visibility check only covers the client
-  // htmx swap. See calendar-autofill-clear.spec.ts for the full rationale.
-  const [request] = await Promise.all([
-    page.waitForRequest(
-      (candidate) =>
-        candidate.method() === 'GET' &&
-        candidate.url().includes(`/calendar/day/${isoDate}`) &&
-        candidate.url().includes('mode=edit'),
-    ),
-    editButton.click(),
-  ]);
-  const response = await request.response();
-  expect(response, `expected a response for GET /calendar/day/${isoDate}?mode=edit`).not.toBeNull();
-  expect(
-    response!.ok(),
-    `GET /calendar/day/${isoDate}?mode=edit failed with ${response!.status()}`,
-  ).toBeTruthy();
-
-  const form = page.locator(`[data-day-editor-form][data-day-editor-date="${isoDate}"]`);
-  await expect(form).toBeVisible();
-  return form;
 }
 
 test.describe('Bug regressions', () => {

--- a/e2e/calendar-autofill-clear.spec.ts
+++ b/e2e/calendar-autofill-clear.spec.ts
@@ -8,6 +8,7 @@ import {
   registerOwnerViaUI,
 } from './support/auth-helpers';
 import { ensureNotesFieldVisible } from './support/note-helpers';
+import { openCalendarDayEditor } from './support/stats-helpers';
 import { setRequestTimezoneFromBrowser } from './support/timezone-helpers';
 
 function shiftISODate(iso: string, days: number): string {
@@ -41,44 +42,6 @@ async function todayISOFromCalendar(page: Page): Promise<string> {
   const todayISO = await todayButton.getAttribute('data-day');
   expect(todayISO).toMatch(/^\d{4}-\d{2}-\d{2}$/);
   return todayISO!;
-}
-
-async function openCalendarDayEditor(page: Page, isoDate: string) {
-  const month = isoDate.slice(0, 7);
-  await page.goto(`/calendar?month=${month}&day=${isoDate}`);
-  await expect(page).toHaveURL(new RegExp(`/calendar\\?month=${month}&day=${isoDate}`));
-
-  const editButton = page.locator(`[data-day-editor-open="${isoDate}"]`).first();
-  if (await editButton.count()) {
-    await expect(editButton).toBeVisible();
-    // The disclosure fires hx-get /calendar/day/{date}?mode=edit into #day-editor.
-    // Bind to this click's own request (waitForRequest fires only for requests
-    // issued after registration, so it captures exactly this GET) rather than
-    // waitForResponse on the URL, which could resolve on the still-in-flight
-    // hx-trigger="load" fetch page.goto already kicked off. Awaiting the response
-    // before the visibility check leaves the 5s window covering only the
-    // client-side htmx swap, not the network round-trip — the part that overran
-    // under full-suite serial CPU contention and flaked this helper.
-    const [request] = await Promise.all([
-      page.waitForRequest(
-        (candidate) =>
-          candidate.method() === 'GET' &&
-          candidate.url().includes(`/calendar/day/${isoDate}`) &&
-          candidate.url().includes('mode=edit'),
-      ),
-      editButton.click(),
-    ]);
-    const response = await request.response();
-    expect(response, `expected a response for GET /calendar/day/${isoDate}?mode=edit`).not.toBeNull();
-    expect(
-      response!.ok(),
-      `GET /calendar/day/${isoDate}?mode=edit failed with ${response!.status()}`,
-    ).toBeTruthy();
-  }
-
-  const form = page.locator(`[data-day-editor-form][data-day-editor-date="${isoDate}"]`);
-  await expect(form).toBeVisible();
-  return form;
 }
 
 async function saveDayEditorForm(page: Page, isoDate: string, form: import('@playwright/test').Locator): Promise<void> {

--- a/e2e/calendar.spec.ts
+++ b/e2e/calendar.spec.ts
@@ -10,6 +10,7 @@ import {
 import { saveSettingsLanguage } from './support/language-helpers';
 import { expectElementAboveMobileTabbar } from './support/mobile-layout-helpers';
 import { ensureNotesFieldVisible } from './support/note-helpers';
+import { openCalendarDayEditor } from './support/stats-helpers';
 import { setRequestTimezoneFromBrowser } from './support/timezone-helpers';
 import { dateFieldRoot, fillDateField } from './support/date-field-helpers';
 
@@ -37,38 +38,6 @@ async function registerOwnerOnCalendar(page: Page, prefix: string): Promise<void
   await setRequestTimezoneFromBrowser(page);
   await page.goto('/calendar');
   await expect(page).toHaveURL(/\/calendar(?:\?.*)?$/);
-}
-
-async function openCalendarDayEditor(page: Page, isoDate: string) {
-  const month = isoDate.slice(0, 7);
-  await page.goto(`/calendar?month=${month}&day=${isoDate}`);
-  await expect(page).toHaveURL(new RegExp(`/calendar\\?month=${month}&day=${isoDate}`));
-
-  const editButton = page.locator(`[data-day-editor-open="${isoDate}"]`).first();
-  await expect(editButton).toBeVisible();
-  // Bind the disclosure click to its own htmx GET /calendar/day/{date}?mode=edit
-  // (waitForRequest -> request.response()) so the network round-trip is awaited
-  // explicitly and the form's default 5s visibility check only covers the client
-  // htmx swap. See calendar-autofill-clear.spec.ts for the full rationale.
-  const [request] = await Promise.all([
-    page.waitForRequest(
-      (candidate) =>
-        candidate.method() === 'GET' &&
-        candidate.url().includes(`/calendar/day/${isoDate}`) &&
-        candidate.url().includes('mode=edit'),
-    ),
-    editButton.click(),
-  ]);
-  const response = await request.response();
-  expect(response, `expected a response for GET /calendar/day/${isoDate}?mode=edit`).not.toBeNull();
-  expect(
-    response!.ok(),
-    `GET /calendar/day/${isoDate}?mode=edit failed with ${response!.status()}`,
-  ).toBeTruthy();
-
-  const form = page.locator(`[data-day-editor-form][data-day-editor-date="${isoDate}"]`);
-  await expect(form).toBeVisible();
-  return form;
 }
 
 async function openCalendarNotes(form: Locator): Promise<void> {

--- a/e2e/settings-password-export-danger.spec.ts
+++ b/e2e/settings-password-export-danger.spec.ts
@@ -2,6 +2,7 @@ import { expect, test, type Locator, type Page } from '@playwright/test';
 import { clearDateField, fillDateField } from './support/date-field-helpers';
 import { ensureNotesFieldVisible } from './support/note-helpers';
 import { setRequestTimezoneFromBrowser } from './support/timezone-helpers';
+import { openCalendarDayEditor } from './support/stats-helpers';
 import {
   completeOnboardingIfPresent,
   confirmRecoveryCode,
@@ -73,38 +74,6 @@ async function todayISOFromCalendar(page: Page): Promise<string> {
   const todayISO = await todayButton.getAttribute('data-day');
   expect(todayISO).toMatch(/^\d{4}-\d{2}-\d{2}$/);
   return todayISO!;
-}
-
-async function openCalendarDayEditor(page: Page, isoDate: string): Promise<Locator> {
-  const month = isoDate.slice(0, 7);
-  await page.goto(`/calendar?month=${month}&day=${isoDate}`);
-  await expect(page).toHaveURL(new RegExp(`/calendar\\?month=${month}&day=${isoDate}`));
-
-  const editButton = page.locator(`[data-day-editor-open="${isoDate}"]`).first();
-  await expect(editButton).toBeVisible();
-  // Bind the disclosure click to its own htmx GET /calendar/day/{date}?mode=edit
-  // (waitForRequest -> request.response()) so the network round-trip is awaited
-  // explicitly and the form's default 5s visibility check only covers the client
-  // htmx swap. See calendar-autofill-clear.spec.ts for the full rationale.
-  const [request] = await Promise.all([
-    page.waitForRequest(
-      (candidate) =>
-        candidate.method() === 'GET' &&
-        candidate.url().includes(`/calendar/day/${isoDate}`) &&
-        candidate.url().includes('mode=edit'),
-    ),
-    editButton.click(),
-  ]);
-  const response = await request.response();
-  expect(response, `expected a response for GET /calendar/day/${isoDate}?mode=edit`).not.toBeNull();
-  expect(
-    response!.ok(),
-    `GET /calendar/day/${isoDate}?mode=edit failed with ${response!.status()}`,
-  ).toBeTruthy();
-
-  const form = page.locator(`[data-day-editor-form][data-day-editor-date="${isoDate}"]`);
-  await expect(form).toBeVisible();
-  return form;
 }
 
 async function openCalendarNotes(form: Locator): Promise<void> {

--- a/e2e/settings-profile-cycle.spec.ts
+++ b/e2e/settings-profile-cycle.spec.ts
@@ -10,6 +10,7 @@ import {
   registerOwnerViaUI,
 } from './support/auth-helpers';
 import { assertNoHorizontalOverflow } from './support/mobile-layout-helpers';
+import { openCalendarDayEditor } from './support/stats-helpers';
 
 function toISODate(date: Date): string {
   const copy = new Date(date);
@@ -155,38 +156,6 @@ async function saveTodayWithSymptom(page: Page, symptomName: string): Promise<st
     .getAttribute('hx-put');
   expect(todayAction).toMatch(/^\/api\/v1\/days\/\d{4}-\d{2}-\d{2}$/);
   return String(todayAction).replace('/api/v1/days/', '');
-}
-
-async function openCalendarDayEditor(page: Page, isoDate: string): Promise<Locator> {
-  const month = isoDate.slice(0, 7);
-  await page.goto(`/calendar?month=${month}&day=${isoDate}`);
-  await expect(page).toHaveURL(new RegExp(`/calendar\\?month=${month}&day=${isoDate}`));
-
-  const editButton = page.locator(`[data-day-editor-open="${isoDate}"]`).first();
-  await expect(editButton).toBeVisible();
-  // Bind the disclosure click to its own htmx GET /calendar/day/{date}?mode=edit
-  // (waitForRequest -> request.response()) so the network round-trip is awaited
-  // explicitly and the form's default 5s visibility check only covers the client
-  // htmx swap. See calendar-autofill-clear.spec.ts for the full rationale.
-  const [request] = await Promise.all([
-    page.waitForRequest(
-      (candidate) =>
-        candidate.method() === 'GET' &&
-        candidate.url().includes(`/calendar/day/${isoDate}`) &&
-        candidate.url().includes('mode=edit'),
-    ),
-    editButton.click(),
-  ]);
-  const response = await request.response();
-  expect(response, `expected a response for GET /calendar/day/${isoDate}?mode=edit`).not.toBeNull();
-  expect(
-    response!.ok(),
-    `GET /calendar/day/${isoDate}?mode=edit failed with ${response!.status()}`,
-  ).toBeTruthy();
-
-  const form = page.locator(`[data-day-editor-form][data-day-editor-date="${isoDate}"]`);
-  await expect(form).toBeVisible();
-  return form;
 }
 
 async function completeOnboardingWithStartDate(page: Page, startDate: string): Promise<void> {

--- a/e2e/support/stats-helpers.ts
+++ b/e2e/support/stats-helpers.ts
@@ -97,10 +97,14 @@ export async function openCalendarDayEditor(page: Page, isoDate: string): Promis
 
   const editButton = page.locator(`[data-day-editor-open="${isoDate}"]`).first();
   await expect(editButton).toBeVisible();
-  // Bind the disclosure click to its own htmx GET /calendar/day/{date}?mode=edit
-  // (waitForRequest -> request.response()) so the network round-trip is awaited
-  // explicitly and the form's default 5s visibility check only covers the client
-  // htmx swap. See calendar-autofill-clear.spec.ts for the full rationale.
+  // The "Add entry"/"Edit entry" disclosure fires hx-get /calendar/day/{date}?mode=edit
+  // into #day-editor. Bind the click to that request's own response (waitForRequest ->
+  // request.response(), as saveDayEditorForm/markCycleStart do) rather than
+  // waitForResponse on the URL, which could resolve on the still-in-flight
+  // hx-trigger="load" fetch page.goto kicked off. Awaiting the response before the
+  // visibility check leaves the default 5s window covering only the client-side htmx
+  // swap, not the network round-trip — the part that overran under full-suite serial
+  // CPU contention and flaked calendar-autofill-clear.spec.ts.
   const [request] = await Promise.all([
     page.waitForRequest(
       (candidate) =>


### PR DESCRIPTION
> **Stacked on #241** (base branch `test/deflake-calendar-autofill-open-editor`). Review/merge that one first; GitHub will retarget this PR to `main` automatically once #241 lands.

## What
Five spec files carried near-identical local copies of `openCalendarDayEditor`. Collapse them onto the single exported helper in `e2e/support/stats-helpers.ts` and import it instead — one source of truth for the htmx-bound disclosure open.

## Behavior
Preserved for the four unconditional callers. `calendar-autofill-clear` moves from a point-in-time `if (count)` disclosure check to the shared helper's retry-based `expect(editButton).toBeVisible()`, which is safe (its days — past days incl. cleared auto-fill neighbors — always render an Add/Edit entry disclosure) and removes a latent point-in-time race.

## Validation
- Compile-check (`playwright test --list`): clean, 471 tests / 27 files.
- 61 tests across all 8 `openCalendarDayEditor` consumers green on stable chromium.

Net: **−170 / +13** across 6 files.

_Note: `stats-helpers.ts` is already the de-facto day/calendar helper module (`markCycleStart`, `saveBBTOnDay` live there too); renaming it is left as separate cleanup._