### PR TITLE
ci(security): route the trivy image pull through docker-pull-retry

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -186,13 +186,29 @@ jobs:
         run: mkdir -p .tmp/security
 
       - name: Pull Trivy image
-        # One pull covers both scan steps below — they reuse the cached image.
+        # Covers the scan step immediately below (same cached image). The SBOM
+        # step further down pulls again — see its own comment — because it must
+        # still run even if this pull's retries are exhausted.
         uses: ./.github/actions/docker-pull-retry
         with:
           image: ${{ env.TRIVY_IMAGE }}
 
       - name: Run Trivy image scan
         run: docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v "${{ github.workspace }}:/work" -w /work "${{ env.TRIVY_IMAGE }}" image --scanners vuln --skip-version-check --severity HIGH,CRITICAL --ignore-unfixed --format sarif --output .tmp/security/trivy-image.sarif --exit-code 1 ovumcy-security:${{ github.sha }}
+
+      - name: Pull Trivy image for SBOM
+        # Generate CycloneDX SBOM below runs `if: always()` so it still executes
+        # when the scan step above fails on findings (--exit-code 1) or when the
+        # pull step above never completed (retries exhausted). The latter used to
+        # fall straight through to `docker run`'s own single, un-retried implicit
+        # pull, which is what let a Docker Hub timeout cascade into the SARIF and
+        # artifact upload steps (run 30202113726). Repeating the retrying pull
+        # here is a cache-hit no-op on the common path and a real retry on the
+        # failure path.
+        if: always()
+        uses: ./.github/actions/docker-pull-retry
+        with:
+          image: ${{ env.TRIVY_IMAGE }}
 
       - name: Generate CycloneDX SBOM
         if: always()


### PR DESCRIPTION
## Incident

Run 30202113726: a Docker Hub timeout during the "Generate CycloneDX SBOM"
step in `security.yml`'s `trivy-image` job cascaded into the SARIF and
artifact upload steps for that job.

Root cause: that step runs `if: always()` so it still produces an SBOM when
the preceding scan step fails on findings (`--exit-code 1`). The job's one
explicit "Pull Trivy image" step (via `docker-pull-retry`, introduced in
#295) does not carry `always()`, so when it fails after exhausting its
retries, the SBOM step still runs and falls through to `docker run`'s own
implicit pull of the trivy image — a single attempt, no retry. If Docker Hub
is still flaky at that point, this pull fails too, and the subsequent
`if: always()` upload steps then fail on missing files (`if-no-files-found:
error` on the artifact upload).

## Fix

Add a second "Pull Trivy image for SBOM" step, also `if: always()`,
immediately before "Generate CycloneDX SBOM", mirroring every other
docker-pull-retry call site in the repo. On the common path this is a
cache-hit no-op (the image is already local from the first pull); on the
failure path it gives the SBOM step its own retrying pull instead of a bare
implicit one. Image reference and pin are unchanged.

## Sites audited

Every `docker run` / `docker create` / `docker build` across all workflow
files, checked for whether it fetches a remote image outside the wrapper:

| Site | Disposition |
|---|---|
| `security.yml` `trivy-fs`: `docker run` (fs scan) | Fine — pulled via `docker-pull-retry` immediately before, no `always()` gap |
| `security.yml` `trivy-image`: `docker run` (image scan) | Fine — pulled via `docker-pull-retry` immediately before, no `always()` gap |
| `security.yml` `trivy-image`: `docker run` (SBOM) | **Fixed** — this PR |
| `docker-image.yml` `publish`: `docker run` (pre-publish scan) | Fine — pulled via `docker-pull-retry` immediately before, no `always()` gap |
| `gitleaks.yml` `gitleaks`: `docker run` | Fine — pulled via `docker-pull-retry` immediately before, no `always()` gap |
| `ci.yml` `image-smoke`: `docker run -d ovumcy-image-smoke:$sha` | Left as is — local image built by `docker/build-push-action` (`load: true`) in the same job, not a registry pull |
| `docker/build-push-action` builds (`security.yml`, `docker-image.yml`, `ci.yml`) pulling the Dockerfile's own `golang`/`alpine` base images via buildx | Left as is — out of scope by the prior decision in #295's introduction of `docker-pull-retry`: wrapping a buildx base-image pull would duplicate the Dockerfile's digest pin in the workflow |
| `scripts/run-e2e.mjs` (Postgres image pull) | Not a workflow file; already retry-wrapped by its own equivalent logic since #295, unaffected here |
| `cflite_batch.yml`, `cflite_pr.yml`, `codeql.yml`, `mutation.yml`, `scorecard.yml` | No raw docker CLI usage — not applicable |

## Changelog

No `CHANGELOG.md` entry. #295 (introducing `docker-pull-retry`, same
CI-reliability category as this change) did not add one. #297 did, but its
own commit message ties that to a genuine operator-visible consequence
(publish latency). This change has no operator-visible effect, so it follows
#295's precedent.

## Validation

- `git diff` scoped to the single inserted step plus one updated comment in
  `security.yml`; step IDs, ordering, and outputs of every other step are
  unchanged.
- YAML parsed successfully (PyYAML) for every workflow file and the
  composite action; `actionlint` is not present in this repo/toolchain (no
  script, no binary on PATH), so this substitutes for it.
- Confirmed structurally via a parsed walk of the `trivy-image` job's step
  list: the new step sits between "Run Trivy image scan" and "Generate
  CycloneDX SBOM", with `if: always()` and the same single `image` input as
  every other `docker-pull-retry` call site (`attempts` left at its default).
- Real validation happens on this PR's own CI.