### PR TITLE
docs(security): complete the data inventory and correct the OIDC trust direction

### DIFF
--- a/docs/security/data-handling.md
+++ b/docs/security/data-handling.md
@@ -12,8 +12,11 @@ What Ovumcy persists per account and per record. All storage is in the operator'
 - Credentials: `password_hash` (bcrypt cost 12), `recovery_code_hash` (bcrypt cost 12), `local_auth_enabled`, `auth_session_version`, `must_change_password`.
 - Onboarding: `onboarding_completed`.
 - Cycle preferences: `cycle_length`, `period_length`, `luteal_phase`, `auto_period_fill`, `irregular_cycle`, `unpredictable_cycle`, `age_group`, `usage_goal`, `last_period_start`, `long_period_warning_cycle_start`.
-- Tracking preferences: `track_bbt`, `temperature_unit`, `track_cervical_mucus`, `hide_sex_chip`, `hide_cycle_factors`, `hide_notes_field`, `show_historical_phases`, `shown_period_tip`.
+- Tracking preferences: `track_bbt`, `temperature_unit`, `track_cervical_mucus`, `hide_sex_chip`, `hide_cycle_factors`, `hide_notes_field`, `show_historical_phases`, `shown_period_tip`, `week_starts_on`.
+- Interface: `timezone` — the last known IANA zone name observed on a request, used to resolve "today" for date-only writes. Not a secret.
 - 2FA: `totp_enabled`, `totp_secret` (AES-256-GCM aad-bound under an HKDF-derived key, see *Field-Level Encryption*), `totp_last_used_step` (RFC 6238 replay floor).
+- Webhook reminders (only meaningful once the owner enables them): `webhook_enabled`, `webhook_url` (**AES-256-GCM aad-bound under an HKDF-derived key, the same field-encryption path as `totp_secret`** — it is an owner-chosen egress destination, not a display value), `webhook_notify_period`, `webhook_notify_ovulation`, `reminder_lead_days`, and the per-kind send watermarks `webhook_period_last_sent_cycle_start` / `webhook_ovulation_last_sent_cycle_start` that stop a reminder firing twice for one cycle.
+- Calendar (`.ics`) feed subscription (only populated once the owner generates a feed): `calendar_feed_selector` — the non-secret lookup half of the capability token — plus `calendar_feed_verifier_mac` (keyed HMAC-SHA256 under a `SECRET_KEY`-derived label, the value the endpoint actually compares) and the legacy `calendar_feed_verifier_hash` (bcrypt, still written for rollback and still accepted for rows created before migration 032). This is the one sanctioned bearer-token surface; see *Calendar feed subscription* in `SECURITY.md`.
 
 **`daily_logs`** — one row per (user, calendar day). Dates are stored as UTC midnight and rendered in the user's timezone at read time.
 
@@ -39,6 +42,8 @@ What Ovumcy persists per account and per record. All storage is in the operator'
 - Deletes every `daily_logs` row for the user.
 - Deletes every user-defined row in `symptom_types` (built-in symptoms remain).
 - Resets cycle and tracking preferences to documented defaults.
+- **Disarms webhook reminders**: clears `webhook_enabled`, blanks the encrypted `webhook_url`, resets `reminder_lead_days` and the per-kind opt-ins to their defaults, and clears both send watermarks so no reminder fires against the freshly emptied account.
+- **Revokes the calendar feed**: NULLs `calendar_feed_selector` and both verifier columns, so a subscribe URL issued earlier stops resolving and answers `404`. Calendar clients holding it need a fresh URL from Settings.
 - Atomically bumps `auth_session_version`, invalidating every other auth cookie for the account. The originating device is re-issued a fresh cookie inline so the user stays signed in there.
 
 `clear-data` does **not** touch email, password hash, recovery code hash, role, display name, OIDC identity links, TOTP state, or onboarding status.

--- a/docs/security/logging.md
+++ b/docs/security/logging.md
@@ -19,6 +19,6 @@ When enabled, these lines are visible to the operator through their container ru
 
 If you enable `AUDIT_LOG_ENABLED=true`, plan retention and access control around the persistent-identifier content (`user_id`, role). Treat the resulting log stream as the same sensitivity class as the database itself.
 
