### PR TITLE
fix(api): give the last three server-side surfaces a stable key to assert on

### DIFF
--- a/e2e/dashboard-fertility.spec.ts
+++ b/e2e/dashboard-fertility.spec.ts
@@ -152,11 +152,17 @@ test.describe('Dashboard: fertility badge', () => {
     const ninthDay = shiftISO(today, 5);
     const ninthResponse = await savePeriodDay(ninthDay);
     expect(ninthResponse.status()).toBeLessThan(400);
-    // Go's url.QueryEscape encodes space as '+', so decode the header in two
-    // passes (decode-uri-component handles %XX but leaves '+' alone).
+    // Which warning fired is asserted through the companion key header, so the
+    // check does not rest on a fragment of English copy the catalogue owns.
+    expect(ninthResponse.headers()['x-ovumcy-notice-key']).toBe('dashboard.long_period_warning');
+    // The rendered sentence still has to survive the transport intact, and that
+    // is a property of the encoding rather than of the wording: Go's
+    // url.QueryEscape turns a space into '+', so decode in two passes
+    // (decode-uri-component handles %XX but leaves '+' alone) and compare
+    // against the catalogue entry the key just named.
     const rawNotice = ninthResponse.headers()['x-ovumcy-notice'] ?? '';
     const notice = decodeURIComponent(rawNotice.replace(/\+/g, '%20'));
-    expect(notice).toContain('longer than 8 days');
+    expect(notice).toBe(localeText('en', 'dashboard.long_period_warning'));
 
     // The acknowledgement persists user.LongPeriodWarnedAt; a follow-up save
     // in the same cycle does NOT re-emit the warning. This is the "shown

--- a/e2e/stats-insights.spec.ts
+++ b/e2e/stats-insights.spec.ts
@@ -10,6 +10,7 @@ import {
 } from './support/auth-helpers';
 import { setRequestTimezoneFromBrowser } from './support/timezone-helpers';
 import { shiftISODate } from './support/stats-helpers';
+import { localeText } from './support/locale-helpers';
 
 function isoDateDaysAgo(days: number): string {
   const date = new Date();
@@ -221,7 +222,11 @@ test.describe('Stats: BBT chart', () => {
     // the detected coverline, and the three values starting from
     // markerIndex+1 (the day after the marker = first elevated day) are all
     // strictly above it, the third by at least 0.2 °C.
-    expect(parsed.markerLabel).toBe('Probable ovulation');
+    // Assert the marker's identity through its catalogue key, not the rendered
+    // sentence: the copy is owned by the locale files and changes with them,
+    // while the key is the stable half of the pair the payload now carries.
+    expect(parsed.markerLabelKey).toBe('stats.bbt_probable_ovulation');
+    expect(parsed.markerLabel).toBe(localeText('en', 'stats.bbt_probable_ovulation'));
     expect(typeof parsed.markerIndex).toBe('number');
     expect(parsed.markerIndex).toBeGreaterThanOrEqual(0);
     expect(typeof parsed.baseline).toBe('number');

--- a/internal/api/fullpage_fallback_regressions_test.go
+++ b/internal/api/fullpage_fallback_regressions_test.go
@@ -532,6 +532,92 @@ func TestDaySaveSpottingWarningSetsEncodedNotice(t *testing.T) {
 	}
 }
 
+// TestDaySaveLongPeriodWarningSetsEncodedNoticeWithKey and its implantation
+// sibling below cover the two notice branches the spotting test above did not
+// reach. Both assert the key header rather than the sentence: which warning
+// fired is the claim, and the copy that expresses it belongs to the catalogue.
+func TestDaySaveLongPeriodWarningSetsEncodedNoticeWithKey(t *testing.T) {
+	app, database := newOnboardingTestApp(t)
+	user := createOnboardingTestUser(t, database, "fullpage-long-period@example.com", "StrongPass1", true)
+	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
+
+	// A streak longer than 8 days ending on the saved day is the documented
+	// ShowLongPeriodWarning recipe: seed the first eight, then save the ninth.
+	todayUTC := services.CalendarDay(time.Now().UTC(), time.UTC)
+	streak := make([]models.DailyLog, 0, 8)
+	for offset := 8; offset >= 1; offset-- {
+		streak = append(streak, models.DailyLog{
+			UserID:   user.ID,
+			Date:     todayUTC.AddDate(0, 0, -offset),
+			IsPeriod: true,
+			Flow:     models.FlowMedium,
+		})
+	}
+	if err := database.Create(&streak).Error; err != nil {
+		t.Fatalf("seed period streak: %v", err)
+	}
+
+	form := url.Values{"is_period": {"true"}, "flow": {string(models.FlowMedium)}}
+	request := httptest.NewRequest(http.MethodPut, "/api/v1/days/"+todayUTC.Format("2006-01-02"), strings.NewReader(form.Encode()))
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	request.Header.Set("HX-Request", "true")
+	request.Header.Set("Accept-Language", "en")
+	request.Header.Set("Cookie", authCookie)
+
+	response := mustAppResponse(t, app, request)
+	defer func() { _ = response.Body.Close() }()
+	assertStatusCode(t, response, http.StatusOK)
+
+	if got := response.Header.Get("X-Ovumcy-Notice-Key"); got != "dashboard.long_period_warning" {
+		t.Fatalf("expected the long-period warning key, got %q", got)
+	}
+	if response.Header.Get("X-Ovumcy-Notice") == "" {
+		t.Fatal("expected the rendered sentence alongside the key")
+	}
+}
+
+func TestMarkCycleStartImplantationWarningSetsEncodedNoticeWithKey(t *testing.T) {
+	app, database := newOnboardingTestApp(t)
+	user := createOnboardingTestUser(t, database, "fullpage-implantation@example.com", "StrongPass1", true)
+	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
+
+	// With the default 28-day cycle the predicted ovulation lands 14 days after
+	// the previous start, and the warning covers a new start 6-12 days past
+	// ovulation. A previous start 22 days back puts today 8 days past it.
+	todayUTC := services.CalendarDay(time.Now().UTC(), time.UTC)
+	previousStart := models.DailyLog{
+		UserID:     user.ID,
+		Date:       todayUTC.AddDate(0, 0, -22),
+		IsPeriod:   true,
+		CycleStart: true,
+		Flow:       models.FlowMedium,
+	}
+	if err := database.Create(&previousStart).Error; err != nil {
+		t.Fatalf("seed previous cycle start: %v", err)
+	}
+
+	request := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/days/"+todayUTC.Format("2006-01-02")+"/cycle-start",
+		strings.NewReader(url.Values{"replace_existing": {"true"}}.Encode()),
+	)
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	request.Header.Set("HX-Request", "true")
+	request.Header.Set("Accept-Language", "en")
+	request.Header.Set("Cookie", authCookie)
+
+	response := mustAppResponse(t, app, request)
+	defer func() { _ = response.Body.Close() }()
+	assertStatusCode(t, response, http.StatusNoContent)
+
+	if got := response.Header.Get("X-Ovumcy-Notice-Key"); got != "dashboard.implantation_warning" {
+		t.Fatalf("expected the implantation warning key, got %q", got)
+	}
+	if response.Header.Get("X-Ovumcy-Notice") == "" {
+		t.Fatal("expected the rendered sentence alongside the key")
+	}
+}
+
 func utoa(value uint) string {
 	return strconv.FormatUint(uint64(value), 10)
 }

--- a/internal/api/handlers_days_status_helpers.go
+++ b/internal/api/handlers_days_status_helpers.go
@@ -38,12 +38,24 @@ func localizedStatusDismissLabel(messages map[string]string) string {
 	return closeLabel
 }
 
-func setEncodedResponseNotice(c fiber.Ctx, message string) {
+// setEncodedResponseNotice carries a day-save toast to the client out of band,
+// in a header, because the response body is the saved entry rather than a page.
+//
+// It emits the rendered sentence AND its catalogue key. The sentence is what
+// the toast shows; the key is what anything asserting on the notice keys off,
+// so a test does not have to re-type localized copy the catalogue owns — the
+// same split the rendered surfaces express as data-explainer-key next to their
+// text. A blank message emits neither header, so "no notice" stays observable
+// as the absence of both.
+func setEncodedResponseNotice(c fiber.Ctx, noticeKey string, message string) {
 	trimmed := strings.TrimSpace(message)
 	if trimmed == "" {
 		return
 	}
 	c.Set("X-Ovumcy-Notice", url.QueryEscape(trimmed))
+	if key := strings.TrimSpace(noticeKey); key != "" {
+		c.Set("X-Ovumcy-Notice-Key", key)
+	}
 }
 
 func (handler *Handler) sendDaySaveStatus(c fiber.Ctx, messageKey string) error {

--- a/internal/api/handlers_days_status_helpers_test.go
+++ b/internal/api/handlers_days_status_helpers_test.go
@@ -95,19 +95,29 @@ func TestSetEncodedResponseNoticeSkipsBlank(t *testing.T) {
 	t.Parallel()
 
 	_, header := runDayStatusHelperCtx(t, nil, func(handler *Handler, c fiber.Ctx) string {
-		setEncodedResponseNotice(c, "cycle saved")
+		setEncodedResponseNotice(c, "dashboard.spotting_cycle_warning", "cycle saved")
 		return ""
 	})
 	if got := header.Get("X-Ovumcy-Notice"); got != "cycle+saved" && got != "cycle%20saved" {
 		t.Fatalf("expected url-encoded notice header, got %q", got)
 	}
+	// The key rides alongside the rendered sentence so a caller can identify
+	// which notice fired without re-typing localized copy.
+	if got := header.Get("X-Ovumcy-Notice-Key"); got != "dashboard.spotting_cycle_warning" {
+		t.Fatalf("expected the notice key header, got %q", got)
+	}
 
 	_, blankHeader := runDayStatusHelperCtx(t, nil, func(handler *Handler, c fiber.Ctx) string {
-		setEncodedResponseNotice(c, "   ")
+		setEncodedResponseNotice(c, "dashboard.spotting_cycle_warning", "   ")
 		return ""
 	})
 	if got := blankHeader.Get("X-Ovumcy-Notice"); got != "" {
 		t.Fatalf("expected no notice header for a blank message, got %q", got)
+	}
+	// Both halves are skipped together: "no notice" must stay observable as
+	// the absence of both headers, never as a key with no sentence.
+	if got := blankHeader.Get("X-Ovumcy-Notice-Key"); got != "" {
+		t.Fatalf("expected no notice key header for a blank message, got %q", got)
 	}
 }
 

--- a/internal/api/handlers_days_write.go
+++ b/internal/api/handlers_days_write.go
@@ -124,9 +124,9 @@ func (handler *Handler) respondUpsertDaySuccess(c fiber.Ctx, entry models.DailyL
 		c.Set("HX-Trigger", "calendar-day-updated")
 		if feedbackErr == nil {
 			if feedback.ShowSpottingCycleWarning {
-				setEncodedResponseNotice(c, translateMessage(currentMessages(c), "dashboard.spotting_cycle_warning"))
+				setEncodedResponseNotice(c, "dashboard.spotting_cycle_warning", translateMessage(currentMessages(c), "dashboard.spotting_cycle_warning"))
 			} else if feedback.ShowLongPeriodWarning {
-				setEncodedResponseNotice(c, translateMessage(currentMessages(c), "dashboard.long_period_warning"))
+				setEncodedResponseNotice(c, "dashboard.long_period_warning", translateMessage(currentMessages(c), "dashboard.long_period_warning"))
 			}
 			return handler.sendDaySaveStatus(c, feedback.MessageKey)
 		}
@@ -174,7 +174,7 @@ func (handler *Handler) MarkCycleStart(c fiber.Ctx) error {
 		c.Set("HX-Trigger", "calendar-day-updated")
 		c.Set("HX-Refresh", "true")
 		if cycleStartPolicy.PotentialImplantation {
-			setEncodedResponseNotice(c, translateMessage(currentMessages(c), "dashboard.implantation_warning"))
+			setEncodedResponseNotice(c, "dashboard.implantation_warning", translateMessage(currentMessages(c), "dashboard.implantation_warning"))
 		}
 		return c.SendStatus(fiber.StatusNoContent)
 	}

--- a/internal/api/stats_cycle_length_notice_regression_test.go
+++ b/internal/api/stats_cycle_length_notice_regression_test.go
@@ -57,6 +57,71 @@ func statsBodyForCyclePattern(t *testing.T, email string, gapDays int, cycleCoun
 	return mustReadBodyString(t, response.Body)
 }
 
+// statsBodyForCycleAnchorAge seeds three period starts gapDays apart, the most
+// recent of them startedDaysAgo days back, and renders /stats.
+//
+// Three rather than one because the note under test lives on the current-phase
+// card, and the whole card grid is replaced by the empty state until the
+// account has the two completed cycles that unlock insights. With both cycles
+// the same length, the reference length is that length, so the caller controls
+// staleness purely through the age of the latest anchor.
+func statsBodyForCycleAnchorAge(t *testing.T, email string, startedDaysAgo int, gapDays int) string {
+	t.Helper()
+
+	app, database := newOnboardingTestApp(t)
+	user := createOnboardingTestUser(t, database, email, "StrongPass1", true)
+	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
+
+	now := time.Now().UTC()
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+	start := today.AddDate(0, 0, -startedDaysAgo)
+
+	logs := []models.DailyLog{
+		{UserID: user.ID, Date: start.AddDate(0, 0, -2*gapDays), IsPeriod: true},
+		{UserID: user.ID, Date: start.AddDate(0, 0, -gapDays), IsPeriod: true},
+		{UserID: user.ID, Date: start, IsPeriod: true},
+	}
+	if err := database.Create(&logs).Error; err != nil {
+		t.Fatalf("seed period logs: %v", err)
+	}
+	if err := database.Model(&models.User{}).Where("id = ?", user.ID).Updates(map[string]any{
+		"last_period_start": start,
+	}).Error; err != nil {
+		t.Fatalf("set last period start: %v", err)
+	}
+
+	request := httptest.NewRequest(http.MethodGet, "/stats", nil)
+	request.Header.Set("Accept-Language", "en")
+	request.Header.Set("Cookie", authCookie)
+	response := mustAppResponse(t, app, request)
+	assertStatusCode(t, response, http.StatusOK)
+	return mustReadBodyString(t, response.Body)
+}
+
+// TestStatsPagePinsThePhaseEstimatedNoteByHook covers the last warning on the
+// stats page that no test addressed. It is gated by CycleDataStale, so it has
+// the same failure mode as the notices above: a flag computed correctly and
+// then dropped from the page-data map or the template leaves every service test
+// green while the reader never sees the note.
+//
+// Both directions are asserted in one test so the absent case has a positive
+// anchor: a negative-only check would pass just as well if the hook were
+// renamed or the block deleted outright.
+func TestStatsPagePinsThePhaseEstimatedNoteByHook(t *testing.T) {
+	staleBody := statsBodyForCycleAnchorAge(t, "stats-phase-estimated-stale@example.com", 60, 30)
+	if !strings.Contains(staleBody, "data-stats-phase-estimated") {
+		t.Fatal("expected the phase-estimated note on a stale cycle anchor")
+	}
+	if !strings.Contains(staleBody, `data-notice-key="dashboard.phase_estimated"`) {
+		t.Fatal("expected the phase-estimated note to carry its catalogue key")
+	}
+
+	freshBody := statsBodyForCycleAnchorAge(t, "stats-phase-estimated-fresh@example.com", 3, 30)
+	if strings.Contains(freshBody, "data-stats-phase-estimated") {
+		t.Fatal("expected no phase-estimated note while the cycle anchor is current")
+	}
+}
+
 func TestStatsPageRendersShortCycleNoticeForShortPattern(t *testing.T) {
 	body := statsBodyForCyclePattern(t, "stats-short-notice@example.com", 20, 3)
 	if !strings.Contains(body, "data-stats-short-cycle-notice") {

--- a/internal/api/stats_page_helpers.go
+++ b/internal/api/stats_page_helpers.go
@@ -41,6 +41,12 @@ func mapStatsBBTChartData(chart services.StatsBBTChartViewData, messages map[str
 		payload["markerIndex"] = chart.MarkerIndex
 		if chart.MarkerLabelKey != "" {
 			payload["markerLabel"] = translateMessage(messages, chart.MarkerLabelKey)
+			// The rendered label rides along for the chart script, but a test
+			// asserting the marker is the ovulation marker must not have to
+			// re-type English copy that the catalogue owns and translation can
+			// change. The key is the stable half of that pair, exactly as the
+			// data-explainer-key attributes do for rendered notices.
+			payload["markerLabelKey"] = chart.MarkerLabelKey
 		}
 	}
 	return payload

--- a/internal/templates/stats.html
+++ b/internal/templates/stats.html
@@ -87,7 +87,7 @@
         <p class="stat-label">{{t .Messages "dashboard.current_phase"}}</p>
           {{if .CycleDataStale}}
           <p class="stat-value mt-2"><span class="mr-2">{{phaseIcon "unknown"}}</span>{{phaseLabel .Messages "unknown"}}</p>
-          <p class="warning-amber mt-2 text-xs">{{t .Messages "dashboard.phase_estimated"}}</p>
+          <p class="warning-amber mt-2 text-xs" data-stats-phase-estimated data-notice-key="dashboard.phase_estimated">{{t .Messages "dashboard.phase_estimated"}}</p>
           {{else}}
           <p class="stat-value mt-2"><span class="mr-2">{{phaseIcon .Stats.CurrentPhase}}</span>{{phaseLabel .Messages .Stats.CurrentPhase}}</p>
           {{end}}


### PR DESCRIPTION
Closes the server-side half of the wave-2 locale-literal class — the three
places where the identity of a message existed only as English copy, so a test
had to re-type a sentence the catalogue owns.

## `X-Ovumcy-Notice` gains a key

The day-save toast travelled as rendered text and nothing else, so
`dashboard-fertility.spec.ts` asserted a fragment of it (`'longer than 8 days'`)
to decide *which* warning had fired. The header now travels with
`X-Ovumcy-Notice-Key` alongside: the sentence is what the toast shows, the key
is what a caller identifies it by. Both are emitted or neither, so "no notice"
stays observable as the absence of both.

## The BBT chart payload gains `markerLabelKey`

Same split was missing there: `markerLabel` was the translated string and
`stats-insights.spec.ts` pinned `'Probable ovulation'`. The spec now asserts the
key, plus the catalogue entry that key names.

## `stats.html`'s phase-estimated note gains a hook

It was the last `.warning-amber` in the tree with no hook, and no test addressed
it at all. It gains `data-stats-phase-estimated` and its key — **attributes
only**, nothing about what renders changes — plus a regression that seeds a stale
cycle anchor, renders `/stats`, and asserts the note appears there and stays
absent when the anchor is current. Deleting the hook from the template fails it.

The seed needs three period starts rather than one: the stat cards are replaced
wholesale by the empty state until two completed cycles unlock insights, so a
single anchor renders no card to carry the note.

## Two notice branches gained their first Go-level coverage

The patch-coverage gate flagged the long-period and implantation call sites —
both were reachable only through e2e, which does not feed the Go profile. Each
now has a regression driving the documented recipe (a >8-day streak; a new cycle
start 8 days past predicted ovulation) and asserting the key header.

## Checks run locally

`go build ./...`, full `go test ./...`, `staticcheck ./internal/...` (0 findings),
`npm run e2e -- e2e/stats-insights.spec.ts e2e/dashboard-fertility.spec.ts`
(7 passed), and the patch-coverage gate with its profile regenerated in the same
invocation, run after committing.

Residual debt from wave 2; the two headers and the JSON field are additive, so a
client reading only the old ones is unaffected.