### PR TITLE
fix(api): bound every request with a deadline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Requests now carry a deadline, so work the caller abandoned stops.** Nothing
+  in the request path was bounded: fiber v3 hands a handler `context.Background()`
+  until something calls `SetContext`, so the ctx threaded handler → service →
+  repository had neither a deadline nor a cancellation, and `database/sql` waited
+  for a free connection indefinitely. fasthttp does not cancel a handler when the
+  client disconnects either, so abandoned work kept running — a burst of 120
+  concurrent day writes held an instance unready for **16.6 minutes** after the
+  last client had given up, answering `500` with latencies past 14 minutes, while
+  `/healthz` stayed green at 1 ms and the container kept reporting healthy. Every
+  request is now bounded at 60 seconds (matching the server's write timeout, and
+  far outside any legitimate request including a full-size import), and one that
+  outlives its budget answers `503` with the stable key `request_timeout` instead
+  of whatever internal `500` the domain that caught the expiry happened to map.
+
 - **`ovumcy reset-password` can be run without an interactive terminal.** It is
   the operator's documented way back in for an owner locked out by a
   `SECRET_KEY` rotation, or for an OIDC-only account with no retained recovery

--- a/internal/api/error_mapping_transport.go
+++ b/internal/api/error_mapping_transport.go
@@ -60,6 +60,24 @@ func RespondRequestEntityTooLarge(c fiber.Ctx) error {
 	return apiError(c, requestTooLargeErrorSpec())
 }
 
+// requestTimeoutErrorSpec maps a request that outlived its budget
+// (RequestBudget, enforced by RequestDeadlineGuard) to the shared error-spec
+// shape. 503 rather than 500: nothing about the request was wrong and the
+// condition is transient, so the stable key "request_timeout" tells a client to
+// retry rather than to report a fault. Global for the same reason as its 413
+// sibling — the deadline expires somewhere below the handler, so there is no
+// form field to scope it to.
+func requestTimeoutErrorSpec() APIErrorSpec {
+	return globalErrorSpec(fiber.StatusServiceUnavailable, APIErrorCategoryInternal, "request_timeout")
+}
+
+// RespondRequestTimeout renders that 503 through the same content-negotiated
+// formatting as every other mapped error. Exported because the guard that
+// detects the condition is middleware, registered in the composition root.
+func RespondRequestTimeout(c fiber.Ctx) error {
+	return apiError(c, requestTimeoutErrorSpec())
+}
+
 // requestHeadersTooLargeErrorSpec maps a transport-level 431 (the request head —
 // start line plus every header, cookies included — not fitting fasthttp's read
 // buffer) to the shared error-spec shape, for the same reason as the 413 above:

--- a/internal/api/middleware_request_deadline.go
+++ b/internal/api/middleware_request_deadline.go
@@ -1,0 +1,66 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/gofiber/fiber/v3"
+)
+
+// RequestBudget bounds how long one request may spend inside the app.
+//
+// Without it there is no deadline anywhere in the request path. Fiber v3's
+// c.Context() returns context.Background() until something calls SetContext, so
+// every ctx threaded handler → service → repository carried neither a deadline
+// nor a cancellation, and database/sql waits for a free connection forever.
+// fasthttp does not cancel a handler when the client goes away either, so work
+// the caller has abandoned keeps running: a burst of 120 concurrent day writes
+// held a stand unready for 16.6 minutes after the last client had given up,
+// answering 500 with latencies past 14 minutes, while /healthz stayed green at
+// 1 ms and the container kept reporting healthy.
+//
+// The budget is a constant rather than an operator knob for the reason api.md
+// declines a READ_BUFFER_SIZE: it can be set wrong in both directions, and the
+// value that matters is bounded by the transport around it. 60s matches the
+// server's WriteTimeout — a handler that outlives the write timeout cannot
+// deliver its response anyway — and leaves the widest legitimate request, a
+// full-size import, far inside the bound.
+const RequestBudget = 60 * time.Second
+
+// RequestDeadlineGuard gives every request a deadline and answers the one it
+// cannot finish inside as a mapped 503.
+//
+// It is registered ahead of the routes so the deadline reaches every handler,
+// including the ones that never read a body. The answer is decided after
+// c.Next() rather than by inspecting each domain error, mirroring
+// requestBodyLimitGuard: a deadline that expires surfaces deep in a repository
+// call as an opaque driver error and would otherwise be mapped by whichever
+// domain happened to catch it — the day upsert turns it into
+// "failed to update day", a 500. One place, one status, and no domain needs to
+// learn about deadlines.
+//
+// 503 rather than 500 because the condition is transient and the caller's
+// request was not malformed: retrying later is exactly the right response.
+//
+// budget is a parameter so the expiry path is reachable in a test without a
+// wall-clock wait; the composition root passes RequestBudget. A non-positive
+// value falls back to it rather than being honoured, so a miswired caller
+// cannot remove the bound — the same guard ReadinessService puts on its own
+// probe timeout.
+func RequestDeadlineGuard(budget time.Duration) fiber.Handler {
+	if budget <= 0 {
+		budget = RequestBudget
+	}
+	return func(c fiber.Ctx) error {
+		ctx, cancel := context.WithTimeout(c.Context(), budget)
+		defer cancel()
+		c.SetContext(ctx)
+
+		err := c.Next()
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return RespondRequestTimeout(c)
+		}
+		return err
+	}
+}