-The Fiber request log (`time | status | latency | method | path`) is independent of `AUDIT_LOG_ENABLED` and remains enabled in all configurations. It does not include `user_id` or authenticated-session metadata.
+The Fiber request log (`time | status | latency | method | path | error`) is independent of `AUDIT_LOG_ENABLED` and remains enabled in all configurations. It does not include `user_id` or authenticated-session metadata. Both of its potentially sensitive columns are sanitized before they are written: the path through `SafeRequestLogPath` (route template, opaque tokens masked) and the trailing error through `SafeLogError`, which masks emails and opaque tokens so a handler error string cannot carry an account identifier into the log.
 
 The startup banner reflects the current setting (`audit_log=true|false`) so operators can confirm the effective configuration on each boot.

--- a/docs/security/oidc-and-sessions.md
+++ b/docs/security/oidc-and-sessions.md
@@ -26,5 +26,6 @@ Operations that rotate a long-lived credential bump `users.auth_session_version`
 - Recovery-code regeneration (`POST /api/v1/users/current/recovery-code`) — the current request receives a freshly issued cookie so the originating session stays alive, but every other device is signed out.
 - Forced password reset via the `ovumcy reset-password` operator command.
 - TOTP 2FA enable (`PUT /api/v1/users/current/2fa`) and disable (`DELETE /api/v1/users/current/2fa`) — toggling the second factor is also a change to the account's auth posture, so any cookie issued before the toggle is invalidated. The originating device receives a freshly issued cookie inline; every other device is signed out.
+- Clear data (`POST /api/v1/users/current/data-wipe`) — the bump happens inside the same transaction as the wipe, so a stolen session that triggered the wipe cannot retain access to the emptied account, and a "panic clear" really does sign other devices out. The originating device is re-issued a cookie inline. See *Retention and Deletion*.
 
 If you suspect a session compromise, regenerating the recovery code is the fastest way to force every other device to re-authenticate without changing your password.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -9,7 +9,7 @@ _Part of the [Ovumcy security policy](../../SECURITY.md)._
 - Credential stuffing and bot enumeration against `/api/v1/sessions`, `/api/v1/users`, and `/api/v1/password-resets` (rate limits, sealed pickup, bcrypt-timing equalization).
 - Replay of captured sealed cookies (server-side single-use for register pickup; session-version checks for `ovumcy_auth`).
 - DOM-XSS into HTMX error responses (status-error fragment is parsed with `DOMParser` and rebuilt via `document.createElement` + `textContent`, never `innerHTML`).
