### PR TITLE
docs(export): document both import size caps and fix the summary date semantics

### DIFF
--- a/docs/export.md
+++ b/docs/export.md
@@ -136,7 +136,7 @@ Response is JSON (not a file download), used by the Settings UI before showing t
 }
 ```
 
-`date_from`/`date_to` are absent or empty strings when the range is unbounded.
+All four keys are always present. `date_from`/`date_to` report the **extent of the data found**, not the requested range: they are the earliest and latest logged day inside it, so an unbounded query with logs still returns concrete dates. They are empty strings exactly when the range holds no entries at all (alongside `has_data: false` and `total_entries: 0`).
 
 ## Import (restore)
 
@@ -158,7 +158,18 @@ Response `200`:
 - `skipped` — days that already existed and were left untouched.
 - `rejected` — malformed or duplicate day records dropped without writing.
 
-Error responses use stable, PII-free keys: `400 invalid import file` (not valid JSON), `413 import file too large`, `500 failed to import data`.
+### Size limits
+
+Two independent caps bound a restore, and they surface as **two different 413 keys** — a client keying on the error string needs both:
+
+| Cap | Value | Error |
+| --- | --- | --- |
+| Request body | **16 MiB** | `413 request_too_large`. Enforced at the transport layer before the handler runs, so a body over the limit never reaches the import service. |
+| Entries per file | **20 000** | `413 import file too large`. Enforced by the import service on the parsed payload. |
+
+The body limit is sized to the entry cap (20 000 day records serialize to roughly 8–12 MiB), so a file at the documented entry ceiling stays comfortably under it. A file that trips the body limit is therefore either far past the entry cap or carrying unusually large `notes`.
+
+Error responses use stable, PII-free keys: `400 invalid import file` (not valid JSON), the two 413s above, and `500 failed to import data`.
 
 Importing from other trackers (e.g. Drip) is out of scope for this endpoint — see [issue #116](https://github.com/ovumcy/ovumcy-web/issues/116).
 


### PR DESCRIPTION
Finishes the doc-reconciliation sweep: `docs/export.md` (169 lines) and `docs/notifications.md` (402 lines) checked against the code.

## Two 413s, one documented

The restore endpoint has **two independent size caps that surface as two different error keys**, and the guide named only one:

| Cap | Value | Error | Where |
| --- | --- | --- | --- |
| Request body | 16 MiB | `request_too_large` | transport layer (`BodyLimit` → `ovumcyErrorHandler` → `RespondRequestEntityTooLarge`); the handler never runs |
| Entries per file | 20 000 | `import file too large` | `ImportService` on the parsed payload (`ErrImportTooLarge`) |

A client implementing against the documented error vocabulary would not recognise the first — which is the one an oversized file actually hits. And **neither number appeared in any markdown file in the repository** (only a diagram box in `architecture.md` mentions "16 MiB body limit"), so "too large" had no stated meaning in either sense.

## The summary date fields were misdescribed

Documented as "`date_from`/`date_to` are absent or empty strings when the range is unbounded". Both halves are wrong:

- the handler builds a `fiber.Map` with all four keys, so they are **never absent**;
- they report the extent of the **data found** — `CalendarDayKey(first)` / `CalendarDayKey(last)` over the fetched logs — **not** the requested range. An unbounded query over a populated account returns concrete dates. They are empty exactly when the range holds no entries (with `has_data: false`, `total_entries: 0`).

A client would reasonably have read them as an echo of the query range.

## Verified, no change needed

- **JSON entry shape** — matches `ExportJSONEntry` field for field, in order, including `bbt` being `omitempty`; the 16 symptom keys match `ExportSymptomFlags` and the doc's stated order is the struct's order.
- **CSV columns** — all 29 match `ExportCSVHeaders` exactly, in order, including the `Swelling`-inserted-mid-file note and the `BBT (C)` header kept for stability.
- **Import response + remaining error keys** — `{ok, added, skipped, rejected}` and `invalid import file` / `failed to import data` match `respondImportSuccess` and `mapImportError`.

## `docs/notifications.md` — zero findings

Checked and correct in every enumeration: the 6-field webhook payload matches the delivery struct exactly; the envelope claims (10 s timeout, `DisableKeepAlives`, refusing `CheckRedirect`, `http`/`https` only) match the constants; the private-address list matches `isPrivateIP` including RFC 6598 CGNAT and the NAT64 well-known prefix recursing on the embedded IPv4; the `REGISTRATION_MODE=open` + `WEBHOOK_BLOCK_PRIVATE_ADDRESSES=false` startup warning exists; the scheduler's defaults, hour range, once-per-local-day marker and drain on graceful stop all match `internal/reminders`; and the `SECRET_KEY`-rotation consequences for both the webhook URL and the calendar feed are already documented there.

That contrast is the useful part: `notifications.md` is the most mechanism-dense document in the repo and it has not drifted, because the webhook and feed slices updated it in the same change. The operator runbook (#292) drifted on exactly those same mechanisms — it was not in any of those slices' blast radius.

`go test ./...` green.