### PR TITLE
test(e2e): bind saves to their own PUT, anchor negative auth tests, send Origin on direct API calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -370,6 +370,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 
+- **Three latent e2e-suite defects, each proven by an executed probe before the
+  fix and re-proven closed after it.** The day-editor save helper
+  (`saveDayEditorForm`) moved from a single spec into `e2e/support/stats-helpers.ts`
+  and now backs the five save-then-navigate call sites that raced their own PUT
+  — with 1.5 s of injected server latency the old form silently lost the save
+  and the test failed on its own persistence check; the helper version survives
+  the same probe. The two hand-rolled settings-language saves ride
+  `saveSettingsLanguage` for the same reason. The 2FA invalid-code test now
+  anchors on the rendered `error.totp_invalid_code` server error — a handler
+  replaced by an unconditional bounce back to `/auth/2fa` used to pass both of
+  its negative assertions, and now fails naming the missing control. The
+  registration URL-leak test drives the server path directly with a weak-password
+  `POST /api/v1/users` and pins the clean `303` redirect: the client-side
+  validator swallows the UI submit before it reaches the network (an intercept
+  counted zero requests), so the previous version never exercised the surface it
+  was written for. Separately, every direct `page.request` call now sends an
+  explicit `Origin` — the suite convention that keeps direct API calls valid
+  under the HTTPS posture — and the GET-only export calls drop their dead
+  `csrf_token` form bodies (CSRF gates state-changing methods only, and a GET
+  should not carry a request body at all).
+
 - Browser coverage that cancelling a confirmation is inert now reaches deleting
   a calendar day entry — where the action has no undo — and hiding a custom
   symptom, instead of the calendar-feed settings flow alone. Each new test

--- a/e2e/auth-2fa.spec.ts
+++ b/e2e/auth-2fa.spec.ts
@@ -196,6 +196,12 @@ test.describe('Auth: TOTP two-factor authentication', () => {
 
     // Should stay on challenge page
     await expect(page).toHaveURL('/auth/2fa', { timeout: 5_000 });
+    // Positive anchor: the challenge endpoint ran and rejected this exact code.
+    // Without it, a handler that unconditionally bounces back to /auth/2fa
+    // passes both negative assertions around it.
+    await expect(
+      page.locator('[data-auth-server-error][data-error-key="error.totp_invalid_code"]')
+    ).toBeVisible();
     const authCookie = await cookieByName(context, 'ovumcy_auth');
     expect(authCookie).toBeFalsy();
   });

--- a/e2e/bugs.spec.ts
+++ b/e2e/bugs.spec.ts
@@ -2,6 +2,7 @@ import { expect, test, type Page } from '@playwright/test';
 import { clearDateField, fillDateField } from './support/date-field-helpers';
 import { openCalendarDayEditor } from './support/stats-helpers';
 import { checkStyledControl } from './support/form-helpers';
