### PR TITLE
fix(api): return the enveloped 413 for over-limit compressed request bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **A compressed request body that only passes the 16 MiB cap once decompressed
+  now answers with the standard `413 request_too_large` envelope.** The cap is
+  applied to the decompressed stream inside the framework's body accessor, which
+  reports the overflow by stamping `413` on the response and handing the handler
+  a short internal error string in place of the payload — after the request has
+  already been routed. Two things followed from that substitution: the JSON
+  restore parsed the substituted string, failed, and answered `400 invalid import
+  file`, blaming the owner's export for what was a size rejection; and any route
+  that read the body without writing a response of its own leaked the framework's
+  bare-text `413`, which the app-wide error-envelope contract forbids. The
+  overflow is now detected once at the transport layer, before any handler runs,
+  and answered through the same mapped, content-negotiated envelope as the
+  wire-level `413`. No service ever receives the substituted bytes, so an
+  oversized upload can no longer be reported as a malformed file. An uncompressed
+  body is unaffected — its wire size and parsed size are the same number — and a
+  compressed body inside the cap still restores normally. See
+  [docs/export.md](docs/export.md) → Size limits.
+
 - **A `SECRET_KEY` rotation now revokes calendar-feed subscriptions of every
   generation.** Rows armed before migration 032 carry only a bcrypt verifier
   hash, which does not depend on `SECRET_KEY` — a rotated key left those

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -160,6 +160,7 @@ Policy-level claims (threat model in/out-of-scope, design rationale, marketing-s
 | Imported records are re-validated and owner-scoped; round-tripping an export reproduces the same entries | `TestImportServiceRoundTripPreservesEntries` in [internal/services/import_service_test.go](internal/services/import_service_test.go) |
 | A crafted file cannot persist an inconsistent anchor (`cycle_start` on a non-period day) | `TestImportServiceDropsCycleStartOnNonPeriodDay` in [internal/services/import_service_test.go](internal/services/import_service_test.go) |
 | Custom-symptom creation on import is bounded (`MaxImportCustomSymptoms`), so a crafted file cannot force unbounded catalog growth / DB churn | `TestImportServiceCapsCustomSymptomCreation` in [internal/services/import_service_test.go](internal/services/import_service_test.go) |
+| A compressed upload that only crosses the transport body cap once decompressed is refused at the transport layer with the mapped `413 request_too_large`: the import pipeline is never entered, nothing is persisted, and the rejection is never reported as a malformed file — while a body at the cap still restores normally | `TestImportJSONRejectsGzipBodyExceedingDecompressedCap`, `TestImportJSONAcceptsGzipBodyAtTheDecompressedCap` in [internal/api/imports_regressions_test.go](internal/api/imports_regressions_test.go) |
 
 ### Webhook Notifications (outbound egress)
 

--- a/docs/export.md
+++ b/docs/export.md
@@ -164,14 +164,14 @@ Two independent caps bound a restore, and they surface as **two different 413 ke
 
 | Cap | Value | Error |
 | --- | --- | --- |
-| Request body | **16 MiB** | `413 request_too_large` for an uncompressed body, enforced at the transport layer before the handler runs — the import service never sees the bytes. A compressed body behaves differently; see below. |
+| Request body | **16 MiB** | `413 request_too_large`, enforced at the transport layer before the handler runs — the import service never sees the bytes. Applies to the body as the server reads it, decompressed size included; see below. |
 | Entries per file | **20 000** | `413 import file too large`. Enforced by the import service on the parsed payload. |
 
 The body limit is sized to the entry cap (20 000 day records serialize to roughly 8–12 MiB), so a file at the documented entry ceiling stays comfortably under it. A file that trips the body limit is therefore either far past the entry cap or carrying unusually large `notes`.
 
-**Compressed requests (`Content-Encoding: gzip`/`deflate`/`br`/`zstd`) are bounded by the same 16 MiB, but at two different points, with two different outcomes.** The raw bytes on the wire are still capped at the transport layer regardless of encoding, so a compressed body that is itself over 16 MiB gets the clean `413 request_too_large` above without ever reaching the handler — same as the uncompressed case. But a well-compressed body can carry a decompressed payload far larger than 16 MiB while its wire size stays under the cap. In that case the handler **does** run: decompression (inside the framework's body accessor) applies the same 16 MiB cap to the **decompressed** size, and once that trips, the import service receives a short internal error string in place of the real payload rather than a clean 413. That string is not valid JSON, so it fails parsing exactly like a genuinely malformed file and the client receives the already-documented `400 invalid import file` below — not a 413. Uncompressed requests aren't affected by this distinction: their wire size and parsed size are the same number, so the transport-layer 413 is the only path.
+**Compressed requests (`Content-Encoding: gzip`/`deflate`/`br`/`zstd`) are bounded by the same 16 MiB, applied twice.** The raw bytes on the wire are capped regardless of encoding, so a compressed body that is itself over 16 MiB is refused while the request is read. A well-compressed body can stay under that on the wire and still expand past 16 MiB, so the cap is applied a second time to the **decompressed** stream, and a body that crosses it is refused there too. Either way the answer is the same `413 request_too_large` and the restore never starts: the import service is never handed a partial or substituted payload, so an oversized upload is never reported as a malformed file. Uncompressed requests only ever meet the first check — their wire size and parsed size are the same number.
 
-Error responses use stable, PII-free keys: `400 invalid import file` (not valid JSON — including an over-cap compressed body per above), the two 413s above, and `500 failed to import data`.
+Error responses use stable, PII-free keys: `400 invalid import file` (not valid JSON), the two 413s above, and `500 failed to import data`.
 
 Importing from other trackers (e.g. Drip) is out of scope for this endpoint — see [issue #116](https://github.com/ovumcy/ovumcy-web/issues/116).
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -193,8 +193,9 @@ components:
         generic status-class failure.
 
         Two rejections carry this envelope without belonging to any operation
-        below, because the server refuses them before routing: `413`
-        (`request_too_large`, body past the 16 MiB limit) and `431`
+        below, because the server refuses them before any operation runs: `413`
+        (`request_too_large`, body past the 16 MiB limit — wire size, and for a
+        compressed body its decompressed size too) and `431`
         (`request_headers_too_large`, request head past the read buffer). They
         are listed here rather than per-path — the request never reached an
         operation, so attaching them to one would misdescribe what happened.
@@ -1449,7 +1450,8 @@ paths:
             Payload exceeds the size or entry-count limit. Two independent caps
             produce two different keys: `import file too large` from the entry
             cap (20 000), and `request_too_large` from the 16 MiB body limit,
-            which the server enforces before the handler runs.
+            which the server enforces before the handler runs — on the wire body
+            and, when the request is compressed, on its decompressed size.
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ApiError' }

--- a/internal/api/error_mapping_transport_regression_test.go
+++ b/internal/api/error_mapping_transport_regression_test.go
@@ -1,10 +1,13 @@
 package api
 
 import (
+	"bytes"
+	"compress/gzip"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -102,6 +105,142 @@ func TestRespondMappedErrorSettingsFormRedirectsWithFlashOnly(t *testing.T) {
 	if payload.AuthError != "" || payload.SettingsSuccess != "" {
 		t.Fatalf("expected only settings error in flash payload, got %#v", payload)
 	}
+}
+
+// bodyLimitGuardTestLimit keeps the compressed probes small: a payload crossing
+// it gzips to a couple of hundred bytes, so the wire cap is never the thing
+// under test.
+const bodyLimitGuardTestLimit = 1024
+
+func gzipTestBody(t *testing.T, payload []byte) []byte {
+	t.Helper()
+
+	var compressed bytes.Buffer
+	writer := gzip.NewWriter(&compressed)
+	if _, err := writer.Write(payload); err != nil {
+		t.Fatalf("gzip payload: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close gzip writer: %v", err)
+	}
+	return compressed.Bytes()
+}
+
+// TestFiberSignalsDecompressedOverflowByStampingTheResponseStatus pins the
+// framework seam requestBodyLimitGuard is built on, because that seam is the
+// whole reason the guard exists and nothing else in the repo would notice it
+// moving.
+//
+// Fiber v3 decodes a Content-Encoding body lazily inside its body accessor and
+// applies the configured BodyLimit to the DECODED stream. The accessor returns
+// no error: it swallows fasthttp.ErrBodyTooLarge, stamps 413 on the response,
+// and hands the caller the error's text in place of the payload. So the only
+// observable signal is the stamped status — and the substituted text is what
+// used to reach the import service. If a fiber upgrade changes either half
+// (returns the real prefix, stops stamping, moves the enforcement point), this
+// test fails and the guard must be re-derived rather than silently becoming a
+// no-op or a false positive.
+func TestFiberSignalsDecompressedOverflowByStampingTheResponseStatus(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New(fiber.Config{BodyLimit: bodyLimitGuardTestLimit})
+
+	var observedBody string
+	var observedStatus int
+	app.Post("/probe", func(c fiber.Ctx) error {
+		observedBody = string(c.Body())
+		observedStatus = c.Response().StatusCode()
+		return c.SendStatus(fiber.StatusTeapot)
+	})
+
+	marker := strings.Repeat("payload-", 4)
+	payload := bytes.Repeat([]byte(marker), 1+bodyLimitGuardTestLimit/len(marker))
+	request := httptest.NewRequest(http.MethodPost, "/probe", bytes.NewReader(gzipTestBody(t, payload)))
+	request.Header.Set("Content-Encoding", "gzip")
+
+	assertStatusCode(t, mustAppResponse(t, app, request), fiber.StatusTeapot)
+
+	if observedStatus != fiber.StatusRequestEntityTooLarge {
+		t.Fatalf("expected fiber to stamp 413 on the response while decoding an over-limit body, got %d", observedStatus)
+	}
+	if strings.Contains(observedBody, marker) {
+		t.Fatalf("expected none of the decoded payload to reach the handler, got %q", observedBody)
+	}
+}
+
+// TestRequestBodyLimitGuardRejectsOnlyTheOverflowStamp pins the guard's three
+// compressed-body branches on one app: an over-limit decoded body is answered
+// with the mapped 413 and never reaches the route (previously a route that read
+// the body without writing a response returned fiber's bare-text 413, which the
+// app-wide envelope contract forbids); a body inside the cap reaches the route
+// decoded; and an encoding fiber cannot decode is left exactly as it was, with
+// no trace of the guard's probe on the response.
+func TestRequestBodyLimitGuardRejectsOnlyTheOverflowStamp(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New(fiber.Config{BodyLimit: bodyLimitGuardTestLimit})
+	app.Use(requestBodyLimitGuard)
+
+	routeReached := false
+	app.Post("/probe", func(c fiber.Ctx) error {
+		routeReached = true
+		return c.SendString("route saw " + strconv.Itoa(len(c.Body())) + " bytes")
+	})
+	// A route that reads the body and writes nothing of its own: whatever the
+	// framework stamped while decoding stands, which is how the bare-text 413
+	// used to escape.
+	app.Post("/passive", func(c fiber.Ctx) error {
+		routeReached = true
+		_ = c.Body()
+		return nil
+	})
+
+	t.Run("over the decoded cap", func(t *testing.T) {
+		for _, path := range []string{"/probe", "/passive"} {
+			routeReached = false
+			request := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(gzipTestBody(t, bytes.Repeat([]byte("a"), bodyLimitGuardTestLimit+1))))
+			request.Header.Set("Content-Encoding", "gzip")
+			request.Header.Set("Accept", "application/json")
+
+			response := mustAppResponse(t, app, request)
+			assertStatusCode(t, response, fiber.StatusRequestEntityTooLarge)
+			if body := mustReadBodyString(t, response.Body); !strings.Contains(body, `"error":"request_too_large"`) {
+				t.Fatalf("%s: expected the mapped request_too_large envelope, got %q", path, body)
+			}
+			if routeReached {
+				t.Fatalf("%s: expected the over-limit request to be rejected before the route ran", path)
+			}
+		}
+	})
+
+	t.Run("inside the decoded cap", func(t *testing.T) {
+		routeReached = false
+		request := httptest.NewRequest(http.MethodPost, "/probe", bytes.NewReader(gzipTestBody(t, bytes.Repeat([]byte("a"), bodyLimitGuardTestLimit))))
+		request.Header.Set("Content-Encoding", "gzip")
+
+		response := mustAppResponse(t, app, request)
+		assertStatusCode(t, response, fiber.StatusOK)
+		if !routeReached {
+			t.Fatal("expected a body inside the cap to reach the route")
+		}
+		if body := mustReadBodyString(t, response.Body); body != "route saw "+strconv.Itoa(bodyLimitGuardTestLimit)+" bytes" {
+			t.Fatalf("expected the route to receive the fully decoded body, got %q", body)
+		}
+	})
+
+	t.Run("undecodable encoding is left to the route", func(t *testing.T) {
+		routeReached = false
+		request := httptest.NewRequest(http.MethodPost, "/probe", strings.NewReader("whatever"))
+		request.Header.Set("Content-Encoding", "not-an-encoding")
+
+		response := mustAppResponse(t, app, request)
+		if !routeReached {
+			t.Fatal("expected an undecodable encoding to still reach the route")
+		}
+		// The route's own body read re-raises fiber's 415; what matters is that
+		// the guard's probe added nothing of its own on the way there.
+		assertStatusCode(t, response, fiber.StatusUnsupportedMediaType)
+	})
 }
 
 func newErrorMappingTransportTestApp(t *testing.T) (*fiber.App, *Handler) {

--- a/internal/api/imports_regressions_test.go
+++ b/internal/api/imports_regressions_test.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"bytes"
+	"compress/gzip"
 	"encoding/json"
 	"errors"
 	"io"
@@ -9,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ovumcy/ovumcy-web/internal/models"
 	"github.com/ovumcy/ovumcy-web/internal/services"
 )
 
@@ -122,6 +125,162 @@ func TestMapImportErrorCoversAllBranches(t *testing.T) {
 		if spec.Status != tc.status || spec.Key != tc.key {
 			t.Fatalf("mapImportError(%v) = {status:%d key:%q}, want {status:%d key:%q}", tc.err, spec.Status, spec.Key, tc.status, tc.key)
 		}
+	}
+}
+
+// importBodyCapTestLimit is the BodyLimit the compressed-restore regressions
+// run their app with. Small enough that a payload crossing it stays a few
+// hundred bytes on the wire once gzipped, so the transport cap under test is
+// the DECODED size and never the wire size.
+const importBodyCapTestLimit = 4096
+
+// gzipImportPayload builds a restore payload of exactly decodedSize bytes and
+// returns it gzipped. The payload is one valid day entry padded with trailing
+// spaces, which encoding/json accepts after a top-level value — so the only
+// thing that varies between the over-cap and at-cap cases is the decoded length.
+func gzipImportPayload(t *testing.T, decodedSize int) []byte {
+	t.Helper()
+
+	entry := `{"entries":[{"date":"2026-07-01","period":true,"flow":"medium","cycle_factors":[]}]}`
+	if decodedSize < len(entry) {
+		t.Fatalf("decodedSize %d is below the minimum valid payload of %d bytes", decodedSize, len(entry))
+	}
+	payload := entry + strings.Repeat(" ", decodedSize-len(entry))
+
+	var compressed bytes.Buffer
+	writer := gzip.NewWriter(&compressed)
+	if _, err := writer.Write([]byte(payload)); err != nil {
+		t.Fatalf("gzip payload: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close gzip writer: %v", err)
+	}
+	if compressed.Len() >= importBodyCapTestLimit {
+		t.Fatalf("gzipped payload is %d bytes, at or above the %d wire cap; the test would exercise the wire limit instead of the decoded one", compressed.Len(), importBodyCapTestLimit)
+	}
+	return compressed.Bytes()
+}
+
+func newGzipImportRequest(ctx settingsSecurityTestContext, compressed []byte) *http.Request {
+	request := httptest.NewRequest(http.MethodPost, "/api/v1/imports/json", bytes.NewReader(compressed))
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Content-Encoding", "gzip")
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("Cookie", settingsCookieHeader(ctx.authCookie, ctx.csrfCookie))
+	request.Header.Set("X-CSRF-Token", ctx.csrfToken)
+	return request
+}
+
+func countImportedDays(t *testing.T, ctx settingsSecurityTestContext) int64 {
+	t.Helper()
+
+	var rows int64
+	if err := ctx.database.Model(&models.DailyLog{}).Where("user_id = ?", ctx.user.ID).Count(&rows).Error; err != nil {
+		t.Fatalf("count imported days: %v", err)
+	}
+	return rows
+}
+
+// TestImportJSONRejectsGzipBodyExceedingDecompressedCap pins the compressed
+// half of the transport body cap. A gzipped body is small on the wire, so the
+// pre-routing rejection never fires; the cap is applied to the DECODED stream
+// inside fiber's body accessor, while the request is already routed. Left
+// unguarded, the accessor substitutes an internal error string for the payload,
+// which the import service reports as a malformed file — so an oversized upload
+// answered "400 invalid import file", blaming the owner's export for a size
+// rejection, and the import pipeline ran on bytes that were never the payload.
+//
+// The second half of the test is the positive anchor for the row assertion: the
+// same entry, gzipped under the cap, must still restore normally — proving the
+// day-row observable is live and that the guard does not reject valid
+// compressed restores.
+func TestImportJSONRejectsGzipBodyExceedingDecompressedCap(t *testing.T) {
+	t.Parallel()
+
+	ctx := newSettingsSecurityTestContextWithOptions(t, "import-gzip-overflow@example.com", onboardingTestAppOptions{
+		enableCSRF: true,
+		bodyLimit:  importBodyCapTestLimit,
+	})
+
+	oversized := gzipImportPayload(t, importBodyCapTestLimit+1)
+	response, err := ctx.app.Test(newGzipImportRequest(ctx, oversized), testConfigNoTimeout)
+	if err != nil {
+		t.Fatalf("oversized gzip import failed: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+
+	if response.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected 413 for a body whose decompressed size passes the cap, got %d", response.StatusCode)
+	}
+	var payload struct {
+		Error       string `json:"error"`
+		ErrorDetail struct {
+			Key      string `json:"key"`
+			Category string `json:"category"`
+			Target   string `json:"target"`
+		} `json:"error_detail"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode 413 envelope: %v", err)
+	}
+	if payload.Error != "request_too_large" {
+		t.Fatalf("expected the stable transport key request_too_large, got %q", payload.Error)
+	}
+	if payload.ErrorDetail.Key != "request_too_large" || payload.ErrorDetail.Category != "too_large" || payload.ErrorDetail.Target != "global" {
+		t.Fatalf("expected the shared global too_large error_detail, got %+v", payload.ErrorDetail)
+	}
+	if rows := countImportedDays(t, ctx); rows != 0 {
+		t.Fatalf("expected the rejected upload to reach no import pipeline, got %d persisted days", rows)
+	}
+
+	accepted := gzipImportPayload(t, importBodyCapTestLimit)
+	anchor, err := ctx.app.Test(newGzipImportRequest(ctx, accepted), testConfigNoTimeout)
+	if err != nil {
+		t.Fatalf("under-cap gzip import failed: %v", err)
+	}
+	defer func() { _ = anchor.Body.Close() }()
+
+	if anchor.StatusCode != http.StatusOK {
+		t.Fatalf("expected a gzipped body at the cap to restore normally, got %d", anchor.StatusCode)
+	}
+	if rows := countImportedDays(t, ctx); rows != 1 {
+		t.Fatalf("expected the accepted upload to persist 1 day, got %d", rows)
+	}
+}
+
+// TestImportJSONAcceptsGzipBodyAtTheDecompressedCap pins the other side of the
+// boundary: a decoded body of exactly BodyLimit bytes is domain input, not a
+// transport rejection, and flows through the normal restore result. Together
+// with the overflow case above this fixes the cap at "limit passes, limit+1
+// rejects" rather than somewhere nearby.
+func TestImportJSONAcceptsGzipBodyAtTheDecompressedCap(t *testing.T) {
+	t.Parallel()
+
+	ctx := newSettingsSecurityTestContextWithOptions(t, "import-gzip-boundary@example.com", onboardingTestAppOptions{
+		enableCSRF: true,
+		bodyLimit:  importBodyCapTestLimit,
+	})
+
+	response, err := ctx.app.Test(newGzipImportRequest(ctx, gzipImportPayload(t, importBodyCapTestLimit)), testConfigNoTimeout)
+	if err != nil {
+		t.Fatalf("at-cap gzip import failed: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 at the cap, got %d", response.StatusCode)
+	}
+	var result struct {
+		OK       bool `json:"ok"`
+		Added    int  `json:"added"`
+		Skipped  int  `json:"skipped"`
+		Rejected int  `json:"rejected"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&result); err != nil {
+		t.Fatalf("decode import result: %v", err)
+	}
+	if !result.OK || result.Added != 1 || result.Skipped != 0 || result.Rejected != 0 {
+		t.Fatalf("expected {ok:true added:1 skipped:0 rejected:0}, got %+v", result)
 	}
 }
 

--- a/internal/api/middleware_body_limit.go
+++ b/internal/api/middleware_body_limit.go
@@ -1,0 +1,65 @@
+package api
+
+import "github.com/gofiber/fiber/v3"
+
+// requestBodyLimitGuard turns an over-limit *compressed* request body into the
+// mapped 413, before any handler reads it.
+//
+// Why this is needed. The configured BodyLimit bounds the wire body, and
+// fasthttp rejects an over-limit wire body while reading the request — that
+// rejection surfaces as a fiber error and is answered by the top-level
+// ErrorHandler through RespondRequestEntityTooLarge. But a body carrying
+// Content-Encoding is decoded lazily, inside fiber's body accessor, and the
+// SAME limit is applied to the DECODED size (fiber v3 req.go tryDecodeBodyInOrder
+// → fasthttp Request.BodyGunzipWithLimit → copyZeroAllocWithLimit, which returns
+// fasthttp.ErrBodyTooLarge once the decoded stream passes the limit). By then the
+// request is already routed and the handler is running.
+//
+// The seam provides no error return: fiber's Body() swallows the decode error,
+// stamps StatusRequestEntityTooLarge on the response via SendStatus, and hands
+// the caller []byte(err.Error()) — the literal text "body size exceeds the given
+// limit" — in place of the payload. So the observable overflow signal is the
+// status fiber stamps on the response while the body accessor runs. Two things
+// went wrong downstream of that substitution:
+//   - a handler that parses the body reports a domain error about the
+//     substituted text (the JSON restore answered "400 invalid import file",
+//     blaming the file for what is a size rejection) and its status overwrites
+//     the stamped 413;
+//   - a handler that reads the body without writing its own response leaves
+//     SendStatus's output in place, so the client gets fiber's bare-text
+//     "Request Entity Too Large" instead of the app-wide error envelope.
+//
+// Running the probe once, at the transport edge, fixes both at the same point
+// and keeps every body-reading endpoint consistent: the request is rejected with
+// the same mapped envelope as the wire-level 413, and no handler — and therefore
+// no service — ever receives the substituted bytes.
+//
+// Requests without Content-Encoding skip the probe entirely: their wire size and
+// decoded size are the same number, already bounded before routing. A compressed
+// request that passes the probe is decoded once more by whatever reads its body,
+// which is a deliberate trade: the request is left byte-for-byte as it arrived
+// (no rewritten body, no dropped header) and only a client that opts into
+// compressing its upload pays for it.
+func requestBodyLimitGuard(c fiber.Ctx) error {
+	if len(c.Request().Header.ContentEncoding()) == 0 {
+		return c.Next()
+	}
+
+	statusBeforeProbe := c.Response().StatusCode()
+	_ = c.Body()
+	statusAfterProbe := c.Response().StatusCode()
+	if statusAfterProbe == statusBeforeProbe {
+		return c.Next()
+	}
+	if statusAfterProbe == fiber.StatusRequestEntityTooLarge {
+		return RespondRequestEntityTooLarge(c)
+	}
+
+	// fiber also stamps a status when it refuses to decode at all (415 for an
+	// unknown encoding, 501 for "compress"). Those are a different condition,
+	// answered as before by the handler that reads the body; undo the stamp so
+	// the probe leaves no trace on the response the handler goes on to write.
+	c.Response().ResetBody()
+	c.Status(statusBeforeProbe)
+	return c.Next()
+}

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -3,6 +3,12 @@ package api
 import "github.com/gofiber/fiber/v3"
 
 func RegisterRoutes(app *fiber.App, handler *Handler) {
+	// Registered here, alongside the routes it protects, rather than in the
+	// composition root's middleware chain: it must cover every route this
+	// function registers — page and /api/v1 alike — and an app assembled without
+	// it would answer an over-limit compressed body with a domain error or
+	// fiber's bare text. See requestBodyLimitGuard.
+	app.Use(requestBodyLimitGuard)
 	registerPageRoutes(app, handler)
 	registerV1APIRoutes(app, handler)
 }

--- a/internal/api/test_onboarding_app_setup_helpers_test.go
+++ b/internal/api/test_onboarding_app_setup_helpers_test.go
@@ -42,6 +42,11 @@ type onboardingTestAppOptions struct {
 	oidcService      OIDCWorkflowService
 	auditLogEnabled  bool
 	assetVersion     string
+	// bodyLimit overrides fiber's DefaultBodyLimit for this app. Zero keeps the
+	// default. Body-cap regressions set a small value so the compressed payload
+	// under test stays a few hundred bytes on the wire while its decoded size
+	// crosses the cap.
+	bodyLimit int
 }
 
 func newOnboardingTestAppWithOptions(t *testing.T, options onboardingTestAppOptions) (*fiber.App, *gorm.DB) {
@@ -74,7 +79,7 @@ func newOnboardingTestAppWithOptions(t *testing.T, options onboardingTestAppOpti
 		handler.SetAssetVersion(options.assetVersion)
 	}
 
-	app := fiber.New()
+	app := fiber.New(fiber.Config{BodyLimit: options.bodyLimit})
 	app.Use(handler.LanguageMiddleware)
 	if options.enableCSRF {
 		app.Use(csrf.New(testCSRFMiddlewareConfig(options.cookieSecure, handler)))


### PR DESCRIPTION
## Problem

The transport body cap (16 MiB) is applied to the **decoded** stream when a request carries `Content-Encoding`. That check happens lazily, inside the framework's body accessor, long after the request has been routed, and it reports the overflow only by stamping `413` on the response: no error is returned, and the caller receives a short internal error string in place of the payload.

Two things followed from that substitution:

- **A misleading domain error.** The JSON restore (`POST /api/v1/imports/json`) parsed the substituted string, failed, and answered `400 invalid import file` — blaming the owner's export for what was a size rejection — while the import pipeline ran on bytes that were never the payload.
- **A bare-text 413.** A route that reads the body without writing a response of its own left the framework's plain `Request Entity Too Large` in place, which the app-wide error-envelope contract forbids.

Both are reachable by any client that compresses its upload: a small body on the wire can expand well past the cap.

## Fix

A transport-layer guard runs the decode probe once, ahead of every registered route, and answers an overflow through the existing `RespondRequestEntityTooLarge` — the same mapped, content-negotiated envelope (stable key `request_too_large`) as the wire-level 413. No handler, and therefore no service, ever receives the substituted bytes. A body inside the cap reaches its route fully decoded, unchanged. An encoding the framework cannot decode at all is a different condition and is left exactly as it was, with no trace of the probe on the response.

The guard is registered by `RegisterRoutes`, so it covers page and `/api/v1` routes alike and cannot be omitted by an app that registers the routes it protects. Transport-only: no service, handler, or domain code changed.

## Testing

- An over-cap gzip restore asserts `413`, the envelope shape, the stable key, and that nothing was persisted; the same test's second half is its positive anchor — an identical entry gzipped inside the cap still restores and the row appears.
- A payload whose decoded size is exactly the cap restores normally, fixing the boundary at "cap passes, cap+1 rejects".
- The guard's three compressed-body branches are pinned on one app, including the passive route shape that used to leak the bare text.
- The framework seam the guard reads is pinned in its own test, so an upgrade that moves it fails loudly instead of turning the guard into a silent no-op.
- Verified by reverting the guard and confirming the new regressions fail naming the old behavior (`got 400`, `got "Request Entity Too Large"`, `got "route saw 33 bytes"`), then restoring it.
- Full `go test ./cmd/... ./internal/... ./migrations/... ./scripts/... ./web/...` green on a freshly regenerated profile; `scripts/patchcov` gate clean in the same invocation.

## Documentation

- `docs/export.md` → *Size limits*: the compressed path no longer documents the `400 invalid import file` outcome; both caps now produce the same `413 request_too_large` before the restore starts.
- `docs/openapi.yaml`: the shared envelope note and the import `413` description say the limit covers decompressed size too.
- `SECURITY.md` → *Data Import (Restore)*: new Test Enforcement Matrix row for the claim, with its tests.
- `CHANGELOG.md`: entry under Unreleased → Security.
