### PR TITLE
ci(codecov): suppress the misleading service PR comment

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -29,3 +29,9 @@ ignore:
 
 github_checks:
   annotations: true
+
+# The authoritative patch gate is the in-CI scripts/patchcov job (required
+# status "patch-coverage"), which understands this repo's inline codecov:ignore
+# convention. The Codecov service cannot parse those annotations, so suppress
+# its PR comment to avoid a misleading second opinion.
+comment: false


### PR DESCRIPTION
`scripts/patchcov` (required status `patch-coverage`) is the authoritative patch gate here and understands the repo's inline `// codecov:ignore` convention. The Codecov service can't parse those annotations, so its PR **comment** reports genuinely-unreachable annotated lines as missing coverage — a misleading second opinion next to the real gate. Adds `comment: false`; status checks and dashboards are unaffected. (Matches the sync-community change.)