### PR TITLE
Unblock merges: the vulnerable brace-expansion pin + the Codecov CI gate

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,7 +2,24 @@
 # curl -X POST --data-binary @codecov.yml https://codecov.io/validate
 
 codecov:
-  require_ci_to_pass: true
+  # Deliberately false. When true, Codecov withholds every status until it has
+  # independently concluded that CI passed — and on 2026-07-21 it stopped
+  # deriving that signal, leaving `ci_passed` null on pull-request heads while
+  # coverage itself ingested normally.
+  #
+  # The authoritative patch gate here is the in-CI `patch-coverage` job, so a
+  # withheld Codecov status cannot freeze merges in this repository the way it
+  # did where a `codecov/*` check was required. What it does instead is worse
+  # than useless: the advisory second opinion disappears silently rather than
+  # reporting, so a coverage regression Codecov would have flagged looks the
+  # same as a clean run.
+  #
+  # Nothing is lost by dropping it: the ruleset on `main` already requires test,
+  # e2e, e2e-postgres-smoke, gosec, trivy-fs, trivy-image, patch-coverage, and
+  # all three CodeQL analyses to pass on their own. Codecov's opinion about
+  # whether CI passed duplicated a gate GitHub enforces directly, while standing
+  # in front of it as a single point of failure.
+  require_ci_to_pass: false
 
 coverage:
   status:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1320,9 +1320,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "tailwindcss": "^4.3.0"
   },
   "overrides": {
-    "brace-expansion": "5.0.6"
+    "brace-expansion": "^5.0.7"
   }
 }


### PR DESCRIPTION
Two independent unblockers, kept together because either alone leaves the
repository unable to merge cleanly. Mirrors ovumcy-app#161, which combined the
same pair for the same reason.

## 1. The brace-expansion override pinned the vulnerable version

`overrides: { "brace-expansion": "5.0.6" }` was added in 6b0d23f as the fix for
GHSA-jxxr-4gwj-5jf2 — 5.0.6 was the patched release at the time.
GHSA-3jxr-9vmj-r5cp (CVE-2026-13149, high) now covers `3.0.0 - 5.0.6`, so the
pin that closed the previous advisory is what holds the tree on the vulnerable
version today.

`trivy-fs` runs with `--severity HIGH,CRITICAL --ignore-unfixed
--include-dev-deps` and is a required check, so this fails every pull request in
the repository, not just this one. It is dev-only (eslint -> minimatch ->
brace-expansion) and never reaches the `FROM scratch` runtime image, but the
gate does not care and should not.

Raised to `^5.0.7` rather than another exact pin. The override exists to keep a
transitive above a known-vulnerable floor; an exact version guarantees a repeat
of exactly this on the next patch advisory, and reproducibility already comes
from the lockfile. `npm audit`: 0 vulnerabilities.

## 2. Codecov withholds its statuses when it cannot see CI

`require_ci_to_pass: true` tells Codecov to withhold every status until it has
independently concluded that our CI passed. On 2026-07-21 it stopped deriving
that signal: `ci_passed` came back null on pull-request heads while coverage
itself ingested normally, `state=complete`, totals present.

Where a `codecov/*` check is required, that freezes every merge. Here it cannot
— the authoritative patch gate is the in-CI `patch-coverage` job and the Codecov
statuses are `informational: true`. What happens instead is quieter: the
advisory status does not go red, it disappears. A pull request that regressed
coverage renders exactly like one that did not.

Nothing is lost by dropping it. The ruleset on `main` already requires `test`,
`e2e`, `e2e-postgres-smoke`, `gosec`, `trivy-fs`, `trivy-image`,
`patch-coverage`, and all three CodeQL analyses on their own. Codecov's opinion
about whether CI passed duplicated a gate GitHub enforces directly, while
standing in front of it as a single point of failure.

The 100% patch target, the `informational` flags, the `ignore` list, and
`comment: false` are untouched.

## Verification

- `npm audit` -> 0 vulnerabilities; lockfile resolves brace-expansion 5.0.7
- `curl -X POST --data-binary @codecov.yml https://codecov.io/validate` -> `Valid!`