+import { saveSettingsLanguage } from './support/language-helpers';
 import {
   dashboardCurrentCycleDay,
   dashboardCurrentPhaseText,
@@ -421,10 +422,38 @@ test.describe('Bug regressions', () => {
       await page.locator('#register-confirm-password').fill('weak');
       await page.locator('form[action="/api/v1/users"] button[type="submit"]').click();
 
+      // Positive anchor: the weak password really was rejected. The client-side
+      // validator blocks this submit before it reaches the network, so without
+      // the visible-error assertion the URL checks below pass even when nothing
+      // validated anything.
+      await expect(page.locator('#register-client-status .status-error')).toBeVisible();
       await expect(page).toHaveURL(/\/register$/);
       const currentURL = page.url().toLowerCase();
       expect(currentURL).not.toContain('email=');
       expect(currentURL).not.toContain('error=');
+
+      // The client validator swallows the UI submit above, so the server-side
+      // error path — the surface this test is about — must be driven directly:
+      // a weak password POSTed to /api/v1/users comes back as a redirect whose
+      // Location must carry no email or error parameters.
+      const csrfToken =
+        (await page.locator('meta[name="csrf-token"]').getAttribute('content')) ?? '';
+      const response = await page.request.post('/api/v1/users', {
+        headers: apiOriginHeader(page),
+        form: {
+          csrf_token: csrfToken,
+          email: 'anyuser@ovumcy.lan',
+          password: 'weak',
+          confirm_password: 'weak',
+          consent: 'true',
+        },
+        maxRedirects: 0,
+      });
+      expect(response.status()).toBe(303);
+      const location = String(response.headers()['location'] ?? '').toLowerCase();
+      expect(location).not.toBe('');
+      expect(location).not.toContain('email=');
+      expect(location).not.toContain('error=');
     });
 
     test('login unknown email and wrong password produce identical message', async ({ page }) => {
@@ -546,10 +575,10 @@ test.describe('Bug regressions', () => {
 
       await page.goto('/settings');
       await expect(page).toHaveURL(/\/settings$/);
-      const interfaceForm = page.locator('[data-settings-interface-form]');
-      await interfaceForm.locator('[data-settings-interface-language-option="ru"] .radio-tile').click();
-      await interfaceForm.locator('[data-settings-interface-save]').click();
-      await expect(page).toHaveURL(/\/settings$/);
+      // Bind the language save to its own PATCH before the data-wipe API call
+      // below — a bare save click races the in-flight request and can drop the
+      // just-chosen language (saveSettingsLanguage documents the mechanism).
+      await saveSettingsLanguage(page, 'ru');
       await expect(page.locator('html')).toHaveAttribute('lang', 'ru');
 
       const csrfToken = (await page.locator('meta[name="csrf-token"]').getAttribute('content')) ?? '';

--- a/e2e/calendar-autofill-clear.spec.ts
+++ b/e2e/calendar-autofill-clear.spec.ts
@@ -8,7 +8,7 @@ import {
   registerOwnerViaUI,
 } from './support/auth-helpers';
 import { ensureNotesFieldVisible } from './support/note-helpers';
-import { openCalendarDayEditor } from './support/stats-helpers';
+import { openCalendarDayEditor, saveDayEditorForm } from './support/stats-helpers';
 import { setRequestTimezoneFromBrowser } from './support/timezone-helpers';
 
 function shiftISODate(iso: string, days: number): string {
@@ -42,36 +42,6 @@ async function todayISOFromCalendar(page: Page): Promise<string> {
   const todayISO = await todayButton.getAttribute('data-day');
   expect(todayISO).toMatch(/^\d{4}-\d{2}-\d{2}$/);
   return todayISO!;
-}
-
-async function saveDayEditorForm(page: Page, isoDate: string, form: import('@playwright/test').Locator): Promise<void> {
-  // Bind the wait to the request this click issues, not to any PUT response for
-  // the date. waitForResponse would resolve on the first matching response to
-  // arrive after registration — under CPU contention a still-in-flight earlier
-  // PUT's response can land inside this window and satisfy the predicate before
-  // the actual save lands. The `request` event only fires for requests issued
-  // after registration, so this captures exactly the click's PUT; awaiting that
-  // request's own response then blocks until this save has truly committed.
-  const [request] = await Promise.all([
-    page.waitForRequest(
-      (candidate) =>
-        candidate.method() === 'PUT' && candidate.url().includes(`/api/v1/days/${isoDate}`),
-    ),
-    form.locator('button[data-save-button]').click(),
-  ]);
-  const response = await request.response();
-  expect(response, `expected a response for PUT /api/v1/days/${isoDate}`).not.toBeNull();
-  expect(response!.ok(), `PUT /api/v1/days/${isoDate} failed with ${response!.status()}`).toBeTruthy();
-
-  // The PUT response only means the write committed. Its htmx afterSwap then
-  // fires `calendar-day-updated`, which reloads the whole calendar grid
-  // (GET /calendar) and re-lazy-loads the day editor — a cascade that outlives
-  // this click. If the caller navigates (openCalendarDayEditor → page.goto)
-  // while that cascade is still hitting the server, the next page's own
-  // hx-trigger="load" editor fetch competes with it and, under CPU contention,
-  // can miss the 5s visibility window. Let the app go quiescent first so the
-  // save is fully settled — not just committed — before returning.
-  await page.waitForLoadState('networkidle');
 }
 
 test.describe('calendar auto-fill clear-on-toggle-off', () => {

--- a/e2e/calendar.spec.ts
+++ b/e2e/calendar.spec.ts
@@ -11,7 +11,7 @@ import {
 import { saveSettingsLanguage } from './support/language-helpers';
 import { expectElementAboveMobileTabbar } from './support/mobile-layout-helpers';
 import { ensureNotesFieldVisible } from './support/note-helpers';
-import { openCalendarDayEditor } from './support/stats-helpers';
+import { openCalendarDayEditor, saveDayEditorForm } from './support/stats-helpers';
 import { setRequestTimezoneFromBrowser } from './support/timezone-helpers';
 import { checkStyledControl } from './support/form-helpers';
 import { dateFieldRoot, fillDateField } from './support/date-field-helpers';
@@ -155,7 +155,7 @@ test.describe('Calendar page', () => {
     const noteText = `calendar-note-${Date.now()}`;
     await openCalendarNotes(dayEditorForm);
     await dayEditorForm.locator('#calendar-notes').fill(noteText);
-    await dayEditorForm.locator('button[data-save-button]').click();
+    await saveDayEditorForm(page, pastISO, dayEditorForm);
 
     await page.goto(`/calendar?month=${pastMonth}&day=${pastISO}`);
     await expect(page).toHaveURL(new RegExp(`/calendar\\?month=${pastMonth}&day=${pastISO}`));
@@ -180,7 +180,7 @@ test.describe('Calendar page', () => {
     await dayEditorForm.locator('[data-sex-activity-option="protected"]').click();
     await openCalendarNotes(dayEditorForm);
     await dayEditorForm.locator('#calendar-notes').fill(`calendar-marker-${Date.now()}`);
-    await dayEditorForm.locator('button[data-save-button]').click();
+    await saveDayEditorForm(page, pastISO, dayEditorForm);
 
     await page.goto(`/calendar?month=${pastMonth}&day=${pastISO}`);
     const dayButton = page.locator(`button[data-day="${pastISO}"]`);
@@ -201,7 +201,7 @@ test.describe('Calendar page', () => {
     await dayEditorForm.locator('input[name="is_period"]').check();
     await openCalendarNotes(dayEditorForm);
     await dayEditorForm.locator('#calendar-notes').fill(noteText);
-    await dayEditorForm.locator('button[data-save-button]').click();
+    await saveDayEditorForm(page, pastISO, dayEditorForm);
 
     await page.goto(`/calendar?month=${pastMonth}&day=${pastISO}`);
     await expect(page.locator('#day-editor')).toContainText(noteText);

--- a/e2e/cross-browser-smoke.spec.ts
+++ b/e2e/cross-browser-smoke.spec.ts
@@ -7,6 +7,7 @@ import {
   readRecoveryCode,
   registerOwnerViaUI,
 } from './support/auth-helpers';
+import { saveSettingsLanguage } from './support/language-helpers';
 import { ensureNotesFieldVisible } from './support/note-helpers';
 import { setRequestTimezoneFromBrowser } from './support/timezone-helpers';
 
@@ -83,9 +84,10 @@ test.describe('Cross-browser smoke', () => {
     const interfaceForm = page.locator('[data-settings-interface-form]');
     await interfaceForm.locator('[data-settings-interface-theme-option="dark"] .radio-tile').click();
     await expect(html).toHaveAttribute('data-theme', 'dark');
-    await interfaceForm.locator('[data-settings-interface-language-option="es"] .radio-tile').click();
-    await interfaceForm.locator('[data-settings-interface-save]').click();
-    await expect(page).toHaveURL(/\/settings$/);
+    // Bind the language save to its own PATCH before navigating away — a bare
+    // save click followed by page.goto races the in-flight request and can drop
+    // the just-chosen language (saveSettingsLanguage documents the mechanism).
+    await saveSettingsLanguage(page, 'es');
     await expect(html).toHaveAttribute('lang', 'es');
     await expect(page.locator('h1.journal-title')).toContainText('Configuración');
 

--- a/e2e/security-role.spec.ts
+++ b/e2e/security-role.spec.ts
@@ -154,8 +154,11 @@ test.describe('Security and role-based access', () => {
     await expect(page.locator('[data-export-section]')).toBeVisible();
     await expect(page.locator('form[action="/api/v1/users/current/data-wipe"]')).toBeVisible();
 
+    // GET-only route: CSRF gates state-changing methods (see the comment in the
+    // csrf-basics test above), so no token is sent; the explicit Origin keeps
+    // the call valid under the HTTPS posture.
     const exportResponse = await page.request.get('/api/v1/exports/csv', {
-      form: { csrf_token: await readCSRFToken(page) },
+      headers: apiOriginHeader(page),
     });
     expect(exportResponse.status()).toBe(200);
     expect(exportResponse.headers()['content-type'] || '').toContain('text/csv');

--- a/e2e/settings-calendar-feed.spec.ts
+++ b/e2e/settings-calendar-feed.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test, type Locator, type Page } from '@playwright/test';
 import {
+  apiOriginHeader,
   completeOnboardingIfPresent,
   continueFromRecoveryCode,
   createCredentials,
@@ -291,7 +292,7 @@ test.describe('Settings: calendar feed one-time reveal', () => {
 
     // The subscribe URL works before any of this — the anchor every assertion
     // below is measured against.
-    const beforeCancel = await page.request.get(armed.url);
+    const beforeCancel = await page.request.get(armed.url, { headers: apiOriginHeader(page) });
     expect(beforeCancel.status(), 'the freshly generated feed must serve').toBe(200);
 
     const rotateForm = feedSection(page).locator('[data-settings-calendar-feed-rotate]');
@@ -329,7 +330,7 @@ test.describe('Settings: calendar feed one-time reveal', () => {
       'data-calendar-feed-status',
       'configured'
     );
-    const afterCancel = await page.request.get(armed.url);
+    const afterCancel = await page.request.get(armed.url, { headers: apiOriginHeader(page) });
     expect(afterCancel.status(), 'a cancelled rotate/revoke must leave the URL working').toBe(200);
 
     // Positive anchor: the same control, accepted, really does revoke — so the
@@ -340,7 +341,7 @@ test.describe('Settings: calendar feed one-time reveal', () => {
     );
     await expect(page.locator('#settings-calendar-feed-status .status-ok')).toBeVisible();
 
-    const afterAccept = await page.request.get(armed.url);
+    const afterAccept = await page.request.get(armed.url, { headers: apiOriginHeader(page) });
     expect(afterAccept.status(), 'an accepted revoke must kill the URL').toBe(404);
   });
 });

--- a/e2e/settings-import.spec.ts
+++ b/e2e/settings-import.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test, type Page } from '@playwright/test';
 import {
+  apiOriginHeader,
   completeOnboardingIfPresent,
   continueFromRecoveryCode,
   createCredentials,
@@ -51,7 +52,9 @@ function lastToast(page: Page) {
 }
 
 async function exportedDates(page: Page): Promise<string[]> {
-  const response = await page.request.get('/api/v1/exports/json');
+  const response = await page.request.get('/api/v1/exports/json', {
+    headers: apiOriginHeader(page),
+  });
   expect(response.ok()).toBeTruthy();
   const payload = (await response.json()) as ExportPayload;
   return (payload.entries ?? []).map((entry) => String(entry.date ?? ''));

--- a/e2e/settings-password-export-danger.spec.ts
+++ b/e2e/settings-password-export-danger.spec.ts
@@ -2,9 +2,10 @@ import { expect, test, type Locator, type Page } from '@playwright/test';
 import { clearDateField, fillDateField } from './support/date-field-helpers';
 import { ensureNotesFieldVisible } from './support/note-helpers';
 import { setRequestTimezoneFromBrowser } from './support/timezone-helpers';
-import { openCalendarDayEditor } from './support/stats-helpers';
+import { openCalendarDayEditor, saveDayEditorForm } from './support/stats-helpers';
 import { checkStyledControl } from './support/form-helpers';
 import {
+  apiOriginHeader,
   completeOnboardingIfPresent,
   confirmRecoveryCode,
   continueFromRecoveryCode,
@@ -264,10 +265,12 @@ test.describe('Settings: password, export, clear data, delete account', () => {
 
     await page.goto('/settings');
     await expect(page).toHaveURL(/\/settings$/);
-    const csrfToken = await readCSRFToken(page);
 
+    // GET-only route: CSRF gates state-changing methods, so no token is sent.
+    // The explicit Origin keeps the call valid under the HTTPS posture, where
+    // the CSRF middleware rejects mutating requests without one (testing.md).
     const csvResponse = await page.request.get('/api/v1/exports/csv', {
-      form: { csrf_token: csrfToken },
+      headers: apiOriginHeader(page),
     });
 
     expect(csvResponse.status()).toBe(200);
@@ -276,7 +279,7 @@ test.describe('Settings: password, export, clear data, delete account', () => {
     expect(await csvResponse.text()).toContain(exportNote);
 
     const jsonResponse = await page.request.get('/api/v1/exports/json', {
-      form: { csrf_token: csrfToken },
+      headers: apiOriginHeader(page),
     });
 
     expect(jsonResponse.status()).toBe(200);
@@ -305,7 +308,7 @@ test.describe('Settings: password, export, clear data, delete account', () => {
     await dayEditorForm.locator('input[name="is_period"]').check();
     await openCalendarNotes(dayEditorForm);
     await dayEditorForm.locator('#calendar-notes').fill(`future-export-${Date.now()}`);
-    await dayEditorForm.locator('button[data-save-button]').click();
+    await saveDayEditorForm(page, futureISO, dayEditorForm);
 
     await page.goto('/settings');
     await expect(page).toHaveURL(/\/settings$/);
@@ -368,7 +371,7 @@ test.describe('Settings: password, export, clear data, delete account', () => {
     await dayEditorForm.locator('input[name="is_period"]').check();
     await openCalendarNotes(dayEditorForm);
     await dayEditorForm.locator('#calendar-notes').fill(`future-preset-${Date.now()}`);
-    await dayEditorForm.locator('button[data-save-button]').click();
+    await saveDayEditorForm(page, futureISO, dayEditorForm);
 
     await page.goto('/settings');
     await expect(page).toHaveURL(/\/settings$/);

--- a/e2e/stats-insights.spec.ts
+++ b/e2e/stats-insights.spec.ts
@@ -132,7 +132,7 @@ test.describe('Stats: BBT chart', () => {
     for (let offset = -5; offset <= 0; offset += 1) {
       const isoDate = shiftISODate(today, offset);
       const response = await page.request.get(`/api/v1/days/${isoDate}`, {
-        headers: { Accept: 'application/json' },
+        headers: { Accept: 'application/json', ...apiOriginHeader(page) },
       });
       expect(response.status(), `GET ${isoDate}`).toBe(200);
       const body = await response.json();

--- a/e2e/support/stats-helpers.ts
+++ b/e2e/support/stats-helpers.ts
@@ -61,7 +61,7 @@ export async function markCycleStart(page: Page, isoDate: string): Promise<void>
   await expect(manualStartButton).toBeVisible();
   // Bind to the click's own request, not any matching response: waitForResponse
   // can resolve on a still-in-flight earlier request under load (see
-  // saveDayEditorForm in calendar-autofill-clear.spec.ts).
+  // saveDayEditorForm below).
   const [request] = await Promise.all([
     page.waitForRequest(
       (candidate) =>
@@ -128,6 +128,38 @@ export async function openCalendarDayEditor(page: Page, isoDate: string): Promis
   const form = page.locator(`[data-day-editor-form][data-day-editor-date="${isoDate}"]`);
   await expect(form).toBeVisible();
   return form;
+}
+
+export async function saveDayEditorForm(page: Page, isoDate: string, form: Locator): Promise<void> {
+  // Bind the wait to the request this click issues, not to any PUT response for
+  // the date. waitForResponse would resolve on the first matching response to
+  // arrive after registration — under CPU contention a still-in-flight earlier
+  // PUT's response can land inside this window and satisfy the predicate before
+  // the actual save lands. The `request` event only fires for requests issued
+  // after registration, so this captures exactly the click's PUT; awaiting that
+  // request's own response then blocks until this save has truly committed.
+  const [request] = await Promise.all([
+    page.waitForRequest(
+      (candidate) =>
+        candidate.method() === 'PUT' && candidate.url().includes(`/api/v1/days/${isoDate}`),
+    ),
+    form.locator('button[data-save-button]').click(),
+  ]);
+  const response = await request.response();
+  expect(response, `expected a response for PUT /api/v1/days/${isoDate}`).not.toBeNull();
+  expect(response!.ok(), `PUT /api/v1/days/${isoDate} failed with ${response!.status()}`).toBeTruthy();
+
+  // The PUT response only means the write committed. Its htmx afterSwap then
+  // fires `calendar-day-updated`, which reloads the whole calendar grid
+  // (GET /calendar) and re-lazy-loads the day editor — a cascade that outlives
+  // this click. If the caller navigates (openCalendarDayEditor → page.goto)
+  // while that cascade is still hitting the server, the next page's own
+  // hx-trigger="load" editor fetch competes with it and, under CPU contention,
+  // can miss the 5s visibility window. A bare click followed by page.goto is
+  // worse still: the navigation aborts a PUT that has not committed yet and the
+  // save is silently lost. Let the app go quiescent first so the save is fully
+  // settled — not just committed — before returning.
+  await page.waitForLoadState('networkidle');
 }
 
 export async function saveCycleFactorOnDay(


### PR DESCRIPTION
## What

Mechanical fixes for three e2e-suite defect classes, each demonstrated by an executed probe before the fix and re-proven closed after it, plus an Origin sweep over every direct API call.

### Save-then-navigate races (silent data loss under latency)
- `saveDayEditorForm` is lifted verbatim (rationale comment included) from `calendar-autofill-clear.spec.ts` into `e2e/support/stats-helpers.ts` and now backs the five call sites that clicked `[data-save-button]` and immediately navigated: `calendar.spec.ts` (3), `settings-password-export-danger.spec.ts` (2).
- The two hand-rolled settings-language saves (`cross-browser-smoke.spec.ts`, `bugs.spec.ts` BUG-05) now call `saveSettingsLanguage`, which binds to the PATCH it issues.
- Probe: 1.5 s of injected latency on the PUT (`page.route`) made the old form lose the save — the navigation aborted the in-flight request and the test failed on its own persistence assertion. The same probe against the fixed test passes.

### Negative auth tests without a positive anchor
- `auth-2fa.spec.ts` invalid-code test now asserts the rendered `[data-auth-server-error][data-error-key="error.totp_invalid_code"]`. Probe: a handler replaced by an unconditional 303 back to `/auth/2fa` passed the old test; against the fixed test it fails naming the missing control.
- `bugs.spec.ts` registration URL-leak test: an intercept counted **zero** network requests — the client-side validator swallows the UI submit, so the server path the test exists for was never exercised. The test keeps the UI half (now anchored on the visible client error) and additionally drives `POST /api/v1/users` directly with a weak password, pinning the `303` redirect whose `Location` carries no `email=` / `error=`.

### Origin on every direct API call
- Adds the explicit `Origin` header to the six GET call sites that lacked it (`security-role`, `settings-password-export-danger` ×2, `settings-import` helper, `settings-calendar-feed` ×3, `stats-insights`); every mutating call already carried it. These GETs were exercised under `COOKIE_SECURE=true` before the change and passed — the CSRF middleware validates Origin on state-changing methods only — so this is convention alignment that keeps the sweep allowlist-free, not a behavior fix.
- The GET-only export calls drop their dead `csrf_token` form bodies: CSRF never gates GET, and a GET should not carry a request body at all.

## Validation

- All ten affected specs green locally: **67/67**.
- Regression proofs executed and reverted in the same session: slow-save probe (red before / green after), dead-rejection probe (green before / red after, failing on the new anchor).
- The Origin call sites were additionally validated under `COOKIE_SECURE=true` (27/27) prior to the change.
