### PR TITLE
fix(cli): let reset-password read a piped password, like users create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`ovumcy reset-password` can be run without an interactive terminal.** It is
+  the operator's documented way back in for an owner locked out by a
+  `SECRET_KEY` rotation, or for an OIDC-only account with no retained recovery
+  code — but it prompted unconditionally, so the plain `docker exec` form the
+  runbook shows for the other subcommands failed with `secure password prompt
+  requires an interactive terminal`, and recovering several accounts at once
+  could not be scripted. It now reads the password from piped stdin exactly as
+  `users create` already did, keeping the interactive prompt when stdin is a
+  terminal. The password still never travels in argv or the environment. The
+  runbook gained a section showing both invocations against the shell-free
+  image.
+
 - **The 2FA challenge now accepts the JSON body its published contract
   advertises.** `POST /api/v1/sessions/2fa-challenge` is documented in
   `docs/openapi.yaml` with a single request media type, `application/json`, but

--- a/docs/self-hosted.md
+++ b/docs/self-hosted.md
@@ -14,7 +14,7 @@ Ovumcy's supported self-hosted baseline is a single application instance with a 
 - [Local/Private Postgres Stack](#official-localprivate-postgres-stack) · [Public Postgres Reverse-Proxy Stacks](#official-public-postgres-reverse-proxy-stacks)
 
 **Running it**
-- [Health Checks by Deployment Mode](#health-checks-by-deployment-mode) · [Secret Handling and Rotation](#secret-handling-and-rotation)
+- [Health Checks by Deployment Mode](#health-checks-by-deployment-mode) — [operator CLI](#running-the-operator-cli-against-the-container) · [Secret Handling and Rotation](#secret-handling-and-rotation)
 - [Backup and Restore Contract](#backup-and-restore-contract) — [volume backup](#docker-named-volume-backup), [volume restore](#docker-named-volume-restore), [post-restore verification](#post-restore-verification)
 - [Safe Upgrade Procedure](#safe-upgrade-procedure) · [Downgrade Caveats](#downgrade-caveats)
 
@@ -260,6 +260,22 @@ Use the health check that matches your deployment path:
   - `docker exec ovumcy /app/ovumcy healthcheck` should exit `0`;
   - `docker exec ovumcy /app/ovumcy readycheck` should exit `0`.
 
+### Running the operator CLI against the container
+
+The runtime image is shell-free, so the operator subcommands are reached through `docker exec` on the binary itself. The probes above take no input and run as shown. The account subcommands (`users create`, `reset-password`) ask for a password, and how you invoke them decides how they read it:
+
+```bash
+# Interactive: prompts twice with echo disabled.
+docker exec -it ovumcy /app/ovumcy reset-password owner@example.com
+
+# Scripted: the password is the first line of stdin. Never pass it in the
+# command line or an environment variable — both are visible to other
+# processes and land in shell history.
+printf '%s\n' "$NEW_PASSWORD" | docker exec -i ovumcy /app/ovumcy reset-password owner@example.com
+```
+
+Use the scripted form when you need to recover several accounts at once — for example after a `SECRET_KEY` rotation, where every 2FA-enabled owner needs a way back in.
+
 For the public reverse-proxy stacks, do not treat a missing host-level `127.0.0.1:8080` listener as a problem. In the preferred deployment model, that port is intentionally not published to the host at all.
 
 ## Secret Handling and Rotation
@@ -271,7 +287,7 @@ Treat the application secret as part of the deployment identity, whether you pas
 - Store the underlying secret privately and back it up separately from the SQLite archive.
 - Rotating the application secret invalidates existing sealed cookies and active sign-ins.
 - Restoring SQLite data with a different application secret is valid, but users should expect a fresh sign-in and new sealed-cookie state.
-- Rotating the secret on a database with TOTP-enabled accounts will leave their `users.totp_secret` ciphertexts undecryptable; affected users must sign in with their recovery code (or have the operator run `ovumcy reset-password <email>`) and re-enrol TOTP under the new secret.
+- Rotating the secret on a database with TOTP-enabled accounts will leave their `users.totp_secret` ciphertexts undecryptable; affected users must sign in with their recovery code (or have the operator run `ovumcy reset-password <email>` — see [Running the operator CLI against the container](#running-the-operator-cli-against-the-container)) and re-enrol TOTP under the new secret.
 - Rotation also breaks the **other** field-encrypted column, `users.webhook_url`. The daily reminder pass fails safe rather than delivering to a garbage target: it skips that owner (logging only the owner id) and keeps going for everyone else. Nothing surfaces in the UI, so reminders simply stop for those accounts until each owner re-saves their endpoint in Settings.
 - Rotation **disarms armed calendar (`.ics`) feeds**. The feed verifier is a keyed MAC derived from the application secret, and a MAC that no longer matches is refused outright — deliberately never re-checked against the row's older bcrypt hash. Subscribed calendar clients get `404` until each owner generates a fresh subscribe URL from Settings. Plan a rotation as a "re-issue the feed URLs" event, the same way you plan it as a "re-enrol TOTP" event. Feeds armed on versions before the MAC landed (pre-migration-032 rows) are disarmed by the first start under the new secret — the startup log prints `SECRET_KEY rotation detected: N legacy calendar feed(s) disarmed`. Two sharp edges: the detection baseline is recorded on the first boot after upgrading to the release that introduced it, so a rotation performed **in that same maintenance window** is not detectable — boot the upgrade once first, or have owners revoke/rotate feeds manually; and starting the app with a mistyped `SECRET_KEY` counts as a rotation, permanently disarming those legacy rows.
 - See the *SECRET_KEY Usage Map* section in [SECURITY.md](../SECURITY.md) for the per-subsystem impact table these three bullets summarize.

--- a/internal/cli/reset.go
+++ b/internal/cli/reset.go
@@ -15,7 +15,37 @@ import (
 )
 
 func RunResetPasswordCommand(databaseConfig db.Config, email string) error {
-	return runResetPasswordCommand(databaseConfig, email, promptNewPassword, os.Stdout)
+	return runResetPasswordCommand(databaseConfig, email, resetPasswordReader(os.Stdin), os.Stdout)
+}
+
+// resetPasswordReader picks how the new password is obtained, matching what
+// `users create` already does: an interactive terminal gets the twice-typed,
+// echo-disabled prompt, and piped or redirected stdin is read as the password's
+// first line.
+//
+// The non-interactive path is what makes the documented recovery step runnable
+// without a terminal. `ovumcy reset-password` is the operator's way back in for
+// an owner locked out by a SECRET_KEY rotation or an OIDC-only account with no
+// recovery code, and the runtime image is shell-free, so the only way to reach
+// it is `docker exec`. Prompting unconditionally meant the plain `docker exec`
+// form the runbook shows for the other subcommands failed with "secure password
+// prompt requires an interactive terminal", and recovering several accounts
+// could not be scripted at all. The password still never travels in argv or the
+// environment.
+func resetPasswordReader(input *os.File) passwordPromptFunc {
+	return func() ([]byte, error) {
+		if input == nil {
+			// A typed nil *os.File would satisfy the io.Reader interface and
+			// reach bufio, so refuse it here rather than one frame later.
+			return nil, errors.New("password input is required")
+		}
+		// codecov:ignore:start -- interactive TTY prompt; the terminal branch needs a real terminal and is exercised only interactively
+		if stdinIsTerminal(input) {
+			return promptNewPassword()
+		}
+		// codecov:ignore:end
+		return readPasswordLine(input)
+	}
 }
 
 type passwordPromptFunc func() ([]byte, error)

--- a/internal/cli/reset_additional_test.go
+++ b/internal/cli/reset_additional_test.go
@@ -3,11 +3,63 @@ package cli
 import (
 	"errors"
 	"io"
+	"os"
 	"strings"
 	"testing"
 
 	"github.com/ovumcy/ovumcy-web/internal/db"
 )
+
+// TestRunResetPasswordCommandValidatesBeforeReadingStdin covers the exported
+// entry point, which is otherwise reached only from main. It also pins the
+// ordering that makes the piped form usable in a script: the email is rejected
+// before anything reads stdin, so a typo does not leave the command blocked on
+// input that will never be used.
+func TestRunResetPasswordCommandValidatesBeforeReadingStdin(t *testing.T) {
+	if err := RunResetPasswordCommand(db.Config{}, "   "); err == nil || err.Error() != "email is required" {
+		t.Fatalf("expected blank email error, got %v", err)
+	}
+}
+
+// TestResetPasswordReaderReadsPipedStdin pins the non-interactive path that
+// makes the documented recovery step runnable against the shell-free runtime
+// image: `docker exec -i ... reset-password <email>` with the password on
+// stdin. Before it existed the command answered "secure password prompt
+// requires an interactive terminal" and recovering several accounts after a
+// SECRET_KEY rotation could not be scripted at all.
+func TestResetPasswordReaderReadsPipedStdin(t *testing.T) {
+	t.Parallel()
+
+	read, write, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	t.Cleanup(func() { _ = read.Close() })
+
+	go func() {
+		defer func() { _ = write.Close() }()
+		_, _ = io.WriteString(write, "  StrongPass1  \n")
+	}()
+
+	password, err := resetPasswordReader(read)()
+	if err != nil {
+		t.Fatalf("resetPasswordReader on piped stdin: %v", err)
+	}
+	if string(password) != "StrongPass1" {
+		t.Fatalf("password = %q, want %q (surrounding whitespace trimmed to match web auth)", password, "StrongPass1")
+	}
+}
+
+// TestResetPasswordReaderRejectsMissingStdin covers the typed-nil guard: a nil
+// *os.File satisfies io.Reader, so without the explicit check it would reach
+// bufio instead of returning an error.
+func TestResetPasswordReaderRejectsMissingStdin(t *testing.T) {
+	t.Parallel()
+
+	if _, err := resetPasswordReader(nil)(); err == nil {
+		t.Fatal("expected an error when stdin is missing")
+	}
+}
 
 func TestRunResetPasswordCommandRejectsBlankEmail(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## What

`ovumcy reset-password` prompted unconditionally, so on the shell-free runtime
image the plain `docker exec` form the runbook shows for the other subcommands
failed:

```
$ docker exec -i ovumcy /app/ovumcy reset-password owner@example.com
Enter new password:
read new password: secure password prompt requires an interactive terminal
```

That matters because this is the operator's documented way back in for an owner
locked out by a `SECRET_KEY` rotation (`docs/security/cryptography.md`,
`docs/self-hosted.md`, `docs/security/oidc-and-sessions.md` all name it), and the
only path at all for an OIDC-only account with no retained recovery code.
Recovering several accounts after a rotation could not be scripted.

## Change

The mechanism already existed one file over: `users create` reads the password as
the first line of stdin when stdin is not a terminal — deliberately, for
re-run-safe install scripts. `reset-password` now shares it, keeps the
twice-typed echo-disabled prompt when stdin *is* a terminal, and still never lets
the password travel in argv or the environment.

A typed nil `*os.File` satisfies `io.Reader`, so the reader refuses a nil stdin
explicitly rather than letting it reach `bufio`.

## Docs

`docs/self-hosted.md` gained *Running the operator CLI against the container*,
showing both invocations, and the rotation bullet now links to it — that bullet
named the command as the recovery step without ever showing how to run it against
the image.

## Tests

- piped stdin returns the trimmed password (whitespace trimmed to match web auth,
  as `users create` does);
- a nil stdin is refused;
- the exported entry point validates the email **before** reading stdin, so a
  typo does not leave a script blocked on input that will never be used.

## Checks run locally

`go build ./...`, `go test ./internal/cli/ ./scripts/...`, `staticcheck
./internal/...` (0 findings), patch-coverage gate with the profile regenerated in
the same invocation and run after committing.

Found by the wave-3 audit stand (finding W3-6).