### PR TITLE
test(e2e): cover confirm-dialog cancellation for day deletion and symptom hiding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,6 +173,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   value. Closes a defense-in-depth gap where the invariant rested entirely on
   those two external guarantees instead of its own.
 
+### Internal
+
+- Browser coverage that cancelling a confirmation is inert now reaches deleting
+  a calendar day entry — where the action has no undo — and hiding a custom
+  symptom, instead of the calendar-feed settings flow alone. Each new test
+  records what the page put on the wire while the dialog was dismissed, asserts
+  nothing mutating was sent and the data survived a reload, and anchors that
+  against the same control accepted, which must still perform the action. The
+  dialog's own captions are asserted as rendered button text rather than only as
+  declared attributes.
+
 ## [1.9.2] - 2026-07-24
 
 Italian localization polish and a CI unblock. No database migrations; no

--- a/e2e/calendar.spec.ts
+++ b/e2e/calendar.spec.ts
@@ -15,6 +15,12 @@ import { openCalendarDayEditor } from './support/stats-helpers';
 import { setRequestTimezoneFromBrowser } from './support/timezone-helpers';
 import { checkStyledControl } from './support/form-helpers';
 import { dateFieldRoot, fillDateField } from './support/date-field-helpers';
+import {
+  acceptConfirmDialog,
+  cancelConfirmDialog,
+  expectConfirmDialogCaptions,
+  mutatingRequestsDuring,
+} from './support/confirm-dialog-helpers';
 
 function shiftISODate(iso: string, days: number): string {
   const [y, m, d] = iso.split('-').map((part) => Number(part));
@@ -210,6 +216,85 @@ test.describe('Calendar page', () => {
 
     await expect(page.locator(`[data-day-editor-form][data-day-editor-date="${pastISO}"]`)).toHaveCount(0);
     await expect(page.locator(`[data-day-editor-open="${pastISO}"]`).first()).toBeVisible();
+    await expect(page.locator('#day-editor')).not.toContainText(noteText);
+  });
+
+  // Cancelling the confirmation must be inert. This is a real regression, not a
+  // hypothetical: while the delete control carried `data-confirm`, htmx issued
+  // the DELETE from its own listener on the form before the document-level
+  // interceptor ever ran, so the dialog was decorative and Cancel erased the
+  // day anyway — irrecoverable, since health data has no undo. The control now
+  // uses `hx-confirm`, which htmx gates on. The template-level guard against the
+  // whole class is TestNoTemplateElementMixesHTMXRequestWithDataConfirm; the
+  // sibling cancel-is-inert tests cover the other gated surfaces in
+  // settings-profile-cycle.spec.ts and settings-calendar-feed.spec.ts.
+  test('cancelling the delete confirmation leaves the day entry intact', async ({ page }) => {
+    await registerOwnerOnCalendar(page, 'calendar-delete-cancel');
+
+    const todayISO = await todayISOFromCalendar(page);
+    const pastISO = shiftISODate(todayISO, -2);
+    const pastMonth = pastISO.slice(0, 7);
+    const noteText = `calendar-delete-cancel-${Date.now()}`;
+
+    const dayEditorForm = await openCalendarDayEditor(page, pastISO);
+    await dayEditorForm.locator('input[name="is_period"]').check();
+    await openCalendarNotes(dayEditorForm);
+    await dayEditorForm.locator('#calendar-notes').fill(noteText);
+    // Bind the wait to this click's own PUT and let the htmx cascade it triggers
+    // settle, so the entry is committed — not merely submitted — before the
+    // delete flow starts (same reasoning as saveDayEditorForm in
+    // calendar-autofill-clear.spec.ts).
+    const [saveRequest] = await Promise.all([
+      page.waitForRequest(
+        (candidate) =>
+          candidate.method() === 'PUT' && candidate.url().includes(`/api/v1/days/${pastISO}`)
+      ),
+      dayEditorForm.locator('button[data-save-button]').click(),
+    ]);
+    const saveResponse = await saveRequest.response();
+    expect(saveResponse, `expected a response for PUT /api/v1/days/${pastISO}`).not.toBeNull();
+    expect(
+      saveResponse!.ok(),
+      `PUT /api/v1/days/${pastISO} failed with ${saveResponse!.status()}`
+    ).toBeTruthy();
+    await page.waitForLoadState('networkidle');
+
+    const deleteForm = page.locator(`[data-day-delete-form][data-day-delete-date="${pastISO}"]`);
+    const isDayMutation = (pathname: string) => pathname.endsWith(`/api/v1/days/${pastISO}`);
+
+    const cancelledRequests = await mutatingRequestsDuring(page, isDayMutation, async () => {
+      await openCalendarDayEditor(page, pastISO);
+      const deleteButton = deleteForm.locator('[data-day-delete-button]');
+      await expect(deleteButton).toBeVisible();
+      await deleteButton.click();
+
+      // The dialog must show the captions this surface declared, not a
+      // hardcoded fallback: backend coverage only pins that they are declared.
+      await expectConfirmDialogCaptions(page, deleteForm);
+      await cancelConfirmDialog(page);
+
+      // A reload is the concrete signal that any request the click was going to
+      // issue has had its chance — no arbitrary timeout involved.
+      await page.reload();
+      await expect(page).toHaveURL(new RegExp(`/calendar\\?month=${pastMonth}&day=${pastISO}`));
+    });
+    expect(cancelledRequests, 'cancelling the delete must issue no request').toEqual([]);
+
+    // The entry survived the dialog and the reload — asserted on the server-rendered
+    // grid marker as well as the panel, so this cannot pass on stale client state.
+    await expect(page.locator('#day-editor')).toContainText(noteText);
+    await expect(page.locator(`button[data-day="${pastISO}"]`)).toHaveAttribute(
+      'data-calendar-has-data',
+      'true'
+    );
+
+    // Positive anchor: the same control, accepted, really does delete — so the
+    // assertions above prove Cancel is inert, not that the control is dead.
+    await openCalendarDayEditor(page, pastISO);
+    await deleteForm.locator('[data-day-delete-button]').click();
+    await acceptConfirmDialog(page);
+
+    await expect(deleteForm).toHaveCount(0);
     await expect(page.locator('#day-editor')).not.toContainText(noteText);
   });
 

--- a/e2e/settings-profile-cycle.spec.ts
+++ b/e2e/settings-profile-cycle.spec.ts
@@ -12,6 +12,11 @@ import {
 } from './support/auth-helpers';
 import { assertNoHorizontalOverflow } from './support/mobile-layout-helpers';
 import { openCalendarDayEditor } from './support/stats-helpers';
+import {
+  cancelConfirmDialog,
+  expectConfirmDialogCaptions,
+  mutatingRequestsDuring,
+} from './support/confirm-dialog-helpers';
 
 function toISODate(date: Date): string {
   const copy = new Date(date);
@@ -697,6 +702,75 @@ test.describe('Settings: profile and cycle', () => {
     await expect(
       page.locator(`[data-day-editor-form][data-day-editor-date="${otherISO}"] input[name="symptom_ids"][data-symptom-name="Joint stiffness"]`)
     ).toHaveCount(0);
+  });
+
+  // Cancelling the confirmation must be inert. This is a real regression, not a
+  // hypothetical: while the hide control carried `data-confirm`, htmx issued the
+  // DELETE from its own listener on the form before the document-level
+  // interceptor ever ran, so the dialog was decorative and Cancel archived the
+  // symptom anyway. The control now uses `hx-confirm`, which htmx gates on. The
+  // template-level guard against the whole class is
+  // TestNoTemplateElementMixesHTMXRequestWithDataConfirm; the sibling
+  // cancel-is-inert tests cover the other gated surfaces in calendar.spec.ts and
+  // settings-calendar-feed.spec.ts.
+  test('cancelling the hide confirmation keeps the custom symptom active', async ({ page }) => {
+    await registerOwnerAndOpenSettings(page, 'settings-custom-symptom-hide-cancel');
+
+    const symptomSection = page.locator('#settings-symptoms-section');
+    await createCustomSymptom(symptomSection, 'Joint stiffness', '✨');
+
+    const activeRow = customSymptomRow(symptomSection, 'Joint stiffness', 'active');
+    await expect(activeRow).toBeVisible();
+    const symptomID = await activeRow.getAttribute('data-symptom-id');
+    expect(symptomID).toMatch(/^\d+$/);
+
+    const hideForm = activeRow.locator('form[hx-delete^="/api/v1/symptoms/"]');
+    const isSymptomMutation = (pathname: string) =>
+      pathname.endsWith(`/api/v1/symptoms/${symptomID}`);
+
+    const cancelledRequests = await mutatingRequestsDuring(page, isSymptomMutation, async () => {
+      await hideForm.locator('button[type="submit"]').click();
+
+      // The dialog must show the captions this surface declared, not a
+      // hardcoded fallback: backend coverage only pins that they are declared.
+      const captions = await expectConfirmDialogCaptions(page, hideForm);
+      // This surface names its own action instead of reusing the layout-wide
+      // delete wording, so the rendered caption also proves the per-control
+      // attribute — not the `data-confirm-delete` fallback — drove the button.
+      const layoutFallback = (
+        (await page.locator('body').getAttribute('data-confirm-delete')) ?? ''
+      ).trim();
+      expect(layoutFallback).not.toBe('');
+      expect(captions.accept).not.toBe(layoutFallback);
+
+      await cancelConfirmDialog(page);
+
+      // A reload is the concrete signal that any request the click was going to
+      // issue has had its chance — no arbitrary timeout involved.
+      await page.reload();
+      await expect(page).toHaveURL(/\/settings$/);
+    });
+    expect(cancelledRequests, 'cancelling the hide must issue no request').toEqual([]);
+
+    // Still active after the dialog and the reload: no archived group appeared,
+    // so nothing was hidden behind the owner's back.
+    await expect(customSymptomRow(symptomSection, 'Joint stiffness', 'active')).toBeVisible();
+    await expect(customSymptomRow(symptomSection, 'Joint stiffness', 'archived')).toHaveCount(0);
+    await expect(symptomSection.locator('[data-symptom-group="archived"]')).toHaveCount(0);
+
+    // And still offered for new entries — the behaviour hiding would have taken
+    // away, measured where the owner would notice it.
+    await page.goto('/dashboard');
+    await expect(page).toHaveURL(/\/dashboard$/);
+    await ensureSymptomInputVisible(dashboardSaveForm(page), 'Joint stiffness');
+
+    // Positive anchor: the same control, accepted, really does hide it — so the
+    // assertions above prove Cancel is inert, not that the control is dead.
+    await page.goto('/settings');
+    await expect(page).toHaveURL(/\/settings$/);
+    await archiveCustomSymptom(page, customSymptomRow(symptomSection, 'Joint stiffness', 'active'));
+    await expect(customSymptomRow(symptomSection, 'Joint stiffness', 'archived')).toBeVisible();
+    await expect(customSymptomRow(symptomSection, 'Joint stiffness', 'active')).toHaveCount(0);
   });
 
   test('archived custom symptoms can be renamed, reject duplicates, and restore cleanly', async ({

--- a/e2e/support/confirm-dialog-helpers.ts
+++ b/e2e/support/confirm-dialog-helpers.ts
@@ -1,0 +1,93 @@
+import { expect, type Locator, type Page, type Request } from '@playwright/test';
+
+/**
+ * Helpers for the custom confirm dialog that gates destructive htmx controls.
+ *
+ * The dialog is CSP-safe markup in the base layout driven by an `htmx:confirm`
+ * listener: htmx withholds the request until the promise the listener returns
+ * resolves, so Cancel must leave the page untouched. Proving that needs two
+ * things a plain `expect(...).toBeVisible()` cannot give — a record of what the
+ * page actually put on the wire, and the captions the dialog really rendered.
+ */
+
+export type ConfirmDialogCaptions = {
+  accept: string;
+  cancel: string;
+};
+
+/**
+ * Asserts the open dialog renders the captions the surface declared, as visible
+ * button text.
+ *
+ * The accept caption is per-control (`data-confirm-accept` on the element that
+ * carries `hx-confirm`); the cancel caption is layout-wide
+ * (`data-confirm-cancel` on `<body>`). Backend coverage pins that both are
+ * declared — this pins that they survive the trip into the dialog instead of
+ * silently falling back to the layout default or to a hardcoded English word.
+ * Both declarations are asserted non-empty first so an empty attribute cannot
+ * make the comparison pass against empty rendered text.
+ */
+export async function expectConfirmDialogCaptions(
+  page: Page,
+  trigger: Locator
+): Promise<ConfirmDialogCaptions> {
+  await expect(page.locator('#confirm-modal')).toBeVisible();
+
+  const accept = ((await trigger.getAttribute('data-confirm-accept')) ?? '').trim();
+  expect(accept, 'the confirm-gated control must declare data-confirm-accept').not.toBe('');
+
+  const cancel = ((await page.locator('body').getAttribute('data-confirm-cancel')) ?? '').trim();
+  expect(cancel, 'the layout must declare data-confirm-cancel').not.toBe('');
+
+  const acceptButton = page.locator('#confirm-modal-accept');
+  const cancelButton = page.locator('#confirm-modal-cancel');
+  await expect(acceptButton).toBeVisible();
+  await expect(cancelButton).toBeVisible();
+  await expect(acceptButton).toHaveText(accept);
+  await expect(cancelButton).toHaveText(cancel);
+
+  return { accept, cancel };
+}
+
+/** Dismisses the open dialog and waits for it to close. */
+export async function cancelConfirmDialog(page: Page): Promise<void> {
+  await expect(page.locator('#confirm-modal')).toBeVisible();
+  await page.locator('#confirm-modal-cancel').click();
+  await expect(page.locator('#confirm-modal')).toBeHidden();
+}
+
+/** Confirms the open dialog, which is what releases the withheld htmx request. */
+export async function acceptConfirmDialog(page: Page): Promise<void> {
+  await expect(page.locator('#confirm-modal')).toBeVisible();
+  await page.locator('#confirm-modal-accept').click();
+}
+
+/**
+ * Records every non-GET request the page issues to a matching path while
+ * `action` runs. Method is part of the filter because the day endpoints serve
+ * saves and deletes under the same pathname, and reads (reloads, htmx partial
+ * fetches) must not be mistaken for a mutation that escaped the dialog.
+ */
+export async function mutatingRequestsDuring(
+  page: Page,
+  matchesPath: (pathname: string) => boolean,
+  action: () => Promise<void>
+): Promise<string[]> {
+  const seen: string[] = [];
+  const listener = (request: Request) => {
+    if (request.method() === 'GET') {
+      return;
+    }
+    if (matchesPath(new URL(request.url()).pathname)) {
+      seen.push(`${request.method()} ${request.url()}`);
+    }
+  };
+
+  page.on('request', listener);
+  try {
+    await action();
+  } finally {
+    page.off('request', listener);
+  }
+  return seen;
+}


### PR DESCRIPTION
## What

Adds browser coverage that **cancelling** an `hx-confirm` dialog is inert on the
two surfaces that had accept-path coverage only:

- `e2e/calendar.spec.ts` — day-entry deletion (`day_editor_partial.html`)
- `e2e/settings-profile-cycle.spec.ts` — hiding a custom symptom (`components/settings_symptoms.html`)

Also asserts the dialog's accept/cancel captions as **rendered button text**, not
only as declared attributes.

## Why

Gating the four htmx-driven confirmations with `hx-confirm` left behavioural proof
that Cancel is inert on one surface only — the calendar-feed settings flow. The
other three kept accept-path tests alone, so a regression re-arming the original
defect (htmx issuing the request before the dialog resolved) would have gone
unnoticed on the one surface where the action has no undo.

Caption coverage stopped at "the attributes are declared". Nothing checked that a
declared caption reaches the dialog instead of silently falling back to the
layout-wide default or a hardcoded English word.

## How

Both new tests follow the existing calendar-feed pattern: record every mutating
request the page issues while the dialog is dismissed, assert none was sent, and
assert the data survived a reload — the day entry still rendered and still marked
on the server-rendered grid, the custom symptom still active and still offered in
the day picker. Each closes with the same control **accepted**, which must still
perform the action, so the negative assertions cannot pass against a dead control.

The symptom surface additionally asserts its rendered caption differs from the
layout-wide `data-confirm-delete` fallback, proving the per-control attribute
drove the button.

Existing accept-path tests are unchanged. Shared logic lives in
`e2e/support/confirm-dialog-helpers.ts` so neither spec duplicates it. The
structural template guard `TestNoTemplateElementMixesHTMXRequestWithDataConfirm`
is untouched.

## Testing

`npm run e2e -- e2e/calendar.spec.ts e2e/settings-profile-cycle.spec.ts e2e/settings-calendar-feed.spec.ts`
→ **33 passed** (chromium, stable mode, 1 worker, 2.7m). `npm run lint` and
`npm run test:unit` (41 passed) clean.

Both new negative assertions were proven to bite: flipping each Cancel into an
Accept fails with `cancelling the delete must issue no request` /
`cancelling the hide must issue no request`, then passes again once restored.
The caption assertion was checked the same way — corrupting the expected value
reports `Expected: "Hide from new entries!!TEMP"` against
`Received: "Hide from new entries"`, confirming it reads real rendered text.

Test-only change; no production code touched.
