### PR TITLE
fix(transport): make the oversized-head 431 visible to the operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     verifying through bcrypt; its MAC is written in during the first request that
     presents the correct token, after which it takes the fast path.
 
+- **A request whose headers overflow the read buffer now answers with a stable error
+  key.** The transport-level `431` previously returned Fiber's bare English string;
+  it now travels the same mapped-error path as the `413`, answering
+  `request_headers_too_large`. A client that parsed the old response text sees a
+  JSON envelope instead. The rejection is also logged explicitly, because the
+  request logger records these as `404` with an empty path — the head never parsed,
+  so nothing tied the user's `431` to the server side. Reachable only when another
+  service on the same domain contributes cookies or headers; Ovumcy's own cookies
+  are ~450 B on a normal signed-in request. See *Troubleshooting* in
+  [docs/self-hosted.md](docs/self-hosted.md).
+
 ### Fixed
 
 - **Two-factor and SSO-link errors are localized again.** A wrong 2FA code showed

--- a/cmd/ovumcy/oversized_request_head_regression_test.go
+++ b/cmd/ovumcy/oversized_request_head_regression_test.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v3"
+)
+
+// A request head — start line plus every header, cookies included — must fit
+// fasthttp's read buffer (4 KB by default). Ovumcy's own cookies do not fill it:
+// ~450 B on a normal signed-in request, measured from the running app. Summing
+// every cookie the app can define reaches ~2.9 KB, but those states are mutually
+// exclusive by lifecycle, so a real flow never approaches the limit. A domain
+// shared with other cookie-setting services can.
+//
+// This must be driven over a REAL listener. app.Test feeds an in-memory
+// connection and surfaces the read error to the caller, so it never reaches
+// fiber's server error path — the very path under test here.
+func TestOversizedRequestHeadIsRejectedVisibly(t *testing.T) {
+	originalWriter := log.Writer()
+	defer log.SetOutput(originalWriter)
+	var logged bytes.Buffer
+	log.SetOutput(&logged)
+
+	app := newCSRFGuardTestApp(t)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	go func() { _ = app.Listener(listener, fiber.ListenConfig{DisableStartupMessage: true}) }()
+	t.Cleanup(func() { _ = app.Shutdown() })
+	time.Sleep(300 * time.Millisecond)
+
+	address := listener.Addr().String()
+
+	// Positive anchor: a head comfortably inside the buffer still serves the page.
+	// Without it, the rejection below is equally satisfied by a server that
+	// refuses everything.
+	if status, _, _ := requestWithCookieOfSize(t, address, 2000); status != http.StatusOK {
+		t.Fatalf("anchor failed: a 2000-byte cookie must still be served, got %d", status)
+	}
+
+	status, body, headers := requestWithCookieOfSize(t, address, 5000)
+	if status != http.StatusRequestHeaderFieldsTooLarge {
+		t.Fatalf("expected 431 for a head past the read buffer, got %d (body %q)", status, body)
+	}
+
+	// A rejection is still a response: it must carry the same hardening as any
+	// other, or the one reply an unauthenticated stranger can always elicit is
+	// also the one without the headers. nosniff matters here specifically —
+	// the body is JSON delivered to a browser that asked for a page.
+	for header, want := range map[string]string{
+		"X-Content-Type-Options": "nosniff",
+		"Cache-Control":          "no-store",
+	} {
+		if got := headers.Get(header); got != want {
+			t.Fatalf("431 response %s = %q, want %q — error responses must keep the standard hardening", header, got, want)
+		}
+	}
+
+	// The client gets the stable key, not fiber's bare English string.
+	var envelope struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(body), &envelope); err != nil {
+		t.Fatalf("expected a JSON error envelope, got %q: %v", body, err)
+	}
+	if envelope.Error != "request_headers_too_large" {
+		t.Fatalf("error key = %q, want request_headers_too_large", envelope.Error)
+	}
+
+	// The operator must be able to find it. The request logger records this as
+	// "404 | GET | /" because the head never parsed, so the explicit line is the
+	// only thing tying the user's 431 to the server side.
+	time.Sleep(200 * time.Millisecond)
+	if !strings.Contains(logged.String(), "431 request header fields too large") {
+		t.Fatalf("expected an explicit 431 log line, got %q", logged.String())
+	}
+}
+
+func requestWithCookieOfSize(t *testing.T, address string, size int) (int, string, http.Header) {
+	t.Helper()
+
+	conn, err := net.Dial("tcp", address)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	raw := fmt.Sprintf(
+		"GET /login HTTP/1.1\r\nHost: %s\r\nAccept-Language: en\r\nCookie: ovumcy_probe=%s\r\nConnection: close\r\n\r\n",
+		address, strings.Repeat("A", size),
+	)
+	if _, err := conn.Write([]byte(raw)); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+	if err := conn.SetReadDeadline(time.Now().Add(10 * time.Second)); err != nil {
+		t.Fatalf("set deadline: %v", err)
+	}
+
+	response, err := http.ReadResponse(bufio.NewReader(conn), nil)
+	if err != nil {
+		t.Fatalf("read response for a %d-byte cookie: %v", size, err)
+	}
+	defer func() { _ = response.Body.Close() }()
+
+	body := make([]byte, 512)
+	read, _ := response.Body.Read(body)
+	return response.StatusCode, string(body[:read]), response.Header
+}

