### PR TITLE
fix(api): refuse secretless TOTP setup cookies and re-home stray crypto and mappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The TOTP enrollment cookie refuses to seal without a secret.** The reader
+  has always rejected a setup payload whose secret is blank, but the writer
+  sealed one without complaint, so a caller that lost the secret produced a
+  well-formed, correctly-attributed cookie that could only fail later, at read
+  time, in a different request. The writer now refuses a blank secret exactly
+  as it refuses a missing owner id — the failure surfaces in the request that
+  caused it, and no prior setup cookie is left behind.
+
 - **Requests now carry a deadline, so work the caller abandoned stops.** Nothing
   in the request path was bounded: fiber v3 hands a handler `context.Background()`
   until something calls `SetContext`, so the ctx threaded handler → service →

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,23 @@ Security issues should not be reported publicly. Use [SECURITY.md](SECURITY.md).
   start image tag, cosign/attestation/SBOM verification examples, Releases section) to the new tag.
   `go test ./scripts/readmeversion/...` fails if any occurrence disagrees with the others.
 
+## Migrations
+
+Migration files are immutable once released: fix forward with a new migration, never edit an
+applied one. The prose inside a migration is a snapshot of the contract at the time it shipped and
+is not updated afterwards — the current contract always lives in the docs. Two known historical
+spots, kept as shipped:
+
+- `032_calendar_feed_verifier_mac.sql` (both dialects) describes how legacy feed rows behaved
+  before the key-rotation sentinel existed; the current rotation contract is documented in
+  [docs/security/cryptography.md](docs/security/cryptography.md) and
+  [docs/self-hosted.md](docs/self-hosted.md).
+- `003_daily_logs_schema_reconcile.sql` and `024_daily_logs_bbt_nullable.sql` end with
+  `INSERT OR REPLACE INTO sqlite_sequence(…)`. `sqlite_sequence` has no unique index, so the
+  statement appends a duplicate row instead of replacing one. The value it writes matches what
+  SQLite already maintains through the preceding `INSERT … SELECT`, so the extra row is inert —
+  do not copy the pattern into a new migration.
+
 ## API Stability Contract
 
 `internal/api/routes.go` is the source of truth for HTTP endpoints; [docs/openapi.yaml](docs/openapi.yaml) is the authoritative description of the JSON surface.

--- a/internal/api/auth_recovery_code_transport_regressions_test.go
+++ b/internal/api/auth_recovery_code_transport_regressions_test.go
@@ -2,15 +2,47 @@ package api
 
 import (
 	"encoding/json"
+	"go/parser"
+	"go/token"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"strings"
 	"testing"
 	"time"
 
 	"golang.org/x/net/html"
 )
+
+// TestTransportLayerDoesNotImportBcrypt sweeps every non-test file in the
+// package for a golang.org/x/crypto/bcrypt import. Credential and
+// recovery-code verification decisions belong to the services layer; the
+// register-pickup handler carried the one bcrypt comparison living in
+// transport until it moved behind AuthService.VerifyStoredRecoveryCode. No
+// allowlist: a future import fails here by file name.
+func TestTransportLayerDoesNotImportBcrypt(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read package dir: %v", err)
+	}
+	fileSet := token.NewFileSet()
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		parsed, err := parser.ParseFile(fileSet, name, nil, parser.ImportsOnly)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		for _, imported := range parsed.Imports {
+			if strings.Trim(imported.Path.Value, `"`) == "golang.org/x/crypto/bcrypt" {
+				t.Errorf("%s imports golang.org/x/crypto/bcrypt: credential verification belongs in internal/services", name)
+			}
+		}
+	}
+}
 
 func TestRegisterJSONSuccessDoesNotExposeRecoveryCode(t *testing.T) {
 	app, _ := newOnboardingTestApp(t)

--- a/internal/api/error_mapping_auth.go
+++ b/internal/api/error_mapping_auth.go
@@ -202,6 +202,23 @@ func mapOIDCLinkConfirmPasswordError(err error) APIErrorSpec {
 	}
 }
 
+// mapOIDCLinkConfirmError maps failures of the link-confirm flow itself
+// (identity resolution, the link write, provider availability) onto the
+// link-confirm error contract; password-verification failures have their own
+// mapper above.
+func mapOIDCLinkConfirmError(err error) APIErrorSpec {
+	switch {
+	case errors.Is(err, services.ErrOIDCLinkFailed),
+		errors.Is(err, services.ErrOIDCIdentityResolveFailed):
+		return authOIDCUnavailableErrorSpec()
+	case errors.Is(err, services.ErrOIDCDisabled),
+		errors.Is(err, services.ErrOIDCUnavailable):
+		return authOIDCUnavailableErrorSpec()
+	default:
+		return authOIDCAuthenticationFailedErrorSpec()
+	}
+}
+
 func authOIDCLinkConfirmUnavailableErrorSpec() APIErrorSpec {
 	return authFormErrorSpec(fiber.StatusForbidden, APIErrorCategoryForbidden, "sso link confirmation unavailable")
 }

