### PR TITLE
fix(cli): let the startup banner name the revision it is running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The startup banner can name the revision it is running.** `rev:` read the
+  VCS stamp Go embeds during `go build`, and the Docker build context excludes
+  `.git`, so every container image — including every published release — printed
+  `rev: unknown`. The commit sha the image build already receives went only to
+  the asset cache-bust token. The banner now falls back to that same stamp when
+  no VCS revision is present, so an operator following the upgrade procedure can
+  confirm which build actually booted instead of trusting the image tag alone. A
+  VCS stamp still wins when there is one: it is the only source that can report
+  a dirty tree, and a release stamp must not hide that.
+
 - **The 2FA challenge now accepts the JSON body its published contract
   advertises.** `POST /api/v1/sessions/2fa-challenge` is documented in
   `docs/openapi.yaml` with a single request media type, `application/json`, but

--- a/cmd/ovumcy/main_test.go
+++ b/cmd/ovumcy/main_test.go
@@ -2740,6 +2740,72 @@ func TestVCSRevisionFromBuildInfo(t *testing.T) {
 	}
 }
 
+// TestResolveBuildRevisionFallbackChain pins the banner's identity resolution,
+// including the case the shipped image is always in: a container build carries
+// no vcs.* setting (.dockerignore excludes .git), so without the ldflags
+// fallback every published image reported "unknown". The order is deliberately
+// the opposite of assetCacheBustToken's — only the VCS stamp can report a dirty
+// tree, so a release stamp must not outrank it.
+func TestResolveBuildRevisionFallbackChain(t *testing.T) {
+	fullRevision := "0123456789abcdef0123456789abcdef01234567"
+	infoWithRevision := buildInfoWithSettings(debug.BuildSetting{Key: "vcs.revision", Value: fullRevision})
+
+	tests := []struct {
+		name           string
+		ldflagsVersion string
+		info           *debug.BuildInfo
+		want           string
+	}{
+		{
+			name:           "container build: no VCS stamp, ldflags names the revision",
+			ldflagsVersion: fullRevision,
+			info:           buildInfoWithSettings(debug.BuildSetting{Key: "-ldflags", Value: "-s -w"}),
+			want:           fullRevision,
+		},
+		{
+			name:           "nil build info still reports the ldflags stamp",
+			ldflagsVersion: "v1.9.2",
+			info:           nil,
+			want:           "v1.9.2",
+		},
+		{
+			name:           "VCS stamp outranks the ldflags stamp",
+			ldflagsVersion: "v1.7.0",
+			info:           infoWithRevision,
+			want:           fullRevision,
+		},
+		{
+			name:           "a dirty tree is reported even when a release stamp is present",
+			ldflagsVersion: "v1.7.0",
+			info: buildInfoWithSettings(
+				debug.BuildSetting{Key: "vcs.revision", Value: fullRevision},
+				debug.BuildSetting{Key: "vcs.modified", Value: "true"},
+			),
+			want: fullRevision + "-dirty",
+		},
+		{
+			name:           "whitespace-only ldflags stamp is not an identity",
+			ldflagsVersion: "   ",
+			info:           nil,
+			want:           "unknown",
+		},
+		{
+			name: "neither stamp: unknown",
+			info: nil,
+			want: "unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveBuildRevision(tt.ldflagsVersion, tt.info)
+			if got != tt.want {
+				t.Fatalf("resolveBuildRevision(%q, ...) = %q, want %q", tt.ldflagsVersion, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestAssetCacheBustTokenFallbackChain(t *testing.T) {
 	fullRevision := "0123456789abcdef0123456789abcdef01234567"
 	processStart := time.Date(2026, time.July, 5, 12, 0, 0, 0, time.UTC)

--- a/cmd/ovumcy/version.go
+++ b/cmd/ovumcy/version.go
@@ -16,37 +16,39 @@ import (
 // cache-bust token then falls back to VCS or process-start identity.
 var buildVersion string
 
-// codecov:ignore:start -- startup-banner revision string. The VCS branches
-// (vcs.revision/vcs.modified present, dirty suffix, missing BuildInfo) are only
-// reachable in a real `go build` with VCS stamping; `go test` binaries carry no
-// vcs.* settings, so they cannot be exercised without a fault-injection seam.
-// The seamed, per-input logic is covered by vcsRevisionFromBuildInfo's tests.
+// buildRevision is the identity the startup banner prints. It reads the process
+// build info and defers every decision to resolveBuildRevision, which is pure
+// and testable on explicit inputs.
 func buildRevision() string {
-	info, ok := debug.ReadBuildInfo()
-	if !ok || info == nil {
-		return "unknown"
-	}
-
-	revision := "unknown"
-	modified := "false"
-	for _, setting := range info.Settings {
-		switch setting.Key {
-		case "vcs.revision":
-			if strings.TrimSpace(setting.Value) != "" {
-				revision = setting.Value
-			}
-		case "vcs.modified":
-			modified = strings.TrimSpace(setting.Value)
-		}
-	}
-
-	if modified == "true" {
-		return revision + "-dirty"
-	}
-	return revision
+	info, _ := debug.ReadBuildInfo() // codecov:ignore -- process-wide read; the decision it feeds is covered on explicit inputs
+	return resolveBuildRevision(buildVersion, info)
 }
 
-// codecov:ignore:end
+// resolveBuildRevision picks what the banner reports, preferring the VCS stamp
+// over the ldflags one — the opposite order from assetCacheBustToken, and
+// deliberately so. The asset token wants one stable value per release, so a
+// release stamp outranks everything. The banner is a truth claim about the
+// running binary, and only the VCS stamp can say the tree was dirty, so a build
+// carrying both must not let the release stamp hide that.
+//
+// The ldflags fallback is what makes the field usable in the shipped image at
+// all: `.dockerignore` excludes `.git`, so a container build carries no vcs.*
+// setting and this used to report "unknown" for every published image — exactly
+// where an operator rolling back to a previous tag needs to know which revision
+// booted. The Dockerfile already forwards its BUILD_REVISION build-arg into
+// main.buildVersion for the asset token; the banner now reads the same stamp.
+func resolveBuildRevision(ldflagsVersion string, info *debug.BuildInfo) string {
+	if revision, modified := vcsRevisionFromBuildInfo(info); revision != "" {
+		if modified {
+			return revision + "-dirty"
+		}
+		return revision
+	}
+	if version := strings.TrimSpace(ldflagsVersion); version != "" {
+		return version
+	}
+	return "unknown"
+}
 
 // vcsRevisionFromBuildInfo extracts the raw vcs.revision stamped into info
 // and whether the working tree was modified. revision is "" when info is nil


### PR DESCRIPTION
## What

The banner's `rev:` field read the VCS stamp Go embeds during `go build`.
`.dockerignore` excludes `.git`, so a container build carries no `vcs.*` setting
and **every published image printed `rev: unknown`** — observed on an image built
from `main` with the repository `Dockerfile` and `BUILD_REVISION` set:

```
Ovumcy listening on http://0.0.0.0:8080 (rev: unknown, tz: UTC, ...)
```

That is the one place the field matters. Step 6 of *Safe Upgrade Procedure* tells
an operator to roll back to the previous image tag, and nothing else in the
process can confirm which build actually booted.

The sha was already reaching the binary — the `Dockerfile` forwards
`BUILD_REVISION` into `main.buildVersion`, which only `resolveAssetVersion` read.
The banner now falls back to the same stamp.

## Resolution order

Deliberately the opposite of `assetCacheBustToken`'s, and the comment says why:
that token wants one stable value per release, so a release stamp outranks
everything; the banner is a truth claim about the running binary, and only the
VCS stamp can report a dirty tree, so a build carrying both reports the VCS one.

## Testability

The decision moved into a pure `resolveBuildRevision(ldflagsVersion, info)`. The
old function was wrapped in a `codecov:ignore` block because a `go test` binary
carries no `vcs.*` settings and could not reach those branches; they are now
covered on explicit inputs, and the ignore block is gone.

## Proof on defect

Removing the ldflags fallback fails `TestResolveBuildRevisionFallbackChain` on
both no-VCS rows:

```
resolveBuildRevision("0123...4567", ...) = "unknown", want "0123...4567"
resolveBuildRevision("v1.9.2", ...)      = "unknown", want "v1.9.2"
```

## Checks run locally

`go build ./...`, `go test ./cmd/ovumcy/`, `staticcheck ./cmd/...` (0 findings),
and the patch-coverage gate with its profile regenerated in the same invocation —
this time run **after** committing, since the gate diffs `origin/main...HEAD` and
reports a vacuous pass on an uncommitted tree.

Found by the wave-3 audit stand (finding W3-7).