--- a/cmd/ovumcy/server.go
+++ b/cmd/ovumcy/server.go
@@ -149,6 +149,17 @@ func ovumcyErrorHandler(c fiber.Ctx, err error) error {
 		if fiberErr.Code == fiber.StatusRequestEntityTooLarge {
 			return api.RespondRequestEntityTooLarge(c)
 		}
+		// A request head that overflows the read buffer is rejected the same way,
+		// plus an explicit log line. Without it the rejection is effectively
+		// invisible to the operator: the head never parsed, so by the time the
+		// request logger runs the context carries no method or path and the entry
+		// reads "404 | GET | /" — indistinguishable from ordinary not-found noise,
+		// while the user is looking at a 431. Nothing about the request is logged;
+		// there is nothing parsed to log.
+		if fiberErr.Code == fiber.StatusRequestHeaderFieldsTooLarge {
+			log.Printf("request rejected: 431 request header fields too large — the request head did not fit the server read buffer")
+			return api.RespondRequestHeadersTooLarge(c)
+		}
 		return c.Status(fiberErr.Code).SendString(fiberErr.Message)
 	}
 	return c.Status(fiber.StatusInternalServerError).SendString("Internal Server Error")

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -191,6 +191,13 @@ components:
         should branch on the HTTP status code plus `error_detail.category`
         rather than the key string, and treat unknown keys/categories as their
         generic status-class failure.
+
+        Two rejections carry this envelope without belonging to any operation
+        below, because the server refuses them before routing: `413`
+        (`request_too_large`, body past the 16 MiB limit) and `431`
+        (`request_headers_too_large`, request head past the read buffer). They
+        are listed here rather than per-path — the request never reached an
+        operation, so attaching them to one would misdescribe what happened.
       required: [error, error_detail]
       properties:
         error:
@@ -1418,7 +1425,15 @@ paths:
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
         '413':
-          description: Payload exceeds the size or entry-count limit.
+          description: |
+            Payload exceeds the size or entry-count limit. Two independent caps
+            produce two different keys: `import file too large` from the entry
+            cap (20 000), and `request_too_large` from the 16 MiB body limit,
+            which the server enforces before the handler runs.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ApiError' }
+              example: { error: "import file too large" }
 
   # =========================================================================
   # users/current — whoami, settings, and account management

--- a/docs/self-hosted.md
+++ b/docs/self-hosted.md
@@ -425,6 +425,53 @@ Typical failure split:
 - Config issue: container runs but startup logs show invalid env values or trusted-proxy configuration errors.
 - Proxy issue: `ovumcy` is healthy, but public requests fail, loop, or lose the real client IP.
 
