### PR TITLE
test(e2e): address rendered copy via data hooks, collapse per-language branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -370,6 +370,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 
+- **Rendered copy in the browser suite is addressed through `data-*` hooks, and
+  the per-language literal branches are gone.** Sixteen specs pinned localized
+  sentences as their only address — `getByRole('link', { name: 'Today' })` ×6
+  languages, `getByText('Stress')` for chips the test itself had seeded by key,
+  `/Menstrual|Менструальная|Menstrual/i` (an alternation whose EN and ES arms are
+  the same word, so it matched any phase in either language), and negated phrases
+  such as `not.toContainText('Cannot be changed.')` that had been tautologies
+  since the copy was removed from the templates. Each now addresses a hook and
+  asserts state: `data-dashboard-phase` on the cycle hero, `data-fertility-badge`
+  + variant/key, `data-cycle-factor` on every static factor chip,
+  `data-symptom-pattern-day-start`/`-end` and `data-stat-card="cycle-range"` on
+  the stats cards, `data-future-cycle-start-notice` shared by the two specs that
+  used to pin the same notice two different ways, `data-symptom-create-error`
+  next to the existing row-level error, `data-title-key` on every page `h1`, and
+  `data-nav-link` on the three nav renderings. Nine explainer sites converged on
+  `toHaveAttribute('data-explainer-key', …)`, and the `/disable/i` caption that
+  was the sole discriminator in six 2FA tests became the form's own
+  `hx-delete` endpoint. Template edits add attributes only — no markup, class, or
+  copy changed.
+
+  Where rendered copy is genuinely the subject (the language-switch spec, the
+  registration enumeration scan), the expected strings now come from
+  `internal/i18n/locales/*.json` through one helper (`e2e/support/locale-helpers.ts`)
+  instead of being re-typed per language. That is what makes the enumeration scan
+  cover all six locales rather than the two it happened to list: it derives the
+  account-existence keys from the English catalogue and expands them across every
+  shipped language, so a seventh locale is covered the day it lands. The two
+  EN-US date-shape regexes are replaced by `Intl`-derived expectations that
+  verify each fragment is a real calendar date in the app's display format —
+  `/\w{3} \d{1,2}, \d{4}/` matched `Foo 99, 0000`.
+
 - **Three latent e2e-suite defects, each proven by an executed probe before the
   fix and re-proven closed after it.** The day-editor save helper
   (`saveDayEditorForm`) moved from a single spec into `e2e/support/stats-helpers.ts`

--- a/e2e/auth-2fa.spec.ts
+++ b/e2e/auth-2fa.spec.ts
@@ -10,6 +10,13 @@ import {
   registerOwnerViaUI,
 } from './support/auth-helpers';
 
