### PR TITLE
docs(self-hosted): make post-restore verification able to fail

### DIFF
--- a/docs/self-hosted.md
+++ b/docs/self-hosted.md
@@ -358,12 +358,15 @@ After startup, verify the restored app using the health check appropriate for yo
 
 ## Post-Restore Verification
 
+Steps 1-3 below check that the app is **up**. Step 4 is the only one that checks that your **data came back**, and it is the step that catches the failure this procedure would otherwise hide: an archive that missed the database restores into an instance that boots cleanly, reports healthy, answers `/readyz` with `200`, and renders a perfectly ordinary login page. The usual way to end up with one is a per-file copy of `ovumcy.db` taken while the app was running — on an instance that has not yet checkpointed, nearly the whole database still lives in `ovumcy.db-wal` and the main file is close to empty. Do not stop at step 3.
+
 After restore:
 
 1. Confirm the container becomes healthy.
-2. Confirm `/healthz` responds successfully using the health check appropriate for your deployment mode.
+2. Confirm `/healthz` **and** `/readyz` respond successfully using the health check appropriate for your deployment mode.
 3. Open the main UI once and verify the app renders normally.
-4. If you restored with a different `SECRET_KEY`, expect existing auth sessions and sealed cookies to be invalid and require a fresh sign-in.
+4. Sign in and confirm the records are there: open the calendar on a month you know had entries before the backup, or download `Settings → Export` and compare it against an export taken before the restore. Do this even when the app looks perfectly healthy — every signal above stays green on an empty database.
+5. If you restored with a different `SECRET_KEY`, expect existing auth sessions and sealed cookies to be invalid and require a fresh sign-in. Read that expectation carefully against step 4, because the two failures look similar for one screen and mean opposite things: with a changed key your **password still works** (password hashes do not depend on `SECRET_KEY`) and you are merely signed out — 2FA is the part that breaks, and the recovery path for it is in [Secret Handling and Rotation](#secret-handling-and-rotation). A sign-in that is rejected as *wrong credentials* is not a key symptom at all; it means the account is not in the restored database, which is step 4 failing.
 
 ## Safe Upgrade Procedure
 


### PR DESCRIPTION
## What

Every step of *Post-Restore Verification* tested that the app was **up**; none
looked at the **data**. The checklist therefore passes in full on an instance
that lost everything.

## Measured on a stand

Built from `main` with the repository `Dockerfile`, 40 days of records, then
three archives restored into separate volumes:

| archive | `ovumcy.db` | boots | `/readyz` | sign-in | entries | feed |
| --- | --- | --- | --- | --- | --- | --- |
| per-file copy of `ovumcy.db`, app running | 4 KB | yes | **200** | **401** | **0** | **404** |
| whole volume, app running (the supported flow) | 4 KB + WAL | yes | 200 | 200 | 40 | 200 |
| whole volume after `docker compose stop` | 122 KB | yes | 200 | 200 | 40 | 200 |

The first row is the one this change is about: on a young instance SQLite has not
checkpointed yet, so nearly the whole database lives in `ovumcy.db-wal`
(1.4 MB against a 4 KB main file) and a per-file copy carries the header alone.
Steps 1-3 of the checklist all pass on it.

The two supported flows restored byte-identically (33 660-byte export, feed
serving) — the runbook's backup section is correct and unchanged here.

## The sharper half

Step 4 used to read "if you restored with a different `SECRET_KEY`, expect ... a
fresh sign-in", which supplies a benign explanation for the one symptom total
data loss produces. The two cases are opposites:

- **changed key, intact data** — the password still works (bcrypt hashes do not
  depend on `SECRET_KEY`); only cookies are invalid, and 2FA is the part that
  breaks;
- **empty database** — the password is rejected as wrong credentials, because the
  account is not there.

The checklist now adds a step that observes records, states why the green signals
above it prove nothing about the data, and separates those two symptoms.

## Checks run locally

`go test ./scripts/...` — `scripts/readmeversion` reads policy files, so a docs
change is not test-free here. No behavior change; rollback is a revert.

Found by the wave-3 audit stand (finding W3-2, severity P2).