### PR TITLE
refactor(cli): decompose CLI dispatch and webhook-set parser below gocyclo 15

### DIFF
--- a/cmd/ovumcy/commands.go
+++ b/cmd/ovumcy/commands.go
@@ -33,78 +33,97 @@ func tryRunCLICommandWithHandlers(args []string, handlers cliCommandHandlers) (b
 		return false, nil
 	}
 
-	command := strings.TrimSpace(args[0])
-	switch command {
+	switch strings.TrimSpace(args[0]) {
 	case "reset-password":
-		if len(args) != 2 {
-			return true, fmt.Errorf("usage: ovumcy reset-password <email>")
-		}
-		if handlers.runResetPassword == nil {
-			return true, fmt.Errorf("reset-password handler is required")
-		}
-		databaseConfig, err := resolveDatabaseConfig()
-		if err != nil {
-			return true, fmt.Errorf("invalid database config: %w", err)
-		}
-		email := strings.TrimSpace(args[1])
-		return true, handlers.runResetPassword(databaseConfig, email)
+		return handleResetPasswordCommand(args, handlers)
 	case "users":
-		if len(args) < 2 {
-			return true, fmt.Errorf("usage: ovumcy users <list|delete|create>")
-		}
-		if handlers.runUsers == nil {
-			return true, fmt.Errorf("users handler is required")
-		}
-		databaseConfig, err := resolveDatabaseConfig()
-		if err != nil {
-			return true, fmt.Errorf("invalid database config: %w", err)
-		}
-		return true, handlers.runUsers(databaseConfig, args[1:])
+		return handleUsersCommand(args, handlers)
 	case "healthcheck":
-		if len(args) != 1 {
-			return true, fmt.Errorf("usage: ovumcy healthcheck")
-		}
-		if handlers.runHealthcheck == nil {
-			return true, fmt.Errorf("healthcheck handler is required")
-		}
-		port, err := resolvePort()
-		if err != nil {
-			return true, fmt.Errorf("invalid PORT: %w", err)
-		}
-		return true, handlers.runHealthcheck(port, 0)
+		return handleHealthcheckCommand(args, handlers)
 	case "notify":
-		if handlers.runNotify == nil {
-			return true, fmt.Errorf("notify handler is required")
-		}
-		databaseConfig, err := resolveDatabaseConfig()
-		if err != nil {
-			return true, fmt.Errorf("invalid database config: %w", err)
-		}
-		secretKey, err := resolveSecretKey()
-		if err != nil {
-			return true, fmt.Errorf("invalid SECRET_KEY: %w", err)
-		}
-		location := mustLoadLocation(getEnv("TZ", "Local"))
-		defaultLanguage := getEnv("DEFAULT_LANGUAGE", "en")
-		blockPrivateAddresses := getEnvBool("WEBHOOK_BLOCK_PRIVATE_ADDRESSES", false)
-		return true, handlers.runNotify(databaseConfig, secretKey, defaultLanguage, location, blockPrivateAddresses, args[1:])
+		return handleNotifyCommand(args, handlers)
 	case "webhook":
-		if len(args) < 2 {
-			return true, fmt.Errorf("usage: ovumcy webhook <show|set> <email> [flags]")
-		}
-		if handlers.runWebhook == nil {
-			return true, fmt.Errorf("webhook handler is required")
-		}
-		databaseConfig, err := resolveDatabaseConfig()
-		if err != nil {
-			return true, fmt.Errorf("invalid database config: %w", err)
-		}
-		secretKey, err := resolveSecretKey()
-		if err != nil {
-			return true, fmt.Errorf("invalid SECRET_KEY: %w", err)
-		}
-		return true, handlers.runWebhook(databaseConfig, secretKey, args[1:])
+		return handleWebhookCommand(args, handlers)
 	default:
 		return false, nil
 	}
+}
+
+func handleResetPasswordCommand(args []string, handlers cliCommandHandlers) (bool, error) {
+	if len(args) != 2 {
+		return true, fmt.Errorf("usage: ovumcy reset-password <email>")
+	}
+	if handlers.runResetPassword == nil {
+		return true, fmt.Errorf("reset-password handler is required")
+	}
+	databaseConfig, err := resolveDatabaseConfig()
+	if err != nil {
+		return true, fmt.Errorf("invalid database config: %w", err)
+	}
+	email := strings.TrimSpace(args[1])
+	return true, handlers.runResetPassword(databaseConfig, email)
+}
+
+func handleUsersCommand(args []string, handlers cliCommandHandlers) (bool, error) {
+	if len(args) < 2 {
+		return true, fmt.Errorf("usage: ovumcy users <list|delete|create>")
+	}
+	if handlers.runUsers == nil {
+		return true, fmt.Errorf("users handler is required")
+	}
+	databaseConfig, err := resolveDatabaseConfig()
+	if err != nil {
+		return true, fmt.Errorf("invalid database config: %w", err)
+	}
+	return true, handlers.runUsers(databaseConfig, args[1:])
+}
+
+func handleHealthcheckCommand(args []string, handlers cliCommandHandlers) (bool, error) {
+	if len(args) != 1 {
+		return true, fmt.Errorf("usage: ovumcy healthcheck")
+	}
+	if handlers.runHealthcheck == nil {
+		return true, fmt.Errorf("healthcheck handler is required")
+	}
+	port, err := resolvePort()
+	if err != nil {
+		return true, fmt.Errorf("invalid PORT: %w", err)
+	}
+	return true, handlers.runHealthcheck(port, 0)
+}
+
+func handleNotifyCommand(args []string, handlers cliCommandHandlers) (bool, error) {
+	if handlers.runNotify == nil {
+		return true, fmt.Errorf("notify handler is required")
+	}
+	databaseConfig, err := resolveDatabaseConfig()
+	if err != nil {
+		return true, fmt.Errorf("invalid database config: %w", err)
+	}
+	secretKey, err := resolveSecretKey()
+	if err != nil {
+		return true, fmt.Errorf("invalid SECRET_KEY: %w", err)
+	}
+	location := mustLoadLocation(getEnv("TZ", "Local"))
+	defaultLanguage := getEnv("DEFAULT_LANGUAGE", "en")
+	blockPrivateAddresses := getEnvBool("WEBHOOK_BLOCK_PRIVATE_ADDRESSES", false)
+	return true, handlers.runNotify(databaseConfig, secretKey, defaultLanguage, location, blockPrivateAddresses, args[1:])
+}
+
+func handleWebhookCommand(args []string, handlers cliCommandHandlers) (bool, error) {
+	if len(args) < 2 {
+		return true, fmt.Errorf("usage: ovumcy webhook <show|set> <email> [flags]")
+	}
+	if handlers.runWebhook == nil {
+		return true, fmt.Errorf("webhook handler is required")
+	}
+	databaseConfig, err := resolveDatabaseConfig()
+	if err != nil {
+		return true, fmt.Errorf("invalid database config: %w", err)
+	}
+	secretKey, err := resolveSecretKey()
+	if err != nil {
+		return true, fmt.Errorf("invalid SECRET_KEY: %w", err)
+	}
+	return true, handlers.runWebhook(databaseConfig, secretKey, args[1:])
 }