-- Cross-site form submission (CSRF middleware on every state-changing endpoint; OIDC callback uses provider-issued `state`/`nonce` instead).
+- Cross-site form submission (CSRF middleware on every state-changing endpoint, which also matches the browser `Origin`/`Referer` against the app's own scheme and host). The OIDC callback is the single exemption and is covered instead by the sealed one-time state cookie: `state`, `nonce`, and the PKCE verifier are generated **by Ovumcy** (`crypto/rand`) and held HttpOnly, and the callback is refused unless the value the provider echoes back matches the sealed one. The provider never chooses them — that is the whole basis of the substitution defence.
 - Algorithm-confusion attacks against ID tokens (asymmetric-algorithm allowlist; `HS*` and `none` are rejected even if the provider advertises them).
 - Malicious OIDC discovery metadata redirecting the logout flow to attacker-controlled hosts (`end_session_endpoint` host-pinned to the configured issuer).
 - Malicious OIDC discovery metadata redirecting the JWKS key fetch to attacker-controlled hosts (`jwks_uri` origin-pinned to the configured issuer, so token-signature keys are only fetched same-origin).

--- a/internal/db/user_repository.go
+++ b/internal/db/user_repository.go
@@ -579,7 +579,9 @@ func (repo *UserRepository) ClearAllDataAndResetSettings(ctx context.Context, us
 			"webhook_ovulation_last_sent_cycle_start": nil,
 			"reminder_lead_days":                      models.DefaultReminderLeadDays,
 			// Calendar (.ics) feed token: a clear-data wipe revokes the feed by
-			// NULLing both columns, so any previously-issued feed URL 404s against
+			// NULLing all three columns (selector plus both verifier columns —
+			// the MAC arrived with migration 032, after this comment was
+			// written), so any previously-issued feed URL 404s against
 			// the freshly emptied account (its selector no longer resolves). This
 			// is the data-reset arm of the approved force-rotate-on-recovery rule;
 			// the password-reset / operator-reset / recovery-regen force-rotate


### PR DESCRIPTION
Reconciles the five unread files under `docs/security/` against the code. Five findings; **each was verified in the source before being written up**, and the doc text quotes the mechanism it found there.

## 1. `data-handling.md` — the data inventory was incomplete

The document's stated job is "what Ovumcy persists per account and per record". The `users` list omitted, among others, the two security-relevant groups:

- **webhook reminders** (7 columns) — including `webhook_url`, which is field-encrypted through `security.EncryptField` AAD-bound to the user id, i.e. **the same AES-256-GCM path the document already calls out for `totp_secret`**;
- **calendar feed** (3 columns) — `calendar_feed_selector` plus `calendar_feed_verifier_mac` (HKDF-SHA256-derived key → `hmac.New(sha256.New, …)`) and the legacy bcrypt `calendar_feed_verifier_hash`, still written for rollback and still compared for rows predating migration 032. This is the product's one sanctioned bearer-token surface.

Also added `timezone` and `week_starts_on` (the latter missing from the tracking-preferences line).

## 2. `data-handling.md` — clear-data understated what it clears

The description stopped at "resets cycle and tracking preferences to documented defaults". `ClearAllDataAndResetSettings` also:

- disarms webhook delivery — `webhook_enabled=false`, blanks the encrypted `webhook_url`, resets the lead window and per-kind opt-ins, clears **both** send watermarks;
- revokes the calendar feed — NULLs the selector and both verifier columns, so a subscribe URL issued earlier stops resolving and answers `404`.

Both are consequences an owner needs before pressing the button.

## 3. `oidc-and-sessions.md` — the session-invalidation list omitted clear-data

The enumeration of operations that bump `auth_session_version` listed password change, reset, recovery-code regen, operator reset, and TOTP toggle — but not clear-data, which the repository does **inside the wipe transaction**. `known-disclosures.md`, in this same policy set, already listed it correctly, so the two files disagreed.

## 4. `threat-model.md` — the OIDC trust direction was inverted

It described the callback as protected by "provider-issued `state`/`nonce`".

Both are generated by **Ovumcy** — `newOIDCAuthState` → `security.RandomString(32, …)` — sealed into the HttpOnly state cookie, and the callback is refused unless the echoed value matches (`matchesState`). The provider never chooses them; that is precisely the basis of the substitution defence the sentence was claiming. Restated, and the clause now also mentions PKCE and the `Origin`/`Referer` match (which #286 pinned in Go).

## 5. `logging.md` — the request-log shape was missing a column

Documented as `time | status | latency | method | path`. The real format (`requestLoggerFormat`) has a trailing **error** column — the one field that can carry a handler error string, which is why `SafeLogError` exists. Added the column and named both sanitizers (`SafeRequestLogPath`, `SafeLogError`) with what each masks.

## Plus a stale code comment

`user_repository.go` said clear-data revokes the feed by "NULLing both columns" while NULLing three — the MAC column arrived with migration 032 after that comment was written.

## Method note

Consistent with the pattern recorded earlier: docs describing **mechanisms** drift with the code. `architecture.md` (structure) yielded 0 findings; `oidc.md` yielded 1, `gdpr.md` 3, and this set 5 — four of them in the two documents that enumerate *things* (columns, operations), which is where an addition to the code silently leaves the list behind.

`go test ./...` green (the docs are read by `scripts/readmeversion`, so the suite is not a no-op for a docs change).