### PR TITLE
ci(docker-image): grant artifact-metadata:write for attest storage record

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -18,6 +18,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
+      artifact-metadata: write
       attestations: write
       contents: read
       id-token: write


### PR DESCRIPTION
The release `docker-image` workflow logged two non-fatal warnings on every tagged release (seen on v1.9.1 and v1.9.2):

- `Please check that the "artifact-metadata:write" permission has been included`
- `Failed to create storage record: … no artifacts found`

`actions/attest-build-provenance` v4 (a wrapper over `actions/attest`) emits an **artifact metadata storage record** when `push-to-registry: true`, and its docs require `artifact-metadata: write` for it. The `publish` job already had the other four documented permissions (`id-token`, `packages`, `contents`, `attestations`) but not this one, so the record failed to persist. The attestation itself still succeeded and was pushed to the registry, so the warnings were benign — this just adds the missing permission so the storage record is created and the log is clean.

No change to the image, signing, or the attestation.

Note: this workflow runs on push to `main`/tags, **not** on PRs, so it won't execute on this PR. The permission key is the documented one from the `actions/attest` README (container-image example block).
