### PR TITLE
ci: report every required check on merge_group events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
   pull_request:
+  # Merge-queue validation runs: every workflow that owns a required status
+  # check must also report on merge_group, or a queued merge waits forever.
+  merge_group:
   release:
     types:
       - published

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
   pull_request:
+  # Merge-queue validation runs: every workflow that owns a required status
+  # check must also report on merge_group, or a queued merge waits forever.
+  merge_group:
   schedule:
     - cron: "23 3 * * 1"
   workflow_dispatch:

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -14,6 +14,9 @@ on:
     branches:
       - main
   pull_request:
+  # Merge-queue validation runs: every workflow that owns a required status
+  # check must also report on merge_group, or a queued merge waits forever.
+  merge_group:
   schedule:
     - cron: "47 3 * * 1"
   workflow_dispatch:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - main
   pull_request:
+  # Merge-queue validation runs: every workflow that owns a required status
+  # check must also report on merge_group, or a queued merge waits forever.
+  merge_group:
   schedule:
     - cron: "41 3 * * 1"
   workflow_dispatch:


### PR DESCRIPTION
Twin of sync#107 / managed#233 / app#193 — the last repo of the four. Adds `merge_group:` to **ci** (test, e2e, e2e-postgres-smoke, patch-coverage, race), **security** (gosec, govulncheck, trivy-fs, trivy-image), **codeql** (Analyze ×3), **gitleaks**. Inert until the queue rule is added to the `Protect main` ruleset (settings step after this merges).

By construction: `changes` treats merge_group as non-PR → full battery + both e2e lanes run in the queue; `image-smoke` keeps its push/release scoping; `patch-coverage` stays PR-only → skipped-satisfied in the queue.