### PR TITLE
docs: correct five operator-facing claims a stand drill contradicted

### DIFF
--- a/docs/security/cryptography.md
+++ b/docs/security/cryptography.md
@@ -60,7 +60,7 @@ The sealed-cookie and field-crypto HKDF label pairs live next to the shared AEAD
 
 **Operational caveat — rotating `SECRET_KEY` with 2FA accounts:**
 
-`users.totp_secret` is encrypted under a key derived from the current `SECRET_KEY`. Rotating the secret without a coordinated re-encryption step leaves TOTP-enabled accounts unable to complete the 2FA challenge — they will see a failed verification even when their authenticator app produces the correct code. Recovery options for each affected user are:
+`users.totp_secret` is encrypted under a key derived from the current `SECRET_KEY`. Rotating the secret without a coordinated re-encryption step leaves TOTP-enabled accounts unable to complete the 2FA challenge. Be precise about what those users see, because it is not a rejected code: the stored ciphertext no longer opens, so the challenge answers **HTTP 500 with the stable key `totp internal error`** even when the authenticator app produces the correct code. Nothing in that response points at the recovery path, and on the operator's side every affected sign-in is a 5xx event, so a planned rotation with 2FA accounts on the instance will look like an application fault until you connect it to the maintenance window. Recovery options for each affected user are:
 
 1. Sign in with the recovery code, then re-enrol TOTP under the new key.
 2. Ask the operator to run `ovumcy reset-password <email>` and disable 2FA via Settings once signed back in.

--- a/docs/security/logging.md
+++ b/docs/security/logging.md
@@ -6,7 +6,7 @@ _Part of the [Ovumcy security policy](../../SECURITY.md)._
 
 Ovumcy does **not** emit per-action audit logs by default. The `AUDIT_LOG_ENABLED` environment variable controls the audit-event stream:
 
