### PR TITLE
fix(i18n): localize the 2FA and SSO-link errors instead of showing spec keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     verifying through bcrypt; its MAC is written in during the first request that
     presents the correct token, after which it takes the fast path.
 
+### Fixed
+
+- **Two-factor and SSO-link errors are localized again.** A wrong 2FA code showed
+  every user the untranslated English string `totp invalid code`, regardless of
+  the interface language, and the OIDC link-confirmation page did the same with
+  its own error strings. The translations existed in all six locales the whole
+  time; nothing connected them to the errors the pages were reporting. Affects
+  displayed text only — no flow, status code, or rate limit changes.
+
 ## [1.9.2] - 2026-07-24
 
 Italian localization polish and a CI unblock. No database migrations; no

--- a/internal/api/auth_oidc_regressions_test.go
+++ b/internal/api/auth_oidc_regressions_test.go
@@ -824,6 +824,62 @@ func TestCompleteOIDCLinkConfirmationKeepsCookieOnWrongPassword(t *testing.T) {
 	}
 }
 
+// TestShowOIDCLinkConfirmPageRendersLocalizedFlashError closes the render half of
+// the wrong-password path above: the existing tests stop at the flash payload,
+// which carries the error SPEC key, and the page used to hand that key straight
+// to the template. Since the template translates ErrorKey and an unknown key
+// comes back unchanged, the page displayed the raw English "sso link confirmation
+// invalid password" to every language while the localized entries sat unused.
+func TestShowOIDCLinkConfirmPageRendersLocalizedFlashError(t *testing.T) {
+	t.Parallel()
+
+	app, database := newOnboardingTestAppWithOptions(t, onboardingTestAppOptions{
+		cookieSecure: true,
+		oidcService:  newStubOIDCWorkflowService(true),
+	})
+	user := createOnboardingTestUser(t, database, "link-flash-render@example.com", "StrongPass1", true)
+
+	pendingPayload, err := newOIDCLinkPendingPayload(time.Now().UTC(), user.ID, "https://idp.example", "subject-flash-render", user.Email)
+	if err != nil {
+		t.Fatalf("newOIDCLinkPendingPayload: %v", err)
+	}
+	pendingCookie := oidcLinkPendingCookieName + "=" + sealLinkPendingCookieForTest(t, pendingPayload)
+
+	postRequest := httptest.NewRequest(http.MethodPost, oidcLinkConfirmPath, strings.NewReader(url.Values{
+		"password": {"WrongPass2"},
+	}.Encode()))
+	postRequest.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	postRequest.Header.Set("Cookie", pendingCookie)
+
+	postResponse := mustAppResponse(t, app, postRequest)
+	assertStatusCode(t, postResponse, http.StatusSeeOther)
+	flashCookie := responseCookie(postResponse.Cookies(), flashCookieName)
+	if flashCookie == nil || strings.TrimSpace(flashCookie.Value) == "" {
+		t.Fatal("expected flash cookie with invalid-password error")
+	}
+
+	getRequest := httptest.NewRequest(http.MethodGet, oidcLinkConfirmPath, nil)
+	getRequest.Header.Set("Accept-Language", "en")
+	getRequest.Header.Set("Cookie", joinCookieHeader(pendingCookie, cookiePair(flashCookie)))
+
+	getResponse := mustAppResponse(t, app, getRequest)
+	assertStatusCode(t, getResponse, http.StatusOK)
+	body := mustReadBodyString(t, getResponse.Body)
+
+	specKey := authOIDCLinkConfirmInvalidPasswordErrorSpec().Key
+	localeKey := services.AuthErrorTranslationKey(specKey)
+	if localeKey == "" {
+		t.Fatalf("error spec %q has no locale mapping — the page cannot localize it", specKey)
+	}
+	errorBlock := htmlAuthErrorByKey(mustParseHTMLDocument(t, body), localeKey)
+	if errorBlock == nil {
+		t.Fatalf("expected the link-confirm page to report the error under the locale key %s after a wrong password", localeKey)
+	}
+	if message := normalizeHTMLText(htmlNodeText(errorBlock)); strings.Contains(message, specKey) {
+		t.Fatalf("link-confirm page rendered the raw error spec key as its message: %q", message)
+	}
+}
+
 func TestCompleteOIDCLinkConfirmationWithEmptyPasswordFlashesInvalidPassword(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/handlers_auth_2fa.go
+++ b/internal/api/handlers_auth_2fa.go
@@ -20,8 +20,12 @@ func (handler *Handler) ShowTOTPChallengePage(c fiber.Ctx) error {
 	flash := handler.popFlashCookie(c)
 	messages := currentMessages(c)
 	data := fiber.Map{
-		"Title":    localizedPageTitle(messages, "auth.2fa.title", "Ovumcy | Two-Factor Authentication"),
-		"ErrorKey": flash.AuthError,
+		"Title": localizedPageTitle(messages, "auth.2fa.title", "Ovumcy | Two-Factor Authentication"),
+		// The flash carries the error SPEC key ("totp invalid code"); the template
+		// translates whatever ErrorKey holds, so it has to be resolved to a locale
+		// key here — exactly as the other auth pages do. Passing the spec key
+		// straight through rendered it verbatim in every language.
+		"ErrorKey": services.AuthErrorTranslationKey(services.ResolveAuthErrorSource(flash.AuthError)),
 	}
 	return handler.render(c, "auth_2fa", data)
 }

--- a/internal/api/handlers_auth_2fa_test.go
+++ b/internal/api/handlers_auth_2fa_test.go
@@ -275,8 +275,13 @@ func TestVerifyTOTPLogin_InvalidCode_DoesNotIssueSession(t *testing.T) {
 	followResp := mustAppResponse(t, app, follow)
 	defer func() { _ = followResp.Body.Close() }()
 	rendered := mustReadBodyString(t, followResp.Body)
-	if htmlAuthErrorByKey(mustParseHTMLDocument(t, rendered), "totp invalid code") == nil {
-		t.Fatalf("expected the invalid-code error on the challenge page; a request that never reached verification carries a session-expired flash instead, with an identical status and destination")
+	// The page reports the error by its LOCALE key: the flash carries the error
+	// spec key ("totp invalid code") and the page resolves it through
+	// AuthErrorTranslationKey before rendering, so the observable hook is
+	// error.totp_invalid_code. Keyed off the spec so the two cannot drift.
+	invalidCodeKey := services.AuthErrorTranslationKey(totpInvalidCodeErrorSpec().Key)
+	if htmlAuthErrorByKey(mustParseHTMLDocument(t, rendered), invalidCodeKey) == nil {
+		t.Fatalf("expected the invalid-code error (%s) on the challenge page; a request that never reached verification carries a session-expired flash instead, with an identical status and destination", invalidCodeKey)
 	}
 }
 
@@ -367,6 +372,72 @@ func TestVerifyTOTPLogin_ReplayCode_Rejected(t *testing.T) {
 
 	if c := responseCookie(resp2.Cookies(), authCookieName); c != nil && c.Value != "" {
 		t.Error("replayed code must not issue a new auth cookie — replay protection failed")
+	}
+}
+
+// TestVerifyTOTPLogin_InvalidCodeRendersLocalizedErrorNotTheSpecKey walks the
+// real browser path of a wrong 2FA code — form POST, flash cookie, redirect back
+// to the challenge page — and pins that the page renders a LOCALIZED message.
+//
+// The challenge page used to pass the flash value (the error spec key) straight
+// into ErrorKey, and the template translates whatever ErrorKey holds; an unknown
+// key comes back unchanged from translateMessage, so every user in every language
+// was shown the literal string "totp invalid code". Nothing failed: the four
+// error.totp_* locale entries existed all along, unreferenced.
+func TestVerifyTOTPLogin_InvalidCodeRendersLocalizedErrorNotTheSpecKey(t *testing.T) {
+	app, database := newOnboardingTestAppWithCSRF(t)
+	user := createOnboardingTestUser(t, database, "totp-i18n@example.com", "StrongPass1", true)
+	secretKey := []byte("test-secret-key")
+	setupTOTPForUser(t, database, user.ID, secretKey)
+	csrfToken, csrfCookieHeader := extractCSRFCookieAndToken(t, app)
+
+	pending := sealTOTPPendingCookieForTest(t, secretKey, user.ID, false)
+	challengeResponse := doTOTPChallengeRequest(t, app, joinCookieHeader(pending, csrfCookieHeader), "000000", csrfToken)
+	flashCookie := responseCookie(challengeResponse.Cookies(), flashCookieName)
+	status := challengeResponse.StatusCode
+	_ = challengeResponse.Body.Close()
+
+	if status != http.StatusSeeOther {
+		t.Fatalf("wrong code status = %d, want 303 (flash redirect back to the challenge page)", status)
+	}
+	if flashCookie == nil || flashCookie.Value == "" {
+		t.Fatal("expected the wrong code to set a flash cookie — the rest of this test has no premise without it")
+	}
+
+	specKey := totpInvalidCodeErrorSpec().Key
+	localeKey := services.AuthErrorTranslationKey(specKey)
+	if localeKey == "" {
+		t.Fatalf("error spec %q has no locale mapping — the page cannot localize it", specKey)
+	}
+
+	rendered := map[string]string{}
+	for _, language := range []string{"en", "ru"} {
+		request := httptest.NewRequest(http.MethodGet, "/auth/2fa", nil)
+		request.Header.Set("Accept-Language", language)
+		request.Header.Set("Cookie", joinCookieHeader(pending, cookiePair(flashCookie)))
+
+		response := mustAppResponse(t, app, request)
+		body := mustReadBodyString(t, response.Body)
+		_ = response.Body.Close()
+
+		errorBlock := htmlAuthErrorByKey(mustParseHTMLDocument(t, body), localeKey)
+		if errorBlock == nil {
+			t.Fatalf("expected the challenge page (%s) to report the error under the locale key %s after a wrong code", language, localeKey)
+		}
+		message := normalizeHTMLText(htmlNodeText(errorBlock))
+		if strings.Contains(message, specKey) {
+			t.Fatalf("challenge page (%s) rendered the raw error spec key as its message: %q", language, message)
+		}
+		if message == "" {
+			t.Fatalf("challenge page (%s) rendered an empty error message", language)
+		}
+		rendered[language] = message
+	}
+
+	// Two languages resolving to the same string would mean the lookup is not
+	// reaching the locale files at all — the failure mode this test exists for.
+	if rendered["en"] == rendered["ru"] {
+		t.Fatalf("expected per-language messages, got the same string for en and ru: %q", rendered["en"])
 	}
 }
 

--- a/internal/api/handlers_auth_oidc_link_confirm.go
+++ b/internal/api/handlers_auth_oidc_link_confirm.go
@@ -84,8 +84,11 @@ func (handler *Handler) ShowOIDCLinkConfirmPage(c fiber.Ctx) error {
 	flash := handler.popFlashCookie(c)
 	messages := currentMessages(c)
 	data := fiber.Map{
-		"Title":        localizedPageTitle(messages, "auth.oidc.link_confirm.title", "Ovumcy | Confirm OIDC link"),
-		"ErrorKey":     flash.AuthError,
+		"Title": localizedPageTitle(messages, "auth.oidc.link_confirm.title", "Ovumcy | Confirm OIDC link"),
+		// Same resolution the other auth pages perform: the flash holds the error
+		// spec key, the template translates ErrorKey, so the spec key has to become
+		// a locale key here or the page renders it verbatim.
+		"ErrorKey":     services.AuthErrorTranslationKey(services.ResolveAuthErrorSource(flash.AuthError)),
 		"TargetEmail":  payload.Email,
 		"TOTPRequired": totpRequired,
 	}

--- a/internal/services/i18n_policy.go
+++ b/internal/services/i18n_policy.go
@@ -6,18 +6,28 @@ import (
 )
 
 var authErrorTranslationKeys = map[string]string{
-	"invalid input":                                   "auth.error.invalid_input",
-	"consent required":                                "auth.error.consent_required",
-	"registration disabled":                           "auth.error.registration_disabled",
-	"invalid credentials":                             "auth.error.invalid_credentials",
-	"too many requests":                               "common.error.too_many_requests",
-	"common.error.too_many_requests":                  "common.error.too_many_requests",
-	"email already exists":                            "auth.error.email_exists",
-	"register pickup unavailable":                     "auth.error.post_register_signin",
-	"weak password":                                   "auth.error.weak_password",
-	"password mismatch":                               "auth.error.password_mismatch",
-	"invalid recovery code":                           "auth.error.invalid_recovery_code",
-	"too many recovery attempts":                      "auth.error.too_many_recovery_attempts",
+	"invalid input":                  "auth.error.invalid_input",
+	"consent required":               "auth.error.consent_required",
+	"registration disabled":          "auth.error.registration_disabled",
+	"invalid credentials":            "auth.error.invalid_credentials",
+	"too many requests":              "common.error.too_many_requests",
+	"common.error.too_many_requests": "common.error.too_many_requests",
+	"email already exists":           "auth.error.email_exists",
+	"register pickup unavailable":    "auth.error.post_register_signin",
+	"weak password":                  "auth.error.weak_password",
+	"password mismatch":              "auth.error.password_mismatch",
+	"invalid recovery code":          "auth.error.invalid_recovery_code",
+	"too many recovery attempts":     "auth.error.too_many_recovery_attempts",
+	// The 2FA challenge's locale entries live under the flat error.totp_* namespace
+	// (present in all six locales), unlike the auth.error.* keys around them. Kept
+	// under their own names rather than renamed: the translations are correct and
+	// the defect was that nothing mapped the spec keys onto them, so a wrong 2FA
+	// code rendered the raw English "totp invalid code" in every language.
+	"totp invalid code":      "error.totp_invalid_code",
+	"totp session expired":   "error.totp_session_expired",
+	"totp internal error":    "error.totp_internal_error",
+	"totp too many attempts": "error.totp_too_many_attempts",
+
 	"sso temporarily unavailable":                     "auth.error.sso_temporarily_unavailable",
 	"sso authentication failed":                       "auth.error.sso_authentication_failed",
 	"sso sign-in unavailable":                         "auth.error.sso_sign_in_unavailable",

--- a/internal/services/i18n_policy_test.go
+++ b/internal/services/i18n_policy_test.go
@@ -1,6 +1,59 @@
 package services
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/ovumcy/ovumcy-web/internal/i18n"
+)
+
+// TestAuthErrorTranslationKeyCoversTOTPChallenge pins the four 2FA error specs
+// onto their locale entries. They were absent from the map while the entries had
+// existed in all six locales from the start, and translateMessage answers an
+// unknown key with the key itself — so a wrong 2FA code showed every user, in
+// every language, the literal English spec key "totp invalid code".
+func TestAuthErrorTranslationKeyCoversTOTPChallenge(t *testing.T) {
+	expected := map[string]string{
+		"totp invalid code":      "error.totp_invalid_code",
+		"totp session expired":   "error.totp_session_expired",
+		"totp internal error":    "error.totp_internal_error",
+		"totp too many attempts": "error.totp_too_many_attempts",
+	}
+	for source, want := range expected {
+		if got := AuthErrorTranslationKey(source); got != want {
+			t.Fatalf("AuthErrorTranslationKey(%q) = %q, want %q", source, got, want)
+		}
+	}
+}
+
+// TestAuthErrorTranslationKeysResolveInEveryLocale is the guard for the defect
+// CLASS, not just the four entries above: a mapping is only worth anything if the
+// key it points at actually exists in the locale files. A typo, a renamed locale
+// entry, or a new mapping invented without its translations all degrade silently
+// to the raw key on screen, which is precisely how the TOTP gap survived.
+//
+// internal/i18n is imported by this TEST only — the services layer itself keeps
+// no dependency on it, and i18n depends on nothing inside the repo, so there is
+// no cycle and no production coupling.
+func TestAuthErrorTranslationKeysResolveInEveryLocale(t *testing.T) {
+	manager, err := i18n.NewManager("en")
+	if err != nil {
+		t.Fatalf("init i18n manager: %v", err)
+	}
+
+	languages := manager.SupportedLanguages()
+	if len(languages) == 0 {
+		t.Fatal("expected the i18n manager to report supported languages")
+	}
+
+	for _, language := range languages {
+		messages := manager.Messages(language)
+		for source, key := range authErrorTranslationKeys {
+			if value, ok := messages[key]; !ok || value == "" {
+				t.Errorf("locale %q has no entry for %q (mapped from error spec %q): the message would render as the raw key", language, key, source)
+			}
+		}
+	}
+}
 
 func TestAuthErrorTranslationKey(t *testing.T) {
 	if got := AuthErrorTranslationKey("  TOO MANY LOGIN ATTEMPTS "); got != "auth.error.too_many_login_attempts" {


### PR DESCRIPTION
## The bug

Enter a wrong 2FA code and the challenge page shows the literal English string `totp invalid code` — in Russian, German, Spanish, French and Italian too. The four `error.totp_*` locale entries have existed in all six locale files from the start; nothing referenced them.

Two independent gaps produced it, and both are fixed here.

**1. The mapping was missing.** `authErrorTranslationKeys` (`internal/services/i18n_policy.go`) had no entry for any of the four TOTP specs (`error_mapping_auth.go:22-39`). `translateMessage` answers an unknown key with the key itself, so `apiError` and `respondSettingsError` fell through to the raw spec key on the HTMX and JSON paths.

**2. Two pages bypassed the mapping entirely.** `ShowTOTPChallengePage` and `ShowOIDCLinkConfirmPage` passed the flash value — the error *spec* key — straight into `ErrorKey`, and the template renders `{{t .Messages .ErrorKey}}`. The four other auth page builders resolve through `AuthErrorTranslationKey` first; these two did not, so on the full-page path even a correctly mapped key rendered verbatim.

That second gap also silently disabled the `sso link confirmation *` messages, which *were* already in the map — the link-confirm page showed `sso link confirmation invalid password` as its error text.

The 2FA form is a plain `method="post"` form, so the full-page path is the one users actually hit.

## The fix

- four entries in `authErrorTranslationKeys`, pointing at the existing locale keys (kept under their outlier flat `error.totp_*` names rather than renamed — the translations are correct, only the wiring was missing);
- both page builders now resolve the flash through `services.AuthErrorTranslationKey`, matching the other four auth pages.

## Coverage

| Test | Guards |
| --- | --- |
| `TestAuthErrorTranslationKeyCoversTOTPChallenge` | the four mappings |
| `TestAuthErrorTranslationKeysResolveInEveryLocale` | **the defect class** — every mapped locale key must exist in every locale |
| `TestVerifyTOTPLogin_InvalidCodeRendersLocalizedErrorNotTheSpecKey` | the real browser path: POST wrong code → flash → GET the page; asserts the locale key, absence of the raw spec key, and that `en` and `ru` differ |
| `TestShowOIDCLinkConfirmPageRendersLocalizedFlashError` | the same for link-confirm, whose existing tests stop at the flash payload and never render the page |

The class-level sweep is the one worth keeping: a typo, a renamed locale entry, or a new mapping invented without translations all degrade to the raw key on screen with nothing failing. It passes on the other ~60 mappings, so no further entry is broken.

No copy is asserted anywhere — the tests pin `data-error-key` and compare rendered text across two languages.

## Mutants killed

- restore `"ErrorKey": flash.AuthError` in `handlers_auth_2fa.go` → the 2FA render test fails (`error key = "totp invalid code"`);
- restore it in `handlers_auth_oidc_link_confirm.go` → the link-confirm test fails;
- typo one map value → the sweep fails in all six locales.

## Scope

Displayed text only. No flow, status code, or rate-limit change. `CHANGELOG.md` gets a `### Fixed` entry under Unreleased.

`go test ./...` — full suite green.