### PR TITLE
test: give negative assertions a positive anchor in the same test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,11 @@ coverage
 coverage.*
 *.coverprofile
 profile.cov
+# rapid writes a reproduction failfile per failing property test under the
+# package's testdata/rapid/<TestName>/. Only that subdirectory — the rest of
+# testdata/ is tracked fixtures (the shared cycle-prediction golden vectors).
+# Needs the leading **/ to match below the repo root.
+**/testdata/rapid/
 
 # Dependency directories (remove the comment below to include it)
 # vendor/

--- a/internal/api/handlers_days_autofill_regressions_test.go
+++ b/internal/api/handlers_days_autofill_regressions_test.go
@@ -83,6 +83,18 @@ func TestUpsertDayAutoFillCanBeDisabled(t *testing.T) {
 	}
 }
 
+// TestUpsertDayAutoFillDoesNotCreateFutureDays pins that auto-fill stops at
+// today: a period logged with room left in the period length fills the days up to
+// today and creates nothing beyond it.
+//
+// The anchor day is YESTERDAY on purpose. Anchoring on today leaves every
+// candidate day in the future, so the only assertion left is "tomorrow was not
+// created" — which is equally satisfied by an auto-fill that does nothing at all.
+// Verified: with `AutoFillFollowingPeriodDays` short-circuited to return
+// immediately, the today-anchored version of this test stayed green while three
+// sibling auto-fill tests failed. Anchoring a day earlier puts one candidate at or
+// before today and one after it, so the test now proves the guard is a DATE
+// boundary rather than a global off switch.
 func TestUpsertDayAutoFillDoesNotCreateFutureDays(t *testing.T) {
 	app, database := newOnboardingTestApp(t)
 	user := createOnboardingTestUser(t, database, "upsert-day-autofill-future-guard@example.com", "StrongPass1", true)
@@ -95,13 +107,13 @@ func TestUpsertDayAutoFillDoesNotCreateFutureDays(t *testing.T) {
 
 	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
 	today := services.DateAtLocation(time.Now().In(time.UTC), time.UTC)
-	todayRaw := today.Format("2006-01-02")
+	anchor := today.AddDate(0, 0, -1)
 
 	form := url.Values{
 		"is_period": {"true"},
 		"flow":      {models.FlowLight},
 	}
-	request := httptest.NewRequest(http.MethodPut, "/api/v1/days/"+todayRaw, strings.NewReader(form.Encode()))
+	request := httptest.NewRequest(http.MethodPut, "/api/v1/days/"+anchor.Format("2006-01-02"), strings.NewReader(form.Encode()))
 	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	request.Header.Set("HX-Request", "true")
 	request.Header.Set("Accept-Language", "en")
@@ -110,13 +122,26 @@ func TestUpsertDayAutoFillDoesNotCreateFutureDays(t *testing.T) {
 	response := mustAppResponse(t, app, request)
 	assertStatusCode(t, response, http.StatusOK)
 
-	tomorrow := today.AddDate(0, 0, 1)
-	entry, err := fetchLogByDateForTest(database, user.ID, tomorrow, time.UTC)
+	// Positive anchor: with period_length 4 the anchor's run covers anchor+1
+	// (today), which is not in the future and must be filled.
+	todayEntry, err := fetchLogByDateForTest(database, user.ID, today, time.UTC)
 	if err != nil {
-		t.Fatalf("load tomorrow entry after autofill attempt: %v", err)
+		t.Fatalf("load today entry after autofill: %v", err)
 	}
-	if entry.ID != 0 {
-		t.Fatalf("did not expect autofill to create future entry for %s", tomorrow.Format("2006-01-02"))
+	if todayEntry.ID == 0 || !todayEntry.IsPeriod {
+		t.Fatalf("anchor failed: expected autofill to mark today (%s) as a period day, so the future-day assertion below proves the date boundary rather than a dead autofill", today.Format("2006-01-02"))
+	}
+
+	// Subject: anchor+2 and anchor+3 are still in the future and must not exist.
+	for offset := 2; offset < 4; offset++ {
+		futureDay := anchor.AddDate(0, 0, offset)
+		entry, err := fetchLogByDateForTest(database, user.ID, futureDay, time.UTC)
+		if err != nil {
+			t.Fatalf("load %s after autofill attempt: %v", futureDay.Format("2006-01-02"), err)
+		}
+		if entry.ID != 0 {
+			t.Fatalf("did not expect autofill to create future entry for %s", futureDay.Format("2006-01-02"))
+		}
 	}
 }
 

--- a/internal/api/settings_notifications_regression_test.go
+++ b/internal/api/settings_notifications_regression_test.go
@@ -6,6 +6,8 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+
+	"golang.org/x/net/html"
 )
 
 func TestSettingsFlashErrorTakesPrecedenceOverQueryError(t *testing.T) {
@@ -46,27 +48,11 @@ func TestSettingsFlashErrorTakesPrecedenceOverQueryError(t *testing.T) {
 	}
 }
 
-func TestSettingsStatusIgnoresQueryWhenFlashMissing(t *testing.T) {
-	ctx := newSettingsSecurityTestContext(t, "settings-notify-status@example.com")
-
-	request := httptest.NewRequest(http.MethodGet, "/settings?status=password_changed", nil)
-	request.Header.Set("Accept-Language", "en")
-	request.Header.Set("Cookie", ctx.authCookie)
-
-	response, err := ctx.app.Test(request, testConfigNoTimeout)
-	if err != nil {
-		t.Fatalf("settings request failed: %v", err)
-	}
-	defer func() { _ = response.Body.Close() }()
-
-	document := mustParseHTMLDocument(t, mustReadBodyString(t, response.Body))
-	if htmlFlashByKey(document, "settings.success.password_changed") != nil {
-		t.Fatal("expected query status to be ignored without flash state")
-	}
-}
-
-func TestSettingsFlashSuccessTakesPrecedenceOverQueryStatus(t *testing.T) {
-	ctx := newSettingsSecurityTestContext(t, "settings-notify-success@example.com")
+// settingsSuccessFlashCookie performs a real settings mutation (a profile rename)
+// and returns the sealed flash cookie it sets, so a test can render the settings
+// page in a state where a success flash genuinely exists.
+func settingsSuccessFlashCookie(t *testing.T, ctx settingsSecurityTestContext) string {
+	t.Helper()
 
 	form := url.Values{"display_name": {"Maya"}}
 	form.Set("csrf_token", ctx.csrfToken)
@@ -83,22 +69,67 @@ func TestSettingsFlashSuccessTakesPrecedenceOverQueryStatus(t *testing.T) {
 	if response.StatusCode != http.StatusSeeOther {
 		t.Fatalf("expected status 303, got %d", response.StatusCode)
 	}
-
 	flashValue := responseCookieValue(response.Cookies(), flashCookieName)
 	if flashValue == "" {
 		t.Fatalf("expected flash cookie for settings success")
 	}
+	return flashValue
+}
 
-	followRequest := httptest.NewRequest(http.MethodGet, "/settings?status=password_changed", nil)
-	followRequest.Header.Set("Accept-Language", "en")
-	followRequest.Header.Set("Cookie", ctx.authCookie+"; "+flashCookieName+"="+flashValue)
-	followResponse, err := ctx.app.Test(followRequest, testConfigNoTimeout)
+// settingsPageDocument renders /settings with the given query string and cookie
+// header and returns the parsed document, asserting the page actually rendered
+// (a redirect to /login would otherwise satisfy any "element absent" assertion).
+func settingsPageDocument(t *testing.T, ctx settingsSecurityTestContext, query string, cookieHeader string) *html.Node {
+	t.Helper()
+
+	request := httptest.NewRequest(http.MethodGet, "/settings"+query, nil)
+	request.Header.Set("Accept-Language", "en")
+	request.Header.Set("Cookie", cookieHeader)
+
+	response, err := ctx.app.Test(request, testConfigNoTimeout)
 	if err != nil {
 		t.Fatalf("settings request failed: %v", err)
 	}
-	defer func() { _ = followResponse.Body.Close() }()
+	defer func() { _ = response.Body.Close() }()
 
-	document := mustParseHTMLDocument(t, mustReadBodyString(t, followResponse.Body))
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("expected the settings page to render with 200, got %d", response.StatusCode)
+	}
+	return mustParseHTMLDocument(t, mustReadBodyString(t, response.Body))
+}
+
+// TestSettingsStatusIgnoresQueryWhenFlashMissing pins that ?status= is never a
+// flash source: without flash state the page shows no success banner.
+//
+// The claim is a NEGATIVE one, so it needs a positive anchor in the same test or
+// it is satisfied by a settings page that renders no flash at all. Verified that
+// this is not hypothetical: breaking the success-flash `data-flash-key` hook in
+// settings.html leaves the assertion below green while the sibling precedence
+// test fails. The anchor renders the same URL through the same helper with a real
+// flash cookie first, so a page or hook that can no longer surface a flash fails
+// here rather than passing quietly.
+func TestSettingsStatusIgnoresQueryWhenFlashMissing(t *testing.T) {
+	ctx := newSettingsSecurityTestContext(t, "settings-notify-status@example.com")
+
+	anchored := settingsPageDocument(t, ctx, "?status=password_changed",
+		joinCookieHeader(ctx.authCookie, flashCookieName+"="+settingsSuccessFlashCookie(t, ctx)))
+	if htmlFlashByKey(anchored, "settings.success.profile_updated") == nil {
+		t.Fatal("anchor failed: the settings page does not surface a success flash that genuinely exists, so the negative assertion below would prove nothing")
+	}
+
+	document := settingsPageDocument(t, ctx, "?status=password_changed", ctx.authCookie)
+	if htmlFlashByKey(document, "settings.success.password_changed") != nil {
+		t.Fatal("expected query status to be ignored without flash state")
+	}
+}
+
+func TestSettingsFlashSuccessTakesPrecedenceOverQueryStatus(t *testing.T) {
+	ctx := newSettingsSecurityTestContext(t, "settings-notify-success@example.com")
+
+	flashValue := settingsSuccessFlashCookie(t, ctx)
+
+	document := settingsPageDocument(t, ctx, "?status=password_changed",
+		joinCookieHeader(ctx.authCookie, flashCookieName+"="+flashValue))
 	if htmlFlashByKey(document, "settings.success.profile_updated") == nil {
 		t.Fatal("expected flash success keyed to settings.success.profile_updated")
 	}

--- a/internal/services/day_service_coverage_test.go
+++ b/internal/services/day_service_coverage_test.go
@@ -26,6 +26,10 @@ type dayserviceCovUserStub struct {
 	loadErr   error
 	updateErr error
 
+	// updateCalls counts UpdateByID calls so a test can assert a guard wrote
+	// nothing, rather than only that it did not panic.
+	updateCalls int
+
 	// AcknowledgePeriodTip persistence capture.
 	shownPeriodTipPersisted bool
 	shownPeriodTipValue     bool
@@ -39,6 +43,7 @@ func (s *dayserviceCovUserStub) LoadSettingsByID(context.Context, uint) (models.
 }
 
 func (s *dayserviceCovUserStub) UpdateByID(ctx context.Context, _ uint, updates map[string]any) error {
+	s.updateCalls++
 	if s.updateErr != nil {
 		return s.updateErr
 	}
@@ -550,40 +555,53 @@ func TestDayService_ClearCompetingCycleStarts_ClearsIsUncertain(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Line 667 — refreshDerivedCycleSettings: nil guard (side-effect function)
+// refreshDerivedCycleSettings: nil guard (side-effect function)
 //
 // The nil guard (service == nil || service.users == nil || service.logs == nil)
-// protects against panics. A mutant removing it would cause a nil-dereference.
-// We can test the observable behavior: calling the function on a service with
-// nil users must not panic and must not attempt any DB write.
+// protects against a nil dereference, so surviving the call at all already kills
+// the mutant that removes it. That is not the whole claim: the two tests below
+// assert the guard is also a NO-OP — no log read, no settings write — because
+// "did not panic" is equally true of a guard that fell through and did the work
+// against a live dependency.
 //
-// We cannot easily create service == nil (method on nil pointer would require
-// a pointer receiver trick that's implementation-dependent). Instead test the
-// users==nil and logs==nil branches by constructing a service with those fields.
+// service == nil is not constructed here: reaching it needs a typed-nil receiver
+// call, which is an implementation detail of the call sites rather than a state a
+// caller can produce. The users==nil and logs==nil branches are built directly.
 // ---------------------------------------------------------------------------
 
-// TestDayService_RefreshDerivedCycleSettings_NilUsersNoOp verifies that
-// refreshDerivedCycleSettings is a no-op when service.users is nil, and does
-// not panic.
+// TestDayService_RefreshDerivedCycleSettings_NilUsersNoOp verifies the nil-users
+// guard returns BEFORE touching the log repository — the "no-op" its name claims,
+// not merely the absence of a panic. Surviving the call proves the guard exists
+// (removing it nil-derefs); the listCalls assertion proves the guard is the reason
+// nothing happened.
 func TestDayService_RefreshDerivedCycleSettings_NilUsersNoOp(t *testing.T) {
-	// Build a service with nil users to trigger the nil-guard early return.
+	logs := newDayLogRepositoryStub()
 	service := &DayService{
-		logs:  newDayLogRepositoryStub(),
+		logs:  logs,
 		users: nil,
 	}
-	// Must not panic.
+
 	service.refreshDerivedCycleSettings(context.Background(), 10, time.UTC)
+
+	if logs.listCalls != 0 {
+		t.Fatalf("expected the nil-users guard to return before reading logs, got %d ListByUser call(s)", logs.listCalls)
+	}
 }
 
-// TestDayService_RefreshDerivedCycleSettings_NilLogsNoOp verifies that
-// refreshDerivedCycleSettings is a no-op when service.logs is nil, and does
-// not panic.
+// TestDayService_RefreshDerivedCycleSettings_NilLogsNoOp is the same for the
+// nil-logs guard: no settings write may be attempted.
 func TestDayService_RefreshDerivedCycleSettings_NilLogsNoOp(t *testing.T) {
+	users := &dayserviceCovUserStub{}
 	service := &DayService{
 		logs:  nil,
-		users: &dayserviceCovUserStub{},
+		users: users,
 	}
+
 	service.refreshDerivedCycleSettings(context.Background(), 10, time.UTC)
+
+	if users.updateCalls != 0 {
+		t.Fatalf("expected the nil-logs guard to write nothing, got %d UpdateByID call(s)", users.updateCalls)
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -600,20 +618,30 @@ func TestDayService_RefreshDerivedCycleSettings_NilLogsNoOp(t *testing.T) {
 // NilXNoOp tests above. The happy path is smoke-tested below.
 // ---------------------------------------------------------------------------
 
-// TestDayService_RefreshDerivedCycleSettings_EmptyLogSetNoPanic is a happy-path
-// smoke test: with a valid users/logs pair and no stored logs,
-// refreshDerivedCycleSettings must run to completion without panicking. The
-// list-error branch is not injectable through dayLogRepositoryStub (no
-// ListByUser error hook), and the nil-guard early returns are covered by the
-// two NilXNoOp tests above.
-func TestDayService_RefreshDerivedCycleSettings_EmptyLogSetNoPanic(t *testing.T) {
+// TestDayService_RefreshDerivedCycleSettings_EmptyLogSetPersistsDefaultLutealPhase
+// drives the happy path with no stored logs, where the luteal inference cannot
+// conclude anything: the refresh must still persist the DEFAULT luteal phase.
+//
+// This replaces a version whose only assertion was "did not panic" — which held
+// equally for a refresh that read the logs and then wrote nothing at all. The
+// list-error branch remains uninjectable through dayLogRepositoryStub (no
+// ListByUser error hook); the nil-guard early returns are covered above.
+func TestDayService_RefreshDerivedCycleSettings_EmptyLogSetPersistsDefaultLutealPhase(t *testing.T) {
 	logs := newDayLogRepositoryStub()
 	users := &dayserviceCovUserStub{settings: models.User{PeriodLength: 5}}
 	service := dayserviceCovNewService(logs, users)
 
-	// Empty log set: exercises the normal control flow to completion.
 	service.refreshDerivedCycleSettings(context.Background(), 10, time.UTC)
-	// Reaching here without a panic is the assertion.
+
+	if logs.listCalls != 1 {
+		t.Fatalf("expected the refresh to read the log set exactly once, got %d call(s)", logs.listCalls)
+	}
+	if users.updateCalls != 1 {
+		t.Fatalf("expected the refresh to persist exactly one settings update, got %d", users.updateCalls)
+	}
+	if users.settings.LutealPhase != defaultLutealPhaseDays {
+		t.Fatalf("expected the default luteal phase %d to be persisted when inference has no data, got %d", defaultLutealPhaseDays, users.settings.LutealPhase)
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/services/day_service_workflow_test.go
+++ b/internal/services/day_service_workflow_test.go
@@ -22,6 +22,9 @@ type dayLogRepositoryStub struct {
 	// a later flag write on the same calendar day.
 	saveErrFromCall map[string]int
 	saveCalls       map[string]int
+	// listCalls counts ListByUser calls so a test can assert a guard returned
+	// before reading anything, rather than only that it did not panic.
+	listCalls int
 }
 
 func newDayLogRepositoryStub() *dayLogRepositoryStub {
@@ -41,6 +44,7 @@ func (stub *dayLogRepositoryStub) dayKey(value time.Time) string {
 }
 
 func (stub *dayLogRepositoryStub) ListByUser(ctx context.Context, userID uint) ([]models.DailyLog, error) {
+	stub.listCalls++
 	logs := make([]models.DailyLog, 0)
 	for _, entry := range stub.entries {
 		if entry.UserID == userID {

--- a/internal/services/import_service_coverage_test.go
+++ b/internal/services/import_service_coverage_test.go
@@ -135,9 +135,22 @@ func TestImportServiceEmptySymptomNamesIgnored(t *testing.T) {
 }
 
 // TestImportServiceRefreshNilGuards: the defensive nil guards make the
-// best-effort refresh a no-op on a zero-value service (no panic).
+// best-effort refresh a no-op on a zero-value service.
+//
+// Surviving the zero-value call is a real assertion, not a vacuous one — dropping
+// the users/logs checks from the guard nil-derefs here (verified). The second case
+// adds what the zero-value one cannot observe: with a live users repository and
+// nil logs, the guard must also write NOTHING, so a fall-through cannot hide
+// behind "it did not panic".
 func TestImportServiceRefreshNilGuards(t *testing.T) {
 	(&ImportService{}).refreshDerivedCycleSettings(context.Background(), 1, time.UTC)
+
+	users := &importRecordingUsers{}
+	NewImportService(nil, users, &importStubReconciler{}, nil).
+		refreshDerivedCycleSettings(context.Background(), 1, time.UTC)
+	if len(users.updates) != 0 {
+		t.Fatalf("expected the nil-logs guard to write nothing, got %d update(s)", len(users.updates))
+	}
 }
 
 // importRecordingUsers records every UpdateByID call so a test can assert the


### PR DESCRIPTION
Closes the auditor's findings #5 (MEDIUM) and #6 (LOW). **Every citation was verified by injection before anything was touched** — the handoff flagged that one such accusation had already proved inaccurate, and one of these five did too.

## settings — finding #5, real

`TestSettingsStatusIgnoresQueryWhenFlashMissing` asserted only that `?status=password_changed` produced no success banner.

**Proof it was vacuous:** renaming the success-flash `data-flash-key` hook in `settings.html` — so no success flash can render at all — left it **green** while the sibling precedence test failed. It could not distinguish "the query source is correctly ignored" from "this page never shows a flash".

**Fix:** the test now renders the same URL through the same helper with a *real* flash cookie first and asserts the flash IS found, then checks the query-only case. It fails on that mutant with `anchor failed: the settings page does not surface a success flash that genuinely exists`. The real-flash setup and the page fetch moved into `settingsSuccessFlashCookie` / `settingsPageDocument`, which the sibling test reuses (net removal of duplicated round-trip code); `settingsPageDocument` also asserts a 200, so a redirect to `/login` can no longer satisfy an "element absent" claim.

## autofill — finding #6, real

`TestUpsertDayAutoFillDoesNotCreateFutureDays` anchored the period on **today**, so with `period_length=4` every candidate fill day was in the future and the only assertion was "tomorrow was not created".

**Proof:** short-circuiting `AutoFillFollowingPeriodDays` to return immediately kept it **green** while three sibling autofill tests failed.

**Fix:** anchor a day earlier. One candidate now lands on today (must be filled — the positive anchor) and two beyond it (must not exist — the subject), so the test proves a *date* boundary rather than a global off switch. Verified it now dies on **both** mutants: dead autofill fails the anchor, and `if false && …targetDay.After(today)` fails with `did not expect autofill to create future entry`.

## day service — finding #6, partly real

The two nil-guard tests claimed `NoOp` in their names but only *called* the function. Surviving the call does kill the guard-removal mutant (it nil-derefs — verified: weakening the guard to `service == nil` panics both), so they were **not** vacuous. What went unchecked was the no-op half of their own names.

- both now assert no log read / no settings write, using `listCalls` / `updateCalls` counters added to the existing stubs;
- `..._EmptyLogSetNoPanic` — whose only assertion was the absence of a panic — becomes `..._EmptyLogSetPersistsDefaultLutealPhase` and asserts the observable outcome. Verified it dies when the default-persist is skipped (`got 0` updates).

The block comment above them stated the old rationale and is corrected: surviving the call is the guard's own kill, the counters are the no-op claim.

## import — finding #6, **not a defect**

`TestImportServiceRefreshNilGuards` was cited as assertion-free. It is not:

- dropping the `users`/`logs` checks from the guard makes it **panic** — verified, so it kills its target mutant;
- its comment claims exactly "no panic" and its name does not overclaim (unlike the `NoOp` pair above);
- the positive success path is already covered directly beneath it by `TestImportServiceRefreshUpdatesOnSuccess`.

Left in place. Added only the case a zero-value service cannot express: live `users` + nil `logs` must write nothing — mirroring the day-service guard so the two services are covered identically.

## Testing

`go test ./...` green. Each strengthened assertion was confirmed to fail on its own mutant, and every mutant reverted.