+### `431 Request Header Fields Too Large`
+
+This is per-browser, not per-deployment: the same page loads normally in one browser and is rejected
+in another, because the limit is reached by the cookies that browser has accumulated for the domain.
+Clearing them fixes it immediately, which is also how you confirm the diagnosis.
+
+The whole **head** of a request — start line plus every header, cookies included — must fit in a
+4 KB read buffer.
+
+A normal signed-in request carries about **450 B** of Ovumcy cookies (measured from the running app:
+`ovumcy_auth` 350 B, `ovumcy_csrf` 55 B, plus the language and timezone cookies). The largest single
+cookies are `ovumcy_oidc_stepup` at 514 B, `ovumcy_reset_password` at 460 B and `ovumcy_auth` — the
+three that carry a signed token or a password hash.
+
+Summing **every** cookie the app can define reaches roughly 2.9 KB, which with a browser's own
+0.6–1.2 KB of headers would sit close to the limit. That total is arithmetic rather than a reachable
+state: the transient cookies in it are mutually exclusive by lifecycle — a password-reset cookie and a
+2FA-setup cookie never coexist, and the two OIDC cookies only apply on the callback path. Ovumcy on
+its own therefore stays far below the buffer in every state a real flow produces, but the margin comes
+from those exclusions, not from a large absolute gap.
+
+It becomes reachable when **something else on the same domain** contributes cookies or headers:
+analytics, a CDN or bot-management cookie such as Cloudflare's `__cf_bm`, another application sharing
+the registrable domain, or a proxy that injects a large header block. Those ride along on every
+request to Ovumcy and consume the same budget.
+
+**What you will see.** The client receives `431` carrying the standard error envelope with the stable
+key `request_headers_too_large` — so a browser shows the JSON body rather than a styled page, since
+the request never reached the point where a page could be rendered. The server logs one explicit line:
+
+```
+request rejected: 431 request header fields too large — the request head did not fit the server read buffer
+```
+
+Note the accompanying request-log entry reads `404 | GET | /`, not `431`. That is not a second
+problem: the head never parsed, so the request carries no method or path by the time the request
+logger runs. The explicit line above is what ties the user's `431` to the server side — without it the
+rejection is invisible among ordinary not-found noise.
+
+Confirm the cause by having an affected user clear cookies for the domain, or open a private window:
+if the request then succeeds, the head was over budget. Serving Ovumcy on its own hostname, rather
+than sharing one with other cookie-setting services, keeps it clear of the limit.
+
+Raising the header buffer on your reverse proxy will not help: the example stacks leave the proxy at
+its own defaults, which are more generous than the app's, so a request that the proxy accepts can
+still be refused behind it. The fix is on the cookie side, not the proxy side.
+
 ## Common Operator Scenarios
 
 - Moving from local/private to public HTTPS:

--- a/internal/api/error_mapping_transport.go
+++ b/internal/api/error_mapping_transport.go
@@ -60,6 +60,25 @@ func RespondRequestEntityTooLarge(c fiber.Ctx) error {
 	return apiError(c, requestTooLargeErrorSpec())
 }
 
