### PR TITLE
chore: bump image references to v1.9.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Ovumcy is a menstrual cycle tracker you run on your own server. If the thought o
 
 Ovumcy runs as a single Go service with a server-rendered web UI, can be installed on a phone home screen, and supports SQLite by default with Postgres as an advanced self-hosted path.
 
-This README describes the current `main` branch. The latest tagged release is `v1.9.0`.
+This README describes the current `main` branch. The latest tagged release is `v1.9.1`.
 The public project site is [ovumcy.com](https://ovumcy.com).
 
 > **Just want to run it? Jump to [Quick Start](#quick-start).**
@@ -255,7 +255,7 @@ For the internal layering, trust boundaries, and request lifecycle, see [`docs/a
 
 ### Docker
 
-Uses the prebuilt image from GHCR pinned to the latest tagged release by default (`ghcr.io/ovumcy/ovumcy-web:v1.9.0`).
+Uses the prebuilt image from GHCR pinned to the latest tagged release by default (`ghcr.io/ovumcy/ovumcy-web:v1.9.1`).
 
 Tagged releases from `v0.7.1` onward publish under the GHCR namespace `ghcr.io/ovumcy/ovumcy-web`.
 
@@ -266,13 +266,13 @@ Tagged releases from `v0.7.1` onward publish under the GHCR namespace `ghcr.io/o
 cosign verify \
   --certificate-identity-regexp '^https://github.com/ovumcy/ovumcy-web/\.github/workflows/docker-image\.yml@refs/tags/v' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  ghcr.io/ovumcy/ovumcy-web:v1.9.0
+  ghcr.io/ovumcy/ovumcy-web:v1.9.1
 
 # 2. SLSA build provenance (GitHub attestation)
-gh attestation verify oci://ghcr.io/ovumcy/ovumcy-web:v1.9.0 --repo ovumcy/ovumcy-web
+gh attestation verify oci://ghcr.io/ovumcy/ovumcy-web:v1.9.1 --repo ovumcy/ovumcy-web
 
 # 3. SBOM attached at build time
-docker buildx imagetools inspect ghcr.io/ovumcy/ovumcy-web:v1.9.0 --format '{{ json .SBOM }}'
+docker buildx imagetools inspect ghcr.io/ovumcy/ovumcy-web:v1.9.1 --format '{{ json .SBOM }}'
 ```
 
 For public GHCR images, pull does not require GitHub login. `docker compose up -d` is enough because `pull_policy: always` is enabled.
@@ -288,14 +288,14 @@ docker compose up -d
 Override the pinned default image tag if needed:
 
 ```bash
-OVUMCY_IMAGE=ghcr.io/ovumcy/ovumcy-web:v1.9.0 docker compose up -d
+OVUMCY_IMAGE=ghcr.io/ovumcy/ovumcy-web:v1.9.1 docker compose up -d
 ```
 
-The `v1.9.0` tag is mutable and `pull_policy: always` re-pulls it on every restart, so a one-time Cosign/SLSA check does not by itself guarantee later restarts run the same bytes. To pin the exact image you verified above, set `OVUMCY_IMAGE` to its digest instead of the tag:
+The `v1.9.1` tag is mutable and `pull_policy: always` re-pulls it on every restart, so a one-time Cosign/SLSA check does not by itself guarantee later restarts run the same bytes. To pin the exact image you verified above, set `OVUMCY_IMAGE` to its digest instead of the tag:
 
 ```bash
 # Resolve the digest of the tag you just verified, then pin it in .env:
-docker buildx imagetools inspect ghcr.io/ovumcy/ovumcy-web:v1.9.0 --format '{{ .Manifest.Digest }}'
+docker buildx imagetools inspect ghcr.io/ovumcy/ovumcy-web:v1.9.1 --format '{{ .Manifest.Digest }}'
 # .env → OVUMCY_IMAGE=ghcr.io/ovumcy/ovumcy-web@sha256:<digest>
 ```
 
@@ -480,7 +480,7 @@ For bugs and feature requests, open a GitHub issue:
 
 ## Releases
 
-- Latest tagged release: `v1.9.0`.
+- Latest tagged release: `v1.9.1`.
 - Publish release notes via GitHub Releases and keep [CHANGELOG.md](CHANGELOG.md) updated.
 
 ## Roadmap

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   ovumcy:
-    image: ${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.9.0}
+    image: ${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.9.1}
     pull_policy: always
     container_name: ovumcy
     env_file:

--- a/docs/examples/postgres/docker-compose.yml
+++ b/docs/examples/postgres/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     restart: unless-stopped
 
   ovumcy:
-    image: ${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.9.0}
+    image: ${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.9.1}
     pull_policy: always
     depends_on:
       postgres:

--- a/docs/examples/reverse-proxy/caddy-postgres/docker-compose.yml
+++ b/docs/examples/reverse-proxy/caddy-postgres/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     restart: unless-stopped
 
   ovumcy:
-    image: ${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.9.0}
+    image: ${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.9.1}
     pull_policy: always
     depends_on:
       postgres:

--- a/docs/examples/reverse-proxy/caddy/docker-compose.yml
+++ b/docs/examples/reverse-proxy/caddy/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   ovumcy:
-    image: ${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.9.0}
+    image: ${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.9.1}
     pull_policy: always
     environment:
       TZ: ${TZ:-UTC}

--- a/docs/examples/reverse-proxy/nginx-postgres/docker-compose.yml
+++ b/docs/examples/reverse-proxy/nginx-postgres/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     restart: unless-stopped
 
   ovumcy:
-    image: ${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.9.0}
+    image: ${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.9.1}
     pull_policy: always
     depends_on:
       postgres:

--- a/docs/examples/reverse-proxy/nginx/docker-compose.yml
+++ b/docs/examples/reverse-proxy/nginx/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   ovumcy:
-    image: ${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.9.0}
+    image: ${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.9.1}
     pull_policy: always
     environment:
       TZ: ${TZ:-UTC}


### PR DESCRIPTION
## Summary

Release housekeeping for **v1.9.1** (release notes landed with #260):

- README and all six compose examples now reference `ghcr.io/ovumcy/ovumcy-web:v1.9.1`.
- `CHANGELOG.md` already carries the [1.9.1] section — follow-up remediations from the external audit: privacy/medical copy honesty, pregnancy-pause save feedback, future period entries rendered as recorded facts. No database migrations; no breaking changes.

After merge: tag `v1.9.1` on the merge commit to trigger the image build and release.