### PR TITLE
fix(frontend): gate htmx-driven confirmations with hx-confirm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **"Cancel" now actually cancels on four confirmation dialogs.** Rotating or
+  revoking the calendar feed, hiding a custom symptom, and deleting a calendar
+  day entry each asked for confirmation — but the request was already on its way
+  before the dialog appeared, so cancelling still performed the action (and
+  confirming performed it twice). Rotating a feed the owner had decided to keep
+  invalidated a subscribe URL every subscribed calendar client was using. The
+  dialog on these surfaces was decorative; it now gates the request, and a
+  template-level guard fails the build if any future htmx-driven control is
+  wired the same way.
+
 - **Two-factor and SSO-link errors are localized again.** A wrong 2FA code showed
   every user the untranslated English string `totp invalid code`, regardless of
   the interface language, and the OIDC link-confirmation page did the same with

--- a/e2e/settings-calendar-feed.spec.ts
+++ b/e2e/settings-calendar-feed.spec.ts
@@ -119,6 +119,43 @@ async function generateFeed(page: Page): Promise<RevealedFeed> {
   return readRevealedFeed(page);
 }
 
+/**
+ * Rotate and revoke are htmx-driven and gated by `hx-confirm`, so htmx itself
+ * withholds the request until the dialog resolves. Accepting is therefore what
+ * issues it — binding the wait to the submit click would hang.
+ */
+async function acceptConfirmDialog(page: Page): Promise<void> {
+  await expect(page.locator('#confirm-modal')).toBeVisible();
+  await page.locator('#confirm-modal-accept').click();
+}
+
+async function cancelConfirmDialog(page: Page): Promise<void> {
+  await expect(page.locator('#confirm-modal')).toBeVisible();
+  await page.locator('#confirm-modal-cancel').click();
+  await expect(page.locator('#confirm-modal')).toBeHidden();
+}
+
+/** Records every request the page issues to pathSuffix while `action` runs. */
+async function requestsIssuedDuring(
+  page: Page,
+  pathSuffix: string,
+  action: () => Promise<void>
+): Promise<string[]> {
+  const seen: string[] = [];
+  const listener = (request: { url: () => string; method: () => string }) => {
+    if (new URL(request.url()).pathname.endsWith(pathSuffix)) {
+      seen.push(`${request.method()} ${request.url()}`);
+    }
+  };
+  page.on('request', listener);
+  try {
+    await action();
+  } finally {
+    page.off('request', listener);
+  }
+  return seen;
+}
+
 async function leaveRevealPage(page: Page): Promise<void> {
   await page.locator('[data-calendar-feed-reveal-continue]').click();
   await page.waitForURL(/\/settings(?:\?.*)?$/);
@@ -192,13 +229,12 @@ test.describe('Settings: calendar feed one-time reveal', () => {
     const first = await generateFeed(page);
     await leaveRevealPage(page);
 
-    // Rotate and revoke carry `data-confirm`, but the dialog it opens does not
-    // gate an htmx-driven form: the request is issued by the submit event
-    // itself, so the click below is the action to bind the wait to. Once these
-    // forms gate the request behind the dialog, this spec accepts it here.
+    // Rotate is gated by the confirm dialog, so accepting it — not the submit
+    // click — is what issues the request.
     const rotateForm = feedSection(page).locator('[data-settings-calendar-feed-rotate]');
+    await rotateForm.locator('button[type="submit"]').click();
     await submitAndAwait(page, 'POST', '/api/v1/users/current/calendar-feed/rotate', () =>
-      rotateForm.locator('button[type="submit"]').click()
+      acceptConfirmDialog(page)
     );
     await page.waitForURL(/\/settings\/calendar-feed$/);
 
@@ -216,8 +252,9 @@ test.describe('Settings: calendar feed one-time reveal', () => {
     await expectNoSubscribeURLRendered(page, [first.token, rotated.token]);
 
     const revokeForm = feedSection(page).locator('[data-settings-calendar-feed-revoke]');
+    await revokeForm.locator('button[type="submit"]').click();
     await submitAndAwait(page, 'DELETE', '/api/v1/users/current/calendar-feed', () =>
-      revokeForm.locator('button[type="submit"]').click()
+      acceptConfirmDialog(page)
     );
     await expect(page.locator('#settings-calendar-feed-status .status-ok')).toBeVisible();
 
@@ -236,5 +273,74 @@ test.describe('Settings: calendar feed one-time reveal', () => {
     await page.goto('/settings/calendar-feed');
     await expect(page).toHaveURL(/\/settings$/);
     await expectNoSubscribeURLRendered(page, [first.token, rotated.token]);
+  });
+
+  // Cancelling a confirmation must be inert. This is a real regression, not a
+  // hypothetical: rotate and revoke used to carry `data-confirm`, which is
+  // honored by a document-level submit listener, while htmx listens on the form
+  // itself and issues the request first — so the dialog was decorative and
+  // Cancel rotated the feed anyway, invalidating a subscribe URL the owner had
+  // just decided to keep. Both controls now use `hx-confirm`, which htmx gates
+  // on. The template-level guard against the whole class is
+  // TestNoTemplateElementMixesHTMXRequestWithDataConfirm.
+  test('cancelling rotate or revoke leaves the armed feed working', async ({ page }) => {
+    await registerOwnerAndOpenSettings(page, 'calendar-feed-confirm-cancel');
+
+    const armed = await generateFeed(page);
+    await leaveRevealPage(page);
+
+    // The subscribe URL works before any of this — the anchor every assertion
+    // below is measured against.
+    const beforeCancel = await page.request.get(armed.url);
+    expect(beforeCancel.status(), 'the freshly generated feed must serve').toBe(200);
+
+    const rotateForm = feedSection(page).locator('[data-settings-calendar-feed-rotate]');
+    const rotateRequests = await requestsIssuedDuring(
+      page,
+      '/api/v1/users/current/calendar-feed/rotate',
+      async () => {
+        await rotateForm.locator('button[type="submit"]').click();
+        await cancelConfirmDialog(page);
+        // A reload is the concrete signal that any request the click was going
+        // to issue has had its chance — no arbitrary timeout involved.
+        await page.reload();
+        await expect(page).toHaveURL(/\/settings$/);
+      }
+    );
+    expect(rotateRequests, 'cancelling rotate must issue no request').toEqual([]);
+
+    const revokeForm = feedSection(page).locator('[data-settings-calendar-feed-revoke]');
+    const revokeRequests = await requestsIssuedDuring(
+      page,
+      '/api/v1/users/current/calendar-feed',
+      async () => {
+        await revokeForm.locator('button[type="submit"]').click();
+        await cancelConfirmDialog(page);
+        await page.reload();
+        await expect(page).toHaveURL(/\/settings$/);
+      }
+    );
+    expect(revokeRequests, 'cancelling revoke must issue no request').toEqual([]);
+
+    // Still armed, and — the assertion that would have caught the original
+    // defect — the ORIGINAL subscribe URL still serves, so neither cancelled
+    // action rotated or revoked it behind the owner's back.
+    await expect(feedSection(page).locator('[data-calendar-feed-status]')).toHaveAttribute(
+      'data-calendar-feed-status',
+      'configured'
+    );
+    const afterCancel = await page.request.get(armed.url);
+    expect(afterCancel.status(), 'a cancelled rotate/revoke must leave the URL working').toBe(200);
+
+    // Positive anchor: the same control, accepted, really does revoke — so the
+    // assertions above prove Cancel is inert, not that the control is dead.
+    await revokeForm.locator('button[type="submit"]').click();
+    await submitAndAwait(page, 'DELETE', '/api/v1/users/current/calendar-feed', () =>
+      acceptConfirmDialog(page)
+    );
+    await expect(page.locator('#settings-calendar-feed-status .status-ok')).toBeVisible();
+
+    const afterAccept = await page.request.get(armed.url);
+    expect(afterAccept.status(), 'an accepted revoke must kill the URL').toBe(404);
   });
 });

--- a/internal/api/confirm_gating_regression_test.go
+++ b/internal/api/confirm_gating_regression_test.go
@@ -1,0 +1,109 @@
+package api
+
+import (
+	"io/fs"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/ovumcy/ovumcy-web/internal/templates"
+)
+
+// htmxRequestAttributePattern matches the htmx attributes that make an element
+// issue its own request. An element carrying one of these never reaches the
+// document-level submit interceptor in time (see the test below).
+var htmxRequestAttributePattern = regexp.MustCompile(`\bhx-(get|post|put|patch|delete)\s*=`)
+
+// TestNoTemplateElementMixesHTMXRequestWithDataConfirm kills the whole class
+// behind a defect measured in the browser: `data-confirm` is honored by a
+// document-level `submit` listener (web/src/js/app/22-confirm-modal.js), while
+// htmx listens on the element itself. The element-level listener runs first, so
+// htmx issues the request before the dialog is ever shown — pressing Cancel
+// still rotated the calendar feed, hid a symptom, or deleted a day entry, and
+// accepting fired the request a second time. The dialog was decorative on
+// exactly those surfaces.
+//
+// An htmx-driven element must therefore use `hx-confirm`, which htmx itself
+// gates on: the same modal serves it through the `htmx:confirm` handler and
+// reads `data-confirm-accept` for the button label. `data-confirm` stays
+// correct for plain non-htmx forms (logout, recovery-code regeneration), which
+// really do submit natively.
+//
+// This scans the embedded template sources rather than a rendered page because
+// the defect is a markup contract, not a per-page behavior: a new surface added
+// tomorrow is covered without anyone remembering to write a test for it.
+func TestNoTemplateElementMixesHTMXRequestWithDataConfirm(t *testing.T) {
+	var scanned int
+	err := fs.WalkDir(templates.Files, ".", func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() || !strings.HasSuffix(path, ".html") {
+			return nil
+		}
+		source, readErr := templates.Files.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		scanned++
+
+		// Element boundaries are enough here: every confirm-bearing element in
+		// this codebase is a <form ...> or <button ...> whose attributes sit in
+		// one tag. Splitting on '<' keeps an hx-* on one element from being
+		// paired with a data-confirm on its neighbor.
+		for _, element := range strings.Split(string(source), "<") {
+			if !strings.Contains(element, "data-confirm=") {
+				continue
+			}
+			if htmxRequestAttributePattern.MatchString(element) {
+				t.Errorf(
+					"%s: an element carries both an htmx request attribute and data-confirm.\n"+
+						"htmx submits before the document-level data-confirm interceptor runs, so the dialog is decorative and Cancel does not cancel.\n"+
+						"Use hx-confirm for htmx-driven elements (keep data-confirm-accept for the button label); data-confirm is only for plain non-htmx forms.\n"+
+						"element: <%s",
+					path, strings.TrimSpace(element),
+				)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk embedded templates: %v", err)
+	}
+	if scanned == 0 {
+		t.Fatal("no templates were scanned: the embedded template FS layout changed and this guard silently stopped checking anything")
+	}
+}
+
+// TestConfirmGatedSurfacesDeclareAnAcceptLabel pins the other half of the
+// contract: both gating mechanisms render the accept button's label from
+// data-confirm-accept, so a surface that asks for confirmation without one
+// falls back to the generic body-level default and shows "Delete" on a rotate
+// or hide action.
+func TestConfirmGatedSurfacesDeclareAnAcceptLabel(t *testing.T) {
+	err := fs.WalkDir(templates.Files, ".", func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() || !strings.HasSuffix(path, ".html") {
+			return nil
+		}
+		source, readErr := templates.Files.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		for _, element := range strings.Split(string(source), "<") {
+			asksToConfirm := strings.Contains(element, "data-confirm=") || strings.Contains(element, "hx-confirm=")
+			if !asksToConfirm {
+				continue
+			}
+			if !strings.Contains(element, "data-confirm-accept=") {
+				t.Errorf("%s: a confirm-gated element declares no data-confirm-accept, so its dialog would show the generic default label.\nelement: <%s", path, strings.TrimSpace(element))
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk embedded templates: %v", err)
+	}
+}

--- a/internal/templates/components/settings_calendar_feed.html
+++ b/internal/templates/components/settings_calendar_feed.html
@@ -23,7 +23,7 @@
         action="/api/v1/users/current/calendar-feed/rotate"
         method="post"
         hx-post="/api/v1/users/current/calendar-feed/rotate"
-        data-confirm="{{t .Messages "settings.calendar_feed.confirm_rotate"}}"
+        hx-confirm="{{t .Messages "settings.calendar_feed.confirm_rotate"}}"
         data-confirm-accept="{{t .Messages "settings.calendar_feed.rotate"}}"
         data-settings-calendar-feed-rotate>
         <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
@@ -36,7 +36,7 @@
         hx-delete="/api/v1/users/current/calendar-feed"
         hx-target="#settings-calendar-feed-status"
         hx-swap="innerHTML"
-        data-confirm="{{t .Messages "settings.calendar_feed.confirm_revoke"}}"
+        hx-confirm="{{t .Messages "settings.calendar_feed.confirm_revoke"}}"
         data-confirm-accept="{{t .Messages "settings.calendar_feed.revoke"}}"
         data-settings-calendar-feed-revoke>
         <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">

--- a/internal/templates/components/settings_symptoms.html
+++ b/internal/templates/components/settings_symptoms.html
@@ -91,7 +91,7 @@
       hx-delete="/api/v1/symptoms/{{.Symptom.ID}}"
       hx-target="#settings-symptoms-section"
       hx-swap="outerHTML"
-      data-confirm="{{t $.Messages "settings.symptoms.confirm_hide"}}"
+      hx-confirm="{{t $.Messages "settings.symptoms.confirm_hide"}}"
       data-confirm-accept="{{t $.Messages "settings.symptoms.hide"}}">
       <input type="hidden" name="csrf_token" value="{{$.CSRFToken}}">
       <button type="submit" class="btn-secondary">{{t $.Messages "settings.symptoms.hide"}}</button>

--- a/internal/templates/day_editor_partial.html
+++ b/internal/templates/day_editor_partial.html
@@ -166,7 +166,7 @@
       hx-delete="/api/v1/days/{{.DateString}}?source=calendar"
       hx-target="#day-editor"
       hx-swap="innerHTML"
-      data-confirm="{{t .Messages "confirm.delete_entry"}}"
+      hx-confirm="{{t .Messages "confirm.delete_entry"}}"
       data-confirm-accept="{{t .Messages "confirm.yes"}}"
       data-day-delete-form
       data-day-delete-date="{{.DateString}}">


### PR DESCRIPTION
## The defect (measured, not inferred)

`data-confirm` is honored by a document-level `submit` listener in `web/src/js/app/22-confirm-modal.js`; htmx listens on the element itself, so on an htmx-driven form htmx issues the request **before** the dialog is ever shown. Four surfaces were affected — calendar-feed **rotate** and **revoke**, custom-symptom **hide**, calendar **day-entry delete**: pressing Cancel still performed the action, and Accept performed it a second time. Rotating a feed the owner had just decided to keep invalidates a subscribe URL every subscribed calendar client is using.

Found while adding browser coverage for the feed (#306), where the double-fire showed up as an aborted second request.

## Fix

Those four forms now use `hx-confirm`, which htmx gates on itself; the existing `htmx:confirm` handler in the same modal serves it and still reads `data-confirm-accept` for the button label. Plain non-htmx forms (logout, recovery-code regeneration) keep `data-confirm` — they really do submit natively. `hx-confirm` users that were already correct (delete account, dashboard delete entry) are untouched.

## The guard matters more than the four edits

`TestNoTemplateElementMixesHTMXRequestWithDataConfirm` scans the embedded template sources and fails when any element carries both an htmx request attribute and `data-confirm` — so a surface added tomorrow is covered without anyone remembering this PR. `TestConfirmGatedSurfacesDeclareAnAcceptLabel` closes the neighbouring class (a confirm-gated element with no accept label shows the generic "Delete" on a rotate action).

**Proven against the defect:** reintroducing `data-confirm` on the rotate form fails the guard, naming the offending element and its `hx-post`; restored afterwards.

## E2E

New `cancelling rotate or revoke leaves the armed feed working`: a request spy records zero calls during both cancelled interactions, and — the assertion that would have caught the original defect — the **original subscribe URL still returns 200** afterwards. Positive anchor in the same test: the same control, accepted, revokes for real (404). The two existing feed tests were updated, since the request is now issued by accepting the dialog rather than by the submit click.

Runs: `settings-calendar-feed` + `settings-webhook` **5/5**; `calendar` + `settings-profile-cycle` **28/28** (the day-delete and symptom-hide flows — previously passing for the wrong reason, since the request fired before their dialog).

## Validation

`go build` clean · full `go test ./...` all 16 packages ok · staticcheck clean · golangci-lint (uncapped) 0 issues · patch coverage gate OK.