+// The management view's own control, addressed by the endpoint its form posts
+// to. `{ hasText: /disable/i }` used the localized caption as the sole
+// discriminator between the enroll and disable submits, so the whole 2FA suite
+// hinged on the English word "disable" surviving translation.
+const DISABLE_2FA_SUBMIT =
+  'form[hx-delete="/api/v1/users/current/2fa"] button[type="submit"]';
+
 // Reads the raw TOTP secret from the visible manual-entry element on the
 // enrollment page (the same string the user copies into their authenticator).
 async function readTOTPSecret(page: import('@playwright/test').Page): Promise<string> {
@@ -58,9 +65,7 @@ test.describe('Auth: TOTP two-factor authentication', () => {
     await page.goto('/settings/2fa');
 
     // After successful enrollment the management view shows the disable button.
-    await expect(page.locator('button[type="submit"]', { hasText: /disable/i })).toBeVisible({
-      timeout: 5_000,
-    });
+    await expect(page.locator(DISABLE_2FA_SUBMIT)).toBeVisible({ timeout: 5_000 });
 
     // The ovumcy_totp_setup cookie should be cleared.
     const setupCookie = await cookieByName(context, 'ovumcy_totp_setup');
@@ -89,9 +94,7 @@ test.describe('Auth: TOTP two-factor authentication', () => {
     // Form submit is HTMX-intercepted; wait for inline success then reload.
     await expect(page.locator('#settings-2fa-verify-status .status-ok')).toBeVisible({ timeout: 5_000 });
     await page.goto('/settings/2fa');
-    await expect(page.locator('button[type="submit"]', { hasText: /disable/i })).toBeVisible({
-      timeout: 5_000,
-    });
+    await expect(page.locator(DISABLE_2FA_SUBMIT)).toBeVisible({ timeout: 5_000 });
 
     // Log out (must be DELETE+CSRF; GET to /api/v1/sessions/current is rejected).
     await logoutViaAPI(page);
@@ -131,9 +134,7 @@ test.describe('Auth: TOTP two-factor authentication', () => {
     // reload to render the management view (DB now has TOTPEnabled=true).
     await expect(page.locator('#settings-2fa-verify-status .status-ok')).toBeVisible({ timeout: 5_000 });
     await page.goto('/settings/2fa');
-    await expect(page.locator('button[type="submit"]', { hasText: /disable/i })).toBeVisible({
-      timeout: 5_000,
-    });
+    await expect(page.locator(DISABLE_2FA_SUBMIT)).toBeVisible({ timeout: 5_000 });
 
     // Log out (must be DELETE+CSRF; GET to /api/v1/sessions/current is rejected).
     await logoutViaAPI(page);
@@ -176,9 +177,7 @@ test.describe('Auth: TOTP two-factor authentication', () => {
     // reload to render the management view (DB now has TOTPEnabled=true).
     await expect(page.locator('#settings-2fa-verify-status .status-ok')).toBeVisible({ timeout: 5_000 });
     await page.goto('/settings/2fa');
-    await expect(page.locator('button[type="submit"]', { hasText: /disable/i })).toBeVisible({
-      timeout: 5_000,
-    });
+    await expect(page.locator(DISABLE_2FA_SUBMIT)).toBeVisible({ timeout: 5_000 });
 
     // Log out (must be DELETE+CSRF; GET to /api/v1/sessions/current is rejected).
     await logoutViaAPI(page);
@@ -226,13 +225,11 @@ test.describe('Auth: TOTP two-factor authentication', () => {
     // reload to render the management view (DB now has TOTPEnabled=true).
     await expect(page.locator('#settings-2fa-verify-status .status-ok')).toBeVisible({ timeout: 5_000 });
     await page.goto('/settings/2fa');
-    await expect(page.locator('button[type="submit"]', { hasText: /disable/i })).toBeVisible({
-      timeout: 5_000,
-    });
+    await expect(page.locator(DISABLE_2FA_SUBMIT)).toBeVisible({ timeout: 5_000 });
 
     // Disable
     await page.locator('input[name="password"]').fill(creds.password);
-    await page.locator('button[type="submit"]', { hasText: /disable/i }).click();
+    await page.locator(DISABLE_2FA_SUBMIT).click();
     // HTMX-intercepted; wait for inline success status, then reload to render
     // the setup view (DB now has TOTPEnabled=false).
     await expect(page.locator('#settings-2fa-status .status-ok')).toBeVisible({ timeout: 5_000 });

--- a/e2e/auth-login-register.spec.ts
+++ b/e2e/auth-login-register.spec.ts
@@ -199,10 +199,20 @@ test.describe('Auth: register, login, logout', () => {
     );
     expect(isValidBeforeSubmit).toBe(false);
 
+    // The client validator copies the message the form declared in
+    // data-email-message; compare against that declaration rather than a
+    // three-of-six-languages regex whose alternation matched whichever branch
+    // happened to be rendered. Asserting the declaration is non-empty first
+    // stops an empty attribute from passing against an empty status.
+    const declaredEmailMessage = (
+      (await page.locator('#register-form').getAttribute('data-email-message')) ?? ''
+    ).trim();
+    expect(declaredEmailMessage, 'the register form must declare data-email-message').not.toBe('');
+
     await page.locator('form[action="/api/v1/users"] button[type="submit"]').click();
     await expect(page).toHaveURL(/\/register(?:\?.*)?$/);
     await expect(page.locator('#register-client-status .status-error')).toContainText(
-      /valid email address|корректный адрес|correo válido/i
+      declaredEmailMessage
     );
     expect(
       consoleErrors.some((text) => /Pattern attribute value .* is not a valid regular expression/i.test(text))

--- a/e2e/bugs.spec.ts
+++ b/e2e/bugs.spec.ts
@@ -1,14 +1,15 @@
 import { expect, test, type Page } from '@playwright/test';
-import { clearDateField, fillDateField } from './support/date-field-helpers';
+import { clearDateField, fillDateField, formatDisplayDate } from './support/date-field-helpers';
 import { openCalendarDayEditor } from './support/stats-helpers';
 import { checkStyledControl } from './support/form-helpers';
 import { saveSettingsLanguage } from './support/language-helpers';
 import {
   dashboardCurrentCycleDay,
-  dashboardCurrentPhaseText,
+  dashboardCurrentPhase,
   dashboardCycleHero,
   dashboardPrimarySummaryMode,
 } from './support/dashboard-helpers';
+import { everyLocaleText, localeKeysMatchingEnglish, localeText } from './support/locale-helpers';
 import {
   completeOnboardingIfPresent,
   continueFromRecoveryCode,
@@ -108,8 +109,7 @@ async function setTimezoneCookie(page: Page, timezone: string): Promise<void> {
 async function timezoneToday(page: Page, timezone: string): Promise<{
   iso: string;
   day: string;
-  weekdayEN: string;
-  weekdayRU: string;
+  weekday: string;
 }> {
   return page.evaluate((tz) => {
     const now = new Date();
@@ -122,11 +122,15 @@ async function timezoneToday(page: Page, timezone: string): Promise<{
 
     const byType = Object.fromEntries(parts.map((part) => [part.type, part.value]));
     const iso = `${byType.year}-${byType.month}-${byType.day}`;
+    // Derive the weekday in the language the page is actually rendering in,
+    // rather than testing an EN-or-RU disjunction: that branch passed whenever
+    // either language matched, so it could not notice a third language
+    // rendering the wrong day.
+    const lang = document.documentElement.lang || 'en';
     return {
       iso,
       day: String(Number(byType.day)),
-      weekdayEN: new Intl.DateTimeFormat('en-US', { timeZone: tz, weekday: 'long' }).format(now),
-      weekdayRU: new Intl.DateTimeFormat('ru-RU', { timeZone: tz, weekday: 'long' }).format(now),
+      weekday: new Intl.DateTimeFormat(lang, { timeZone: tz, weekday: 'long' }).format(now),
     };
   }, timezone);
 }
@@ -151,16 +155,7 @@ async function browserMonthYearsAgo(page: Page, years: number): Promise<string> 
   }, years);
 }
 
-async function formatEnglishDisplayDate(page: Page, iso: string): Promise<string> {
-  return page.evaluate((value) => {
-    const date = new Date(`${value}T00:00:00`);
-    return new Intl.DateTimeFormat('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric',
-    }).format(date);
-  }, iso);
-}
+const UNPREDICTABLE_EXPLAINER_KEY = 'prediction.explainer.unpredictable';
 
 test.describe('Bug regressions', () => {
   test.describe('BUG-01: request-local date consistency', () => {
@@ -211,15 +206,16 @@ test.describe('Bug regressions', () => {
       expect(todayAction).toMatch(/^\/api\/v1\/days\/\d{4}-\d{2}-\d{2}$/);
       const actualTodayISO = String(todayAction || '').replace('/api/v1/days/', '');
 
-      const todayCard = page
-        .locator('form[hx-put^="/api/v1/days/"]')
-        .first()
-        .locator('xpath=ancestor::section[contains(@class,"journal-card")][1]');
-      const subtitleText = String((await todayCard.locator('p.journal-muted').first().textContent()) || '');
+      // The date subtitle has its own hook now: `p.journal-muted` + `.first()`
+      // picked whichever muted paragraph the card happened to render first.
+      const subtitleText = String(
+        (await page.locator('[data-dashboard-date-subtitle]').first().textContent()) || ''
+      );
       expect(subtitleText).toContain(expectedToday.day);
       expect(
-        subtitleText.includes(expectedToday.weekdayEN) || subtitleText.toLowerCase().includes(expectedToday.weekdayRU)
-      ).toBeTruthy();
+        subtitleText.toLowerCase(),
+        `date subtitle "${subtitleText}" should name ${expectedToday.weekday}`
+      ).toContain(expectedToday.weekday.toLowerCase());
 
       const expectedCycleDay = page.evaluate(({ todayISO, startISO }) => {
         const today = new Date(`${todayISO}T00:00:00`);
@@ -363,8 +359,8 @@ test.describe('Bug regressions', () => {
       await expect(hero).toBeVisible();
       await expect(page.locator('[data-dashboard-status-line]')).toHaveCount(0);
 
-      const expectedStartLabel = await formatEnglishDisplayDate(page, nextPeriodStart);
-      const expectedEndLabel = await formatEnglishDisplayDate(page, nextPeriodEnd);
+      const expectedStartLabel = await formatDisplayDate(page, nextPeriodStart);
+      const expectedEndLabel = await formatDisplayDate(page, nextPeriodEnd);
       await expect(heroFooter).toContainText(`${expectedStartLabel} — ${expectedEndLabel}`);
 
       await page.goto(`/calendar?month=${nextPeriodStart.slice(0, 7)}&day=${nextPeriodStart}`);
@@ -408,11 +404,33 @@ test.describe('Bug regressions', () => {
       expect(currentURL).not.toContain('email=');
       expect(currentURL).not.toContain('error=');
 
+      // A privacy scan legitimately reads the whole body — the leak could be
+      // anywhere on the page. What it must not do is enumerate phrases by hand
+      // in two of six languages, which is what this checked before: a Spanish,
+      // French, German or Italian leak walked straight past it.
+      //
+      // Derive instead. English is the catalogue's source language, so one
+      // English phrase rule finds the KEYS that assert an account already
+      // exists; `everyLocaleText` then expands those keys into every shipped
+      // language, so a new locale is covered the day it lands.
+      const existenceKeys = localeKeysMatchingEnglish(
+        /already (exists|registered|in use|uses this email)/i
+      );
+      expect(
+        existenceKeys.length,
+        'the account-existence phrase rule must still match catalogue copy'
+      ).toBeGreaterThan(0);
+      const forbiddenPhrases = existenceKeys.flatMap((key) => everyLocaleText(key));
+
       const bodyText = String((await page.locator('body').textContent()) || '').toLowerCase();
-      expect(bodyText).not.toContain('already exists');
-      expect(bodyText).not.toContain('already registered');
-      expect(bodyText).not.toContain('already in use');
-      expect(bodyText).not.toContain('уже существует');
+      for (const phrase of forbiddenPhrases) {
+        expect(bodyText, `body must not reveal account existence: "${phrase}"`).not.toContain(
+          phrase.toLowerCase()
+        );
+      }
+      // Same rule applied to the raw body, so an English string hardcoded
+      // outside the catalogue cannot slip through either.
+      expect(bodyText).not.toMatch(/already (exists|registered|in use|uses this email)/i);
     });
 
     test('registration validation errors do not leak email or error in URL', async ({ page }) => {
@@ -494,7 +512,13 @@ test.describe('Bug regressions', () => {
 
       const identityChip = page.locator('#nav-user-chip-desktop');
       await expect(identityChip).toBeVisible();
-      await expect(identityChip).toHaveAttribute('title', 'Profile settings');
+      // Before a display name is saved the chip falls back to the profile-name
+      // hint; take the expected string from the catalogue instead of pinning
+      // the English wording here.
+      await expect(identityChip).toHaveAttribute(
+        'title',
+        localeText('en', 'nav.profile_name_hint')
+      );
 
       const newName = `TestUser_${Date.now()}`;
       const nameInput = page.locator('#settings-display-name');
@@ -549,21 +573,39 @@ test.describe('Bug regressions', () => {
       await page.goto('/dashboard');
       await expect(page).toHaveURL(/\/dashboard$/);
 
-      const statusLine = page.locator('.dashboard-status-line');
-      await expect(statusLine).toContainText('Next period: unknown');
-      await expect(statusLine).toContainText('Predictions off');
-      await expect(statusLine).not.toContainText('Ovulation:');
-      await expect(page.locator('[data-dashboard-prediction-explainer]')).toHaveText(
-        'Predictions are off in unpredictable cycle mode. Ovumcy shows recorded facts only.'
+      // Unpredictable mode is a state the status line declares; assert it on
+      // the hook and the phase attribute rather than on three copy fragments,
+      // one of which ("Ovulation:") was a negated literal that any rewording
+      // or language switch satisfies.
+      const statusLine = page.locator('[data-dashboard-status-line]');
+      await expect(statusLine).toBeVisible();
+      await expect(statusLine).toHaveAttribute('data-dashboard-phase', /.+/);
+      // [data-dashboard-next-period] exists only in the predictions-on branch
+      // of the status line, and so does the ovulation item — its absence is the
+      // structural proof that predictions are off, which the old
+      // `not.toContainText('Ovulation:')` only approximated in English.
+      await expect(page.locator('[data-dashboard-next-period]')).toHaveCount(0);
+      await expect(statusLine).not.toContainText(localeText('en', 'dashboard.ovulation'));
+      await expect(statusLine).toContainText(localeText('en', 'dashboard.next_period_unknown'));
+      await expect(statusLine).toContainText(
+        localeText('en', 'prediction.explainer.unpredictable_compact')
+      );
+
+      await expect(page.locator('[data-dashboard-prediction-explainer]')).toHaveAttribute(
+        'data-explainer-key',
+        UNPREDICTABLE_EXPLAINER_KEY
       );
 
       await page.goto('/calendar');
       await expect(page).toHaveURL(/\/calendar(?:\?.*)?$/);
       const calendarExplainer = page.locator('[data-calendar-prediction-explainer]');
       await expect(calendarExplainer).toBeVisible();
-      await expect(calendarExplainer).toHaveText(
-        'Predictions are off in unpredictable cycle mode. Ovumcy shows recorded facts only.'
+      await expect(calendarExplainer).toHaveAttribute(
+        'data-explainer-primary-key',
+        UNPREDICTABLE_EXPLAINER_KEY
       );
+      // One rendered-copy assertion for this state, from the catalogue.
+      await expect(calendarExplainer).toContainText(localeText('en', UNPREDICTABLE_EXPLAINER_KEY));
     });
   });
 
@@ -599,8 +641,14 @@ test.describe('Bug regressions', () => {
       await checkStyledControl(dayEditorForm.locator('input[name="flow"][value="spotting"]'));
       await dayEditorForm.locator('button[data-save-button]').click();
 
+      // The toast copy travels in the X-Ovumcy-Notice response header, which
+      // carries no key — the client only ever sees the rendered sentence, so a
+      // data-toast-key would mean widening that API surface. Source the
+      // expected string from ru.json instead: this test is about the Russian
+      // text surviving the URL-encoded round trip intact, so the exact
+      // characters are the subject, and the catalogue owns them.
       await expect(page.locator('.toast-stack .toast-message').last()).toHaveText(
-        'Мажущие выделения могут быть не днём 1. Уточните завтра.'
+        localeText('ru', 'dashboard.spotting_cycle_warning')
       );
     });
   });
@@ -658,10 +706,22 @@ test.describe('Bug regressions', () => {
       await registerOwnerAndReachDashboard(page, 'improvement-menstrual-icon');
 
       const mode = await dashboardPrimarySummaryMode(page);
-      expect(await dashboardCurrentPhaseText(page)).toMatch(/Menstrual|Менструальная|Menstrual/i);
+      // The phase is state, so assert the state attribute. The regex it
+      // replaces listed the EN and ES spellings as separate alternatives of the
+      // same word, which is what a per-language branch degenerates into.
+      expect(await dashboardCurrentPhase(page)).toBe('menstrual');
 
       if (mode === 'hero') {
-        await expect(dashboardCycleHero(page)).toContainText(/Days 1-5|Tag 1-5|Дни 1-5/);
+        // The menstrual phase card reports its own cycle-day window; reading it
+        // off the card beats matching "Days 1-5" / "Tag 1-5" / "Дни 1-5".
+        const menstrualCard = dashboardCycleHero(page).locator('[data-cycle-hero-phase="menstrual"]');
+        await expect(menstrualCard).toBeVisible();
+        await expect(menstrualCard).toHaveAttribute('data-cycle-hero-phase-start', '1');
+        await expect(menstrualCard).toHaveAttribute('data-cycle-hero-phase-current', 'true');
+        const menstrualEnd = Number(await menstrualCard.getAttribute('data-cycle-hero-phase-end'));
+        expect(menstrualEnd).toBeGreaterThanOrEqual(1);
+        // One rendered-copy assertion: the card prints the window it declares.
+        await expect(menstrualCard).toContainText(String(menstrualEnd));
       } else {
         const phaseChip = page.locator('[data-dashboard-status-line] .dashboard-status-item').first();
         await expect(phaseChip).toContainText('🩸');

--- a/e2e/calendar.spec.ts
+++ b/e2e/calendar.spec.ts
@@ -15,6 +15,7 @@ import { openCalendarDayEditor, saveDayEditorForm } from './support/stats-helper
 import { setRequestTimezoneFromBrowser } from './support/timezone-helpers';
 import { checkStyledControl } from './support/form-helpers';
 import { dateFieldRoot, fillDateField } from './support/date-field-helpers';
+import { localeText } from './support/locale-helpers';
 import {
   acceptConfirmDialog,
   cancelConfirmDialog,
@@ -102,7 +103,12 @@ test.describe('Calendar page', () => {
 
     await page.goto('/calendar?month=9999-99');
     await expect(page).toHaveURL(/\/calendar$/);
-    await expect(page.locator('h1')).toContainText(/Calendar|Календарь|Calendario/);
+    // Address the page title by the key it declares. The regex this replaces
+    // listed three of six languages and, being an alternation, matched any of
+    // them regardless of which language the page was actually rendering.
+    const title = page.locator('h1[data-title-key="calendar.title"]');
+    await expect(title).toBeVisible();
+    await expect(title).toHaveText(localeText('en', 'calendar.title'));
   });
 
   test('legend includes period/predicted/fertility/ovulation markers', async ({ page }) => {
@@ -385,7 +391,15 @@ test.describe('Calendar page', () => {
     const manualStartForm = page.locator(`[data-day-cycle-start-form][data-day-cycle-start-date="${tomorrowISO}"]`);
     const manualStartButton = manualStartForm.locator('[data-day-cycle-start-button]');
     await expect(manualStartButton).toBeVisible();
-    await expect(page.locator('#day-editor')).toContainText(/recalculated|пересчитается|recalcular/i);
+    // The notice has its own hook and declares the key it renders — the same
+    // element dashboard-warnings.spec.ts pins, so the two specs can no longer
+    // describe it two different ways.
+    const futureNotice = page.locator('#day-editor [data-future-cycle-start-notice]');
+    await expect(futureNotice.first()).toBeVisible();
+    await expect(futureNotice.first()).toHaveAttribute(
+      'data-notice-key',
+      'warning.future_cycle_start'
+    );
 
     // The onboarding seed anchors last_period_start at today-3, so tomorrow is a
     // 4-day short gap: the backend rejects the start with a 400 unless the owner

--- a/e2e/cross-browser-smoke.spec.ts
+++ b/e2e/cross-browser-smoke.spec.ts
@@ -8,8 +8,20 @@ import {
   registerOwnerViaUI,
 } from './support/auth-helpers';
 import { saveSettingsLanguage } from './support/language-helpers';
+import { localeText, type Locale } from './support/locale-helpers';
 import { ensureNotesFieldVisible } from './support/note-helpers';
 import { setRequestTimezoneFromBrowser } from './support/timezone-helpers';
+
+// Address the page title by the key it declares and take the expected copy from
+// the catalogue. The literals this replaces ('Configuración', 'Calendario') and
+// the /Insights|Аналитика|Análisis/ alternation both re-typed shipped strings
+// into the spec, and the alternation matched any of three languages regardless
+// of which one the page was rendering.
+async function expectPageTitle(page: Page, key: string, locale: Locale = 'en'): Promise<void> {
+  const title = page.locator(`h1[data-title-key="${key}"]`);
+  await expect(title).toBeVisible();
+  await expect(title).toContainText(localeText(locale, key));
+}
 
 async function registerOwnerAndReachDashboard(page: Page, prefix: string): Promise<void> {
   const credentials = createCredentials(prefix);
@@ -71,7 +83,7 @@ test.describe('Cross-browser smoke', () => {
 
     await page.goto('/stats');
     await expect(page).toHaveURL(/\/stats$/);
-    await expect(page.locator('h1.journal-title')).toContainText(/Insights|Аналитика|Análisis/);
+    await expectPageTitle(page, 'stats.title');
   });
 
   test('theme and language switches persist across core routes', async ({ page }) => {
@@ -89,13 +101,13 @@ test.describe('Cross-browser smoke', () => {
     // the just-chosen language (saveSettingsLanguage documents the mechanism).
     await saveSettingsLanguage(page, 'es');
     await expect(html).toHaveAttribute('lang', 'es');
-    await expect(page.locator('h1.journal-title')).toContainText('Configuración');
+    await expectPageTitle(page, 'settings.title', 'es');
 
     await page.goto('/calendar');
     await expect(page).toHaveURL(/\/calendar(?:\?.*)?$/);
     await expect(html).toHaveAttribute('lang', 'es');
     await expect(html).toHaveAttribute('data-theme', 'dark');
     await expect(page.locator('#calendar-grid-panel')).toBeVisible();
-    await expect(page.locator('h1')).toContainText('Calendario');
+    await expectPageTitle(page, 'calendar.title', 'es');
   });
 });

--- a/e2e/dashboard-fertility.spec.ts
+++ b/e2e/dashboard-fertility.spec.ts
@@ -8,6 +8,7 @@ import {
   registerOwnerViaUI,
   apiOriginHeader,
 } from './support/auth-helpers';
+import { localeText } from './support/locale-helpers';
 import { setRequestTimezoneFromBrowser } from './support/timezone-helpers';
 import { openCalendarDayEditor, todayISOFromDashboard } from './support/stats-helpers';
 
@@ -81,11 +82,17 @@ test.describe('Dashboard: fertility badge', () => {
     await page.goto('/dashboard');
     await expect(page).toHaveURL(/\/dashboard$/);
 
-    const heroBadge = page.locator('.dashboard-cycle-hero-badge');
+    const heroBadge = page.locator('[data-dashboard-cycle-hero] [data-fertility-badge]');
     await expect(heroBadge).toBeVisible();
-    await expect(heroBadge).toContainText('High fertility');
-    await expect(heroBadge).not.toHaveClass(/dashboard-cycle-hero-badge-warning/);
-    await expect(heroBadge).not.toHaveClass(/dashboard-cycle-hero-badge-positive/);
+    await expect(heroBadge).toHaveAttribute('data-fertility-badge-variant', 'neutral');
+    await expect(heroBadge).toHaveAttribute(
+      'data-fertility-badge-key',
+      'dashboard.high_fertility_badge'
+    );
+    // One rendered-copy assertion for this surface, taken from the catalogue;
+    // the variant is proved by the attribute above rather than by two negated
+    // class checks.
+    await expect(heroBadge).toContainText(localeText('en', 'dashboard.high_fertility_badge'));
     // The fallback `.dashboard-status-item` copy of the badge only renders
     // when the cycle hero is hidden (`{{if not .CycleHero.Visible}}` in
     // dashboard.html) — exercised separately by tests that suppress the hero.
@@ -163,32 +170,25 @@ test.describe('Dashboard: fertility badge', () => {
     page,
   }) => {
     await registerAndSetEggwhiteToday(page, 'fertility-goals');
-    const heroBadge = page.locator('.dashboard-cycle-hero-badge');
+    const heroBadge = page.locator('[data-dashboard-cycle-hero] [data-fertility-badge]');
 
-    // usage_goal=avoid_pregnancy -> warning copy + warning class.
-    await setUsageGoal(page, 'avoid_pregnancy');
-    await page.goto('/dashboard');
-    await expect(heroBadge).toBeVisible();
-    await expect(heroBadge).toContainText('Fertile period');
-    await expect(heroBadge).not.toContainText('best timing');
-    await expect(heroBadge).not.toContainText('High fertility');
-    await expect(heroBadge).toHaveClass(/dashboard-cycle-hero-badge-warning/);
+    // Each goal selects a distinct badge variant + copy key. Asserting the two
+    // single-valued attributes replaces the mix of positive copy, negated copy
+    // and negated class checks: a key cannot be two values at once, so pinning
+    // it proves the other two variants did not render.
+    const expectedByGoal = [
+      ['avoid_pregnancy', 'warning', 'dashboard.fertility_badge_warning'],
+      ['trying_to_conceive', 'positive', 'dashboard.fertility_badge_positive'],
+      ['health', 'neutral', 'dashboard.high_fertility_badge'],
+    ] as const;
 
-    // usage_goal=trying_to_conceive -> positive copy + positive class.
-    await setUsageGoal(page, 'trying_to_conceive');
-    await page.goto('/dashboard');
-    await expect(heroBadge).toBeVisible();
-    await expect(heroBadge).toContainText('Fertile period, best timing');
-    await expect(heroBadge).toHaveClass(/dashboard-cycle-hero-badge-positive/);
-    await expect(heroBadge).not.toHaveClass(/dashboard-cycle-hero-badge-warning/);
-
-    // usage_goal=health -> generic copy + no variant class. Mirrors the
-    // default state covered by the first test in this describe block.
-    await setUsageGoal(page, 'health');
-    await page.goto('/dashboard');
-    await expect(heroBadge).toBeVisible();
-    await expect(heroBadge).toContainText('High fertility');
-    await expect(heroBadge).not.toHaveClass(/dashboard-cycle-hero-badge-warning/);
-    await expect(heroBadge).not.toHaveClass(/dashboard-cycle-hero-badge-positive/);
+    for (const [goal, variant, copyKey] of expectedByGoal) {
+      await setUsageGoal(page, goal);
+      await page.goto('/dashboard');
+      await expect(heroBadge).toBeVisible();
+      await expect(heroBadge).toHaveAttribute('data-fertility-badge-variant', variant);
+      await expect(heroBadge).toHaveAttribute('data-fertility-badge-key', copyKey);
+      await expect(heroBadge).toContainText(localeText('en', copyKey));
+    }
   });
 });

--- a/e2e/dashboard-prediction-range.spec.ts
+++ b/e2e/dashboard-prediction-range.spec.ts
@@ -7,7 +7,7 @@ import {
   registerOwnerViaUI,
   apiOriginHeader,
 } from './support/auth-helpers';
-import { dateFieldRoot, fillDateField } from './support/date-field-helpers';
+import { dateFieldRoot, displayDatesIn, fillDateField } from './support/date-field-helpers';
 import { dashboardNextPeriodText } from './support/dashboard-helpers';
 import { setRequestTimezoneFromBrowser } from './support/timezone-helpers';
 import { shiftISODate } from './support/stats-helpers';
@@ -89,14 +89,26 @@ test.describe('Dashboard prediction range', () => {
     await page.goto('/dashboard');
     await expect(page).toHaveURL(/\/dashboard$/);
 
+    // Two real calendar dates, in order — derived through Intl from the app's
+    // own display format rather than matched against an EN-US shape regex,
+    // which passed just as happily on "Foo 99, 0000". The exact range width is
+    // the prediction service's business (unit-tested there), so this asserts
+    // the surface contract: a range, forward in time, starting after today.
     const nextPeriodText = await dashboardNextPeriodText(page);
-    expect(nextPeriodText, 'regular user with variability should see a range').toMatch(
-      /\w{3} \d{1,2}, \d{4} — \w{3} \d{1,2}, \d{4}/
-    );
-    expect(nextPeriodText).not.toContain('3 cycles are needed');
+    const renderedDates = await displayDatesIn(page, nextPeriodText);
+    expect(renderedDates, `regular user with variability should see a range: ${nextPeriodText}`)
+      .toHaveLength(2);
+    expect(renderedDates[0] > today).toBeTruthy();
+    expect(renderedDates[1] > renderedDates[0]).toBeTruthy();
 
-    await expect(page.locator('[data-dashboard-prediction-explainer]')).toContainText(
-      'Your prediction shows a range that reflects how much your cycle length varies.'
+    // The explainer's chosen key is the state; the negative it replaces
+    // (not.toContain('3 cycles are needed')) was a phrase check that would have
+    // stayed green through any rewording of the sparse-mode copy. A key is
+    // single-valued, so pinning it here also proves the sparse explainer is not
+    // the one that rendered.
+    await expect(page.locator('[data-dashboard-prediction-explainer]')).toHaveAttribute(
+      'data-explainer-key',
+      'prediction.explainer.variable_ranges'
     );
   });
 

--- a/e2e/dashboard-warnings.spec.ts
+++ b/e2e/dashboard-warnings.spec.ts
@@ -9,6 +9,7 @@ import {
   apiOriginHeader,
 } from './support/auth-helpers';
 import { dateFieldRoot, fillDateField } from './support/date-field-helpers';
+import { localeText } from './support/locale-helpers';
 import { setRequestTimezoneFromBrowser } from './support/timezone-helpers';
 import { openCalendarDayEditor, shiftISODate, todayISOFromDashboard } from './support/stats-helpers';
 
@@ -97,7 +98,7 @@ test.describe('Dashboard: spotting cycle warning', () => {
     // .journal-muted elsewhere on the page cannot mask a regression.
     const periodFields = page.locator('[data-period-fields]');
     await expect(periodFields).toBeVisible();
-    await expect(periodFields).toContainText('Spotting may not be day 1. Check again tomorrow.');
+    await expect(periodFields).toContainText(localeText('en', 'dashboard.spotting_cycle_warning'));
   });
 });
 
@@ -147,7 +148,7 @@ test.describe('Dashboard: period tip once', () => {
     });
     await expect(periodInput).toBeChecked();
     await expect(tipCopy).toBeVisible();
-    await expect(tipCopy).toContainText('Day 1 is the first day of full flow, not spotting.');
+    await expect(tipCopy).toContainText(localeText('en', 'dashboard.period_tip_once'));
     const autosaveRequest = await autosaveRequestPromise;
     const autosaveResponse = await autosaveRequest.response();
     expect(autosaveResponse, `expected a response for PUT ${todayPath}`).not.toBeNull();
@@ -177,7 +178,15 @@ test.describe('Calendar: future cycle start notice', () => {
     const tomorrow = shiftISODate(today, 1);
 
     await openCalendarDayEditor(page, tomorrow);
-    const dayEditor = page.locator('#day-editor');
-    await expect(dayEditor).toContainText('Predictions will be recalculated when that day arrives.');
+    // Addressed through the notice's own hook + key, the same way
+    // calendar.spec.ts pins it: one element, one contract, two specs.
+    const futureNotice = page.locator('#day-editor [data-future-cycle-start-notice]');
+    await expect(futureNotice.first()).toBeVisible();
+    await expect(futureNotice.first()).toHaveAttribute(
+      'data-notice-key',
+      'warning.future_cycle_start'
+    );
+    // One rendered-copy assertion for this notice, sourced from the catalogue.
+    await expect(futureNotice.first()).toHaveText(localeText('en', 'warning.future_cycle_start'));
   });
 });

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -152,14 +152,24 @@ test.describe('Dashboard: today editor', () => {
     const noteSummary = noteDisclosure.locator('summary');
     const notes = page.locator('#today-notes');
     const notesCounter = page.locator('[data-dashboard-notes-field-group] [data-dashboard-notes-count]').first();
+    // The `open` attribute IS the state, and the disclosure declares both label
+    // variants as data attributes for the client script. Assert the rendered
+    // label against the declaration instead of a three-language regex whose
+    // alternation matched any of the three regardless of the page language.
+    const closedLabel = ((await noteDisclosure.getAttribute('data-note-empty-text')) ?? '').trim();
+    const openLabel = ((await noteDisclosure.getAttribute('data-note-open-text')) ?? '').trim();
+    expect(closedLabel, 'the note disclosure must declare data-note-empty-text').not.toBe('');
+    expect(openLabel, 'the note disclosure must declare data-note-open-text').not.toBe('');
+    expect(openLabel).not.toBe(closedLabel);
+
     await expect(noteDisclosure).toHaveCount(1);
     await expect(noteDisclosure).not.toHaveAttribute('open', '');
-    await expect(noteSummary).toContainText(/Add note|Добавить заметку|Agregar nota/);
+    await expect(noteSummary).toContainText(closedLabel);
     await expect(notes).toBeHidden();
 
     await noteSummary.click();
     await expect(noteDisclosure).toHaveAttribute('open', '');
-    await expect(noteSummary).toContainText(/Hide note|Скрыть заметку|Ocultar nota/);
+    await expect(noteSummary).toContainText(openLabel);
     await expect(notes).toBeVisible();
     await expect(notes).toHaveAttribute('rows', '2');
     await expect(notes).toHaveAttribute('maxlength', '2000');
@@ -176,7 +186,7 @@ test.describe('Dashboard: today editor', () => {
 
     await page.reload();
     await expect(noteDisclosure).toHaveAttribute('open', '');
-    await expect(noteSummary).toContainText(/Hide note|Скрыть заметку|Ocultar nota/);
+    await expect(noteSummary).toContainText(openLabel);
     await expect(page.locator('#today-notes')).toHaveValue(filledNoteText);
   });
 

--- a/e2e/navigation-language.spec.ts
+++ b/e2e/navigation-language.spec.ts
@@ -10,6 +10,34 @@ import {
   registerOwnerViaUI,
 } from './support/auth-helpers';
 import { saveSettingsLanguage, switchPublicLanguage } from './support/language-helpers';
+import { localeText, SUPPORTED_LOCALES, type Locale } from './support/locale-helpers';
+
+// This spec's subject IS the localization, so rendered copy is asserted here on
+// purpose — but every expected string comes from the catalogue the app ships
+// (`internal/i18n/locales/*.json`), never re-typed per language. Elements are
+// still addressed structurally (`[data-title-key]`, `[data-nav-link]`,
+// `label[for=…]`), so a copy change syncs itself and a selector change fails
+// loudly instead of silently matching nothing.
+async function expectPageTitle(page: Page, locale: Locale, key: string): Promise<void> {
+  const title = page.locator(`h1[data-title-key="${key}"]`);
+  await expect(title).toBeVisible();
+  await expect(title).toContainText(localeText(locale, key));
+}
+
+async function expectNavLink(page: Page, locale: Locale, hook: string, key: string): Promise<void> {
+  const link = page.locator(`[data-nav-link="${hook}"]`).first();
+  await expect(link).toHaveAttribute('data-nav-link-key', key);
+  await expect(link).toHaveText(localeText(locale, key));
+}
+
+async function expectFieldLabel(
+  page: Page,
+  locale: Locale,
+  fieldID: string,
+  key: string
+): Promise<void> {
+  await expect(page.locator(`label[for="${fieldID}"]`)).toHaveText(localeText(locale, key));
+}
 
 async function registerAndReachDashboard(page: Page, prefix: string): Promise<{ email: string; password: string }> {
   const creds = createCredentials(prefix);
@@ -61,67 +89,21 @@ test.describe('Navigation and language switch', () => {
     await page.goto('/login');
     await expect(page).toHaveURL(/\/login(?:\?.*)?$/);
 
-    await switchPublicLanguage(page, 'en');
-    await expect(page).toHaveURL(/\/login$/);
-    await expect(page.locator('html')).toHaveAttribute('lang', 'en');
-    await expect(page.locator('h1.journal-title')).toContainText('Log in to your account');
+    // Drive every supported locale from one list instead of a copy-pasted block
+    // per language: a seventh locale is covered the day `SUPPORTED_LOCALES`
+    // grows, and no expected string is typed into this file.
+    for (const locale of SUPPORTED_LOCALES) {
+      await switchPublicLanguage(page, locale);
+      await expect(page).toHaveURL(/\/login$/);
+      await expect(page.locator('html')).toHaveAttribute('lang', locale);
+      await expectPageTitle(page, locale, 'auth.login_title');
+      await expectFieldLabel(page, locale, 'login-email', 'auth.email');
 
-    await page.reload();
-    await expect(page.locator('html')).toHaveAttribute('lang', 'en');
-    await expect(page.locator('h1.journal-title')).toContainText('Log in to your account');
-
-    await switchPublicLanguage(page, 'es');
-    await expect(page).toHaveURL(/\/login$/);
-    await expect(page.locator('html')).toHaveAttribute('lang', 'es');
-    await expect(page.locator('h1.journal-title')).toContainText('Inicia sesión en tu cuenta');
-
-    await page.reload();
-    await expect(page.locator('html')).toHaveAttribute('lang', 'es');
-    await expect(page.locator('h1.journal-title')).toContainText('Inicia sesión en tu cuenta');
-
-    await switchPublicLanguage(page, 'ru');
-    await expect(page).toHaveURL(/\/login$/);
-    await expect(page.locator('html')).toHaveAttribute('lang', 'ru');
-    await expect(page.locator('h1.journal-title')).toContainText('Войти в аккаунт');
-    await expect(page.locator('label[for="login-email"]')).toHaveText('Эл. почта');
-
-    await page.reload();
-    await expect(page.locator('html')).toHaveAttribute('lang', 'ru');
-    await expect(page.locator('h1.journal-title')).toContainText('Войти в аккаунт');
-    await expect(page.locator('label[for="login-email"]')).toHaveText('Эл. почта');
-
-    await switchPublicLanguage(page, 'fr');
-    await expect(page).toHaveURL(/\/login$/);
-    await expect(page.locator('html')).toHaveAttribute('lang', 'fr');
-    await expect(page.locator('h1.journal-title')).toContainText('Connexion à votre compte');
-    await expect(page.locator('label[for="login-email"]')).toHaveText('E-mail');
-
-    await page.reload();
-    await expect(page.locator('html')).toHaveAttribute('lang', 'fr');
-    await expect(page.locator('h1.journal-title')).toContainText('Connexion à votre compte');
-    await expect(page.locator('label[for="login-email"]')).toHaveText('E-mail');
-
-    await switchPublicLanguage(page, 'de');
-    await expect(page).toHaveURL(/\/login$/);
-    await expect(page.locator('html')).toHaveAttribute('lang', 'de');
-    await expect(page.locator('h1.journal-title')).toContainText('Melden Sie sich bei Ihrem Konto an');
-    await expect(page.locator('label[for="login-email"]')).toHaveText('E-Mail');
-
-    await page.reload();
-    await expect(page.locator('html')).toHaveAttribute('lang', 'de');
-    await expect(page.locator('h1.journal-title')).toContainText('Melden Sie sich bei Ihrem Konto an');
-    await expect(page.locator('label[for="login-email"]')).toHaveText('E-Mail');
-
-    await switchPublicLanguage(page, 'it');
-    await expect(page).toHaveURL(/\/login$/);
-    await expect(page.locator('html')).toHaveAttribute('lang', 'it');
-    await expect(page.locator('h1.journal-title')).toContainText('Accedi al tuo account');
-    await expect(page.locator('label[for="login-email"]')).toHaveText('Email');
-
-    await page.reload();
-    await expect(page.locator('html')).toHaveAttribute('lang', 'it');
-    await expect(page.locator('h1.journal-title')).toContainText('Accedi al tuo account');
-    await expect(page.locator('label[for="login-email"]')).toHaveText('Email');
+      await page.reload();
+      await expect(page.locator('html')).toHaveAttribute('lang', locale);
+      await expectPageTitle(page, locale, 'auth.login_title');
+      await expectFieldLabel(page, locale, 'login-email', 'auth.email');
+    }
   });
 
   test('language switch while logged in keeps current page and translates navigation/settings', async ({
@@ -134,52 +116,28 @@ test.describe('Navigation and language switch', () => {
 
     await expect(page.locator('[data-settings-interface-form]')).toBeVisible();
 
-    await saveSettingsLanguage(page, 'en');
-    await expect(page).toHaveURL(/\/settings$/);
-    await expect(page.locator('html')).toHaveAttribute('lang', 'en');
-    await expect(page.locator('h1.journal-title')).toContainText('Settings');
-    await expect(page.getByRole('link', { name: 'Today' }).first()).toBeVisible();
+    for (const locale of SUPPORTED_LOCALES) {
+      await saveSettingsLanguage(page, locale);
+      await expect(page).toHaveURL(/\/settings$/);
+      await expect(page.locator('html')).toHaveAttribute('lang', locale);
+      await expectPageTitle(page, locale, 'settings.title');
+      await expectNavLink(page, locale, 'today', 'nav.today');
 
-    await saveSettingsLanguage(page, 'es');
-    await expect(page).toHaveURL(/\/settings$/);
-    await expect(page.locator('html')).toHaveAttribute('lang', 'es');
-    await expect(page.locator('h1.journal-title')).toContainText('Configuración');
-    await expect(page.getByRole('link', { name: 'Hoy' }).first()).toBeVisible();
-    await expectDateFieldVisible(page, 'settings-last-period-start');
-    await expectDateFieldVisible(page, 'export-from');
-    await expectDateFieldVisible(page, 'export-to');
-    await expect(page.locator('[data-date-field-id="export-from"] [data-date-field-open]')).toBeVisible();
-    await expect(page.locator('[data-date-field-id="export-to"] [data-date-field-open]')).toBeVisible();
+      // The segmented date fields must survive every locale — the browser-native
+      // date control is deliberately not used, so a locale that broke the
+      // segmented field would silently lose the whole control.
+      await expectDateFieldVisible(page, 'settings-last-period-start');
+      await expectDateFieldVisible(page, 'export-from');
+      await expectDateFieldVisible(page, 'export-to');
+      await expect(page.locator('[data-date-field-id="export-from"] [data-date-field-open]')).toBeVisible();
+      await expect(page.locator('[data-date-field-id="export-to"] [data-date-field-open]')).toBeVisible();
+    }
 
-    await saveSettingsLanguage(page, 'ru');
-    await expect(page).toHaveURL(/\/settings$/);
-    await expect(page.locator('html')).toHaveAttribute('lang', 'ru');
-    await expect(page.locator('h1.journal-title')).toContainText('Настройки');
-    await expect(page.getByRole('link', { name: 'Сегодня' }).first()).toBeVisible();
-
-    await saveSettingsLanguage(page, 'fr');
-    await expect(page).toHaveURL(/\/settings$/);
-    await expect(page.locator('html')).toHaveAttribute('lang', 'fr');
-    await expect(page.locator('h1.journal-title')).toContainText('Paramètres');
-    await expect(page.getByRole('link', { name: "Aujourd'hui" }).first()).toBeVisible();
-    await expectDateFieldVisible(page, 'settings-last-period-start');
-
-    await saveSettingsLanguage(page, 'de');
-    await expect(page).toHaveURL(/\/settings$/);
-    await expect(page.locator('html')).toHaveAttribute('lang', 'de');
-    await expect(page.locator('h1.journal-title')).toContainText('Einstellungen');
-    await expect(page.getByRole('link', { name: 'Heute' }).first()).toBeVisible();
-    await expectDateFieldVisible(page, 'settings-last-period-start');
-
+    // The saved preference survives a reload, not just the htmx swap that set it.
+    const lastLocale = SUPPORTED_LOCALES[SUPPORTED_LOCALES.length - 1];
     await page.reload();
-    await expect(page.locator('html')).toHaveAttribute('lang', 'de');
-    await expect(page.locator('h1.journal-title')).toContainText('Einstellungen');
-
-    await saveSettingsLanguage(page, 'it');
-    await expect(page).toHaveURL(/\/settings$/);
-    await expect(page.locator('html')).toHaveAttribute('lang', 'it');
-    await expect(page.locator('h1.journal-title')).toContainText('Impostazioni');
-    await expect(page.getByRole('link', { name: 'Oggi' }).first()).toBeVisible();
+    await expect(page.locator('html')).toHaveAttribute('lang', lastLocale);
+    await expectPageTitle(page, lastLocale, 'settings.title');
   });
 
   test('direct /recovery-code access without valid recovery context is blocked', async ({ page }) => {

--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -11,6 +11,7 @@ import {
   registerOwnerViaUI,
 } from './support/auth-helpers';
 import { switchPublicLanguage } from './support/language-helpers';
+import { localeText } from './support/locale-helpers';
 
 function toISODate(date: Date): string {
   const copy = new Date(date);
@@ -186,10 +187,17 @@ test.describe('Onboarding flow', () => {
     await expect(page).toHaveURL(/\/onboarding(?:\?.*)?$/);
     await expect(page.locator('html')).toHaveAttribute('lang', 'ru');
 
+    // Russian copy IS this test's subject, so the strings are asserted — but
+    // read from ru.json rather than re-typed here, so a translation edit syncs
+    // itself instead of failing a test that only looks like a UI regression.
     const quickPickButtons = onboardingQuickPickButtons(page);
-    await expect(quickPickButtons.first()).toContainText('Сегодня');
-    await expect(quickPickButtons.nth(1)).toContainText('Вчера');
-    await expect(quickPickButtons.nth(2)).toContainText('2 дня назад');
+    await expect(quickPickButtons.first()).toContainText(localeText('ru', 'onboarding.step1.today'));
+    await expect(quickPickButtons.nth(1)).toContainText(
+      localeText('ru', 'onboarding.step1.yesterday')
+    );
+    await expect(quickPickButtons.nth(2)).toContainText(
+      localeText('ru', 'onboarding.step1.two_days_ago')
+    );
   });
 
   test('step 1 rejects out-of-range manual dates instead of clamping them', async ({ page }) => {
@@ -331,10 +339,16 @@ test.describe('Onboarding flow', () => {
     await irregularCheckbox.check();
     await submitStepTwo(page);
 
+    // Sparse irregular mode: an "around <date>" estimate plus the
+    // needs-more-cycles note, both sourced from the catalogue rather than
+    // re-typed here (the same strings are asserted in three specs).
     const nextPeriodText = await dashboardNextPeriodText(page);
-    expect(nextPeriodText).toContain('around');
-    expect(nextPeriodText).toContain('3 cycles are needed');
-    expect(nextPeriodText).not.toContain(' - ');
+    expect(nextPeriodText).toContain(localeText('en', 'dashboard.next_period_estimate').replace('%s', '').trim());
+    expect(nextPeriodText).toContain(localeText('en', 'dashboard.next_period_need_cycles'));
+    await expect(page.locator('[data-dashboard-prediction-explainer]')).toHaveAttribute(
+      'data-explainer-key',
+      'prediction.explainer.irregular_sparse'
+    );
   });
 
   test('step 1 surfaces the day-1 spotting clarification tip above the date field', async ({
@@ -348,6 +362,6 @@ test.describe('Onboarding flow', () => {
 
     const stepOnePanel = page.locator('[data-onboarding-panel="1"]');
     await expect(stepOnePanel).toBeVisible();
-    await expect(stepOnePanel).toContainText('Day 1 is the first day of full flow, not spotting.');
+    await expect(stepOnePanel).toContainText(localeText('en', 'onboarding.step1.day1_tip'));
   });
 });

--- a/e2e/privacy.spec.ts
+++ b/e2e/privacy.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { localeText } from './support/locale-helpers';
 import {
   completeOnboardingIfPresent,
   continueFromRecoveryCode,
@@ -50,9 +51,15 @@ test.describe('Privacy page: copy and navigation', () => {
 
     await page.goto('/privacy');
 
-    const breadcrumb = page.locator('p.journal-muted.text-sm a[href="/dashboard"]');
+    // Addressed by hook + href, with the label derived from the key the
+    // template declares: `p.journal-muted.text-sm` was a styling-class path
+    // that any layout tweak breaks, and 'Dashboard' is one of six spellings.
+    const breadcrumb = page.locator('[data-privacy-breadcrumb] [data-privacy-breadcrumb-back]');
     await expect(breadcrumb).toBeVisible();
-    await expect(breadcrumb).toContainText('Dashboard');
+    await expect(breadcrumb).toHaveAttribute('href', '/dashboard');
+    const breadcrumbKey = (await breadcrumb.getAttribute('data-breadcrumb-key')) ?? '';
+    expect(breadcrumbKey, 'the breadcrumb must declare the label key it renders').not.toBe('');
+    await expect(breadcrumb).toHaveText(localeText('en', breadcrumbKey));
 
     const bottomBackLink = page.locator('p.mobile-safe-target a[href="/dashboard"]');
     await expect(bottomBackLink).toBeVisible();

--- a/e2e/pwa-install.spec.ts
+++ b/e2e/pwa-install.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { localeText } from './support/locale-helpers';
 
 test.describe('PWA install prompt', () => {
   test('shows the custom mobile install CTA and triggers the native prompt', async ({ page }) => {
@@ -28,11 +29,17 @@ test.describe('PWA install prompt', () => {
     await page.setViewportSize({ width: 390, height: 844 });
     await page.goto('/login');
 
-    const banner = page.locator('.mobile-install-banner');
+    // Address the banner and its action by their hooks, not by a styling class
+    // and an accessible name: `.mobile-install-banner` is a layout class and
+    // getByRole({ name: 'Install app' }) only resolves in English. The rendered
+    // title is still asserted once, against the key the template declares.
+    const banner = page.locator('[data-pwa-install-banner]');
+    const installTitle = banner.locator('[data-pwa-install-title]');
     await expect(banner).toBeVisible();
-    await expect(banner).toContainText('Install Ovumcy');
+    await expect(installTitle).toHaveAttribute('data-pwa-install-title-key', 'pwa.install.title');
+    await expect(installTitle).toHaveText(localeText('en', 'pwa.install.title'));
 
-    await page.getByRole('button', { name: 'Install app' }).click();
+    await banner.locator('[data-pwa-install-action="install"]').click();
 
     await expect
       .poll(async () => {

--- a/e2e/settings-password-export-danger.spec.ts
+++ b/e2e/settings-password-export-danger.spec.ts
@@ -420,11 +420,14 @@ test.describe('Settings: password, export, clear data, delete account', () => {
     await page.goto('/settings');
     await expect(page).toHaveURL(/\/settings$/);
     await createCustomSymptom(page, 'Reset me');
+    // State before the wipe, asserted structurally: one active custom symptom
+    // and no empty-state panel. The four `not.toContainText(...)` phrase checks
+    // this replaces named copy that no longer exists anywhere in the app, so
+    // they held no matter what the section rendered — including nothing.
     const symptomSection = page.locator('#settings-symptoms-section');
-    await expect(symptomSection).not.toContainText('Shown in new entries.');
-    await expect(symptomSection).not.toContainText('No custom symptoms yet.');
-    await expect(symptomSection).not.toContainText('Kept in history and export.');
-    await expect(symptomSection).not.toContainText('Built-in symptoms always stay available.');
+    await expect(symptomSection.locator('[data-custom-symptom-row]')).toHaveCount(1);
+    await expect(symptomSection.locator('[data-symptom-group="active"]')).toBeVisible();
+    await expect(symptomSection.locator('[data-symptom-empty-state]')).toHaveCount(0);
 
     await dangerZone.locator('#settings-clear-data-password').fill('WrongPass1');
     await dangerZone.locator('form[action="/api/v1/users/current/data-wipe"] button[type="submit"]').click();
@@ -460,7 +463,13 @@ test.describe('Settings: password, export, clear data, delete account', () => {
 
     await page.goto('/settings');
     await expect(page.locator('[data-export-summary-total]')).toContainText('0');
+    // After the wipe the section is back to its empty state: no rows, no
+    // groups, and the "empty" panel rather than the "no active ones left" one.
     await expect(page.locator('#settings-symptoms-section [data-custom-symptom-row]')).toHaveCount(0);
+    await expect(page.locator('#settings-symptoms-section [data-symptom-group]')).toHaveCount(0);
+    await expect(
+      page.locator('#settings-symptoms-section [data-symptom-empty-state="empty"]')
+    ).toBeVisible();
   });
 
   test('delete account requires valid password and removes account on success', async ({ page }) => {

--- a/e2e/settings-profile-cycle.spec.ts
+++ b/e2e/settings-profile-cycle.spec.ts
@@ -17,6 +17,12 @@ import {
   expectConfirmDialogCaptions,
   mutatingRequestsDuring,
 } from './support/confirm-dialog-helpers';
+import { localeText } from './support/locale-helpers';
+
+// The duplicate-name rejection is asserted on three surfaces in this file (the
+// create form twice, an archived row once). Source it once from the catalogue
+// so a copy edit lands in all three without a search-and-replace.
+const DUPLICATE_SYMPTOM_NAME_ERROR = localeText('en', 'settings.symptoms.error.duplicate_name');
 
 function toISODate(date: Date): string {
   const copy = new Date(date);
@@ -190,10 +196,14 @@ test.describe('Settings: profile and cycle', () => {
   }) => {
     const creds = await registerOwnerAndOpenSettings(page, 'settings-profile');
 
+    // The email is displayed, never editable. Assert that structurally: the
+    // panel renders the address as static text and carries no editable control
+    // at all. The previous negated-copy checks ("Cannot be changed." and its ru
+    // variant) passed just as well when the copy was reworded or dropped —
+    // which is exactly what happened, the string no longer renders anywhere.
     const profileAccountPanel = page.locator('[data-profile-email-panel]');
     await expect(profileAccountPanel).toContainText(creds.email);
-    await expect(profileAccountPanel).not.toContainText('Cannot be changed.');
-    await expect(profileAccountPanel).not.toContainText('Эл. почту нельзя изменить.');
+    await expect(profileAccountPanel.locator('input, textarea, select, [contenteditable]')).toHaveCount(0);
     await expect(page.locator('#settings-account input#settings-profile-email')).toHaveCount(0);
 
     const displayNameInput = page.locator('#settings-display-name');
@@ -248,7 +258,13 @@ test.describe('Settings: profile and cycle', () => {
 
     await page.reload();
     await expect(displayNameInput).toHaveValue('');
-    await expect(navIdentityChip(page)).toHaveAttribute('title', 'Profile settings');
+    // With no display name the chip falls back to the profile-name hint. Pin
+    // the key's rendered value from the catalogue rather than an English
+    // literal — the chip is localized like everything else.
+    await expect(navIdentityChip(page)).toHaveAttribute(
+      'title',
+      localeText('en', 'nav.profile_name_hint')
+    );
     await expect(navIdentityChip(page)).not.toContainText(creds.email);
     await expect(navIdentityChip(page)).not.toContainText(creds.email.split('@')[0]);
   });
@@ -328,9 +344,16 @@ test.describe('Settings: profile and cycle', () => {
     await expect(page).toHaveURL(/\/dashboard$/);
 
     const nextPeriodText = await dashboardNextPeriodText(page);
-    expect(nextPeriodText).toContain('around');
-    expect(nextPeriodText).toContain('3 cycles are needed');
-    expect(nextPeriodText).not.toContain(' - ');
+    expect(nextPeriodText).toContain(
+      localeText('en', 'dashboard.next_period_estimate').replace('%s', '').trim()
+    );
+    expect(nextPeriodText).toContain(localeText('en', 'dashboard.next_period_need_cycles'));
+    // Sparse irregular mode, asserted on the explainer key rather than by
+    // forbidding the exact-date separator this state must not render.
+    await expect(page.locator('[data-dashboard-prediction-explainer]')).toHaveAttribute(
+      'data-explainer-key',
+      'prediction.explainer.irregular_sparse'
+    );
   });
 
   test('tracking toggles and BBT unit persist and change the owner day form', async ({ page }) => {
@@ -409,7 +432,9 @@ test.describe('Settings: profile and cycle', () => {
     await page.goto('/dashboard');
     await expect(page).toHaveURL(/\/dashboard$/);
     const dashboardForm = page.locator('[data-dashboard-save-form]').first();
-    const bbtInput = dashboardForm.getByLabel('BBT');
+    // Address the field by its stable id, not its localized label ("BBT" is
+    // «БТТ» in ru), the way every other field in this spec is addressed.
+    const bbtInput = dashboardForm.locator('#dashboard-bbt');
     await expect(bbtInput).toBeVisible();
     await expect(dashboardForm.locator('.measurement-field-unit')).toContainText('°F');
     await expect(dashboardForm).toContainText('93.20-109.40 °F');
@@ -436,7 +461,7 @@ test.describe('Settings: profile and cycle', () => {
     expect(todayAction).toMatch(/^\/api\/v1\/days\/\d{4}-\d{2}-\d{2}$/);
     const todayISO = String(todayAction).replace('/api/v1/days/', '');
     const dayEditorForm = await openCalendarDayEditor(page, todayISO);
-    await expect(dayEditorForm.getByLabel('BBT')).toHaveValue('98.60');
+    await expect(dayEditorForm.locator('#calendar-bbt')).toHaveValue('98.60');
     await expect(dayEditorForm.locator('.measurement-field-unit')).toContainText('°F');
 
     await page.goto('/settings');
@@ -579,9 +604,18 @@ test.describe('Settings: profile and cycle', () => {
 
     await page.locator('a[href="/calendar"]').first().click();
     await expect(page.locator('#confirm-modal')).toBeVisible();
-    await expect(page.locator('#confirm-modal-message')).toContainText(
-      'You have unsaved settings changes. Leave without saving?'
-    );
+    // Compare the dialog against the prompt the form itself declared — the same
+    // pattern expectConfirmDialogCaptions uses for the accept/cancel captions.
+    // Asserting the declaration is non-empty first stops an empty attribute
+    // from making the comparison pass against an empty dialog.
+    const declaredUnsavedPrompt = (
+      (await cycleForm.getAttribute('data-settings-unsaved-prompt')) ?? ''
+    ).trim();
+    expect(
+      declaredUnsavedPrompt,
+      'the draft form must declare data-settings-unsaved-prompt'
+    ).not.toBe('');
+    await expect(page.locator('#confirm-modal-message')).toContainText(declaredUnsavedPrompt);
     await page.locator('#confirm-modal-cancel').click();
     await expect(page).toHaveURL(/\/settings$/);
     await expect(cycleLength).toHaveValue(String(initialCycleLength + 4));
@@ -795,7 +829,7 @@ test.describe('Settings: profile and cycle', () => {
     await selectSymptomIcon(archivedRow.locator('[data-symptom-edit-form]'), '⚡');
     await archivedRow.locator('[data-symptom-edit-form] button[type="submit"]').click();
     await expect(archivedRow.locator('[data-symptom-row-error]')).toContainText(
-      'That symptom name already exists in your list.'
+      DUPLICATE_SYMPTOM_NAME_ERROR
     );
     await expect(archivedRow.locator('input[name="name"]')).toHaveValue('Joint support');
 
@@ -829,19 +863,26 @@ test.describe('Settings: profile and cycle', () => {
     await createCustomSymptom(symptomSection, 'Joint stiffness', '✨');
     await expect(customSymptomRow(symptomSection, 'Joint stiffness', 'active')).toBeVisible();
 
+    // The create form has its own error container ([data-symptom-create-error]),
+    // a sibling of the per-row [data-symptom-row-error]. Addressing it directly
+    // — rather than the bare `.status-error` class shared with every row and
+    // section on the page — is what makes "the CREATE form rejected this"
+    // distinguishable from "something on this page errored".
+    const createError = createForm.locator('[data-symptom-create-error]');
+
     await createForm.locator('#settings-new-symptom-name').fill(' joint STIFFNESS ');
     await selectSymptomIcon(createForm, '🔥');
     await createForm.locator('button[type="submit"]').click();
-    await expect(symptomSection.locator('.status-error')).toContainText('That symptom name already exists in your list.');
+    await expect(createError).toContainText(DUPLICATE_SYMPTOM_NAME_ERROR);
     await expect(symptomSection.locator('[data-custom-symptom-row][data-symptom-name="Joint stiffness"]')).toHaveCount(1);
 
     await createForm.locator('#settings-new-symptom-name').fill('Усталость');
     await createForm.locator('button[type="submit"]').click();
-    await expect(symptomSection.locator('.status-error')).toContainText('That symptom name already exists in your list.');
+    await expect(createError).toContainText(DUPLICATE_SYMPTOM_NAME_ERROR);
 
     await createForm.locator('#settings-new-symptom-name').fill('<script>alert(1)</script>');
     await createForm.locator('button[type="submit"]').click();
-    await expect(symptomSection.locator('.status-error')).toContainText(
+    await expect(createError).toContainText(
       'Use plain text only. Tags and angle brackets are not allowed.'
     );
 
@@ -903,23 +944,27 @@ test.describe('Settings: profile and cycle', () => {
   test('custom symptom empty states explain what happens next until rows exist', async ({ page }) => {
     await registerOwnerAndOpenSettings(page, 'settings-custom-symptom-empty-groups');
 
+    // Group presence is addressed through [data-symptom-group], not through the
+    // localized heading: a getByText('Active custom symptoms').toHaveCount(0)
+    // is satisfied by any rewording or by switching language, so it could not
+    // tell an absent group from a renamed heading.
     const symptomSection = page.locator('#settings-symptoms-section');
     await expect(symptomSection.locator('[data-symptom-empty-state="empty"]')).toContainText(
       'No custom symptoms yet. Add one above to make it available in new entries.'
     );
-    await expect(symptomSection.getByText('Active custom symptoms')).toHaveCount(0);
-    await expect(symptomSection.getByText('Hidden custom symptoms')).toHaveCount(0);
+    await expect(symptomSection.locator('[data-symptom-group="active"]')).toHaveCount(0);
+    await expect(symptomSection.locator('[data-symptom-group="archived"]')).toHaveCount(0);
 
     const createForm = symptomSection.locator('[data-symptom-create-form]');
     await createForm.locator('#settings-new-symptom-name').fill('Joint stiffness');
     await selectSymptomIcon(createForm, '✨');
     await createForm.locator('button[type="submit"]').click();
 
-    await expect(symptomSection.getByText('Active custom symptoms')).toBeVisible();
+    await expect(symptomSection.locator('[data-symptom-group="active"]')).toBeVisible();
     await expect(symptomSection.locator('[data-symptom-group="active"]')).toContainText(
       'These appear in dashboard and calendar day editing.'
     );
-    await expect(symptomSection.getByText('Hidden custom symptoms')).toHaveCount(0);
+    await expect(symptomSection.locator('[data-symptom-group="archived"]')).toHaveCount(0);
     await expect(symptomSection.locator('[data-symptom-empty-state="empty"]')).toHaveCount(0);
   });
 });

--- a/e2e/stats-factor-context.spec.ts
+++ b/e2e/stats-factor-context.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test } from '@playwright/test';
 import { dashboardNextPeriodText } from './support/dashboard-helpers';
+import { displayDatesIn } from './support/date-field-helpers';
+import { localeText } from './support/locale-helpers';
 import {
   markCycleStart,
   registerOwnerAndEnableIrregularMode,
@@ -7,6 +9,10 @@ import {
   shiftISODate,
   todayISOFromDashboard,
 } from './support/stats-helpers';
+
+const SPARSE_EXPLAINER_KEY = 'prediction.explainer.irregular_sparse';
+const RANGES_EXPLAINER_KEY = 'prediction.explainer.irregular_ranges';
+const FACTOR_CONTEXT_EXPLAINER_KEY = 'prediction.explainer.factor_context';
 
 test.describe('Stats factor context', () => {
   test('owner sees sparse irregular explanations before range mode unlocks', async ({ page }) => {
@@ -19,26 +25,33 @@ test.describe('Stats factor context', () => {
       await markCycleStart(page, cycleStart);
     }
 
+    // The explainer key is the state under test on all three surfaces; the copy
+    // is asserted once, from the catalogue, so the three surfaces cannot drift
+    // apart and no sentence is re-typed per surface.
     await page.goto('/dashboard');
     await expect(page).toHaveURL(/\/dashboard$/);
-    expect(await dashboardNextPeriodText(page)).toContain('3 cycles are needed for a reliable range');
-    await expect(page.locator('[data-dashboard-prediction-explainer]')).toContainText(
-      'Irregular cycle mode needs at least 3 completed cycles before Ovumcy can show steadier ranges.'
+    expect(await dashboardNextPeriodText(page)).toContain(
+      localeText('en', 'dashboard.next_period_need_cycles')
     );
+    const dashboardExplainer = page.locator('[data-dashboard-prediction-explainer]');
+    await expect(dashboardExplainer).toHaveAttribute('data-explainer-key', SPARSE_EXPLAINER_KEY);
+    await expect(dashboardExplainer).toContainText(localeText('en', SPARSE_EXPLAINER_KEY));
     await expect(page.locator('[data-dashboard-factor-hint]')).toHaveCount(0);
 
     await page.goto('/stats');
     await expect(page).toHaveURL(/\/stats$/);
-    await expect(page.locator('[data-stats-prediction-explainer]')).toContainText(
-      'Irregular cycle mode needs at least 3 completed cycles before Ovumcy can show steadier ranges.'
+    await expect(page.locator('[data-stats-prediction-explainer]')).toHaveAttribute(
+      'data-explainer-key',
+      SPARSE_EXPLAINER_KEY
     );
 
     await page.goto(`/calendar?month=${today.slice(0, 7)}&day=${today}`);
     await expect(page).toHaveURL(new RegExp(`/calendar\\?month=${today.slice(0, 7)}&day=${today}`));
     const calendarExplainer = page.locator('[data-calendar-prediction-explainer]');
     await expect(calendarExplainer).toBeVisible();
-    await expect(calendarExplainer).toContainText(
-      'Irregular cycle mode needs at least 3 completed cycles before Ovumcy can show steadier ranges.'
+    await expect(calendarExplainer).toHaveAttribute(
+      'data-explainer-primary-key',
+      SPARSE_EXPLAINER_KEY
     );
   });
 
@@ -60,34 +73,55 @@ test.describe('Stats factor context', () => {
     await expect(page).toHaveURL(/\/dashboard$/);
     await expect(page.locator('a[href="/settings#settings-cycle"]')).toHaveCount(0);
     await expect(page.locator('.warning-amber')).toHaveCount(0);
+
+    // Two real calendar dates in order, derived through Intl from the app's own
+    // display format — the EN-US shape regex this replaces matched any
+    // three-letter word followed by digits.
     const nextPeriodText = await dashboardNextPeriodText(page);
-    expect(nextPeriodText).toMatch(/\w{3} \d{1,2}, \d{4} — \w{3} \d{1,2}, \d{4}/);
-    expect(nextPeriodText).not.toContain('3 cycles are needed');
-    await expect(page.locator('[data-dashboard-prediction-explainer]')).toContainText(
-      'Irregular cycle mode uses ranges instead of exact prediction dates.'
+    const renderedDates = await displayDatesIn(page, nextPeriodText);
+    expect(renderedDates, `range mode should render a date range: ${nextPeriodText}`).toHaveLength(2);
+    expect(renderedDates[1] > renderedDates[0]).toBeTruthy();
+
+    // Range mode, not sparse mode — asserted on the single-valued explainer key
+    // rather than by forbidding the sparse phrase, which any rewording defeats.
+    await expect(page.locator('[data-dashboard-prediction-explainer]')).toHaveAttribute(
+      'data-explainer-key',
+      RANGES_EXPLAINER_KEY
     );
+
+    // The chips were seeded by key, so address them by key: getByText('Stress')
+    // only worked because the run happens to be in English.
     const dashboardHint = page.locator('[data-dashboard-factor-hint]');
     await expect(dashboardHint).toBeVisible();
-    await expect(dashboardHint).toContainText('Recent tags can add context when timing feels less steady.');
-    await expect(dashboardHint.getByText('Stress', { exact: true }).first()).toBeVisible();
-    await expect(dashboardHint.getByText('Travel', { exact: true }).first()).toBeVisible();
+    await expect(dashboardHint).toContainText(localeText('en', FACTOR_CONTEXT_EXPLAINER_KEY));
+    await expect(dashboardHint.locator('[data-cycle-factor="stress"]')).toHaveCount(1);
+    await expect(dashboardHint.locator('[data-cycle-factor="travel"]')).toHaveCount(1);
 
     await page.goto('/stats');
     await expect(page).toHaveURL(/\/stats$/);
-    await expect(page.locator('[data-stats-prediction-explainer]')).toContainText(
-      'Irregular cycle mode uses ranges instead of exact prediction dates.'
+    await expect(page.locator('[data-stats-prediction-explainer]')).toHaveAttribute(
+      'data-explainer-key',
+      RANGES_EXPLAINER_KEY
     );
     const factorSection = page.locator('[data-stats-factor-context]');
     await expect(factorSection).toBeVisible();
-    await expect(factorSection).toContainText('Stress');
-    await expect(factorSection).toContainText('Travel');
-    await expect(factorSection).toContainText('Recent cycle context');
+    await expect(factorSection.locator('[data-cycle-factor="stress"]').first()).toBeVisible();
+    await expect(factorSection.locator('[data-cycle-factor="travel"]').first()).toBeVisible();
+    await expect(factorSection.locator('[data-stats-factor-recent-cycles]')).toContainText(
+      localeText('en', 'stats.factor_recent_cycles_title')
+    );
 
     await page.goto(`/calendar?month=${today.slice(0, 7)}&day=${today}`);
     await expect(page).toHaveURL(new RegExp(`/calendar\\?month=${today.slice(0, 7)}&day=${today}`));
     const calendarExplainer = page.locator('[data-calendar-prediction-explainer]');
     await expect(calendarExplainer).toBeVisible();
-    await expect(calendarExplainer).toContainText('Irregular cycle mode uses ranges instead of exact prediction dates.');
-    await expect(calendarExplainer).toContainText('Recent tags can add context when timing feels less steady.');
+    await expect(calendarExplainer).toHaveAttribute(
+      'data-explainer-primary-key',
+      RANGES_EXPLAINER_KEY
+    );
+    await expect(calendarExplainer).toHaveAttribute(
+      'data-explainer-secondary-key',
+      FACTOR_CONTEXT_EXPLAINER_KEY
+    );
   });
 });

--- a/e2e/stats-insights.spec.ts
+++ b/e2e/stats-insights.spec.ts
@@ -294,14 +294,31 @@ test.describe('Stats: symptom patterns', () => {
     await expect(page).toHaveURL(/\/stats$/);
 
     // HasSymptomPatterns gate -> the section renders, and at least one card
-    // shows the localized "Usually on day N of the cycle" / "Usually on days
-    // N-M of the cycle" copy from stats.symptom_pattern_day(s).
-    await expect(page.getByRole('heading', { name: 'Symptom patterns' })).toBeVisible();
-    const patternCard = page
-      .locator('.phase-symptom-card')
-      .filter({ hasText: /Usually on days? \d+(?:-\d+)? of the cycle/ })
-      .first();
+    // reports the cycle-day window it detected. Read the window off the card's
+    // own attributes instead of parsing "Usually on day N of the cycle" out of
+    // the rendered sentence: the copy is localized (and pluralized), so the old
+    // filter only worked because the run happens to be in English, and a card
+    // whose day numbers were wrong still matched.
+    const patternsSection = page.locator('[data-stats-symptom-patterns]');
+    await expect(patternsSection).toBeVisible();
+    await expect(patternsSection.locator('[data-stats-symptom-patterns-heading]')).toHaveAttribute(
+      'data-heading-key',
+      'stats.symptom_patterns_title'
+    );
+
+    const patternCard = patternsSection.locator('[data-symptom-pattern-card]').first();
     await expect(patternCard).toBeVisible();
+    const dayStart = Number(await patternCard.getAttribute('data-symptom-pattern-day-start'));
+    const dayEnd = Number(await patternCard.getAttribute('data-symptom-pattern-day-end'));
+    expect(dayStart).toBeGreaterThan(0);
+    expect(dayEnd).toBeGreaterThanOrEqual(dayStart);
+    // The symptom was logged on cycle day 10 of each completed cycle; a TZ
+    // boundary can shift the derived day by one either way.
+    expect(dayStart).toBeGreaterThanOrEqual(9);
+    expect(dayEnd).toBeLessThanOrEqual(11);
+    // One rendered-copy assertion for this surface: the card really does print
+    // the day window, not just carry it in an attribute.
+    await expect(patternCard).toContainText(String(dayStart));
   });
 });
 
@@ -322,21 +339,24 @@ test.describe('Stats: cycle range', () => {
     await page.goto('/stats');
     await expect(page).toHaveURL(/\/stats$/);
 
-    // Match the stat card by its label, then read the populated value.
+    // Address the card by its hook and read the observed lengths off its own
+    // attributes. Matching `.stat-label` on the literal "Range" and then
+    // parsing "Your cycles: N to M days" out of the value made this test an
+    // English-only test of a localized, pluralized sentence.
     // Avoid pinning the exact numbers: a TZ-induced ±1 boundary shift on
     // the seeded starts can shift the observed cycle lengths by one, and
     // the card behaviour we want to lock in is "renders with two distinct
     // positive integers", not "renders with literal 20 and 25".
-    const rangeArticle = page
-      .locator('article.journal-panel')
-      .filter({ has: page.locator('.stat-label', { hasText: 'Range' }) });
+    const rangeArticle = page.locator('[data-stat-card="cycle-range"]');
     await expect(rangeArticle).toBeVisible();
-    const valueText = (await rangeArticle.locator('.stat-value').textContent()) ?? '';
-    const match = valueText.match(/Your cycles:\s+(\d+)\s+to\s+(\d+)\s+days/);
-    expect(match, `range card value: ${valueText}`).not.toBeNull();
-    const minLen = Number(match![1]);
-    const maxLen = Number(match![2]);
+    const minLen = Number(await rangeArticle.getAttribute('data-cycle-range-min'));
+    const maxLen = Number(await rangeArticle.getAttribute('data-cycle-range-max'));
     expect(minLen).toBeGreaterThan(0);
     expect(maxLen).toBeGreaterThan(minLen);
+    // One rendered-copy assertion: the populated card prints both bounds rather
+    // than only carrying them in attributes.
+    const valueText = (await rangeArticle.locator('.stat-value').textContent()) ?? '';
+    expect(valueText, `range card value: ${valueText}`).toContain(String(minLen));
+    expect(valueText, `range card value: ${valueText}`).toContain(String(maxLen));
   });
 });

--- a/e2e/support/dashboard-helpers.ts
+++ b/e2e/support/dashboard-helpers.ts
@@ -47,12 +47,19 @@ export async function dashboardCurrentCycleDay(page: Page): Promise<number> {
   return Number(match![0]);
 }
 
-export async function dashboardCurrentPhaseText(page: Page): Promise<string> {
+/**
+ * The phase the dashboard reports, as the locale-independent enum value.
+ *
+ * Both primary summaries declare it on `data-dashboard-phase`, so a spec can
+ * assert `'menstrual'` instead of branching over «Менструальная» / "Menstrual"
+ * per language — a regex alternation that quietly reduces to "any of these
+ * words" and passes on the wrong phase whenever two languages share a spelling.
+ */
+export async function dashboardCurrentPhase(page: Page): Promise<string> {
   const mode = await dashboardPrimarySummaryMode(page);
-  const text =
-    mode === 'hero'
-      ? await dashboardCycleHero(page).locator('.dashboard-cycle-hero-center-phase').textContent()
-      : await dashboardFallbackStatusLine(page).locator('.dashboard-status-item').first().textContent();
+  const root = mode === 'hero' ? dashboardCycleHero(page) : dashboardFallbackStatusLine(page);
 
-  return String(text || '').trim();
+  const phase = (await root.getAttribute('data-dashboard-phase')) ?? '';
+  expect(phase, 'the dashboard summary must declare data-dashboard-phase').not.toBe('');
+  return phase;
 }

--- a/e2e/support/date-field-helpers.ts
+++ b/e2e/support/date-field-helpers.ts
@@ -1,4 +1,4 @@
-import { type Locator } from '@playwright/test';
+import { type Locator, type Page } from '@playwright/test';
 
 function splitISODate(isoDate: string): { year: string; month: string; day: string } {
   const parts = String(isoDate || '').trim().split('-');
@@ -36,4 +36,80 @@ export async function clearDateField(field: Locator): Promise<void> {
   await dateFieldSegment(field, 'month').fill('');
   await dateFieldSegment(field, 'year').fill('');
   await dateFieldSegment(field, 'year').blur();
+}
+
+/**
+ * The date exactly as the app's "display" format renders it for the given
+ * locale, derived through `Intl` rather than pinned by a shape regex.
+ *
+ * A `/\w{3} \d{1,2}, \d{4}/` expectation is a per-language literal in disguise:
+ * it encodes the EN-US ordering and separators, so it passes on the wrong date
+ * and fails on any locale whose display format differs. Deriving the string
+ * lets a prediction assertion check *which* date is shown, not merely that
+ * something date-shaped is.
+ */
+export async function formatDisplayDate(
+  page: Page,
+  isoDate: string,
+  intlLocale = 'en-US'
+): Promise<string> {
+  splitISODate(isoDate);
+  return page.evaluate(
+    ({ value, locale }) => {
+      const date = new Date(`${value}T00:00:00`);
+      return new Intl.DateTimeFormat(locale, {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+      }).format(date);
+    },
+    { value: isoDate, locale: intlLocale }
+  );
+}
+
+/**
+ * Every display-formatted calendar date `text` contains, as ISO dates, in the
+ * order they appear.
+ *
+ * Derived rather than pattern-matched: the browser formats a window of real
+ * dates around today through the same `Intl` options the app's display format
+ * uses, and reports which of those strings actually occur. That proves each
+ * fragment is a real calendar date rendered in the app's display format —
+ * something `/\w{3} \d{1,2}, \d{4}/` cannot do (it matches "Foo 99, 0000")
+ * — without hardcoding EN-US ordering or separators anywhere.
+ */
+export async function displayDatesIn(
+  page: Page,
+  text: string,
+  intlLocale = 'en-US',
+  windowDays = 800
+): Promise<string[]> {
+  return page.evaluate(
+    ({ haystack, locale, days }) => {
+      const formatter = new Intl.DateTimeFormat(locale, {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+      });
+      const found: Array<{ at: number; iso: string }> = [];
+      const anchor = new Date();
+      anchor.setHours(0, 0, 0, 0);
+
+      for (let offset = -days; offset <= days; offset += 1) {
+        const candidate = new Date(anchor);
+        candidate.setDate(candidate.getDate() + offset);
+        const at = haystack.indexOf(formatter.format(candidate));
+        if (at === -1) {
+          continue;
+        }
+        const yyyy = candidate.getFullYear();
+        const mm = String(candidate.getMonth() + 1).padStart(2, '0');
+        const dd = String(candidate.getDate()).padStart(2, '0');
+        found.push({ at, iso: `${yyyy}-${mm}-${dd}` });
+      }
+
+      return found.sort((a, b) => a.at - b.at).map((entry) => entry.iso);
+    },
+    { haystack: text, locale: intlLocale, days: windowDays }
+  );
 }

--- a/e2e/support/locale-helpers.ts
+++ b/e2e/support/locale-helpers.ts
@@ -1,0 +1,91 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Single source of truth for every rendered-copy assertion in the e2e suite.
+ *
+ * Specs address rendered text through `data-*` hooks; when the copy itself is
+ * the subject (language switching, a privacy scan that must cover all
+ * languages) the expected strings are read from the locale catalogues the app
+ * itself ships, never re-typed into a spec. A per-language literal branch rots
+ * the moment a translation changes and silently misses a language added later —
+ * reading `internal/i18n/locales/*.json` keeps both problems out of the suite.
+ *
+ * Loading happens in the Playwright worker process (Node), not in the browser.
+ */
+
+/**
+ * The UI locales `i18n.SupportedLanguages()` ships. `TestLocaleKeysParity`
+ * keeps the catalogues key-complete against each other, so every key resolved
+ * here resolves in all six.
+ */
+export const SUPPORTED_LOCALES = ['en', 'ru', 'es', 'fr', 'de', 'it'] as const;
+
+export type Locale = (typeof SUPPORTED_LOCALES)[number];
+
+const LOCALES_DIR = join(__dirname, '..', '..', 'internal', 'i18n', 'locales');
+
+const catalogues = new Map<Locale, Record<string, string>>();
+
+function catalogue(locale: Locale): Record<string, string> {
+  const cached = catalogues.get(locale);
+  if (cached) {
+    return cached;
+  }
+
+  const raw = readFileSync(join(LOCALES_DIR, `${locale}.json`), 'utf8');
+  const loaded = JSON.parse(raw) as Record<string, string>;
+  catalogues.set(locale, loaded);
+  return loaded;
+}
+
+/**
+ * The rendered string for one key in one locale.
+ *
+ * Throws on a missing or blank value rather than returning `''`: an empty
+ * expectation would make `toContainText` pass against anything, turning a
+ * renamed key into a green test.
+ */
+export function localeText(locale: Locale, key: string): string {
+  const value = catalogue(locale)[key];
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`locale "${locale}" has no non-empty value for key "${key}"`);
+  }
+  return value;
+}
+
+/** The rendered string for one key in every supported locale, keyed by locale. */
+export function localeTextByLocale(key: string): Record<Locale, string> {
+  const table = {} as Record<Locale, string>;
+  for (const locale of SUPPORTED_LOCALES) {
+    table[locale] = localeText(locale, key);
+  }
+  return table;
+}
+
+/**
+ * The rendered string for one key across every supported locale.
+ *
+ * Used by scans that must hold in all languages at once (the registration
+ * enumeration check): sourcing the list here means a seventh locale is covered
+ * the day it lands, instead of being silently skipped by a hardcoded list.
+ */
+export function everyLocaleText(key: string): string[] {
+  return SUPPORTED_LOCALES.map((locale) => localeText(locale, key));
+}
+
+/**
+ * Keys whose **English** copy matches `pattern`, sorted for stable output.
+ *
+ * English is the catalogue's source language, so a phrase-shaped rule only has
+ * to be written once, in English. Callers expand the returned keys through
+ * `everyLocaleText` to get the localized strings — which is what keeps a
+ * multi-language forbidden-phrase scan free of per-language literals and
+ * automatically complete when a new string or a new locale lands.
+ */
+export function localeKeysMatchingEnglish(pattern: RegExp): string[] {
+  return Object.entries(catalogue('en'))
+    .filter(([, value]) => typeof value === 'string' && pattern.test(value))
+    .map(([key]) => key)
+    .sort();
+}

--- a/internal/templates/auth_2fa.html
+++ b/internal/templates/auth_2fa.html
@@ -4,7 +4,7 @@
     <p class="journal-kicker">{{t .Messages "app.name"}}</p>
 
     <div>
-      <h1 class="journal-title">{{t .Messages "auth.2fa.title"}}</h1>
+      <h1 class="journal-title" data-title-key="auth.2fa.title">{{t .Messages "auth.2fa.title"}}</h1>
       <p class="journal-muted mt-2">{{t .Messages "auth.2fa.description"}}</p>
     </div>
 

--- a/internal/templates/auth_oidc_link_confirm.html
+++ b/internal/templates/auth_oidc_link_confirm.html
@@ -4,7 +4,7 @@
     <p class="journal-kicker">{{t .Messages "app.name"}}</p>
 
     <div>
-      <h1 class="journal-title">{{t .Messages "auth.oidc.link_confirm.title"}}</h1>
+      <h1 class="journal-title" data-title-key="auth.oidc.link_confirm.title">{{t .Messages "auth.oidc.link_confirm.title"}}</h1>
       <p class="journal-muted mt-2">{{t .Messages "auth.oidc.link_confirm.description"}}</p>
       {{if .TargetEmail}}
       <p class="journal-muted mt-1" data-link-confirm-email>{{.TargetEmail}}</p>

--- a/internal/templates/base.html
+++ b/internal/templates/base.html
@@ -78,10 +78,10 @@
       {{if and .CurrentUser (not .HideNavigation)}}
       <div class="container-main pb-4">
         <nav class="hidden items-center gap-2 sm:flex">
-          <a href="/dashboard" class="nav-link {{if isActiveRoute .CurrentPath "/dashboard"}}nav-link-active{{else if isActiveRoute .CurrentPath "/"}}nav-link-active{{end}}">{{t .Messages "nav.today"}}</a>
-          <a href="/calendar" class="nav-link {{if isActiveRoute .CurrentPath "/calendar"}}nav-link-active{{end}}">{{t .Messages "nav.calendar"}}</a>
-          <a href="/stats" class="nav-link {{if isActiveRoute .CurrentPath "/stats"}}nav-link-active{{end}}">{{t .Messages "nav.insights"}}</a>
-          <a href="/settings" class="nav-link nav-link-icon {{if isActiveRoute .CurrentPath "/settings"}}nav-link-active{{end}}" aria-label="{{t .Messages "nav.settings"}}" title="{{t .Messages "nav.settings"}}">
+          <a href="/dashboard" class="nav-link {{if isActiveRoute .CurrentPath "/dashboard"}}nav-link-active{{else if isActiveRoute .CurrentPath "/"}}nav-link-active{{end}}" data-nav-link="today" data-nav-link-key="nav.today">{{t .Messages "nav.today"}}</a>
+          <a href="/calendar" class="nav-link {{if isActiveRoute .CurrentPath "/calendar"}}nav-link-active{{end}}" data-nav-link="calendar" data-nav-link-key="nav.calendar">{{t .Messages "nav.calendar"}}</a>
+          <a href="/stats" class="nav-link {{if isActiveRoute .CurrentPath "/stats"}}nav-link-active{{end}}" data-nav-link="insights" data-nav-link-key="nav.insights">{{t .Messages "nav.insights"}}</a>
+          <a href="/settings" class="nav-link nav-link-icon {{if isActiveRoute .CurrentPath "/settings"}}nav-link-active{{end}}" data-nav-link="settings" data-nav-link-key="nav.settings" aria-label="{{t .Messages "nav.settings"}}" title="{{t .Messages "nav.settings"}}">
             <span aria-hidden="true">⚙️</span>
           </a>
 
@@ -95,10 +95,10 @@
         </nav>
 
         <nav id="mobile-menu" data-mobile-menu hidden class="mt-2 space-y-2 sm:hidden">
-          <a href="/dashboard" class="nav-link block {{if isActiveRoute .CurrentPath "/dashboard"}}nav-link-active{{else if isActiveRoute .CurrentPath "/"}}nav-link-active{{end}}">{{t .Messages "nav.today"}}</a>
-          <a href="/calendar" class="nav-link block {{if isActiveRoute .CurrentPath "/calendar"}}nav-link-active{{end}}">{{t .Messages "nav.calendar"}}</a>
-          <a href="/stats" class="nav-link block {{if isActiveRoute .CurrentPath "/stats"}}nav-link-active{{end}}">{{t .Messages "nav.insights"}}</a>
-          <a href="/settings" class="nav-link nav-link-icon block {{if isActiveRoute .CurrentPath "/settings"}}nav-link-active{{end}}" aria-label="{{t .Messages "nav.settings"}}" title="{{t .Messages "nav.settings"}}"><span aria-hidden="true">⚙️</span></a>
+          <a href="/dashboard" class="nav-link block {{if isActiveRoute .CurrentPath "/dashboard"}}nav-link-active{{else if isActiveRoute .CurrentPath "/"}}nav-link-active{{end}}" data-nav-link="today" data-nav-link-key="nav.today">{{t .Messages "nav.today"}}</a>
+          <a href="/calendar" class="nav-link block {{if isActiveRoute .CurrentPath "/calendar"}}nav-link-active{{end}}" data-nav-link="calendar" data-nav-link-key="nav.calendar">{{t .Messages "nav.calendar"}}</a>
+          <a href="/stats" class="nav-link block {{if isActiveRoute .CurrentPath "/stats"}}nav-link-active{{end}}" data-nav-link="insights" data-nav-link-key="nav.insights">{{t .Messages "nav.insights"}}</a>
+          <a href="/settings" class="nav-link nav-link-icon block {{if isActiveRoute .CurrentPath "/settings"}}nav-link-active{{end}}" data-nav-link="settings" data-nav-link-key="nav.settings" aria-label="{{t .Messages "nav.settings"}}" title="{{t .Messages "nav.settings"}}"><span aria-hidden="true">⚙️</span></a>
           {{template "nav_user_identity_chip" (dict "CurrentUser" .CurrentUser "Messages" .Messages "ElementID" "nav-user-chip-mobile" "Block" true "SwapOOB" false)}}
           <form action="/logout" method="post" data-confirm="{{t .Messages "auth.confirm_logout"}}" data-confirm-accept="{{t .Messages "nav.logout"}}">
             <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
@@ -120,7 +120,7 @@
           <div class="mobile-install-heading">
             <img src="/static/brand/ovumcy-icon.svg" width="40" height="40" alt="" class="mobile-install-icon" aria-hidden="true">
             <div class="space-y-1">
-              <h2 class="mobile-install-title">{{t .Messages "pwa.install.title"}}</h2>
+              <h2 class="mobile-install-title" data-pwa-install-title data-pwa-install-title-key="pwa.install.title">{{t .Messages "pwa.install.title"}}</h2>
               <p class="mobile-install-text" data-pwa-install-copy="prompt" hidden>{{t .Messages "pwa.install.prompt_text"}}</p>
               <p class="mobile-install-text" data-pwa-install-copy="ios" hidden>{{t .Messages "pwa.install.ios_text"}}</p>
               <p class="mobile-install-text" data-pwa-install-copy="menu" hidden>{{t .Messages "pwa.install.menu_text"}}</p>
@@ -141,10 +141,10 @@
 
     {{if and .CurrentUser (not .HideNavigation)}}
     <nav class="mobile-tabbar sm:hidden" aria-label="{{t .Messages "nav.menu"}}">
-      <a href="/dashboard" class="mobile-tabbar-link {{if isActiveRoute .CurrentPath "/dashboard"}}mobile-tabbar-link-active{{else if isActiveRoute .CurrentPath "/"}}mobile-tabbar-link-active{{end}}">{{t .Messages "nav.today"}}</a>
-      <a href="/calendar" class="mobile-tabbar-link {{if isActiveRoute .CurrentPath "/calendar"}}mobile-tabbar-link-active{{end}}">{{t .Messages "nav.calendar"}}</a>
-      <a href="/stats" class="mobile-tabbar-link {{if isActiveRoute .CurrentPath "/stats"}}mobile-tabbar-link-active{{end}}">{{t .Messages "nav.insights"}}</a>
-      <a href="/settings" class="mobile-tabbar-link mobile-tabbar-icon {{if isActiveRoute .CurrentPath "/settings"}}mobile-tabbar-link-active{{end}}" aria-label="{{t .Messages "nav.settings"}}" title="{{t .Messages "nav.settings"}}"><span class="mobile-tabbar-icon-glyph" aria-hidden="true">⚙️</span></a>
+      <a href="/dashboard" class="mobile-tabbar-link {{if isActiveRoute .CurrentPath "/dashboard"}}mobile-tabbar-link-active{{else if isActiveRoute .CurrentPath "/"}}mobile-tabbar-link-active{{end}}" data-nav-link="today" data-nav-link-key="nav.today">{{t .Messages "nav.today"}}</a>
+      <a href="/calendar" class="mobile-tabbar-link {{if isActiveRoute .CurrentPath "/calendar"}}mobile-tabbar-link-active{{end}}" data-nav-link="calendar" data-nav-link-key="nav.calendar">{{t .Messages "nav.calendar"}}</a>
+      <a href="/stats" class="mobile-tabbar-link {{if isActiveRoute .CurrentPath "/stats"}}mobile-tabbar-link-active{{end}}" data-nav-link="insights" data-nav-link-key="nav.insights">{{t .Messages "nav.insights"}}</a>
+      <a href="/settings" class="mobile-tabbar-link mobile-tabbar-icon {{if isActiveRoute .CurrentPath "/settings"}}mobile-tabbar-link-active{{end}}" data-nav-link="settings" data-nav-link-key="nav.settings" aria-label="{{t .Messages "nav.settings"}}" title="{{t .Messages "nav.settings"}}"><span class="mobile-tabbar-icon-glyph" aria-hidden="true">⚙️</span></a>
     </nav>
     {{end}}
 

--- a/internal/templates/calendar.html
+++ b/internal/templates/calendar.html
@@ -2,8 +2,8 @@
 <section class="space-y-6">
   <div class="journal-card flex flex-col gap-4 p-4 sm:flex-row sm:items-center sm:justify-between sm:p-5">
     <div>
-      <h1 class="journal-subtitle">{{t .Messages "calendar.title"}}</h1>
-      <p class="journal-muted mt-1">{{.MonthLabel}}</p>
+      <h1 class="journal-subtitle" data-title-key="calendar.title">{{t .Messages "calendar.title"}}</h1>
+      <p class="journal-muted mt-1" data-calendar-month-label>{{.MonthLabel}}</p>
     </div>
 
     <div class="flex flex-wrap items-center gap-2">

--- a/internal/templates/calendar_feed_reveal.html
+++ b/internal/templates/calendar_feed_reveal.html
@@ -9,7 +9,7 @@
     <p class="journal-kicker">🗓️ {{t .Messages "settings.calendar_feed.reveal.kicker"}}</p>
 
     <div>
-      <h1 class="journal-title" data-calendar-feed-reveal-heading>
+      <h1 class="journal-title" data-calendar-feed-reveal-heading data-title-key="{{if .CalendarFeedRotated}}settings.calendar_feed.reveal.title_rotated{{else}}settings.calendar_feed.reveal.title{{end}}">
         {{if .CalendarFeedRotated}}{{t .Messages "settings.calendar_feed.reveal.title_rotated"}}{{else}}{{t .Messages "settings.calendar_feed.reveal.title"}}{{end}}
       </h1>
       <p class="journal-muted mt-2">{{t .Messages "settings.calendar_feed.reveal.subtitle"}}</p>

--- a/internal/templates/components/recovery.html
+++ b/internal/templates/components/recovery.html
@@ -10,7 +10,7 @@
   <p class="journal-kicker">{{t .Messages "auth.recovery_title_short"}}</p>
 
   <div>
-    <h1 class="journal-title">{{t .Messages "auth.recovery_code_title"}}</h1>
+    <h1 class="journal-title" data-title-key="auth.recovery_code_title">{{t .Messages "auth.recovery_code_title"}}</h1>
     <p class="journal-muted mt-2">{{t .Messages "auth.recovery_code_subtitle"}}</p>
   </div>
 

--- a/internal/templates/components/settings_symptoms.html
+++ b/internal/templates/components/settings_symptoms.html
@@ -153,7 +153,7 @@
     </div>
 
     {{if .SymptomErrorMessage}}
-    <div class="status-error flex items-center gap-2"><span aria-hidden="true">⚠️</span><span>{{.SymptomErrorMessage}}</span></div>
+    <div class="status-error flex items-center gap-2" data-symptom-create-error><span aria-hidden="true">⚠️</span><span>{{.SymptomErrorMessage}}</span></div>
     {{end}}
     {{if .SymptomStatusMessage}}{{dismissibleStatusOK .Messages .SymptomStatusMessage}}{{end}}
 

--- a/internal/templates/dashboard.html
+++ b/internal/templates/dashboard.html
@@ -1,14 +1,18 @@
 {{define "content"}}
 <section class="space-y-6">
-  <h1 class="sr-only">{{t .Messages "nav.dashboard"}}</h1>
+  <h1 class="sr-only" data-title-key="nav.dashboard">{{t .Messages "nav.dashboard"}}</h1>
   <section class="space-y-3" data-dashboard-shell data-phase="{{.Stats.CurrentPhase}}" data-usage-goal="{{.CurrentUser.UsageGoal}}">
     {{if .CycleHero.Visible}}
-    <section class="journal-card journal-hero dashboard-cycle-hero reveal" data-dashboard-cycle-hero{{if .CycleHero.Approximate}} data-cycle-hero-approximate="true"{{end}}>
+    <section class="journal-card journal-hero dashboard-cycle-hero reveal" data-dashboard-cycle-hero data-dashboard-phase="{{.CycleHero.CurrentPhase}}"{{if .CycleHero.Approximate}} data-cycle-hero-approximate="true"{{end}}>
       <div class="dashboard-cycle-hero-shell">
         <div class="dashboard-cycle-hero-topline">
           <p class="journal-kicker">{{t .Messages "dashboard.cycle_snapshot"}}</p>
           {{if .ShowHighFertilityBadge}}
-          <p class="dashboard-cycle-hero-badge{{if eq .CurrentUser.UsageGoal "avoid_pregnancy"}} dashboard-cycle-hero-badge-warning{{else if eq .CurrentUser.UsageGoal "trying_to_conceive"}} dashboard-cycle-hero-badge-positive{{end}}">
+          <p
+            class="dashboard-cycle-hero-badge{{if eq .CurrentUser.UsageGoal "avoid_pregnancy"}} dashboard-cycle-hero-badge-warning{{else if eq .CurrentUser.UsageGoal "trying_to_conceive"}} dashboard-cycle-hero-badge-positive{{end}}"
+            data-fertility-badge
+            data-fertility-badge-variant="{{if eq .CurrentUser.UsageGoal "avoid_pregnancy"}}warning{{else if eq .CurrentUser.UsageGoal "trying_to_conceive"}}positive{{else}}neutral{{end}}"
+            data-fertility-badge-key="{{if eq .CurrentUser.UsageGoal "avoid_pregnancy"}}dashboard.fertility_badge_warning{{else if eq .CurrentUser.UsageGoal "trying_to_conceive"}}dashboard.fertility_badge_positive{{else}}dashboard.high_fertility_badge{{end}}">
             {{if eq .CurrentUser.UsageGoal "avoid_pregnancy"}}⚠️ {{t .Messages "dashboard.fertility_badge_warning"}}{{else if eq .CurrentUser.UsageGoal "trying_to_conceive"}}✨ {{t .Messages "dashboard.fertility_badge_positive"}}{{else}}💧 {{t .Messages "dashboard.high_fertility_badge"}}{{end}}
           </p>
           {{end}}
@@ -46,7 +50,12 @@
 
           <div class="dashboard-cycle-hero-phases">
             {{range .CycleHero.PhaseCards}}
-            <article class="dashboard-phase-card dashboard-phase-card-{{.Phase}}{{if .IsCurrent}} is-current{{end}}" data-cycle-hero-phase="{{.Phase}}">
+            <article
+              class="dashboard-phase-card dashboard-phase-card-{{.Phase}}{{if .IsCurrent}} is-current{{end}}"
+              data-cycle-hero-phase="{{.Phase}}"
+              data-cycle-hero-phase-start="{{.StartDay}}"
+              data-cycle-hero-phase-end="{{.EndDay}}"
+              data-cycle-hero-phase-current="{{if .IsCurrent}}true{{else}}false{{end}}">
               <p class="dashboard-phase-card-title">
                 <span class="dashboard-phase-card-dot" aria-hidden="true"></span>
                 <span>{{phaseLabel $.Messages .Phase}}</span>
@@ -96,7 +105,11 @@
       <span class="dashboard-status-item">{{t .Messages "prediction.explainer.unpredictable_compact"}}</span>
       {{else}}
         {{if .ShowHighFertilityBadge}}
-        <span class="dashboard-status-item{{if eq .CurrentUser.UsageGoal "avoid_pregnancy"}} dashboard-status-item-warning{{else if eq .CurrentUser.UsageGoal "trying_to_conceive"}} dashboard-status-item-positive{{end}}">
+        <span
+          class="dashboard-status-item{{if eq .CurrentUser.UsageGoal "avoid_pregnancy"}} dashboard-status-item-warning{{else if eq .CurrentUser.UsageGoal "trying_to_conceive"}} dashboard-status-item-positive{{end}}"
+          data-fertility-badge
+          data-fertility-badge-variant="{{if eq .CurrentUser.UsageGoal "avoid_pregnancy"}}warning{{else if eq .CurrentUser.UsageGoal "trying_to_conceive"}}positive{{else}}neutral{{end}}"
+          data-fertility-badge-key="{{if eq .CurrentUser.UsageGoal "avoid_pregnancy"}}dashboard.fertility_badge_warning{{else if eq .CurrentUser.UsageGoal "trying_to_conceive"}}dashboard.fertility_badge_positive{{else}}dashboard.high_fertility_badge{{end}}">
           {{if eq .CurrentUser.UsageGoal "avoid_pregnancy"}}⚠️ {{t .Messages "dashboard.fertility_badge_warning"}}{{else if eq .CurrentUser.UsageGoal "trying_to_conceive"}}✨ {{t .Messages "dashboard.fertility_badge_positive"}}{{else}}💧 {{t .Messages "dashboard.high_fertility_badge"}}{{end}}
         </span>
         {{end}}
@@ -166,7 +179,7 @@
     <div class="flex flex-wrap items-center gap-2 text-sm" data-dashboard-factor-hint>
       <span class="journal-muted">{{t .Messages .PredictionExplanationSecondaryKey}}</span>
       {{range .PredictionFactorHintKeys}}
-      <span class="check-chip check-chip-static">
+      <span class="check-chip check-chip-static" data-cycle-factor="{{.}}">
         <span class="symptom-icon">{{cycleFactorIcon .}}</span>
         <span class="symptom-label">{{cycleFactorLabel $.Messages .}}</span>
       </span>
@@ -184,7 +197,7 @@
       <div class="mb-5 flex flex-wrap items-center justify-between gap-3">
         <div>
           <h2 class="journal-subtitle">{{t .Messages "dashboard.today_editor"}}</h2>
-          <p class="journal-muted">{{.FormattedDate}}</p>
+          <p class="journal-muted" data-dashboard-date-subtitle>{{.FormattedDate}}</p>
         </div>
         {{if and .IsOwner .ShowYesterdayJump}}
         <a href="/calendar?month={{.YesterdayMonth}}&day={{.Yesterday}}&edit=1" class="inline-link text-sm">← {{t .Messages "dashboard.fill_yesterday"}}</a>

--- a/internal/templates/day_editor_partial.html
+++ b/internal/templates/day_editor_partial.html
@@ -150,7 +150,7 @@
     data-cycle-start-short-gap-message="{{t .Messages "dashboard.cycle_start_short_gap_message"}}"
     data-cycle-start-short-gap-accept="{{t .Messages "dashboard.cycle_start_short_gap_accept"}}"></div>
   {{if .ShowFutureCycleStartNotice}}
-  <p class="journal-muted text-sm">{{t .Messages "warning.future_cycle_start"}}</p>
+  <p class="journal-muted text-sm" data-future-cycle-start-notice data-notice-key="warning.future_cycle_start">{{t .Messages "warning.future_cycle_start"}}</p>
   {{end}}
   {{if .ShowCycleStartSuggestion}}
   <p class="journal-muted text-sm">{{t .Messages "dashboard.cycle_start_suggestion"}}</p>
@@ -209,7 +209,7 @@
       {{end}}
     </div>
     {{if .ShowFutureCycleStartNotice}}
-    <p class="journal-muted text-sm">{{t .Messages "warning.future_cycle_start"}}</p>
+    <p class="journal-muted text-sm" data-future-cycle-start-notice data-notice-key="warning.future_cycle_start">{{t .Messages "warning.future_cycle_start"}}</p>
     {{end}}
     {{if .ShowCycleStartSuggestion}}
     <p class="journal-muted text-sm">{{t .Messages "dashboard.cycle_start_suggestion"}}</p>
@@ -252,7 +252,7 @@
         {{end}}
       </div>
       {{if .ShowFutureCycleStartNotice}}
-      <p class="journal-muted text-sm">{{t .Messages "warning.future_cycle_start"}}</p>
+      <p class="journal-muted text-sm" data-future-cycle-start-notice data-notice-key="warning.future_cycle_start">{{t .Messages "warning.future_cycle_start"}}</p>
       {{end}}
       {{if .ShowCycleStartSuggestion}}
       <p class="journal-muted text-sm">{{t .Messages "dashboard.cycle_start_suggestion"}}</p>

--- a/internal/templates/forgot_password.html
+++ b/internal/templates/forgot_password.html
@@ -4,7 +4,7 @@
     <p class="journal-kicker">{{t .Messages "auth.recovery_title_short"}}</p>
 
     <div>
-      <h1 class="journal-title">{{t .Messages "auth.forgot_password_title"}}</h1>
+      <h1 class="journal-title" data-title-key="auth.forgot_password_title">{{t .Messages "auth.forgot_password_title"}}</h1>
       <p class="journal-muted mt-2" data-subtitle-key="{{if .ShowRecoveryCodeStep}}auth.forgot_password_step2_subtitle{{else}}auth.forgot_password_subtitle{{end}}" data-forgot-step="{{if .ShowRecoveryCodeStep}}recovery_code{{else}}email{{end}}">
         {{if .ShowRecoveryCodeStep}}
         {{t .Messages "auth.forgot_password_step2_subtitle"}}

--- a/internal/templates/login.html
+++ b/internal/templates/login.html
@@ -4,7 +4,7 @@
     <p class="journal-kicker">{{t .Messages "app.name"}}</p>
 
     <div>
-      <h1 class="journal-title">{{t .Messages "auth.login_title"}}</h1>
+      <h1 class="journal-title" data-title-key="auth.login_title">{{t .Messages "auth.login_title"}}</h1>
       <p class="journal-muted mt-2">{{t .Messages "auth.login_subtitle"}}</p>
     </div>
 

--- a/internal/templates/onboarding.html
+++ b/internal/templates/onboarding.html
@@ -29,7 +29,7 @@
     </div>
 
     <div data-onboarding-panel="1" class="mt-6 space-y-4" {{if ne .OnboardingStep 1}}hidden{{end}}>
-      <h1 class="journal-title">{{t .Messages "onboarding.step1.title"}}</h1>
+      <h1 class="journal-title" data-title-key="onboarding.step1.title">{{t .Messages "onboarding.step1.title"}}</h1>
       <p class="journal-muted">{{t .Messages "onboarding.step1.subtitle"}}</p>
       <p class="journal-muted text-sm">{{t .Messages "onboarding.step1.day1_tip"}}</p>
       <p class="journal-muted text-sm">{{t .Messages "onboarding.step1.privacy"}}</p>
@@ -66,7 +66,7 @@
     </div>
 
     <div data-onboarding-panel="2" class="mt-6 space-y-4" {{if ne .OnboardingStep 2}}hidden{{end}}>
-      <h1 class="journal-title">{{t .Messages "onboarding.step2.title"}}</h1>
+      <h1 class="journal-title" data-title-key="onboarding.step2.title">{{t .Messages "onboarding.step2.title"}}</h1>
 
       <form
         hx-post="/api/v1/onboarding/steps/2"

--- a/internal/templates/privacy.html
+++ b/internal/templates/privacy.html
@@ -1,12 +1,12 @@
 {{define "content"}}
 <section class="mx-auto max-w-3xl space-y-6">
   <div>
-    <p class="journal-muted text-sm">
-      <a href="{{.BackPath}}" class="inline-link">{{t .Messages .BreadcrumbBackLabelKey}}</a>
+    <p class="journal-muted text-sm" data-privacy-breadcrumb>
+      <a href="{{.BackPath}}" class="inline-link" data-privacy-breadcrumb-back data-breadcrumb-key="{{.BreadcrumbBackLabelKey}}">{{t .Messages .BreadcrumbBackLabelKey}}</a>
       <span aria-hidden="true"> &gt; </span>
       <span>{{t .Messages "privacy.title"}}</span>
     </p>
-    <h1 class="journal-title">{{t .Messages "privacy.title"}}</h1>
+    <h1 class="journal-title" data-title-key="privacy.title">{{t .Messages "privacy.title"}}</h1>
   </div>
 
   <section class="journal-card p-5 sm:p-6 space-y-3" data-privacy-section="zero-collection">

--- a/internal/templates/register.html
+++ b/internal/templates/register.html
@@ -12,7 +12,7 @@
     <p class="journal-kicker">{{t .Messages "app.name"}}</p>
 
     <div>
-      <h1 class="journal-title">{{t .Messages "auth.create_account"}}</h1>
+      <h1 class="journal-title" data-title-key="auth.create_account">{{t .Messages "auth.create_account"}}</h1>
       {{if and .IsFirstLaunch .RegistrationOpen}}
       <p class="journal-muted mt-2" data-subtitle-key="auth.register_subtitle">{{t .Messages "auth.register_subtitle"}}</p>
       {{end}}

--- a/internal/templates/reset_password.html
+++ b/internal/templates/reset_password.html
@@ -4,7 +4,7 @@
     <p class="journal-kicker">{{t .Messages "auth.recovery_title_short"}}</p>
 
     <div>
-      <h1 class="journal-title">{{t .Messages "auth.reset_password_title"}}</h1>
+      <h1 class="journal-title" data-title-key="auth.reset_password_title">{{t .Messages "auth.reset_password_title"}}</h1>
       <p class="journal-muted mt-2">{{t .Messages "auth.reset_password_subtitle"}}</p>
     </div>
 

--- a/internal/templates/settings.html
+++ b/internal/templates/settings.html
@@ -1,7 +1,7 @@
 {{define "content"}}
 <section class="space-y-6">
   <div>
-    <h1 class="journal-title">{{t .Messages "settings.title"}}</h1>
+    <h1 class="journal-title" data-title-key="settings.title">{{t .Messages "settings.title"}}</h1>
     <p class="journal-muted mt-2">{{t .Messages "settings.subtitle"}}</p>
   </div>
 

--- a/internal/templates/settings_2fa.html
+++ b/internal/templates/settings_2fa.html
@@ -1,7 +1,7 @@
 {{define "content"}}
 <section class="mx-auto max-w-3xl space-y-6 px-4 py-8">
   <div>
-    <h1 class="journal-title">{{t .Messages "settings.2fa.title"}}</h1>
+    <h1 class="journal-title" data-title-key="settings.2fa.title">{{t .Messages "settings.2fa.title"}}</h1>
     <p class="journal-muted mt-1 text-sm">{{t .Messages "settings.2fa.description"}}</p>
   </div>
 

--- a/internal/templates/stats.html
+++ b/internal/templates/stats.html
@@ -1,7 +1,7 @@
 {{define "content"}}
 <section class="space-y-6">
   <div>
-    <h1 class="journal-title">{{t .Messages "stats.title"}}</h1>
+    <h1 class="journal-title" data-title-key="stats.title">{{t .Messages "stats.title"}}</h1>
     <p class="journal-muted mt-2">{{t .Messages "stats.subtitle"}}</p>
   </div>
 
@@ -109,7 +109,7 @@
         {{if .HasPredictionFactorHint}}
         <div class="mt-3 flex flex-wrap gap-2">
           {{range .PredictionFactorHintKeys}}
-          <span class="check-chip check-chip-static">
+          <span class="check-chip check-chip-static" data-cycle-factor="{{.}}">
             <span class="symptom-icon">{{cycleFactorIcon .}}</span>
             <span class="symptom-label">{{cycleFactorLabel $.Messages .}}</span>
           </span>
@@ -136,7 +136,11 @@
             </div>
           </div>
         </article>
-        <article class="journal-panel">
+        <article
+          class="journal-panel"
+          data-stat-card="cycle-range"
+          data-cycle-range-min="{{.Stats.MinCycleLength}}"
+          data-cycle-range-max="{{.Stats.MaxCycleLength}}">
           <p class="stat-label">{{t .Messages "stats.cycle_range"}}</p>
           <p class="stat-value mt-2">{{if gt .Stats.MinCycleLength 0}}{{if eq .Stats.MinCycleLength .Stats.MaxCycleLength}}{{.Stats.MaxCycleLength}} {{t .Messages "common.days_short"}}{{else}}{{printf (tn .Messages .Lang "stats.cycle_range_summary" .Stats.MaxCycleLength) .Stats.MinCycleLength .Stats.MaxCycleLength}}{{end}}{{else}}{{.NoDataLabel}}{{end}}</p>
         </article>
@@ -151,7 +155,7 @@
       </div>
       <ul class="flex flex-wrap gap-2">
         {{range .RecentCycleFactors}}
-        <li class="check-chip check-chip-static">
+        <li class="check-chip check-chip-static" data-cycle-factor="{{.Key}}" data-cycle-factor-count="{{.Count}}">
           <span class="symptom-icon">{{cycleFactorIcon .Key}}</span>
           <span class="symptom-label">{{cycleFactorLabel $.Messages .Key}}</span>
           <span class="journal-muted text-xs">· {{.Count}}</span>
@@ -165,7 +169,7 @@
           <p class="field-label">{{t $.Messages (printf "stats.factor_pattern_%s" .Kind)}}</p>
           <div class="flex flex-wrap gap-2">
             {{range .Items}}
-            <span class="check-chip check-chip-static">
+            <span class="check-chip check-chip-static" data-cycle-factor="{{.Key}}" data-cycle-factor-count="{{.Count}}">
               <span class="symptom-icon">{{cycleFactorIcon .Key}}</span>
               <span class="symptom-label">{{cycleFactorLabel $.Messages .Key}}</span>
               <span class="journal-muted text-xs">· {{.Count}}</span>
@@ -188,7 +192,7 @@
           <p class="journal-muted text-xs">{{printf (t $.Messages "stats.factor_cycle_dates") (formatLocalizedDate $.Lang .Start "display") (formatLocalizedDate $.Lang .End "display")}}</p>
           <div class="flex flex-wrap gap-2">
             {{range .FactorKeys}}
-            <span class="check-chip check-chip-static">
+            <span class="check-chip check-chip-static" data-cycle-factor="{{.}}">
               <span class="symptom-icon">{{cycleFactorIcon .}}</span>
               <span class="symptom-label">{{cycleFactorLabel $.Messages .}}</span>
             </span>
@@ -316,14 +320,18 @@
     </div>
 
     {{if and .IsOwner .HasSymptomPatterns}}
-    <section class="journal-card p-5 sm:p-6 space-y-4">
+    <section class="journal-card p-5 sm:p-6 space-y-4" data-stats-symptom-patterns>
       <div>
-        <h2 class="journal-subtitle">{{t .Messages "stats.symptom_patterns_title"}}</h2>
+        <h2 class="journal-subtitle" data-stats-symptom-patterns-heading data-heading-key="stats.symptom_patterns_title">{{t .Messages "stats.symptom_patterns_title"}}</h2>
         <p class="journal-muted mt-2 text-sm">{{t .Messages "stats.symptom_patterns_subtitle"}}</p>
       </div>
       <div class="grid gap-3 sm:grid-cols-2">
         {{range .SymptomPatterns}}
-        <article class="journal-panel phase-symptom-card">
+        <article
+          class="journal-panel phase-symptom-card"
+          data-symptom-pattern-card
+          data-symptom-pattern-day-start="{{.DayStart}}"
+          data-symptom-pattern-day-end="{{.DayEnd}}">
           <div class="flex items-center gap-2">
             <span class="stats-symptom-icon">{{.Icon}}</span>
             <p class="field-label">{{symptomLabel $.Messages .Name}}</p>


### PR DESCRIPTION
## What

Class sweep from the audit wave 2 backlog: rendered copy in the e2e suite is addressed through `data-*` hooks; the per-language literal branches are gone.

- **Template hooks (attributes only — no markup, class, or copy changed):** `data-dashboard-phase`, `data-fertility-badge` + variant/key, `data-cycle-factor` on every static factor chip, `data-symptom-pattern-day-start/-end`, `data-stat-card="cycle-range"` + min/max, `data-future-cycle-start-notice` (+key) on all three notice sites, `data-symptom-create-error`, `data-dashboard-date-subtitle`, `data-title-key` on every page `h1`, `data-nav-link` (+key) on all three nav renderings, calendar/privacy breadcrumb hooks.
- **Spec conversions (18 files):** hook/key addressing replaces `getByText`/`getByRole(name:)`/class-chain scans; nine explainer sites converge on `toHaveAttribute('data-explainer-key', ...)`; the six `/disable/i` discriminators in 2FA tests become the form's own `hx-delete` endpoint; negated copy assertions (tautologies after any rewording) become structural state assertions.
- **Locale source of truth:** `e2e/support/locale-helpers.ts` reads the shipped locale catalogues in the worker — `localeText` throws on missing/blank (an empty expectation cannot pass), and `localeKeysMatchingEnglish` derives the registration enumeration scan's forbidden phrases from the English catalogue and expands them across all six locales, so the scan is complete today and covers a seventh locale on arrival. Two EN-US date-shape regexes are replaced by `Intl`-derived expectations (`/\w{3} \d{1,2}, \d{4}/` matched `Foo 99, 0000`).

Deliberately out of scope (server-side surfaces, recorded in the maintainer's working notes): `markerLabel` inside the BBT chart JSON, `X-Ovumcy-Notice` header copy/key, toast keys (toast copy travels in that same header).

## Validation

- `go test ./internal/api/...` green (template hook guards).
- Five e2e batches across the 18 touched specs: 11/11, 32/33 with a 3/3 re-run, 35/35, 22/23 with a 16/16 re-run, 21/21 (the two intermittent failures were `expectInlineRegisterRecoveryStep` timing out while the app log showed bcrypt-loaded `POST /api/v1/users` at 5.8-7.3 s under back-to-back-run CPU contention; both re-ran green untouched).
- Branch updated onto `main` after #326; only CHANGELOG conflicted (both entries kept).
