### PR TITLE
fix(api): tag clear-data and delete-account audit events as health-data mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The audit stream now tags the two erasure actions as health-data
+  mutations.** Clear-data and delete-account logged through the plain
+  security-event path, so their lines carried the action name alone — no
+  `domain="health_data"`, no `target` — while an ordinary day write or symptom
+  edit carried both. An operator filtering an incident by domain to answer
+  "was any tracked data destroyed?" therefore saw every routine edit and missed
+  the two operations that erase everything. Both now declare a typed mutation
+  kind, like every other audited mutation handler, so the tag cannot be dropped
+  by writing the action out by hand at a call site.
+
+  The `action` values are unchanged (`settings.clear_data`,
+  `settings.delete_account`) and existing filters keep matching, but each of
+  those lines gains two fields: `domain="health_data"` and a `target` naming the
+  erased scope — `account_data` for the wipe, `account` for the deletion.
+  Neither carries an identifier or any free text. The password-only pre-check
+  behind the clear-data confirmation dialog (`settings.clear_data_validate`)
+  mutates nothing and stays on the plain path, unchanged. Field reference:
+  [docs/security/logging.md](docs/security/logging.md#logging-policy).
+
 - **Requests now carry a deadline, so work the caller abandoned stops.** Nothing
   in the request path was bounded: fiber v3 hands a handler `context.Background()`
   until something calls `SetContext`, so the ctx threaded handler → service →

--- a/docs/security/logging.md
+++ b/docs/security/logging.md
@@ -15,6 +15,8 @@ Ovumcy does **not** emit per-action audit logs by default. The `AUDIT_LOG_ENABLE
                   role="owner" domain="health_data" target="day_entry"
   ```
 
+  An action that changes health data carries the two further fields shown above: `domain="health_data"`, and a `target` naming the scope it touched (`day_entry`, `symptom`, `cycle_settings`, and — for the two actions that erase everything — `account_data` for a full data wipe, `account` for an account deletion). The target is a fixed designator chosen per action, never an identifier, an email, or submitted text, so an incident review can filter on `domain="health_data"` to select the data-changing actions, erasures included.
+
 When enabled, these lines are visible to the operator through their container runtime (`docker compose logs`, journald, etc.) and never leave the host. They are intended for ad-hoc incident investigation — for example, to confirm whether a suspected compromise produced state-changing requests, and from which `user_id`. The audit stream is not designed as a compliance audit trail; nothing in Ovumcy itself ships, archives, or rotates these lines.
 
 If you enable `AUDIT_LOG_ENABLED=true`, plan retention and access control around the persistent-identifier content (`user_id`, role). Treat the resulting log stream as the same sensitivity class as the database itself.

--- a/internal/api/handlers_settings_danger.go
+++ b/internal/api/handlers_settings_danger.go
@@ -8,10 +8,27 @@ import (
 	"github.com/ovumcy/ovumcy-web/internal/services"
 )
 
+// The two erasure endpoints are the most destructive health-data mutations the
+// product exposes, so they are audited through the typed mechanism like every
+// other one. Neither acts on a single record: clear-data wipes the account's
+// tracked data and resets its settings, delete-account removes the account with
+// everything attached to it. The target therefore names that scope — a fixed
+// designator that never carries an email, an id, or any free text.
+var (
+	clearDataMutation     = healthMutationKind{action: "settings.clear_data", target: "account_data"}
+	deleteAccountMutation = healthMutationKind{action: "settings.delete_account", target: "account"}
+)
+
+// clearDataValidateAction names the password pre-check behind the clear-data
+// confirmation dialog. It answers whether the password is right and mutates
+// nothing, so it stays on the plain security-event path rather than claiming a
+// health-data domain — but the name still lives here, not at the call site.
+const clearDataValidateAction = "settings.clear_data_validate"
+
 func (handler *Handler) ValidateClearDataPassword(c fiber.Ctx) error {
 	_, spec, valid := handler.validateSettingsActionPassword(c)
 	if !valid {
-		handler.logSecurityError(c, "settings.clear_data_validate", spec)
+		handler.logSecurityError(c, clearDataValidateAction, spec)
 		return handler.respondMappedError(c, spec)
 	}
 
@@ -24,13 +41,10 @@ func (handler *Handler) ValidateClearDataPassword(c fiber.Ctx) error {
 func (handler *Handler) ClearAllData(c fiber.Ctx) error {
 	user, spec, valid := handler.validateSettingsActionPassword(c)
 	if !valid {
-		handler.logSecurityError(c, "settings.clear_data", spec)
-		return handler.respondMappedError(c, spec)
+		return handler.failMutation(c, clearDataMutation, spec)
 	}
 	if err := handler.settingsService.ClearAllData(c.Context(), user.ID); err != nil {
-		spec := settingsClearDataErrorSpec()
-		handler.logSecurityError(c, "settings.clear_data", spec)
-		return handler.respondMappedError(c, spec)
+		return handler.failMutation(c, clearDataMutation, settingsClearDataErrorSpec())
 	}
 
 	// ClearAllDataAndResetSettings bumps auth_session_version atomically;
@@ -39,11 +53,13 @@ func (handler *Handler) ClearAllData(c fiber.Ctx) error {
 	// wipe is invalidated on its next request. Matches the contract used by
 	// password change, recovery-code regen, and 2FA toggle.
 	user.AuthSessionVersion = services.NormalizeAuthSessionVersion(user.AuthSessionVersion) + 1
-	if err := handler.refreshCurrentSession(c, user, "settings.clear_data"); err != nil {
+	// The session-refresh failures below are auth-plumbing events, not the
+	// erasure itself, so they keep the plain path under the same action name.
+	if err := handler.refreshCurrentSession(c, user, clearDataMutation.action); err != nil {
 		return err
 	}
 
-	handler.logSecurityEvent(c, "settings.clear_data", "success")
+	handler.logMutationSuccess(c, clearDataMutation)
 	if acceptsJSON(c) {
 		return c.JSON(fiber.Map{"ok": true})
 	}
@@ -54,18 +70,15 @@ func (handler *Handler) ClearAllData(c fiber.Ctx) error {
 func (handler *Handler) DeleteAccount(c fiber.Ctx) error {
 	user, spec, valid := handler.validateSettingsActionPassword(c)
 	if !valid {
-		handler.logSecurityError(c, "settings.delete_account", spec)
-		return handler.respondMappedError(c, spec)
+		return handler.failMutation(c, deleteAccountMutation, spec)
 	}
 
 	if err := handler.settingsService.DeleteAccount(c.Context(), user.ID); err != nil {
-		spec := settingsDeleteAccountErrorSpec()
-		handler.logSecurityError(c, "settings.delete_account", spec)
-		return handler.respondMappedError(c, spec)
+		return handler.failMutation(c, deleteAccountMutation, settingsDeleteAccountErrorSpec())
 	}
 
 	handler.clearAuthRelatedCookies(c)
-	handler.logSecurityEvent(c, "settings.delete_account", "success")
+	handler.logMutationSuccess(c, deleteAccountMutation)
 	if acceptsJSON(c) {
 		return c.JSON(fiber.Map{"ok": true})
 	}

--- a/internal/api/security_event_logging_mutation_regression_test.go
+++ b/internal/api/security_event_logging_mutation_regression_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+	"fmt"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -246,5 +247,158 @@ func TestUpsertDayLogsSanitizedPathWithoutConcreteDate(t *testing.T) {
 	}
 	if strings.Contains(logLine, "2026-02-17") {
 		t.Fatalf("did not expect concrete health date in mutation logs: %q", logLine)
+	}
+}
+
+// captureDangerZoneAudit drives one danger-zone request against an app with the
+// audit stream on and returns the response together with the security-event
+// output that request produced. The log writer is swapped around the request
+// only, so the captured text holds the handler's own lines and not the sign-in
+// that built the context.
+func captureDangerZoneAudit(t *testing.T, ctx settingsSecurityTestContext, method string, path string, form url.Values) (*http.Response, string) {
+	t.Helper()
+
+	originalWriter := log.Writer()
+	defer log.SetOutput(originalWriter)
+	var output bytes.Buffer
+	log.SetOutput(&output)
+
+	response := settingsFormRequestWithCSRF(t, ctx, method, path, form, map[string]string{
+		"Accept": "application/json",
+	})
+	return response, output.String()
+}
+
+// assertHealthDataMutationAudited pins the three fields the typed mutation
+// mechanism is responsible for: the wire-visible action name operators filter
+// on, the health-data domain tag, and a non-empty target naming what was
+// touched. A handler that logs through the plain security-event path emits the
+// action alone, so the domain/target assertions are what catch the regression.
+func assertHealthDataMutationAudited(t *testing.T, logOutput string, action string, outcome string, target string) {
+	t.Helper()
+
+	header := fmt.Sprintf("security event: action=%q outcome=%q", action, outcome)
+	if !strings.Contains(logOutput, header) {
+		t.Fatalf("expected %s audit line, got %q", header, logOutput)
+	}
+	if !strings.Contains(logOutput, `domain="health_data"`) {
+		t.Fatalf("expected %s to be tagged domain=\"health_data\", got %q", action, logOutput)
+	}
+	if target == "" {
+		t.Fatalf("expected a non-empty target for %s", action)
+	}
+	if !strings.Contains(logOutput, fmt.Sprintf("target=%q", target)) {
+		t.Fatalf("expected %s to carry target=%q, got %q", action, target, logOutput)
+	}
+}
+
+// TestClearAllDataIsAuditedAsHealthDataMutation covers the two branches that
+// erase an owner's tracked data: the accepted wipe and the denial that stops
+// one. Both are health-data mutations and must be greppable as such.
+func TestClearAllDataIsAuditedAsHealthDataMutation(t *testing.T) {
+	ctx := newSettingsSecurityTestContextWithOptions(t, "settings-clear-data-audit@example.com", onboardingTestAppOptions{enableCSRF: true, auditLogEnabled: true})
+
+	denied, deniedLog := captureDangerZoneAudit(t, ctx, http.MethodPost, "/api/v1/users/current/data-wipe", url.Values{
+		"password": {"WrongPass1"},
+	})
+	defer func() { _ = denied.Body.Close() }()
+
+	if denied.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected status 401 for a wrong clear-data password, got %d", denied.StatusCode)
+	}
+	assertHealthDataMutationAudited(t, deniedLog, "settings.clear_data", "denied", "account_data")
+	if !strings.Contains(deniedLog, `reason="invalid password"`) {
+		t.Fatalf("expected the denial reason to survive the mutation path, got %q", deniedLog)
+	}
+
+	accepted, acceptedLog := captureDangerZoneAudit(t, ctx, http.MethodPost, "/api/v1/users/current/data-wipe", url.Values{
+		"password": {"StrongPass1"},
+	})
+	defer func() { _ = accepted.Body.Close() }()
+
+	if accepted.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200 for an accepted clear-data request, got %d", accepted.StatusCode)
+	}
+	assertHealthDataMutationAudited(t, acceptedLog, "settings.clear_data", "success", "account_data")
+	if strings.Contains(acceptedLog, ctx.user.Email) {
+		t.Fatalf("did not expect the owner's email in an erasure audit line: %q", acceptedLog)
+	}
+}
+
+// TestDeleteAccountIsAuditedAsHealthDataMutation is the delete-account half of
+// the same contract: the account and everything attached to it is health data,
+// so its audit line carries the domain and a target naming the erased scope.
+func TestDeleteAccountIsAuditedAsHealthDataMutation(t *testing.T) {
+	ctx := newSettingsSecurityTestContextWithOptions(t, "settings-delete-account-audit@example.com", onboardingTestAppOptions{enableCSRF: true, auditLogEnabled: true})
+
+	denied, deniedLog := captureDangerZoneAudit(t, ctx, http.MethodDelete, "/api/v1/users/current", url.Values{})
+	defer func() { _ = denied.Body.Close() }()
+
+	if denied.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected status 400 for a missing delete-account password, got %d", denied.StatusCode)
+	}
+	assertHealthDataMutationAudited(t, deniedLog, "settings.delete_account", "denied", "account")
+	if !strings.Contains(deniedLog, `reason="invalid password"`) {
+		t.Fatalf("expected the denial reason to survive the mutation path, got %q", deniedLog)
+	}
+
+	accepted, acceptedLog := captureDangerZoneAudit(t, ctx, http.MethodDelete, "/api/v1/users/current", url.Values{
+		"password": {"StrongPass1"},
+	})
+	defer func() { _ = accepted.Body.Close() }()
+
+	if accepted.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200 for an accepted delete-account request, got %d", accepted.StatusCode)
+	}
+	assertHealthDataMutationAudited(t, acceptedLog, "settings.delete_account", "success", "account")
+	if strings.Contains(acceptedLog, ctx.user.Email) {
+		t.Fatalf("did not expect the owner's email in an erasure audit line: %q", acceptedLog)
+	}
+}
+
+// TestErasureStorageFailuresAreAuditedAsHealthDataMutations covers the branch
+// neither handler reaches on a healthy instance: the password was accepted and
+// the erasure itself failed. Both erasure transactions start at daily_logs, so
+// dropping that table fails them without disturbing the users table the auth
+// middleware reads — and leaves the account in place, so one signed-in context
+// exercises both handlers. A 5xx outcome is "failure", not "denied".
+func TestErasureStorageFailuresAreAuditedAsHealthDataMutations(t *testing.T) {
+	ctx := newSettingsSecurityTestContextWithOptions(t, "settings-erasure-failure-audit@example.com", onboardingTestAppOptions{enableCSRF: true, auditLogEnabled: true})
+	if err := ctx.database.Exec("DROP TABLE daily_logs").Error; err != nil {
+		t.Fatalf("drop daily_logs: %v", err)
+	}
+
+	clearData, clearDataLog := captureDangerZoneAudit(t, ctx, http.MethodPost, "/api/v1/users/current/data-wipe", url.Values{
+		"password": {"StrongPass1"},
+	})
+	defer func() { _ = clearData.Body.Close() }()
+
+	if clearData.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected status 500 once clear-data storage is gone, got %d", clearData.StatusCode)
+	}
+	assertHealthDataMutationAudited(t, clearDataLog, "settings.clear_data", "failure", "account_data")
+	if !strings.Contains(clearDataLog, `reason="failed to clear data"`) {
+		t.Fatalf("expected the mapped clear-data failure reason, got %q", clearDataLog)
+	}
+
+	deleteAccount, deleteAccountLog := captureDangerZoneAudit(t, ctx, http.MethodDelete, "/api/v1/users/current", url.Values{
+		"password": {"StrongPass1"},
+	})
+	defer func() { _ = deleteAccount.Body.Close() }()
+
+	if deleteAccount.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected status 500 once delete-account storage is gone, got %d", deleteAccount.StatusCode)
+	}
+	assertHealthDataMutationAudited(t, deleteAccountLog, "settings.delete_account", "failure", "account")
+	if !strings.Contains(deleteAccountLog, `reason="failed to delete account"`) {
+		t.Fatalf("expected the mapped delete-account failure reason, got %q", deleteAccountLog)
+	}
+
+	var usersCount int64
+	if err := ctx.database.Model(&models.User{}).Where("id = ?", ctx.user.ID).Count(&usersCount).Error; err != nil {
+		t.Fatalf("count users: %v", err)
+	}
+	if usersCount != 1 {
+		t.Fatalf("expected a failed erasure to leave the account in place, got count=%d", usersCount)
 	}
 }


### PR DESCRIPTION
## Problem

`internal/api/handlers_settings_danger.go` logged the two most destructive
health-data operations through the plain security-event path, with their action
names written out as string literals at each call site:

```go
handler.logSecurityError(c, "settings.clear_data", spec)
handler.logSecurityEvent(c, "settings.delete_account", "success")
```

The typed mechanism next door (`security_event_logging.go`) exists precisely to
prevent that: a file-level `healthMutationKind` logged via
`failMutation`/`logMutationError`/`logMutationSuccess`, which stamps
`domain="health_data"` and a `target` onto the line. Fourteen other mutation
kinds already declare it; these two did not.

The consequence is in the audit stream, not in behavior. A day write or a
symptom edit emitted `domain="health_data" target="day_entry"`, while a full
data wipe and an account deletion emitted the action alone. An operator
filtering an incident on the domain to answer "was any tracked data destroyed?"
selected every routine edit and missed both operations that erase everything.

## Change

Both handlers declare a kind and log through it. The `target` names the scope
the operation acts on, in the same register as the existing kinds
(`day_entry`, `calendar_feed`, `cycle_settings`): `account_data` for the wipe,
`account` for the deletion. Neither carries an identifier, an email, or
submitted text.

`settings.clear_data_validate` is the password-only pre-check behind the
confirmation dialog. It mutates nothing, so it deliberately stays on the plain
path — but its name moves to a file-level const, leaving no event-name literal
at any call site in the file.

Logging shape only. Same events on the same branches, same reasons, same status
codes; `AuthSessionVersion` handling is untouched.

## Wire-visible effect

The `action` values are unchanged (`settings.clear_data`,
`settings.delete_account`), so existing operator filters keep matching. Each of
those lines gains two fields:

```
action="settings.clear_data" outcome="success" ... domain="health_data" target="account_data"
action="settings.delete_account" outcome="denied" ... domain="health_data" target="account" reason="invalid password"
```

`CHANGELOG.md` records the added fields, and `docs/security/logging.md` — which
showed `domain`/`target` in its example without ever explaining them — now
states which actions carry them and what the target may contain.

## Tests

`security_event_logging_mutation_regression_test.go` gains three cases, each
asserting action + `domain="health_data"` + target:

- `TestClearAllDataIsAuditedAsHealthDataMutation` — denied (wrong password) and
  success.
- `TestDeleteAccountIsAuditedAsHealthDataMutation` — denied (missing password)
  and success.
- `TestErasureStorageFailuresAreAuditedAsHealthDataMutations` — the 5xx branch
  of both handlers, which no test reached before. Both erasure transactions
  start at `daily_logs`, so dropping that table fails them without disturbing
  the `users` table the auth middleware reads, and leaves the account standing
  so one signed-in context covers both. Pins `outcome="failure"` rather than
  `"denied"`.

The success cases also assert the owner's email never appears in an erasure
audit line.

### Proof of regression

Each new assertion was proven against the original defect by restoring the bare
literal call and confirming the failure names the missing control:

```
expected settings.clear_data to be tagged domain="health_data", got
"security event: action=\"settings.clear_data\" outcome=\"success\" method=\"POST\"
 path=\"/api/v1/users/current/data-wipe\" format=\"json\" user_id=\"1\" role=\"owner\"\n"

expected settings.delete_account to be tagged domain="health_data", got
"security event: action=\"settings.delete_account\" outcome=\"denied\" method=\"DELETE\"
 path=\"/api/v1/users/current\" format=\"json\" user_id=\"1\" role=\"owner\" reason=\"invalid password\"\n"
```

## Verification

`gofmt`, `go build ./...`, `go vet ./...`, full `go test ./...` green; patch
coverage gate reports every modified coverable line covered.