--- a/internal/api/middleware_request_deadline_test.go
+++ b/internal/api/middleware_request_deadline_test.go
@@ -1,0 +1,130 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v3"
+)
+
+// TestRequestDeadlineGuardThreadsADeadlineToTheHandler proves the guard does
+// the thing the finding was about: a deadline that actually reaches the ctx a
+// handler passes down to a repository. Asserting only that the middleware ran
+// would pass just as well against c.Context()'s default, which is
+// context.Background() — no deadline, no cancellation, and an unbounded wait
+// for a database connection underneath it.
+func TestRequestDeadlineGuardThreadsADeadlineToTheHandler(t *testing.T) {
+	app := fiber.New()
+	app.Use(RequestDeadlineGuard(RequestBudget))
+
+	var (
+		sawDeadline bool
+		remaining   time.Duration
+	)
+	app.Get("/probe", func(c fiber.Ctx) error {
+		deadline, ok := c.Context().Deadline()
+		sawDeadline = ok
+		if ok {
+			remaining = time.Until(deadline)
+		}
+		return c.SendStatus(fiber.StatusNoContent)
+	})
+
+	resp, err := app.Test(httptest.NewRequest(http.MethodGet, "/probe", nil), testConfigNoTimeout)
+	if err != nil {
+		t.Fatalf("GET /probe: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", resp.StatusCode)
+	}
+	if !sawDeadline {
+		t.Fatal("handler context carried no deadline — an unbounded request path is the defect this guard exists for")
+	}
+	if remaining <= 0 || remaining > RequestBudget {
+		t.Fatalf("remaining budget = %s, want a positive value no greater than %s", remaining, RequestBudget)
+	}
+}
+
+// TestRequestDeadlineGuardRefusesToBeUnbounded pins the fallback on the seam
+// that exists for tests: the budget is a parameter, so a caller could pass a
+// non-positive one and quietly remove the bound this guard exists to impose.
+// A miswired caller gets the constant instead.
+func TestRequestDeadlineGuardRefusesToBeUnbounded(t *testing.T) {
+	for _, budget := range []time.Duration{0, -time.Second} {
+		app := fiber.New()
+		app.Use(RequestDeadlineGuard(budget))
+
+		var remaining time.Duration
+		hadDeadline := false
+		app.Get("/probe", func(c fiber.Ctx) error {
+			deadline, ok := c.Context().Deadline()
+			hadDeadline = ok
+			if ok {
+				remaining = time.Until(deadline)
+			}
+			return c.SendStatus(fiber.StatusNoContent)
+		})
+
+		resp, err := app.Test(httptest.NewRequest(http.MethodGet, "/probe", nil), testConfigNoTimeout)
+		if err != nil {
+			t.Fatalf("GET /probe with budget %s: %v", budget, err)
+		}
+		_ = resp.Body.Close()
+
+		if !hadDeadline {
+			t.Fatalf("budget %s left the request unbounded", budget)
+		}
+		if remaining <= 0 || remaining > RequestBudget {
+			t.Fatalf("budget %s produced a remaining window of %s, want the %s fallback", budget, remaining, RequestBudget)
+		}
+	}
+}
+
+// TestRequestDeadlineGuardAnswersAnExpiredBudgetAsMappedUnavailable pins the
+// answer, not just the expiry. The condition surfaces deep in a repository call
+// as an opaque driver error, so without a single decision point each domain
+// would map it to its own internal 500 ("failed to update day"); the client
+// gets one stable key instead, and a status that says "retry", not "we are
+// broken".
+func TestRequestDeadlineGuardAnswersAnExpiredBudgetAsMappedUnavailable(t *testing.T) {
+	app := fiber.New()
+	app.Use(RequestDeadlineGuard(time.Millisecond))
+	app.Get("/slow", func(c fiber.Ctx) error {
+		// Stand in for a repository call that outlives the budget: block on the
+		// request context exactly as database/sql does while waiting for a free
+		// connection, rather than sleeping past a wall-clock figure. The
+		// handler then returns normally, which is the case that matters — the
+		// guard must answer on the expired budget even when the work below it
+		// reports success.
+		<-c.Context().Done()
+		return c.SendString("handler finished anyway")
+	})
+
+	request := httptest.NewRequest(http.MethodGet, "/slow", nil)
+	request.Header.Set("Accept", "application/json")
+	resp, err := app.Test(request, testConfigNoTimeout)
+	if err != nil {
+		t.Fatalf("GET /slow: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", resp.StatusCode)
+	}
+	body := map[string]any{}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode error envelope: %v", err)
+	}
+	detail, _ := body["error_detail"].(map[string]any)
+	if detail == nil {
+		t.Fatalf("expected the shared error envelope, got %v", body)
+	}
+	if key, _ := detail["key"].(string); key != "request_timeout" {
+		t.Fatalf("error_detail.key = %q, want %q", key, "request_timeout")
+	}
+}

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -11,6 +11,11 @@ func RegisterRoutes(app *fiber.App, handler *Handler) {
 	// rather than on the body-reading groups so a route added outside them still
 	// inherits it; the guard itself decides, from the request method, whether the
 	// decode probe is owed. See requestBodyLimitGuard.
+	// Registered before the body-limit guard so the decode probe below runs
+	// under the deadline too — the probe is the decompression, and an inflate
+	// of a BodyLimit-sized stream is exactly the kind of work that must not
+	// outlive the caller. See RequestDeadlineGuard.
+	app.Use(RequestDeadlineGuard(RequestBudget))
 	app.Use(requestBodyLimitGuard)
 	registerPageRoutes(app, handler)
 	registerV1APIRoutes(app, handler)


### PR DESCRIPTION
## What

Nothing in the request path was bounded. Fiber v3's `c.Context()` returns
`context.Background()` until something calls `SetContext`, and nothing did — so
the ctx threaded handler → service → repository carried neither a deadline nor a
cancellation, and `database/sql` waited for a free connection indefinitely.
fasthttp does not cancel a handler when the client disconnects either, so work
the caller had abandoned kept running.

## Measured

On a stand built from `main` with the repository `Dockerfile`: 120 concurrent day
writes, every client gone after its own 120 s timeout.

- the instance stayed unready for **16.6 minutes** after the burst — ~15 of them
  after the last client had disconnected;
- abandoned requests kept completing, answering `500` with latencies past
  `14m40s`;
- `/healthz` answered `200` in ~1 ms throughout and the container never left
  `healthy`, so neither Docker nor an operator watching the healthcheck saw
  anything;
- CPU sat at ~1.4% and memory was flat — it was queueing, not working.

Recovery was proportional to all work ever accepted, not to the clients still
waiting for an answer. This is the runtime consequence of the wave-1 code-level
candidate A-5 (`api.md` describes threading `ctx` through the chain; the chain
had no deadline to thread).

## Change

`RequestDeadlineGuard` puts a bounded context into `SetContext`, so the whole
chain inherits it and the unbounded pool wait ends.

**The budget is a constant, not an operator knob**, for the reason `api.md`
declines `READ_BUFFER_SIZE`: it can be set wrong in both directions. 60 s matches
the server's `WriteTimeout` — a handler that outlives the write timeout cannot
deliver its response anyway — and leaves the widest legitimate request, a
full-size import, far inside the bound.

**The answer is decided once, after `c.Next()`**, mirroring
`requestBodyLimitGuard`. An expired deadline surfaces deep in a repository call
as an opaque driver error; left to the domains it becomes whichever internal
`500` caught it first (`failed to update day`). One place maps it to **`503`
`request_timeout`** instead: nothing about the request was wrong and the
condition is transient, so the client is told to retry rather than that the
server is broken.

**Registered ahead of `requestBodyLimitGuard`** so the decode probe runs under
the deadline too — that probe *is* the decompression, and a `BodyLimit`-sized
inflate is exactly the work that must not outlive its caller.

## Tests

- the deadline actually reaches the handler's ctx — asserting only that the
  middleware ran would pass against `context.Background()`, which is the defect;
- an expired budget answers `503` with the stable key even when the work below it
  returns success;
- a non-positive budget falls back to the constant, so the seam that exists for
  testing cannot be used to remove the bound (the guard `ReadinessService` puts
  on its own probe timeout).

## Proof on defect

Replacing `context.WithTimeout` with `context.WithCancel` fails
`TestRequestDeadlineGuardThreadsADeadlineToTheHandler` with `handler context
carried no deadline — an unbounded request path is the defect this guard exists
for`.

## Checks run locally

`go build ./...`, the full `go test ./...`, `staticcheck ./internal/... ./cmd/...`
(0 findings), and the patch-coverage gate with its profile regenerated in the same
invocation and run after committing.

Found by the wave-3 audit stand (finding W3-3). This is the last of the eleven.