-- `AUDIT_LOG_ENABLED=false` (default) — the runtime emits no `security event:` lines. Go panics, startup configuration errors, and the Fiber request log remain enabled.
+- `AUDIT_LOG_ENABLED=false` (default) — the runtime emits no `security event:` lines. Everything else keeps writing: Go panics, startup configuration errors and warnings, the Fiber request log, and a small set of operational diagnostics described below.
 - `AUDIT_LOG_ENABLED=true` — the runtime emits per-action security-event lines to stderr via the Go standard `log` package. Each line includes the action name, outcome, request method, **sanitized** request path (concrete date parameters are replaced with `:date` and other identifiers are similarly masked), response format, and — for authenticated requests — `user_id` and role. Example:
 
   ```
@@ -22,3 +22,14 @@ If you enable `AUDIT_LOG_ENABLED=true`, plan retention and access control around
 The Fiber request log (`time | status | latency | method | path | error`) is independent of `AUDIT_LOG_ENABLED` and remains enabled in all configurations. It does not include `user_id` or authenticated-session metadata. Both of its potentially sensitive columns are sanitized before they are written: the path through `SafeRequestLogPath` (route template, opaque tokens masked) and the trailing error through `SafeLogError`, which masks emails, opaque tokens, recovery codes and submitted one-time codes so a handler error string cannot carry an account identifier or a credential into the log. Short secrets are matched by shape rather than by length — a recovery code and a six-digit code are both too short for the opaque-token rule — so that dates, status codes, route templates and ordinary identifiers stay readable for diagnosis.
 
 The startup banner reflects the current setting (`audit_log=true|false`) so operators can confirm the effective configuration on each boot.
+
+## Operational diagnostics (always on)
+
+A handful of lines outside both streams above report that an internal operation could not complete. They are always enabled, and **five of them name an owner by `user_id`**, so `AUDIT_LOG_ENABLED=false` does not mean "no account identifier ever reaches the log":
+
+- the derived-cycle refresh that follows a day write, when it cannot load that owner's logs or store the recomputed luteal phase (`refreshDerivedCycleSettings: … for user N failed: …`) — the only two lines here that also carry the raw driver error, which does not pass through `SafeLogError`;
+- the webhook reminder pass, when an owner's stored endpoint cannot be decrypted, their logs cannot be loaded, or the sent-watermark write fails after delivery (`webhook notify: … owner id=N`).
+
+None of them carries health data, an email, a URL, or a token — the identifier and the reason only. The first pair is a symptom of write contention (see *Concurrency on the SQLite baseline* in [docs/self-hosted.md](../self-hosted.md#concurrency-on-the-sqlite-baseline)); the second is how a `SECRET_KEY` rotation surfaces for webhook owners, and is the signal the reminder pass's own summary does not carry.
+
+If your deployment treats any `user_id` in a log as sensitive, plan retention and access control for the default stream too, not only for the audit stream.

--- a/docs/self-hosted.md
+++ b/docs/self-hosted.md
@@ -14,7 +14,7 @@ Ovumcy's supported self-hosted baseline is a single application instance with a 
 - [Local/Private Postgres Stack](#official-localprivate-postgres-stack) · [Public Postgres Reverse-Proxy Stacks](#official-public-postgres-reverse-proxy-stacks)
 
 **Running it**
-- [Health Checks by Deployment Mode](#health-checks-by-deployment-mode) — [operator CLI](#running-the-operator-cli-against-the-container) · [Secret Handling and Rotation](#secret-handling-and-rotation)
+- [Health Checks by Deployment Mode](#health-checks-by-deployment-mode) — [operator CLI](#running-the-operator-cli-against-the-container) · [Concurrency on the SQLite Baseline](#concurrency-on-the-sqlite-baseline) · [Secret Handling and Rotation](#secret-handling-and-rotation)
 - [Backup and Restore Contract](#backup-and-restore-contract) — [volume backup](#docker-named-volume-backup), [volume restore](#docker-named-volume-restore), [post-restore verification](#post-restore-verification)
 - [Safe Upgrade Procedure](#safe-upgrade-procedure) · [Downgrade Caveats](#downgrade-caveats)
 
@@ -238,11 +238,13 @@ The app exposes two probes, and they answer different questions:
 | Probe | Answers | Touches the database | Fails when |
 | --- | --- | --- | --- |
 | `GET /healthz` | Is the process alive? | No | The process is gone or wedged |
-| `GET /readyz` | Can it actually serve requests? | Yes — one trivial query | Storage is unreachable |
+| `GET /readyz` | Can it actually serve requests? | Yes — one trivial query | Storage does not answer within one second |
 
 `/healthz` deliberately never queries the database. That is what makes it safe as the container health check: a database that is slow for ten seconds, or a Postgres container restarting under the app, must not turn into a killed and restarted app container. It also means `/healthz` alone cannot tell you the app is *working* — it stays green with storage completely gone, which is exactly the case `/readyz` exists to catch.
 
 `/readyz` runs one trivial query against the configured engine and answers `200` when it succeeds, `503` when it does not. Both responses are a fixed one-word body; neither reveals the engine, the database path, or the error. Reach for it when the container is healthy but the app is misbehaving, and use it as the drain signal in front of a load balancer.
+
+The probe is bounded at **one second**, and it reports the same `503` whether storage is gone or merely too busy to answer in time — it deliberately cannot tell you which. Read a `503` on a container that is otherwise healthy as *"the app cannot serve right now"*, and check load before you go looking at the volume. On the SQLite baseline a handful of clients saving days at the same moment is enough to make the probe flap while ordinary requests still succeed, slowly (see [Concurrency on the SQLite baseline](#concurrency-on-the-sqlite-baseline)). The distinguishing signal is elsewhere: if requests are still completing — check the request log for `200`s with multi-second latencies — the storage layer is present and the answer is contention, not an outage.
 
 The runtime image ships both as built-in subcommands, `ovumcy healthcheck` and `ovumcy readycheck`. Each makes an in-process request against `127.0.0.1:$PORT` and exits non-zero on failure, so the scratch-based container image needs no external HTTP client (no `curl`, no `wget`). Docker invokes `ovumcy healthcheck` automatically per the `HEALTHCHECK` directive baked into the image; `ovumcy readycheck` is yours to run on demand. The `HEALTHCHECK` directive is intentionally left on the liveness probe — do not repoint it at `/readyz` unless you actively want a database outage to restart the container.
 
@@ -278,6 +280,25 @@ Use the scripted form when you need to recover several accounts at once — for 
 
 For the public reverse-proxy stacks, do not treat a missing host-level `127.0.0.1:8080` listener as a problem. In the preferred deployment model, that port is intentionally not published to the host at all.
 
+## Concurrency on the SQLite Baseline
+
+The SQLite baseline is sized for a household, and it has a ceiling worth knowing before you meet it. SQLite allows one writer at a time. Reads scale fine — eight clients browsing the dashboard, calendar, stats and exports at once stay in the tens of milliseconds — but **concurrent writers serialize**, and a writer that cannot take the lock waits out the five-second busy timeout before the app retries.
+
+Measured on a release image, mixed traffic with 40% day saves, per-request latency for `PUT /api/v1/days/{date}`:
+
+| Clients writing at once | Median save | 95th percentile |
+| --- | --- | --- |
+| 1 | 8 ms | 11 ms |
+| 2 | 10 ms | 20 ms |
+| 4 | 13 ms | 4.9 s |
+| 8 | 5.0 s | 25 s |
+
+Nothing breaks — there is no crash, no memory growth, no corruption, and the container keeps reporting healthy. Requests queue. What an operator sees is saves that take seconds, and `/readyz` flapping to `503` while ordinary pages still load.
+
+So: one or two people saving entries at the same moment is comfortable. Four is the knee. If your instance regularly has more writers than that — several household members each on a phone and a laptop, or a scripted importer running alongside normal use — move to the Postgres path below. The same traffic at 24 concurrent clients stays at a 57 ms median save with no readiness flapping, because Postgres does not serialize writers.
+
+This is a property of the storage engine, not a tuning knob: raising the connection pool does not help, since the constraint is the single write lock rather than the number of connections.
+
 ## Secret Handling and Rotation
 
 Treat the application secret as part of the deployment identity, whether you pass it via `SECRET_KEY` or `SECRET_KEY_FILE`.
@@ -288,7 +309,7 @@ Treat the application secret as part of the deployment identity, whether you pas
 - Rotating the application secret invalidates existing sealed cookies and active sign-ins.
 - Restoring SQLite data with a different application secret is valid, but users should expect a fresh sign-in and new sealed-cookie state.
 - Rotating the secret on a database with TOTP-enabled accounts will leave their `users.totp_secret` ciphertexts undecryptable; affected users must sign in with their recovery code (or have the operator run `ovumcy reset-password <email>` — see [Running the operator CLI against the container](#running-the-operator-cli-against-the-container)) and re-enrol TOTP under the new secret.
-- Rotation also breaks the **other** field-encrypted column, `users.webhook_url`. The daily reminder pass fails safe rather than delivering to a garbage target: it skips that owner (logging only the owner id) and keeps going for everyone else. Nothing surfaces in the UI, so reminders simply stop for those accounts until each owner re-saves their endpoint in Settings.
+- Rotation also breaks the **other** field-encrypted column, `users.webhook_url`. The daily reminder pass fails safe rather than delivering to a garbage target: it skips that owner (logging only the owner id) and keeps going for everyone else. Nothing surfaces in the UI, so reminders simply stop for those accounts until each owner re-saves their endpoint in Settings. It does not surface in the pass's own summary either — a skipped owner is not counted as a failure, so `ovumcy notify --dry-run` reports `failed: 0` and simply stops listing that owner under *would send*. When you verify a rotation this way, read the log lines above the summary (`webhook notify: decrypt failed, skipping owner id=N`) rather than the counters, and compare the *would send* block against one captured before the rotation.
 - Rotation **disarms armed calendar (`.ics`) feeds**. The feed verifier is a keyed MAC derived from the application secret, and a MAC that no longer matches is refused outright — deliberately never re-checked against the row's older bcrypt hash. Subscribed calendar clients get `404` until each owner generates a fresh subscribe URL from Settings. Plan a rotation as a "re-issue the feed URLs" event, the same way you plan it as a "re-enrol TOTP" event. Feeds armed on versions before the MAC landed (pre-migration-032 rows) are disarmed by the first start under the new secret — the startup log prints `SECRET_KEY rotation detected: N legacy calendar feed(s) disarmed`. Two sharp edges: the detection baseline is recorded on the first boot after upgrading to the release that introduced it, so a rotation performed **in that same maintenance window** is not detectable — boot the upgrade once first, or have owners revoke/rotate feeds manually; and starting the app with a mistyped `SECRET_KEY` counts as a rotation, permanently disarming those legacy rows.
 - See the *SECRET_KEY Usage Map* section in [SECURITY.md](../SECURITY.md) for the per-subsystem impact table these three bullets summarize.
 - **If the secret is lost entirely** (no backup, no way to recover the old value), this is worse than a planned rotation: there is no key to roll forward from, so every `users.totp_secret` ciphertext is permanently unrecoverable — not just temporarily undecryptable — because the encryption key is derived from `SECRET_KEY` via HKDF with no escrow copy stored anywhere. All existing sealed cookies and sessions invalidate the same as with a rotation. Any 2FA-enabled account can still recover via its recovery code and TOTP re-enrolment. But an account with `local_auth_enabled=false` (OIDC-only) that also has no retained recovery code has no self-service path back in at all; it needs an operator to run `ovumcy reset-password <email>` to regain access. Treat total secret loss as a data-loss event, not a rotation, in your incident runbook.


### PR DESCRIPTION
Five findings from the wave-3 audit stand, all the same shape: a document
states something an operator will act on, and the running system behaves
differently. Grouped as one docs change per the precedent set by #298.

## W3-4 — `/readyz` had a single stated cause

The table said the probe fails when "storage is unreachable", and the prose told
the operator that a `503` on a healthy container means "the app is up but its
storage is not". The probe is bounded at **one second** and cannot distinguish
gone from busy: under write contention it returned `503` on **219 of 239 probes**
across a 20-minute run while ordinary requests kept completing with `200`.
`ovumcy readycheck` exits 1, `healthcheck` exits 0, the container stays healthy.
An operator following the old text inspects the volume when the answer is load.

## W3-11 — the baseline's concurrency ceiling was unpublished

Measured on a release image, mixed traffic, median / 95th percentile for
`PUT /api/v1/days/{date}`:

| writers | median | p95 |
| --- | --- | --- |
| 1 | 8 ms | 11 ms |
| 2 | 10 ms | 20 ms |
| 4 | 13 ms | **4.9 s** |
| 8 | **5.0 s** | 25 s |

Nothing breaks: no crash, flat memory across 20 minutes of saturation, database
intact, container healthy throughout. Requests queue. The constraint is SQLite's
single write lock, not the connection pool — eight concurrent **readers** through
the same four-connection pool sustained ~625 rps at a 22 ms p95 — so a larger
pool does not help. The Postgres path was documented as an operator preference
with no hint that it is the answer to this ceiling; the same traffic at 24
clients holds a 57 ms median there with no readiness flapping.

## W3-8 — "a failed verification" after rotation

Rotating with 2FA accounts present answers the challenge with **HTTP 500
`totp internal error`**, not a rejected code: the ciphertext no longer opens. The
response points at no recovery path, and on the operator's side every affected
sign-in is a 5xx event.

## W3-9 — the notify summary reports `failed: 0`

Before rotation the dry run showed `reminders due: 1` and the owner under
*would send*. After rotation, with the endpoint unreadable, the same command
prints `owners scanned: 1 / reminders due: 0 / failed: 0` and no *would send*
block — the skipped owner is not counted as a failure. The only signal is a log
line above the summary. The bullet now says to read that instead of the counters.

## W3-5 — the logging policy's enumeration was incomplete

`AUDIT_LOG_ENABLED=false` was described as leaving "Go panics, startup
configuration errors, and the Fiber request log" enabled, and the request log is
separately documented as carrying no `user_id`. Observed on a stand with
`audit_log=false`:

```
refreshDerivedCycleSettings: update luteal_phase for user 4 failed: database is locked (5) (SQLITE_BUSY)
```

Five always-on diagnostics carry `user_id`; two of them also carry the raw driver
error, which does not pass through `SafeLogError`. The enumeration was the
load-bearing part — it reads as "no account identifier reaches the default log" —
so the gap is named in a new subsection rather than the list being quietly
extended.

## Checks run locally

`go test ./scripts/...` — `scripts/readmeversion` reads policy files, so a docs
change is not test-free here. No behavior change; rollback is a revert.