### PR TITLE
chore: ignore rapid's per-failure reproduction files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,11 @@ coverage
 coverage.*
 *.coverprofile
 profile.cov
+# rapid writes a reproduction failfile per failing property test under the
+# package's testdata/rapid/<TestName>/. Only that subdirectory — the rest of
+# testdata/ is tracked fixtures (the shared cycle-prediction golden vectors).
+# Needs the leading **/ to match below the repo root.
+**/testdata/rapid/
 
 # Dependency directories (remove the comment below to include it)
 # vendor/


### PR DESCRIPTION
## Why

`pgregory.net/rapid` writes a reproduction failfile for every failing property test — `internal/services/testdata/rapid/<TestName>/<TestName>-<timestamp>-<pid>.fail` — and nothing in `.gitignore` covered it. The artifact appears as untracked, so triaging a property-test failure and then running `git add -A` commits it.

Hit it in practice while injecting mutants against the cycle-pipeline property tests: the run left a stray failfile behind that had to be removed by hand before committing.

## Scope

Only the `rapid/` subdirectory is ignored. The rest of `testdata/` is tracked fixtures — including `cycle-prediction-golden-vectors.json`, which must stay byte-identical with ovumcy-app's copy.

The leading `**/` matters and is not decoration: a gitignore pattern with an interior separator is anchored to its own directory, so a bare `testdata/rapid/` would match only at the repo root and miss every package that actually runs rapid.

## Verified

```
git check-ignore -v internal/services/testdata/rapid/TestProbe/probe.fail
  .gitignore:24:**/testdata/rapid/   internal/services/testdata/rapid/TestProbe/probe.fail

git check-ignore -v internal/services/testdata/cycle-prediction-golden-vectors.json
  (no match — still tracked)
```