### PR TITLE
test(e2e): bind remaining waits to concrete signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -370,6 +370,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 
+- **Every remaining e2e wait now binds to a concrete signal instead of to a
+  sleep or to page state that is already true.** The suite's last two fixed
+  250 ms sleeps, which guarded the two XSS "no dialog fired" claims, are gone:
+  the assertions they followed already prove the payload had its chance — the
+  server rejected it and nothing rendered in one test, it is present as *text*
+  rather than markup in the other, so no element exists to fire a deferred
+  `onerror`. `completeOnboardingIfPresent`, which nearly every spec calls, no
+  longer swallows a hung post-registration redirect: the wait stays tolerant of
+  the redirect having already landed, but the settled path is now asserted, so
+  "the redirect never happened" fails at the helper rather than resurfacing as
+  an unrelated failure further down the caller. Calendar and BUG-06 month
+  navigation assert the specific month each control points at, instead of a
+  `?month=` shape the URL already matches before the click. The two
+  "Cancel/Escape did not navigate" claims — the settings leave guard and the
+  logout confirmation — now record what the page put on the wire, or where the
+  main frame went, across the whole window and close it on a reload or on a
+  state transition; the dashboard manual-cycle-start cancel joins them, having
+  asserted only an empty error status, which also holds when the POST fired and
+  succeeded. Two calendar `await request.response()` calls that discarded the
+  status now assert it. Every replacement assertion was proven live by breaking
+  what it guards — accepting the dialog it cancels, aiming the onboarding helper
+  at a path that never arrives, naming the wrong month — and watching it fail
+  while naming the escaped request, the navigation, or the stuck URL.
+
 - **Three latent e2e-suite defects, each proven by an executed probe before the
   fix and re-proven closed after it.** The day-editor save helper
   (`saveDayEditorForm`) moved from a single spec into `e2e/support/stats-helpers.ts`

--- a/e2e/bugs.spec.ts
+++ b/e2e/bugs.spec.ts
@@ -632,8 +632,14 @@ test.describe('Bug regressions', () => {
         if (!href) {
           break;
         }
+
+        // Name the month this iteration must land on: from the second iteration
+        // on, the bare /calendar?month= shape is already satisfied by the URL the
+        // click starts from, so the wait would not bind to the transition.
+        const targetMonth = new URL(href, page.url()).searchParams.get('month');
+        expect(targetMonth).toMatch(/^\d{4}-\d{2}$/);
         await previousControl.click();
-        await expect(page).toHaveURL(/\/calendar\?month=/);
+        await expect(page).toHaveURL(new RegExp(`/calendar\\?month=${targetMonth}$`));
       }
 
       const lowerBoundMonth = await browserMonthYearsAgo(page, 3);

--- a/e2e/calendar.spec.ts
+++ b/e2e/calendar.spec.ts
@@ -84,13 +84,21 @@ test.describe('Calendar page', () => {
     const initialLabel = ((await monthLabel.textContent()) ?? '').trim();
     expect(initialLabel.length).toBeGreaterThan(0);
 
+    // Each wait names the month the control points at. The generic
+    // /calendar?month=\d{4}-\d{2} shape is satisfied by the URL the click starts
+    // from once a month is selected, so it would pass without the transition.
+    const prevMonth = new URL((await prevLink.getAttribute('href')) ?? '', page.url()).searchParams.get('month');
+    expect(prevMonth).toMatch(/^\d{4}-\d{2}$/);
     await prevLink.click();
-    await expect(page).toHaveURL(/\/calendar\?month=\d{4}-\d{2}/);
+    await expect(page).toHaveURL(new RegExp(`/calendar\\?month=${prevMonth}$`));
     const prevLabel = ((await monthLabel.textContent()) ?? '').trim();
     expect(prevLabel).not.toBe(initialLabel);
 
+    const nextMonth = new URL((await nextLink.getAttribute('href')) ?? '', page.url()).searchParams.get('month');
+    expect(nextMonth).toMatch(/^\d{4}-\d{2}$/);
+    expect(nextMonth).not.toBe(prevMonth);
     await nextLink.click();
-    await expect(page).toHaveURL(/\/calendar\?month=\d{4}-\d{2}/);
+    await expect(page).toHaveURL(new RegExp(`/calendar\\?month=${nextMonth}$`));
 
     await todayLink.click();
     await expect(page).toHaveURL(/\/calendar$/);
@@ -361,7 +369,12 @@ test.describe('Calendar page', () => {
       }),
       manualStartButton.click(),
     ]);
-    await req.response();
+    const cycleStartResponse = await req.response();
+    expect(cycleStartResponse, `expected a response for POST /api/v1/days/${pastISO}/cycle-start`).not.toBeNull();
+    expect(
+      cycleStartResponse!.ok(),
+      `POST /api/v1/days/${pastISO}/cycle-start failed with ${cycleStartResponse!.status()}`
+    ).toBeTruthy();
 
     const editButton = page.locator(`[data-day-editor-open="${pastISO}"]`).first();
     await expect(editButton).toBeVisible();
@@ -618,7 +631,12 @@ test.describe('Calendar page', () => {
       ),
       dayEditorForm.locator('button[data-save-button]').click(),
     ]);