--- a/internal/api/error_mapping_regressions_test.go
+++ b/internal/api/error_mapping_regressions_test.go
@@ -3,9 +3,13 @@ package api
 import (
 	"encoding/json"
 	"errors"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -13,6 +17,39 @@ import (
 	"github.com/gofiber/fiber/v3"
 	"github.com/ovumcy/ovumcy-web/internal/services"
 )
+
+// TestErrorMappingSwitchesLiveInErrorMappingFiles sweeps every non-test file
+// in the package for a domain-error mapping switch (a function named
+// map…Error) declared outside the error_mapping_*.go files. The mapping layer
+// is centralized so every error path is reviewed in one place; a mapper hiding
+// in a handler file drifts out of that review (the OIDC link-confirm mapper
+// did exactly that). No allowlist: a future offender fails here by name.
+func TestErrorMappingSwitchesLiveInErrorMappingFiles(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read package dir: %v", err)
+	}
+	fileSet := token.NewFileSet()
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") || strings.HasPrefix(name, "error_mapping_") {
+			continue
+		}
+		parsed, err := parser.ParseFile(fileSet, name, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		for _, decl := range parsed.Decls {
+			funcDecl, ok := decl.(*ast.FuncDecl)
+			if !ok {
+				continue
+			}
+			if strings.HasPrefix(funcDecl.Name.Name, "map") && strings.HasSuffix(funcDecl.Name.Name, "Error") {
+				t.Errorf("%s declares %s: map…Error switches belong in an error_mapping_*.go file", name, funcDecl.Name.Name)
+			}
+		}
+	}
+}
 
 func TestCommonErrorSpecs(t *testing.T) {
 	testCases := []struct {

--- a/internal/api/error_mapping_settings_password.go
+++ b/internal/api/error_mapping_settings_password.go
@@ -7,6 +7,28 @@ import (
 	"github.com/ovumcy/ovumcy-web/internal/services"
 )
 
+// mapLocalPasswordSetupReauthError maps failures of the OIDC step-up exchange
+// that gates local-password enrollment. Stale and identity-mismatch outcomes
+// keep their own specs so the owner learns to redo the step-up; everything
+// else collapses into the generic SSO failure so provider state never leaks
+// through error granularity.
+func mapLocalPasswordSetupReauthError(err error) APIErrorSpec {
+	switch {
+	case errors.Is(err, services.ErrOIDCReauthStale):
+		return settingsOIDCReauthStaleErrorSpec()
+	case errors.Is(err, services.ErrOIDCReauthIdentityMismatch):
+		return settingsOIDCReauthMismatchErrorSpec()
+	case errors.Is(err, services.ErrOIDCCallbackInvalid):
+		return authOIDCAuthenticationFailedErrorSpec()
+	case errors.Is(err, services.ErrOIDCAuthenticationFailed):
+		return authOIDCAuthenticationFailedErrorSpec()
+	case errors.Is(err, services.ErrOIDCDisabled), errors.Is(err, services.ErrOIDCUnavailable):
+		return authOIDCUnavailableErrorSpec()
+	default:
+		return authOIDCAuthenticationFailedErrorSpec()
+	}
+}
+
 func mapSettingsPasswordChangeError(err error) APIErrorSpec {
 	switch {
 	// Checked first: an exhausted re-auth budget is refused before the current

--- a/internal/api/handlers_auth_oidc_link_confirm.go
+++ b/internal/api/handlers_auth_oidc_link_confirm.go
@@ -246,16 +246,3 @@ func (handler *Handler) verifyTOTPForLinkConfirm(c fiber.Ctx, targetUser *models
 	handler.totpService.ResetAttempts(handler.secretKey, c.IP(), targetUser.ID)
 	return APIErrorSpec{}, true
 }
-
-func mapOIDCLinkConfirmError(err error) APIErrorSpec {
-	switch {
-	case errors.Is(err, services.ErrOIDCLinkFailed),
-		errors.Is(err, services.ErrOIDCIdentityResolveFailed):
-		return authOIDCUnavailableErrorSpec()
-	case errors.Is(err, services.ErrOIDCDisabled),
-		errors.Is(err, services.ErrOIDCUnavailable):
-		return authOIDCUnavailableErrorSpec()
-	default:
-		return authOIDCAuthenticationFailedErrorSpec()
-	}
-}

--- a/internal/api/handlers_auth_session_register_pickup.go
+++ b/internal/api/handlers_auth_session_register_pickup.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/gofiber/fiber/v3"
 	"github.com/ovumcy/ovumcy-web/internal/services"
-	"golang.org/x/crypto/bcrypt"
 )
 
 const registerPickupNextPath = "/register/welcome"
@@ -132,7 +131,7 @@ func (handler *Handler) PickupRegister(c fiber.Ctx) error {
 		return handler.redirectToPostRegisterSignin(c, "recovery_hash_missing")
 	}
 
-	if err := bcrypt.CompareHashAndPassword([]byte(user.RecoveryCodeHash), []byte(payload.RC)); err != nil {
+	if !handler.authService.VerifyStoredRecoveryCode(user.RecoveryCodeHash, payload.RC) {
 		return handler.redirectToPostRegisterSignin(c, "decoy_or_mismatch")
 	}
 

--- a/internal/api/handlers_settings_password.go
+++ b/internal/api/handlers_settings_password.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"errors"
 	"time"
 
 	"github.com/gofiber/fiber/v3"
@@ -201,23 +200,6 @@ func (handler *Handler) completeLocalPasswordSetupReauth(c fiber.Ctx, state oidc
 
 func (handler *Handler) validateLocalPasswordSetupReauth(ctx context.Context, code, codeVerifier, nonce string, userID uint, now time.Time) error {
 	return handler.oidcService.ValidateReauthExchange(ctx, code, codeVerifier, nonce, userID, stepupReauthMaxAge, now)
-}
-
-func mapLocalPasswordSetupReauthError(err error) APIErrorSpec {
-	switch {
-	case errors.Is(err, services.ErrOIDCReauthStale):
-		return settingsOIDCReauthStaleErrorSpec()
-	case errors.Is(err, services.ErrOIDCReauthIdentityMismatch):
-		return settingsOIDCReauthMismatchErrorSpec()
-	case errors.Is(err, services.ErrOIDCCallbackInvalid):
-		return authOIDCAuthenticationFailedErrorSpec()
-	case errors.Is(err, services.ErrOIDCAuthenticationFailed):
-		return authOIDCAuthenticationFailedErrorSpec()
-	case errors.Is(err, services.ErrOIDCDisabled), errors.Is(err, services.ErrOIDCUnavailable):
-		return authOIDCUnavailableErrorSpec()
-	default:
-		return authOIDCAuthenticationFailedErrorSpec()
-	}
 }
 
 func parseChangePasswordInput(c fiber.Ctx) (changePasswordInput, error) {

--- a/internal/api/totp_cookies.go
+++ b/internal/api/totp_cookies.go
@@ -105,10 +105,17 @@ func (handler *Handler) clearTOTPPendingCookie(c fiber.Ctx) {
 // id here is what keeps enrollment scoped structurally: once such a payload
 // exists the confirm step has no account to compare against, and would enrol
 // whatever secret the cookie carries against whichever session presented it.
+// A blank rawSecret is refused the same way: the reader already rejects a
+// secretless payload, so sealing one only defers the failure to a later
+// request — both ends of the payload apply the same validation.
 func (handler *Handler) setTOTPSetupCookie(c fiber.Ctx, userID uint, rawSecret string) error {
 	if userID == 0 {
 		handler.clearTOTPSetupCookie(c)
 		return errors.New("totp setup requires an owner id")
+	}
+	if strings.TrimSpace(rawSecret) == "" {
+		handler.clearTOTPSetupCookie(c)
+		return errors.New("totp setup requires a secret")
 	}
 
 	payload := totpSetupCookiePayload{

--- a/internal/api/totp_cookies_test.go
+++ b/internal/api/totp_cookies_test.go
@@ -469,6 +469,45 @@ func TestTOTPSetupCookie_ExpiredPayload_ParseError(t *testing.T) {
 	}
 }
 
+// TestTOTPSetupCookieRefusesSecretlessSeal pins the seal-side half of the
+// secret-presence validation. The reader has always refused a payload whose
+// RawSecret is blank; without the matching writer refusal a caller that lost
+// the secret seals a well-formed, correctly-attributed cookie that only fails
+// later, at read time, in a different request. Both ends of one payload apply
+// the same validation. The positive anchor proves a real secret still seals.
+func TestTOTPSetupCookieRefusesSecretlessSeal(t *testing.T) {
+	secretKey := []byte("test-secret-key")
+	app, _ := newTOTPCookieTestApp(t, secretKey)
+
+	for _, testCase := range []struct {
+		name      string
+		rawSecret string
+	}{
+		{name: "empty", rawSecret: ""},
+		{name: "whitespace only", rawSecret: "%20%20"},
+	} {
+		refused, err := app.Test(httptest.NewRequest(http.MethodGet, "/seal-setup?user_id=42&raw_secret="+testCase.rawSecret, nil), testConfigNoTimeout)
+		if err != nil {
+			t.Fatalf("GET /seal-setup with a %s secret: %v", testCase.name, err)
+		}
+		defer func() { _ = refused.Body.Close() }()
+		if refused.StatusCode != http.StatusInternalServerError {
+			t.Fatalf("expected setTOTPSetupCookie to refuse a %s secret, got status %d", testCase.name, refused.StatusCode)
+		}
+		if written := responseCookieValue(refused.Cookies(), totpSetupCookieName); written != "" {
+			t.Fatalf("a refused seal must not leave a usable setup cookie, got %q", written)
+		}
+	}
+
+	// Positive anchor: the same route still seals a real secret.
+	sealed, err := app.Test(httptest.NewRequest(http.MethodGet, "/seal-setup?user_id=42&raw_secret=JBSWY3DPEHPK3PXP", nil), testConfigNoTimeout)
+	if err != nil {
+		t.Fatalf("GET /seal-setup with a real secret: %v", err)
+	}
+	defer func() { _ = sealed.Body.Close() }()
+	_ = captureCookieValue(t, sealed, totpSetupCookieName)
+}
+
 // TestTOTPSetupCookieRefusesUnattributedOwner pins both halves of the owner
 // scoping on the enrollment setup cookie, at the seal boundary and at the read
 // boundary, so neither depends on the other.

--- a/internal/services/auth_service.go
+++ b/internal/services/auth_service.go
@@ -345,6 +345,16 @@ func (service *AuthService) FindUserByEmailAndRecoveryCode(ctx context.Context, 
 	return &user, nil
 }
 
+// VerifyStoredRecoveryCode reports whether a presented recovery code matches a
+// stored bcrypt recovery-code hash. The code is compared exactly as presented:
+// the register-pickup flow feeds the server-minted value carried by its sealed
+// payload, so normalizing here would only widen what a payload can match.
+// User-typed recovery input goes through the normalizing email+code lookup
+// above instead. A malformed or empty hash fails closed.
+func (service *AuthService) VerifyStoredRecoveryCode(hash string, code string) bool {
+	return bcrypt.CompareHashAndPassword([]byte(hash), []byte(code)) == nil
+}
+
 func (service *AuthService) BuildPasswordResetToken(secretKey []byte, userID uint, passwordHash string, ttl time.Duration, now time.Time) (string, error) {
 	return BuildPasswordResetToken(secretKey, userID, passwordHash, ttl, now)
 }


### PR DESCRIPTION
## What

Four small hygiene items, one PR:

- **Seal-side TOTP secret guard.** `setTOTPSetupCookie` now refuses a blank `rawSecret` the same way it refuses a zero owner id, clearing any prior cookie. The reader has always rejected a secretless payload; without the writer half, a caller that lost the secret minted a well-formed, correctly-attributed cookie that could only fail later, at read time, in a different request. Regression: `TestTOTPSetupCookieRefusesSecretlessSeal` (probe-proven: with the guard removed it fails with `expected setTOTPSetupCookie to refuse a empty secret, got status 200`).
- **No bcrypt in the transport layer.** The register-pickup recovery-code comparison moves behind `AuthService.VerifyStoredRecoveryCode` (compared exactly as presented — the payload carries the server-minted value; the normalizing email+code lookup stays the user-input path). Swept with no allowlist by `TestTransportLayerDoesNotImportBcrypt` (probe-proven: a restored import fails the sweep naming the file).
- **Error mappers live in `error_mapping_*.go`.** `mapOIDCLinkConfirmError` moves to `error_mapping_auth.go`. The new sweep `TestErrorMappingSwitchesLiveInErrorMappingFiles` then found a second, unrecorded stray on its first run — `mapLocalPasswordSetupReauthError` — now moved to `error_mapping_settings_password.go`. Both mappers keep their existing direct table tests; behavior unchanged.
- **CONTRIBUTING gains a Migrations section.** Files are immutable once released and their embedded prose is historical; the two known stale spots are named (032's pre-sentinel rotation prose — current contract in `docs/security/cryptography.md` — and the inert `sqlite_sequence` `INSERT OR REPLACE` in 003/024) so nobody re-fixes or replicates them.

## Notes

- No behavior change outside the new seal-time refusal; both moved mappers are byte-identical switches.
- Full `go test ./...` green locally; `gofmt`/`vet` clean.