### PR TITLE
test(e2e): close the two hygiene items wave 2 left standing

### DIFF
--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -329,7 +329,16 @@ test.describe('Onboarding flow', () => {
     await submitStepTwo(page);
   });
 
-  test('step 2 irregular checkbox carries through to dashboard range prediction', async ({ page }) => {
+  // The name says "sparse estimate", not "range", because that is what the
+  // assertions below prove. Irregular mode shows a range only once the account
+  // has observed cycles to bound it; a freshly onboarded owner has none, so the
+  // dashboard falls back to the "around <date>" estimate plus the
+  // needs-more-cycles note. A name promising a range over assertions checking
+  // the sparse fallback is the desync that let its twin in
+  // settings-profile-cycle.spec.ts assert an ASCII "-" a locale renders as "—".
+  test('step 2 irregular checkbox carries through to the dashboard sparse estimate', async ({
+    page,
+  }) => {
     await registerAndOpenOnboarding(page, 'onboarding-irregular');
 
     const selectedDate = toISODate(new Date(Date.now() - 5 * 24 * 60 * 60 * 1000));

--- a/e2e/support/auth-helpers.ts
+++ b/e2e/support/auth-helpers.ts
@@ -71,9 +71,20 @@ export async function registerOwnerViaUI(
   await requestSubmitForm(page.locator('form[action="/api/v1/users"]'));
 }
 
+// registrationSettleTimeout covers the one step in the suite whose server cost
+// is a deliberate expense rather than a query: POST /api/v1/users hashes a
+// password and a recovery code with bcrypt before it can answer. Measured at
+// 5.8-7.3s under parallel runs, which puts it past Playwright's 5s default and
+// made this the suite's most frequent flake. The wait itself stays bound to a
+// concrete signal — the landed URL and the rendered recovery block — so only
+// the budget is widened, never the condition.
+const registrationSettleTimeout = 20_000;
+
 export async function expectInlineRegisterRecoveryStep(page: Page): Promise<void> {
-  await expect(page).toHaveURL(/\/register(?:\?.*)?$/);
-  await expect(page.locator('[data-auth-inline-recovery]')).toBeVisible();
+  await expect(page).toHaveURL(/\/register(?:\?.*)?$/, { timeout: registrationSettleTimeout });
+  await expect(page.locator('[data-auth-inline-recovery]')).toBeVisible({
+    timeout: registrationSettleTimeout,
+  });
 }
 
 export async function expectDedicatedRecoveryPage(page: Page): Promise<void> {


### PR DESCRIPTION
## Onboarding: a name that promised more than the body proved

`step 2 irregular checkbox carries through to dashboard range prediction`
asserted the **sparse** fallback, not a range: a freshly onboarded owner has no
observed cycles to bound a range with, so the dashboard shows the
"around &lt;date&gt;" estimate plus the needs-more-cycles note — which is what
the body checks, correctly and via `localeText`.

That mismatch is the same shape as its twin in `settings-profile-cycle.spec.ts`,
where a "range" name sat above an assertion for an ASCII `-` that the locale
renders as `—`. There the name was the wrong half too. Renamed to what it
proves, with the precondition a real range needs written down so the next reader
does not re-derive it.

## Register recovery step: the suite's most frequent flake

`expectInlineRegisterRecoveryStep` waited on Playwright's 5s default for a step
whose server cost is deliberate rather than incidental: `POST /api/v1/users`
hashes a password **and** a recovery code with bcrypt before it can answer,
measured at 5.8–7.3s under parallel runs. Both wave-2 readers hit it
independently.

The budget is now 20s, named and explained at the constant. The waits stay bound
to the same concrete signals — the landed URL and the rendered recovery block —
so only the budget widened, never the condition; a genuinely broken registration
still fails, just later.

## Checks run locally

`npm run e2e -- e2e/onboarding.spec.ts` (10 passed) and
`npm run e2e -- e2e/auth-login-register.spec.ts` (15 passed, 1 skipped —
the registration-mode-closed lane needs its own env).

Residual debt from wave 2.