--- a/internal/cli/webhook.go
+++ b/internal/cli/webhook.go
@@ -318,47 +318,8 @@ func parseWebhookShowArgs(args []string) (string, error) {
 func parseWebhookSetArgs(args []string) (webhookSetOptions, error) {
 	opts := webhookSetOptions{}
 	for _, arg := range args {
-		value := strings.TrimSpace(arg)
-		switch {
-		case value == "":
-			continue
-		case value == "--url-stdin":
-			opts.readURLFromStdin = true
-		case value == "--clear-url":
-			opts.clearURL = true
-		case value == "--dry-run":
-			opts.dryRun = true
-		case strings.HasPrefix(value, "--enabled="):
-			parsed, err := parseWebhookBoolFlag(value)
-			if err != nil {
-				return webhookSetOptions{}, err
-			}
-			opts.enabled = parsed
-		case strings.HasPrefix(value, "--notify-period="):
-			parsed, err := parseWebhookBoolFlag(value)
-			if err != nil {
-				return webhookSetOptions{}, err
-			}
-			opts.notifyPeriod = parsed
-		case strings.HasPrefix(value, "--notify-ovulation="):
-			parsed, err := parseWebhookBoolFlag(value)
-			if err != nil {
-				return webhookSetOptions{}, err
-			}
-			opts.notifyOvulation = parsed
-		case strings.HasPrefix(value, "--reminder-lead-days="):
-			parsed, err := parseWebhookIntFlag(value)
-			if err != nil {
-				return webhookSetOptions{}, err
-			}
-			opts.reminderLeadDays = parsed
-		case strings.HasPrefix(value, "--"):
-			return webhookSetOptions{}, errors.New(webhookUsage)
-		default:
-			if opts.email != "" {
-				return webhookSetOptions{}, errors.New(webhookUsage)
-			}
-			opts.email = value
+		if err := applyWebhookSetArg(&opts, strings.TrimSpace(arg)); err != nil {
+			return webhookSetOptions{}, err
 		}
 	}
 
@@ -369,6 +330,54 @@ func parseWebhookSetArgs(args []string) (webhookSetOptions, error) {
 		return webhookSetOptions{}, errors.New("--clear-url and --url-stdin are mutually exclusive")
 	}
 	return opts, nil
+}
+
+// applyWebhookSetArg mutates opts for a single trimmed `webhook set` argument.
+// An empty argument is a no-op; an unknown flag, a malformed value, or a second
+// positional returns webhookUsage (or the flag parser's error).
+func applyWebhookSetArg(opts *webhookSetOptions, value string) error {
+	switch {
+	case value == "":
+		return nil
+	case value == "--url-stdin":
+		opts.readURLFromStdin = true
+	case value == "--clear-url":
+		opts.clearURL = true
+	case value == "--dry-run":
+		opts.dryRun = true
+	case strings.HasPrefix(value, "--enabled="):
+		parsed, err := parseWebhookBoolFlag(value)
+		if err != nil {
+			return err
+		}
+		opts.enabled = parsed
+	case strings.HasPrefix(value, "--notify-period="):
+		parsed, err := parseWebhookBoolFlag(value)
+		if err != nil {
+			return err
+		}
+		opts.notifyPeriod = parsed
+	case strings.HasPrefix(value, "--notify-ovulation="):
+		parsed, err := parseWebhookBoolFlag(value)
+		if err != nil {
+			return err
+		}
+		opts.notifyOvulation = parsed
+	case strings.HasPrefix(value, "--reminder-lead-days="):
+		parsed, err := parseWebhookIntFlag(value)
+		if err != nil {
+			return err
+		}
+		opts.reminderLeadDays = parsed
+	case strings.HasPrefix(value, "--"):
+		return errors.New(webhookUsage)
+	default:
+		if opts.email != "" {
+			return errors.New(webhookUsage)
+		}
+		opts.email = value
+	}
+	return nil
 }
 
 // parseWebhookBoolFlag parses a --key=<true|false> flag value into a *bool. It


### PR DESCRIPTION
## What

Decompose two pre-existing high-complexity production functions so `gocyclo -over 15` reports no production functions.

- `cmd/ovumcy/commands.go` — `tryRunCLICommandWithHandlers` split into a thin dispatcher + per-command handlers (`handleResetPasswordCommand`, `handleUsersCommand`, `handleHealthcheckCommand`, `handleNotifyCommand`, `handleWebhookCommand`). Cyclomatic **23 → 7**.
- `internal/cli/webhook.go` — `applyWebhookSetArg` extracted from `parseWebhookSetArgs` (the flag switch moves into its own function). Cyclomatic **19 → 6**; `applyWebhookSetArg` sits at 15 (not over).

## Why

Both functions predate v1.8.0 (`tryRunCLICommandWithHandlers` was in `main.go` before the #253 file split; `parseWebhookSetArgs` unchanged since v1.8.0). goreportcard already grades A+, so this does not change the grade — it clears the stricter local `gocyclo -over 15` gate used in release validation. Remaining functions over 15 are test helpers only, intentionally left as-is.

## Safety

Behaviour-preserving refactor. No change to flag semantics, `--url-stdin` / `--clear-url` mutual exclusion, stdin-only URL handling (webhook secret stays out of argv), command dispatch order, or error messages. No security invariant touched: purely structural changes in the CLI dispatcher and argument parser — privacy boundary, secrets-in-transport, sessions, and CSRF are all out of scope of this diff.

## Verification

- `go build ./...` ✅
- `gofmt -s -l` ✅ (empty)
- `go vet ./...` ✅
- `gocyclo -over 15` — both production functions now absent ✅
- `go test ./cmd/... ./internal/cli/...` ✅
- `go test ./...` ✅ (0 failures)
