### PR TITLE
docs(openapi): declare both transports the 2FA challenge accepts

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1000,6 +1000,8 @@ paths:
         content:
           application/json:
             schema: { $ref: '#/components/schemas/TOTPLoginRequest' }
+          application/x-www-form-urlencoded:
+            schema: { $ref: '#/components/schemas/TOTPLoginRequest' }
       responses:
         '200':
           description: 2FA verified; `ovumcy_auth` issued.


### PR DESCRIPTION
#329 made `POST /api/v1/sessions/2fa-challenge` read the submitted code from a
JSON body as well as a form — the spec published `application/json` as the only
media type and the handler accepted neither, so every spec-conforming client got
`401 totp invalid code` for a correct code.

The spec was deliberately left alone there: that change fixed the direction that
mattered (an unimplementable contract) and left the opposite one standing. The
document now **understates** the endpoint, naming JSON while the browser form it
actually serves — and which every caller in the tree uses — goes undocumented.

Both media types are now declared against the same schema, since both carry the
same single field.

`TestOpenAPIContractMatchesRegisteredRoutes` passes; note that it compares route
presence in both directions and not request shape, which is why neither this gap
nor the original one was visible to it.

Residual noted when #329 landed; documentation only.