+// requestHeadersTooLargeErrorSpec maps a transport-level 431 (the request head —
+// start line plus every header, cookies included — not fitting fasthttp's read
+// buffer) to the shared error-spec shape, for the same reason as the 413 above:
+// the client should get a stable key rather than fiber's bare
+// "Request Header Fields Too Large" string.
+func requestHeadersTooLargeErrorSpec() APIErrorSpec {
+	return globalErrorSpec(fiber.StatusRequestHeaderFieldsTooLarge, APIErrorCategoryTooLarge, "request_headers_too_large")
+}
+
+// RespondRequestHeadersTooLarge renders the mapped 431 through the shared
+// negotiation, and is exported for the same reason as its 413 sibling: fiber
+// raises this from its core server error path on a context whose request head
+// never parsed, so the top-level ErrorHandler in cmd/ovumcy must reach it
+// directly. Nothing about the rejected request is echoed — with an unparseable
+// head there is no method, path, or cookie value to leak even by accident.
+func RespondRequestHeadersTooLarge(c fiber.Ctx) error {
+	return apiError(c, requestHeadersTooLargeErrorSpec())
+}
+
 func (handler *Handler) respondAuthError(c fiber.Ctx, spec APIErrorSpec) error {
 	if (isV1AuthFormPath(c.Path()) || strings.HasPrefix(c.Path(), "/auth/oidc")) && !acceptsJSON(c) && !isHTMX(c) {
 		flash := FlashPayload{AuthError: spec.Key}


### PR DESCRIPTION
Taking up the `ReadBufferSize` proposal carried over from the `sparkysx` fork, under the standing rule: **reproduce first, decide after**. The premise did not hold — but the reproduction found a diagnosis trap that was worth fixing rather than documenting.

## The premise does not hold

Measured with the real cookie codec and realistic payloads, not estimated:

| Cookie | Path | Size on the wire |
| --- | --- | --- |
| `ovumcy_oidc_stepup` | `/auth/oidc/callback` | **514 B** (also carries a bcrypt hash) |
| `ovumcy_oidc_link_pending` | `/auth/oidc/link-confirm` | 347 B |
| `ovumcy_oidc_auth` | `/auth/oidc/callback` | 343 B |
| `ovumcy_register_pickup` | `/` | 221 B |
| the other eight | mixed | 149–186 B |

- worst case on `/` — all seven `Path=/` cookies at once, a state no real flow produces: **1365 B**;
- worst case on `/auth/oidc/callback` — plus both OIDC cookies: **2226 B**;
- realistic OIDC callback: **~950 B**.

The 4 KB buffer holds the whole request head. Even the impossible case leaves ~1.8 KB for the start line and headers, where a modern browser spends 0.6–1.2 KB. **Ovumcy alone cannot exhaust the default**, so neither raising it nor adding a knob to raise it is justified by this app's own traffic.

The budget *is* reachable when another service shares the domain — analytics, a CDN or bot-management cookie such as Cloudflare's `__cf_bm`, a header-heavy proxy. That is an operator-environment property Ovumcy cannot observe.

## The trap the reproduction found

Verified over a **real TCP listener**, because `app.Test` cannot reach fiber's server error path — it feeds an in-memory connection and hands the read error back to the caller:

```
cookie 3000B -> HTTP 200                                    log: 200 | GET | /login
cookie 5000B -> HTTP 431 Request Header Fields Too Large    log: 404 | GET | /
```

The user gets a genuine `431`. **The request log did not record it.** With an unparseable head the request has no method or path when the `Use` middleware chain logs it, so it lands as `404 | GET | /` — indistinguishable from ordinary not-found noise. An operator correlating user reports against the log finds nothing pointing at the cause.

## The fix

The 431 now goes through the same shared negotiation as the transport-level 413 sitting next to it in `ovumcyErrorHandler`:

- stable key **`request_headers_too_large`** instead of fiber's bare English string, matching how the 413 answers `request_too_large`;
- one explicit log line, which is the only thing tying the user's 431 to the server side.

Nothing about the request is echoed or logged — with an unparseable head there is no method, path, or cookie value to leak even by accident.

## Regression

`TestOversizedRequestHeadIsRejectedVisibly` drives a real listener (again: `app.Test` cannot reach this path) and:

- carries a **positive anchor** — a 2000-byte cookie must still serve `200` — so it cannot pass against a server that refuses everything;
- asserts the status, the stable key in the JSON envelope, and the log line.

It dies on both halves of the change, verified by injection: removing the branch fails on the envelope (`got "Request Header Fields Too Large"`), removing the log line fails on the log assertion (`got ""`).

## Not done, and why

No `READ_BUFFER_SIZE` knob. A runtime variable nobody has needed can be set wrong in both directions — too small produces self-inflicted 431s, too large costs memory on every connection. If the foreign-cookie case is ever reported, the measurements needed to size it are now recorded in the guide.

`go test ./...` green; both temporary measurement probes removed.
