### PR TITLE
fix(api): accept the JSON body the 2FA challenge contract publishes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The 2FA challenge now accepts the JSON body its published contract
+  advertises.** `POST /api/v1/sessions/2fa-challenge` is documented in
+  `docs/openapi.yaml` with a single request media type, `application/json`, but
+  the handler read the code through `c.FormValue`, which never sees a JSON body.
+  A client written against the published spec therefore got
+  `401 totp invalid code` for every code it submitted — the same answer a wrong
+  code gets, so the failure read as "the user is typing it wrong" rather than as
+  an unimplemented contract. The browser flow posts a form and was unaffected,
+  which is why nothing caught it: the only callers in the tree, the Playwright
+  spec and the Go regression, both submit forms. The endpoint now reads the code
+  from either transport, and one regression drives a valid code through both and
+  asserts each documented outcome (`200` for JSON, `303` for the form). A sweep
+  of all 28 request bodies in the spec against their handlers found this to be
+  the only endpoint whose declared media type the implementation did not accept.
+
 - **The request log now redacts short credentials, not just long ones.** The
   always-on Fiber request log sanitizes its error column so a handler error
   string cannot carry a secret into the log, but it recognized a secret only by

--- a/internal/api/handlers_auth_2fa.go
+++ b/internal/api/handlers_auth_2fa.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/gofiber/fiber/v3"
@@ -30,6 +31,22 @@ func (handler *Handler) ShowTOTPChallengePage(c fiber.Ctx) error {
 	return handler.render(c, "auth_2fa", data)
 }
 