-    await saveRequest.response();
+    const saveResponse = await saveRequest.response();
+    expect(saveResponse, `expected a response for PUT /api/v1/days/${tomorrowISO}`).not.toBeNull();
+    expect(
+      saveResponse!.ok(),
+      `PUT /api/v1/days/${tomorrowISO} failed with ${saveResponse!.status()}`
+    ).toBeTruthy();
 
     // Reload the summary (non-edit) view for tomorrow. It now renders the
     // with-data branch: the logged note is shown by owner_log_summary, which the

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -7,6 +7,7 @@ import {
   readRecoveryCode,
   registerOwnerViaUI,
 } from './support/auth-helpers';
+import { cancelConfirmDialog, mutatingRequestsDuring } from './support/confirm-dialog-helpers';
 import { expectElementAboveMobileTabbar } from './support/mobile-layout-helpers';
 import { ensureNotesFieldVisible } from './support/note-helpers';
 import { setRequestTimezoneFromBrowser } from './support/timezone-helpers';
@@ -427,11 +428,23 @@ test.describe('Dashboard: today editor', () => {
 
     const manualStartButton = manualCycleStartButton(page);
     await expect(manualStartButton).toBeVisible();
-    await manualStartButton.click();
-    await expect(page.locator('#confirm-modal')).toBeVisible();
-    await page.locator('#confirm-modal-cancel').click();
-    await expect(page.locator('#confirm-modal')).toBeHidden();
-    await expect(page.locator('#save-status .status-error')).toHaveCount(0);
+
+    // Cancel must issue nothing at all. An empty #save-status .status-error is a
+    // weaker claim than it looks — it also holds when the POST fired and
+    // succeeded — so record the wire instead, and reload inside the window so any
+    // request the cancelled click was going to issue has had its chance.
+    const cancelledRequests = await mutatingRequestsDuring(
+      page,
+      (pathname) => pathname.endsWith('/cycle-start'),
+      async () => {
+        await manualStartButton.click();
+        await cancelConfirmDialog(page);
+
+        await page.reload();
+        await expect(manualStartButton).toBeVisible();
+      }
+    );
+    expect(cancelledRequests, 'cancelling the manual cycle start must issue no request').toEqual([]);
 
     const [request] = await Promise.all([
       page.waitForRequest(

--- a/e2e/security-role.spec.ts
+++ b/e2e/security-role.spec.ts
@@ -66,8 +66,11 @@ test.describe('Security and role-based access', () => {
     await expect(page.locator('#settings-display-name')).toHaveValue(payload);
     await expect(page.locator('#settings-account img')).toHaveCount(0);
 
-    await page.waitForTimeout(250);
-    expect(dialogTriggered).toBe(false);
+    // The listener has been installed since before the save, and the assertions
+    // above are the concrete signal that the payload has had its chance: the
+    // server rejected it, and the surfaces that would have carried it hold no
+    // `<img>` to fire a deferred `onerror`. No sleep is needed to make that safe.
+    expect(dialogTriggered, 'the rejected display name must not execute').toBe(false);
   });
 
   test('xss payload in notes is stored as plain text and does not execute', async ({ page }) => {
@@ -94,8 +97,12 @@ test.describe('Security and role-based access', () => {
     await expect(page).toHaveURL(new RegExp(`/calendar\\?month=${month}&day=${savedDay}`));
     await expect(page.locator('#day-editor')).toContainText(payload);
 
-    await page.waitForTimeout(250);
-    expect(dialogTriggered).toBe(false);
+    // The listener has been installed since before the save, and the assertion
+    // above is the concrete signal: the payload is present as *text*, so neither
+    // the `<script>` (which would have run during parsing) nor the `<img>` (which
+    // would be an element, not text, and would fire `onerror` on its failed load)
+    // was ever parsed as markup. No sleep is needed to make that safe.
+    expect(dialogTriggered, 'the stored payload must not execute').toBe(false);
   });
 
   test('csrf basics: missing token is rejected for state-changing endpoints', async ({ page }) => {

--- a/e2e/support/auth-helpers.ts
+++ b/e2e/support/auth-helpers.ts
@@ -120,15 +120,23 @@ export async function continueFromRecoveryCode(page: Page): Promise<void> {
   await expect(page).toHaveURL(/\/(onboarding|dashboard)(?:\?.*)?$/);
 }
 
+const POST_REGISTRATION_PATHS = ['/onboarding', '/dashboard', '/login'];
+
 export async function completeOnboardingIfPresent(page: Page): Promise<void> {
   const currentPath = pathOf(page.url());
-  if (currentPath !== '/onboarding' && currentPath !== '/dashboard') {
+  if (!POST_REGISTRATION_PATHS.includes(currentPath)) {
+    // Tolerant of the redirect having already landed, never of it never landing:
+    // the bare `.catch` used to swallow a hung redirect and let it resurface as
+    // an unrelated failure further down whichever spec called this helper, so the
+    // settled path is asserted here instead.
     await page
-      .waitForURL((url) => {
-        const path = new URL(url).pathname;
-        return path === '/onboarding' || path === '/dashboard' || path === '/login';
-      })
+      .waitForURL((url) => POST_REGISTRATION_PATHS.includes(new URL(url).pathname), { timeout: 15000 })
       .catch(() => {});
+
+    expect(
+      POST_REGISTRATION_PATHS,
+      `post-registration redirect never landed, still at ${page.url()}`
+    ).toContain(pathOf(page.url()));
   }
 
   if (pathOf(page.url()) !== '/onboarding') {

--- a/e2e/theme-dark-mode.spec.ts
+++ b/e2e/theme-dark-mode.spec.ts
@@ -1,5 +1,6 @@
-import { expect, test, type Page } from '@playwright/test';
+import { expect, test, type Frame, type Page } from '@playwright/test';
 import { dashboardPrimarySummaryMode } from './support/dashboard-helpers';
+import { cancelConfirmDialog } from './support/confirm-dialog-helpers';
 import {
   completeOnboardingIfPresent,
   continueFromRecoveryCode,
@@ -64,14 +65,36 @@ test.describe('Theme mode', () => {
       .poll(async () => page.evaluate(() => window.localStorage.getItem('ovumcy_theme')))
       .toBe(storedBefore);
 
-    await page.locator('a.brand-mark').click();
-    await expect(page.locator('#confirm-modal')).toBeVisible();
-    await page.locator('#confirm-modal-cancel').click();
-    await expect(page).toHaveURL(/\/settings$/);
-    await expect(html).toHaveAttribute('data-theme', nextTheme);
+    // Cancelling the unsaved-changes prompt must leave the page where it is. A
+    // URL assertion is already true the moment it runs, so it would pass just as
+    // well with the guarded navigation still pending: record what the main frame
+    // actually navigates to across the whole window instead.
+    const brandLink = page.locator('a.brand-mark');
+    const leaveTarget = new URL((await brandLink.getAttribute('href')) ?? '', page.url()).pathname;
+    expect(leaveTarget).toBe('/dashboard');
 
-    await discardButton.click();
-    await expect(html).toHaveAttribute('data-theme', String(initialTheme));
+    const navigatedTo: string[] = [];
+    const recordNavigation = (frame: Frame) => {
+      if (frame === page.mainFrame()) {
+        navigatedTo.push(frame.url());
+      }
+    };
+    page.on('framenavigated', recordNavigation);
+    try {
+      await brandLink.click();
+      await cancelConfirmDialog(page);
+      await expect(html).toHaveAttribute('data-theme', nextTheme);
+
+      // Concrete signal that the guarded link has had its chance: discarding the
+      // draft is a real interaction with — and a state transition on — the very
+      // document the accept branch would have navigated away from.
+      await discardButton.click();
+      await expect(html).toHaveAttribute('data-theme', String(initialTheme));
+    } finally {
+      page.off('framenavigated', recordNavigation);
+    }
+    expect(navigatedTo, `cancelling the prompt must not navigate to ${leaveTarget}`).toEqual([]);
+
     await expect(nextOption).toHaveAttribute('data-selected', 'false');
     await expect(previousOption).toHaveAttribute('data-selected', 'true');
     await expect(saveButton).toBeDisabled();

--- a/e2e/visual-a11y.spec.ts
+++ b/e2e/visual-a11y.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test, type Locator, type Page } from '@playwright/test';
+import { mutatingRequestsDuring } from './support/confirm-dialog-helpers';
 import { fillDateField } from './support/date-field-helpers';
 import {
   completeOnboardingIfPresent,
@@ -176,11 +177,24 @@ test.describe('Visual and accessibility regressions', () => {
     await page.keyboard.press('Shift+Tab');
     await expect(page.locator('#confirm-modal-accept')).toBeFocused();
 
-    // Escape closes the dialog and returns focus to the invoking button.
-    await page.keyboard.press('Escape');
-    await expect(modal).toBeHidden();
-    await expect(logoutButton).toBeFocused();
-    await expect(page).toHaveURL(/\/dashboard$/);
+    // Escape closes the dialog, returns focus to the invoking button, and must
+    // not release the logout it gated. A URL assertion is already true the moment
+    // it runs, so record what the page puts on the wire across the whole window
+    // and close it on a reload: a surviving session still serves /dashboard,
+    // whereas an escaped logout would redirect to /login.
+    const escapedLogouts = await mutatingRequestsDuring(
+      page,
+      (pathname) => pathname === '/logout',
+      async () => {
+        await page.keyboard.press('Escape');
+        await expect(modal).toBeHidden();
+        await expect(logoutButton).toBeFocused();
+
+        await page.reload();
+        await expect(page).toHaveURL(/\/dashboard$/);
+      }
+    );
+    expect(escapedLogouts, 'dismissing the logout dialog must issue no logout').toEqual([]);
   });
 
   test('stats insight state stays readable on mobile and exposes accessible summaries', async ({


### PR DESCRIPTION
## What

Class sweep from the audit wave 2 backlog: every remaining e2e wait binds to a concrete signal instead of a sleep or already-true page state.

- `security-role.spec.ts`: the suite's last two `waitForTimeout(250)` sleeps (XSS "no dialog fired" claims) removed — the assertions they followed already prove the payload had its chance (server rejection + no rendered element in one; payload present as text in the other). `git grep waitForTimeout -- e2e/` is now empty.
- `support/auth-helpers.ts`: `completeOnboardingIfPresent` no longer swallows a hung post-registration redirect — the wait stays tolerant, but the settled path is asserted with a loud in-place message.
- `calendar.spec.ts` / `bugs.spec.ts` (BUG-06): month navigation asserts the specific month the clicked control points at (derived from its own `href`), not a `?month=` shape the URL already matches. Two `await request.response()` calls now assert `.ok()`.
- `theme-dark-mode.spec.ts`: leave-guard cancel records main-frame navigations across the whole window (a navigation escape is a GET, so the mutating-request helper cannot see it) and closes the window on the discard state transition.
- `visual-a11y.spec.ts` / `dashboard.spec.ts`: Escape-on-logout and manual-cycle-start cancel record the wire via `mutatingRequestsDuring` with a reload closing the window.

## Validation

- Nine affected specs: **84 passed, 1 skipped** (the opt-in registration-closed lane, skipped on main too).
- Every replacement assertion proven live by breaking what it guards: accepting the cancelled dialog recorded the escaped `POST .../cycle-start` and `POST /logout`; aiming the helper at a never-arriving path failed in-helper with the stuck URL; naming the wrong month failed with expected-vs-received months.
