### PR TITLE
chore: bump image references and release notes to v1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,76 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.0] - 2026-07-20
+
+Reworks BBT ovulation detection into a single shared "3-over-6" coverline
+detector with disturbance rejection, and lands a batch of external-audit
+remediations across cycle logic, onboarding privacy copy, import performance,
+and accessibility. No database migrations; no breaking changes.
+
+### Changed
+
+- **BBT ovulation detection unified on a "3-over-6" coverline with disturbance
+  rejection.** One detector (`detectBBTShiftFirstHighDay`) now drives all three
+  surfaces — luteal-phase inference, the calendar tentative-ovulation signal, and
+  the stats BBT chart coverline + marker — which previously disagreed. The
+  coverline is the max of the six immediately preceding *undisturbed* recorded
+  temperatures; a shift is three calendar-consecutive days strictly above it with
+  the third day ≥ coverline + 0.2 °C; ovulation is dated to the day before the
+  first elevated day. Readings on days tagged `illness` / `sleep_disruption` are
+  excluded from the detection series so a fever can neither inflate the coverline
+  nor confirm a streak (display series unchanged). The chart draws the coverline
+  only once a shift is confirmed; the accessibility summary gains a no-shift
+  sentence; all six locales adopt coverline terminology. (#255, #250)
+- **Age group is genuinely optional.** A "not specified" option replaces the
+  silent `under_40` onboarding default. (#250)
+- **Import writes days in one batch** — a single range read plus one chunked
+  `CreateBatch` instead of lookup-and-insert per day (with a 20k-unique-date load
+  test), speeding up large restores. (#250)
+
+### Fixed
+
+- **Settings section navigation stays pinned below the header while scrolling on
+  desktop** (`>=640px`); on mobile it remains a static top-of-page index. (#252)
+- **A period day with unset flow now reads "not specified" instead of "none"**,
+  which had wrongly implied "no bleeding". (#250)
+- **The calendar distinguishes projected (future / auto-filled) period days from
+  logged facts**, which were previously indistinguishable. (#250)
+- **Removed the false "we do not store identity data" onboarding claim** in all
+  six locales — email and display name are stored. (#250)
+- Accessibility: password-reveal and mobile-menu tap targets raised to 44px; the
+  prediction disclaimer given a visible accent; the onboarding quick-pick group
+  labelled. (#250)
+
+### Security
+
+- **Cloud/IMDS webhook guidance.** `docs/notifications.md` now documents that on a
+  cloud host an owner-configured webhook URL can reach the instance metadata
+  endpoint (`169.254.169.254`) when the private-address gate is off, and
+  recommends `WEBHOOK_BLOCK_PRIVATE_ADDRESSES=true` for any cloud (non-LAN)
+  deployment. The delivery envelope already discards the response body (no
+  exfiltration path); the residual risk is blind internal-network probing by a
+  co-tenant owner. Runtime behavior and defaults are unchanged.
+- **Startup warning for the exposed webhook combination** — the server logs a boot
+  warning when `REGISTRATION_MODE=open` is combined with
+  `WEBHOOK_BLOCK_PRIVATE_ADDRESSES=false`, surfacing the multi-owner /
+  publicly-reachable SSRF exposure. Defaults unchanged. (#250)
+
+### Internal
+
+- Oversized files split to cut merge/regression risk (#251, #253); the CLI command
+  dispatcher and the `webhook set` argument parser decomposed below the gocyclo-15
+  gate (#256).
+- Test hygiene: onboarding i18n date-field tests collapsed into one table-driven
+  test with Italian coverage (#257); round-3 mutation sweeps split from six theme
+  aggregates into per-source files, dropping one duplicate (#258); v1.8.x
+  mutation-hardening baseline (#246).
+- A dependency-free route↔OpenAPI contract test and a `checkStyledControl` e2e
+  helper centralizing 12 `force:true` clicks (#250); README contents / Quick-Start
+  / digest-pin guidance and `.bin/` excluded from the Docker build context (#250);
+  codecov PR-comment noise suppressed (#254); GitHub Actions and npm dev-dependency
+  bumps (#247, #248).
+
 ## [1.8.0] - 2026-07-11
 
 Adds three opt-in notification/subscription surfaces (webhook reminders, an in-process daily reminder scheduler, and a read-only calendar `.ics` feed), per-user timezone and week-start preferences, Italian localization, and an OIDC response-mode switch, alongside auth hardening. Six additive database migrations (026–031, SQLite and Postgres). The only breaking change is the `swelling` export-shape change noted under Changed.
@@ -620,7 +690,8 @@ build-hardening work. No database migrations; no breaking API changes.
   - CSV/JSON export,
   - Russian/English localization.
 
-[Unreleased]: https://github.com/ovumcy/ovumcy-web/compare/v1.8.0...HEAD
+[Unreleased]: https://github.com/ovumcy/ovumcy-web/compare/v1.9.0...HEAD
+[1.9.0]: https://github.com/ovumcy/ovumcy-web/compare/v1.8.0...v1.9.0
 [1.8.0]: https://github.com/ovumcy/ovumcy-web/compare/v1.7.0...v1.8.0
 [1.7.0]: https://github.com/ovumcy/ovumcy-web/compare/v1.6.0...v1.7.0
 [1.6.0]: https://github.com/ovumcy/ovumcy-web/compare/v1.5.0...v1.6.0

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Ovumcy is a menstrual cycle tracker you run on your own server. If the thought o
 
 Ovumcy runs as a single Go service with a server-rendered web UI, can be installed on a phone home screen, and supports SQLite by default with Postgres as an advanced self-hosted path.
 
-This README describes the current `main` branch. The latest tagged release is `v1.8.0`.
+This README describes the current `main` branch. The latest tagged release is `v1.9.0`.
 The public project site is [ovumcy.com](https://ovumcy.com).
 
 > **Just want to run it? Jump to [Quick Start](#quick-start).**
@@ -255,7 +255,7 @@ For the internal layering, trust boundaries, and request lifecycle, see [`docs/a
 
 ### Docker
 
-Uses the prebuilt image from GHCR pinned to the latest tagged release by default (`ghcr.io/ovumcy/ovumcy-web:v1.8.0`).
+Uses the prebuilt image from GHCR pinned to the latest tagged release by default (`ghcr.io/ovumcy/ovumcy-web:v1.9.0`).
 
 Tagged releases from `v0.7.1` onward publish under the GHCR namespace `ghcr.io/ovumcy/ovumcy-web`.
 
@@ -266,13 +266,13 @@ Tagged releases from `v0.7.1` onward publish under the GHCR namespace `ghcr.io/o
 cosign verify \
   --certificate-identity-regexp '^https://github.com/ovumcy/ovumcy-web/\.github/workflows/docker-image\.yml@refs/tags/v' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  ghcr.io/ovumcy/ovumcy-web:v1.8.0
+  ghcr.io/ovumcy/ovumcy-web:v1.9.0
 
 # 2. SLSA build provenance (GitHub attestation)
-gh attestation verify oci://ghcr.io/ovumcy/ovumcy-web:v1.8.0 --repo ovumcy/ovumcy-web
+gh attestation verify oci://ghcr.io/ovumcy/ovumcy-web:v1.9.0 --repo ovumcy/ovumcy-web
 
 # 3. SBOM attached at build time
-docker buildx imagetools inspect ghcr.io/ovumcy/ovumcy-web:v1.8.0 --format '{{ json .SBOM }}'
+docker buildx imagetools inspect ghcr.io/ovumcy/ovumcy-web:v1.9.0 --format '{{ json .SBOM }}'
 ```
 
 For public GHCR images, pull does not require GitHub login. `docker compose up -d` is enough because `pull_policy: always` is enabled.
@@ -288,14 +288,14 @@ docker compose up -d
 Override the pinned default image tag if needed:
 
 ```bash
-OVUMCY_IMAGE=ghcr.io/ovumcy/ovumcy-web:v1.8.0 docker compose up -d
+OVUMCY_IMAGE=ghcr.io/ovumcy/ovumcy-web:v1.9.0 docker compose up -d
 ```
 
-The `v1.8.0` tag is mutable and `pull_policy: always` re-pulls it on every restart, so a one-time Cosign/SLSA check does not by itself guarantee later restarts run the same bytes. To pin the exact image you verified above, set `OVUMCY_IMAGE` to its digest instead of the tag:
+The `v1.9.0` tag is mutable and `pull_policy: always` re-pulls it on every restart, so a one-time Cosign/SLSA check does not by itself guarantee later restarts run the same bytes. To pin the exact image you verified above, set `OVUMCY_IMAGE` to its digest instead of the tag:
 
 ```bash
 # Resolve the digest of the tag you just verified, then pin it in .env:
-docker buildx imagetools inspect ghcr.io/ovumcy/ovumcy-web:v1.8.0 --format '{{ .Manifest.Digest }}'
+docker buildx imagetools inspect ghcr.io/ovumcy/ovumcy-web:v1.9.0 --format '{{ .Manifest.Digest }}'
 # .env → OVUMCY_IMAGE=ghcr.io/ovumcy/ovumcy-web@sha256:<digest>
 ```
 
@@ -480,7 +480,7 @@ For bugs and feature requests, open a GitHub issue:
 
 ## Releases
 
-- Latest tagged release: `v1.8.0`.
+- Latest tagged release: `v1.9.0`.
 - Publish release notes via GitHub Releases and keep [CHANGELOG.md](CHANGELOG.md) updated.
 
 ## Roadmap

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   ovumcy:
-    image: ${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.8.0}
+    image: ${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.9.0}
     pull_policy: always
     container_name: ovumcy
     env_file:

--- a/docs/examples/postgres/docker-compose.yml
+++ b/docs/examples/postgres/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     restart: unless-stopped
 
   ovumcy:
-    image: ${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.8.0}
+    image: ${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.9.0}
     pull_policy: always
     depends_on:
       postgres:

--- a/docs/examples/reverse-proxy/caddy-postgres/docker-compose.yml
+++ b/docs/examples/reverse-proxy/caddy-postgres/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     restart: unless-stopped
 
   ovumcy:
-    image: ${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.8.0}
+    image: ${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.9.0}
     pull_policy: always
     depends_on:
       postgres:

--- a/docs/examples/reverse-proxy/caddy/docker-compose.yml
+++ b/docs/examples/reverse-proxy/caddy/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   ovumcy:
-    image: ${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.8.0}
+    image: ${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.9.0}
     pull_policy: always
     environment:
       TZ: ${TZ:-UTC}

--- a/docs/examples/reverse-proxy/nginx-postgres/docker-compose.yml
+++ b/docs/examples/reverse-proxy/nginx-postgres/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     restart: unless-stopped
 
   ovumcy:
-    image: ${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.8.0}
+    image: ${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.9.0}
     pull_policy: always
     depends_on:
       postgres:

--- a/docs/examples/reverse-proxy/nginx/docker-compose.yml
+++ b/docs/examples/reverse-proxy/nginx/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   ovumcy:
-    image: ${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.8.0}
+    image: ${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.9.0}
     pull_policy: always
     environment:
       TZ: ${TZ:-UTC}

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -296,6 +296,18 @@ Operator-relevant summary (the full, test-backed claim list lives in
   scheduler. The server also logs a startup warning when `REGISTRATION_MODE=open`
   is combined with `WEBHOOK_BLOCK_PRIVATE_ADDRESSES=false`, surfacing exactly this
   multi-owner / publicly-reachable exposure at boot.
+- **Cloud deployments: turn hardening on.** The default above (LAN allowed) is
+  meant for self-hosting on a home/office network. On a cloud VM
+  (AWS/GCP/Azure/etc.) the link-local range also reaches the instance **metadata
+  service** (`169.254.169.254`), which — like any other private target — an
+  owner-controlled webhook URL would let the notify pass POST to. Delivery only
+  sends a fixed JSON body and discards the (size-capped) response, so there is no
+  response-body exfiltration path; the residual risk is a semi-trusted owner using
+  status/timing differences to probe the instance's own internal network (a
+  *blind* SSRF). If you deploy Ovumcy to any cloud or otherwise non-LAN host, set
+  `WEBHOOK_BLOCK_PRIVATE_ADDRESSES=true` — the resolve-and-pin check above then
+  refuses loopback/private/link-local targets, including the metadata endpoint,
+  with DNS-rebinding protection.
 - **Host-only logging.** Every log line the delivery path emits — success,
   failure, or skip — includes at most the destination **hostname**, never the
   full URL, path, query string, or userinfo.


### PR DESCRIPTION
Release-prep artifact commit for **v1.9.0** (tag to be created on `main` after merge).

## Contents
- **CHANGELOG.md** — reconciled the empty `[Unreleased]` into `[1.9.0] - 2026-07-20` (Changed / Fixed / Security / Internal) with the `v1.8.0...v1.9.0` compare link. Covers #250, #252, #255 (user-facing) and #246/#251/#253/#254/#256/#257/#258 (internal).
- **README.md, docker-compose.yml, docs/examples/\*** — bumped default image tag and 'latest tagged release' references `v1.8.0` → `v1.9.0`.
- **docs/notifications.md** — new Security-notes bullet documenting the cloud/IMDS webhook SSRF angle and recommending `WEBHOOK_BLOCK_PRIVATE_ADDRESSES=true` for cloud (non-LAN) deployments (from the external security audit; docs-only, no runtime change).

## Verification
- `go test ./scripts/readmeversion/ ./scripts/examplecompose/` ✅ (version-consistency)
- Full backend/frontend/e2e already green on the release delta; browser smoke via Claude-Chrome green (register→onboarding→dashboard→calendar→stats→settings, 0 CSP errors).

No database migrations; no breaking changes.