+// parseTOTPChallengeCode reads the submitted code from either transport the
+// endpoint serves: the JSON body `docs/openapi.yaml` publishes for API clients,
+// and the urlencoded form the challenge page posts. `c.FormValue` alone never
+// sees a JSON body, so a spec-conforming client got `totp invalid code` for
+// every code it sent — indistinguishable from a wrong one.
+func parseTOTPChallengeCode(c fiber.Ctx) string {
+	if hasJSONBody(c) {
+		input := totpChallengeInput{}
+		if err := c.Bind().Body(&input); err != nil {
+			return ""
+		}
+		return strings.TrimSpace(input.Code)
+	}
+	return strings.TrimSpace(c.FormValue("code"))
+}
+
 // VerifyTOTPLogin validates the 6-digit TOTP code submitted on the challenge page.
 // On success it issues the auth session cookie and redirects to the dashboard.
 func (handler *Handler) VerifyTOTPLogin(c fiber.Ctx) error {
@@ -50,7 +67,7 @@ func (handler *Handler) VerifyTOTPLogin(c fiber.Ctx) error {
 		return handler.respondMappedError(c, spec)
 	}
 
-	code := c.FormValue("code")
+	code := parseTOTPChallengeCode(c)
 	if len(code) != 6 {
 		spec := totpInvalidCodeErrorSpec()
 		handler.logSecurityError(c, "auth.2fa", spec)

--- a/internal/api/handlers_auth_2fa_test.go
+++ b/internal/api/handlers_auth_2fa_test.go
@@ -379,6 +379,39 @@ func TestVerifyTOTPLogin_AcceptsBothPublishedAndFormBodies(t *testing.T) {
 	}
 }
 
+// TestVerifyTOTPLogin_MalformedJSONBody_AnswersInvalidCode covers the other
+// branch of the JSON transport: a body that announces itself as JSON and does
+// not parse. It must land on the same neutral "invalid code" answer as a wrong
+// code — never a 500, and never a message that tells a caller how its payload
+// was misread.
+func TestVerifyTOTPLogin_MalformedJSONBody_AnswersInvalidCode(t *testing.T) {
+	app, database := newOnboardingTestAppWithCSRF(t)
+	user := createOnboardingTestUser(t, database, "totp-malformed@example.com", "StrongPass1", true)
+	secretKey := []byte("test-secret-key")
+	setupTOTPForUser(t, database, user.ID, secretKey)
+	pendingCookie := sealTOTPPendingCookieForTest(t, secretKey, user.ID, false)
+
+	csrfToken, csrfCookieHeader := extractCSRFCookieAndToken(t, app)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/2fa-challenge",
+		strings.NewReader(`{"code":`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-CSRF-Token", csrfToken)
+	req.Header.Set("Cookie", joinCookieHeader(pendingCookie, csrfCookieHeader))
+	req.Header.Set("Accept-Language", "en")
+	resp, err := app.Test(req, testConfigNoTimeout)
+	if err != nil {
+		t.Fatalf("POST /api/v1/sessions/2fa-challenge: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 for a malformed JSON body", resp.StatusCode)
+	}
+	if authCookie := responseCookie(resp.Cookies(), authCookieName); authCookie != nil && authCookie.Value != "" {
+		t.Error("a malformed body must not issue an auth cookie")
+	}
+}
+
 func TestVerifyTOTPLogin_InvalidCode_DoesNotIssueSession(t *testing.T) {
 	app, database := newOnboardingTestAppWithCSRF(t)
 	user := createOnboardingTestUser(t, database, "totp-invalid@example.com", "StrongPass1", true)

--- a/internal/api/handlers_auth_2fa_test.go
+++ b/internal/api/handlers_auth_2fa_test.go
@@ -310,6 +310,75 @@ func TestVerifyTOTPLogin_ValidCode_IssuesSessionAndRedirects(t *testing.T) {
 	}
 }
 
+// TestVerifyTOTPLogin_AcceptsBothPublishedAndFormBodies pins the endpoint's two
+// transports against each other in one test: the JSON body docs/openapi.yaml
+// publishes as the request shape, and the urlencoded form the challenge page
+// posts. Reading the code with c.FormValue alone answered every JSON request
+// with "totp invalid code" — the same answer a wrong code gets — so an API
+// client written against the published contract could never complete 2FA while
+// the browser flow, and every test driving it, stayed green.
+func TestVerifyTOTPLogin_AcceptsBothPublishedAndFormBodies(t *testing.T) {
+	for _, transport := range []struct {
+		name        string
+		contentType string
+		wantStatus  int
+		body        func(code, csrfToken string) string
+	}{
+		{
+			// The spec documents both outcomes for this endpoint: 200 with
+			// {"ok":true} for a JSON caller, 303 for the browser form.
+			name:        "json body (published contract)",
+			contentType: "application/json",
+			wantStatus:  http.StatusOK,
+			body: func(code, _ string) string {
+				return `{"code":"` + code + `"}`
+			},
+		},
+		{
+			name:        "urlencoded form (challenge page)",
+			contentType: "application/x-www-form-urlencoded",
+			wantStatus:  http.StatusSeeOther,
+			body: func(code, csrfToken string) string {
+				return url.Values{"code": {code}, "csrf_token": {csrfToken}}.Encode()
+			},
+		},
+	} {
+		t.Run(transport.name, func(t *testing.T) {
+			app, database := newOnboardingTestAppWithCSRF(t)
+			user := createOnboardingTestUser(t, database, "totp-transport@example.com", "StrongPass1", true)
+			secretKey := []byte("test-secret-key")
+			rawSecret := setupTOTPForUser(t, database, user.ID, secretKey)
+			pendingCookie := sealTOTPPendingCookieForTest(t, secretKey, user.ID, false)
+
+			code, err := totp.GenerateCode(rawSecret, time.Now())
+			if err != nil {
+				t.Fatalf("GenerateCode: %v", err)
+			}
+
+			csrfToken, csrfCookieHeader := extractCSRFCookieAndToken(t, app)
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/2fa-challenge",
+				strings.NewReader(transport.body(code, csrfToken)))
+			req.Header.Set("Content-Type", transport.contentType)
+			req.Header.Set("X-CSRF-Token", csrfToken)
+			req.Header.Set("Cookie", joinCookieHeader(pendingCookie, csrfCookieHeader))
+			req.Header.Set("Accept-Language", "en")
+			resp, err := app.Test(req, testConfigNoTimeout)
+			if err != nil {
+				t.Fatalf("POST /api/v1/sessions/2fa-challenge: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != transport.wantStatus {
+				t.Fatalf("status = %d, want %d — the valid code was not accepted over %s",
+					resp.StatusCode, transport.wantStatus, transport.contentType)
+			}
+			if authCookie := responseCookie(resp.Cookies(), authCookieName); authCookie == nil || authCookie.Value == "" {
+				t.Errorf("expected an auth cookie after a valid code over %s", transport.contentType)
+			}
+		})
+	}
+}
+
 func TestVerifyTOTPLogin_InvalidCode_DoesNotIssueSession(t *testing.T) {
 	app, database := newOnboardingTestAppWithCSRF(t)
 	user := createOnboardingTestUser(t, database, "totp-invalid@example.com", "StrongPass1", true)

--- a/internal/api/input_types.go
+++ b/internal/api/input_types.go
@@ -27,6 +27,10 @@ type symptomPayload struct {
 	Color string `json:"color" form:"color"`
 }
 
+type totpChallengeInput struct {
+	Code string `json:"code" form:"code"`
+}
+
 type forgotPasswordInput struct {
 	Email        string `json:"email" form:"email"`
 	RecoveryCode string `json:"recovery_code" form:"recovery_code"`


### PR DESCRIPTION
## What

`POST /api/v1/sessions/2fa-challenge` declares exactly one request media type in
`docs/openapi.yaml` — `application/json` — but the handler read the submitted
code through `c.FormValue`, which never sees a JSON body. Every code a
spec-conforming client sent came back `401 totp invalid code`: the same answer a
wrong code gets, so an unimplemented contract read as a user mistyping their
authenticator.

Measured on a stand built from `main` with the repository `Dockerfile`, same
valid code, same session, consecutive seconds:

```
application/json                  -> 401 {"error":"totp invalid code"}
application/x-www-form-urlencoded -> 200 {"ok":true}
```

## Why nothing caught it

Both callers in the tree post forms — `e2e/auth-2fa.spec.ts` submits the
challenge page's form, `internal/api/handlers_auth_2fa_test.go` builds a
urlencoded body. `TestOpenAPIContractMatchesRegisteredRoutes` compares route
presence in both directions, never the request shape.

## Change

`parseTOTPChallengeCode` reads the code from either transport, branching on
`hasJSONBody` the way the settings endpoints already do. The browser path is
untouched.

## Class sweep, no allowlist

All 28 `requestBody` declarations in the spec were extracted and compared with
their handlers. Five handlers read only form values: this endpoint, `PUT`/`DELETE
/api/v1/users/current/2fa`, `POST /api/v1/days/{date}/cycle-start` and
`POST /lang`. The spec declares `application/x-www-form-urlencoded` for the other
four, which matches. This is the only mismatch.

## Proof on defect

`TestVerifyTOTPLogin_AcceptsBothPublishedAndFormBodies` drives one valid code
through both transports and asserts the outcome each is documented to produce
(200 for JSON, 303 for the form). Restoring the `c.FormValue`-only line fails it
with `status = 401, want 200 — the valid code was not accepted over
application/json`; restoring the fix returns it to green.

## Checks run locally

`go build ./...`, `go test ./internal/api/ ./internal/services/ ./cmd/...`,
`go vet ./...`, `staticcheck ./...` (0 findings), and the patch-coverage gate
with its profile regenerated in the same invocation.

## Residual, deliberately not in this PR

The spec still lists only `application/json`, so it now understates what the
endpoint accepts (the browser's form transport). Left as-is per the decision to
fix the code rather than restate the contract; worth revisiting if the spec ever
enumerates transports per endpoint uniformly.

Found by the wave-3 audit stand (finding W3-1, severity P2).