### PR TITLE
ci: skip PR fuzzing when a pull request touches nothing fuzzable

### DIFF
--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -7,6 +7,18 @@ on:
   pull_request:
     branches:
       - main
+    # PR fuzzing can only catch regressions introduced through fuzzable
+    # inputs, and the Go+libFuzzer toolchain occasionally SEGVs at process
+    # startup (TracePC::ClearInlineCounters) independent of the change under
+    # test — so docs/CI-only PRs skip it instead of rolling that dice. The
+    # "PR" context is not a required check, so a workflow-level paths filter
+    # is safe here (nothing waits on a report that never comes). The daily
+    # batch workflow still fuzzes every target regardless.
+    paths:
+      - "**.go"
+      - "go.mod"
+      - "go.sum"
+      - ".clusterfuzzlite/**"
 
 permissions:
   contents: read


### PR DESCRIPTION
Same filter as ovumcy-managed's `cflite_pr.yml` and ovumcy-sync-community#106. The fuzz targets here are pure policy parsers in `internal/services` (dates, password strength, email/recovery normalization, onboarding sanitize) — no templates or embedded assets — so `**.go`, `go.mod`, `go.sum`, `.clusterfuzzlite/**` covers everything fuzzable. "PR" is not a required check → a workflow-level filter is safe. The daily cflite batch still fuzzes every target regardless.