### PR TITLE
fix(api): name the owner in audit events from the step-up callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,18 +138,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   drills are now specified against a populated stack: an empty target is the one
   case where a broken restore procedure still looks correct.
 
-- **An erasure confirmed through SSO now names the owner it erased.** The audit
-  stream takes the actor from the request context, and only the authenticated-
-  route middleware published it there. The two step-up completion handlers
-  resolve their session themselves — `/auth/oidc/callback` cannot carry that
-  middleware, because ordinary sign-in has to work for a visitor with no session
-  — so every event they emitted was unattributed, including the health-data
-  mutation recording a cleared diary or a deleted account. On an instance
-  hosting more than one owner, the two most destructive operations in the
-  product left a log line that did not say whose data they touched. The session
-  resolver now publishes the actor for the whole request, which covers both
-  step-up purposes and any handler that resolves a session the same way later.
-
 - **The language switch is rate-limited.** `POST /lang` is the one
   unauthenticated route outside `/api` that reads a request body, so the `/api`
   budget's path prefix never reached it and it was the only body-reading
@@ -359,6 +347,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the file from being moved or deleted. The connection is now released on any
   failure that happens after it is open, and the error reported to the operator
   is still the migration failure that caused it.
+
+- **An erasure confirmed through SSO now names the owner it erased.** The audit
+  stream takes the actor from the request context, and only the authenticated-
+  route middleware published it there. The two step-up completion handlers
+  resolve their session themselves — `/auth/oidc/callback` cannot carry that
+  middleware, because ordinary sign-in has to work for a visitor with no session
+  — so every event they emitted was unattributed, including the health-data
+  mutation recording a cleared diary or a deleted account. On an instance
+  hosting more than one owner, the two most destructive operations in the
+  product left a log line that did not say whose data they touched. The session
+  resolver now publishes the actor for the whole request, which covers both
+  step-up purposes and any handler that resolves a session the same way later.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **An erasure confirmed through SSO now names the owner it erased.** The audit
+  stream takes the actor from the request context, and only the authenticated-
+  route middleware published it there. The two step-up completion handlers
+  resolve their session themselves — `/auth/oidc/callback` cannot carry that
+  middleware, because ordinary sign-in has to work for a visitor with no session
+  — so every event they emitted was unattributed, including the health-data
+  mutation recording a cleared diary or a deleted account. On an instance
+  hosting more than one owner, the two most destructive operations in the
+  product left a log line that did not say whose data they touched. The session
+  resolver now publishes the actor for the whole request, which covers both
+  step-up purposes and any handler that resolves a session the same way later.
+
 - **The language switch is rate-limited.** `POST /lang` is the one
   unauthenticated route outside `/api` that reads a request body, so the `/api`
   budget's path prefix never reached it and it was the only body-reading

--- a/internal/api/middleware_auth_helpers.go
+++ b/internal/api/middleware_auth_helpers.go
@@ -67,5 +67,13 @@ func (handler *Handler) authenticateRequest(c fiber.Ctx) (*models.User, error) {
 	}
 
 	c.Locals(contextAuthSessionKey, claims)
+	// Publish the actor for the whole request, not only on routes that reach
+	// here through AuthRequired. The two step-up completion handlers resolve
+	// their session by calling this directly (the OIDC callback cannot carry
+	// AuthRequired, because ordinary sign-in has to work for a visitor with no
+	// session), and emitSecurityEvent reads the actor from this key — so
+	// without it, erasure performed through the callback logs a health-data
+	// mutation that does not name the owner whose data it erased.
+	c.Locals(contextUserKey, user)
 	return user, nil
 }

--- a/internal/api/security_event_logging_mutation_regression_test.go
+++ b/internal/api/security_event_logging_mutation_regression_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -267,6 +268,103 @@ func captureDangerZoneAudit(t *testing.T, ctx settingsSecurityTestContext, metho
 		"Accept": "application/json",
 	})
 	return response, output.String()
+}
+
+// assertSecurityEventNamesActor asserts that the one audit line carrying the
+// given action/outcome header names the owner it acted for. It matches the
+// line rather than the whole buffer on purpose: a request emits several
+// events, and a buffer-wide search for user_id passes as long as any one of
+// them is attributed.
+func assertSecurityEventNamesActor(t *testing.T, logOutput string, action string, outcome string, userID uint) {
+	t.Helper()
+
+	header := fmt.Sprintf("security event: action=%q outcome=%q", action, outcome)
+	for _, line := range strings.Split(logOutput, "\n") {
+		if !strings.Contains(line, header) {
+			continue
+		}
+		if !strings.Contains(line, fmt.Sprintf("user_id=%q", strconv.FormatUint(uint64(userID), 10))) {
+			t.Fatalf("%s must name the owner it acted for, got %q", header, line)
+		}
+		if !strings.Contains(line, fmt.Sprintf("role=%q", models.RoleOwner)) {
+			t.Fatalf("%s must carry the actor's role, got %q", header, line)
+		}
+		return
+	}
+	t.Fatalf("expected an audit line for %s, got %q", header, logOutput)
+}
+
+// captureStepupCallbackAudit drives an OIDC step-up callback with the audit
+// stream captured, and returns the response together with the emitted lines.
+func captureStepupCallbackAudit(t *testing.T, fixture *oidcStepupFixture, stepupCookie string, state string) (*http.Response, string) {
+	t.Helper()
+
+	originalWriter := log.Writer()
+	defer log.SetOutput(originalWriter)
+	var output bytes.Buffer
+	log.SetOutput(&output)
+
+	response := postOIDCStepupCallback(t, fixture, stepupCookie, state, "callback-code")
+	return response, output.String()
+}
+
+// TestStepupCallbacksAuditTheOwnerTheyActFor covers the two completion
+// handlers that resolve their session by calling authenticateRequest directly
+// instead of sitting behind AuthRequired: /auth/oidc/callback cannot carry
+// that middleware, because ordinary sign-in has to work for a visitor with no
+// session. The actor has to be published anyway — an erasure that names no
+// owner is unusable in a review of an instance hosting more than one, which is
+// exactly the household case this product supports. Both purposes are covered
+// because the gap belongs to the shared resolver, not to either flow.
+func TestStepupCallbacksAuditTheOwnerTheyActFor(t *testing.T) {
+	t.Parallel()
+
+	t.Run("erasure", func(t *testing.T) {
+		t.Parallel()
+
+		fixture := newOIDCStepupFixtureWithAudit(t, "stepup-audit-erasure@example.com", true)
+		fixture.oidcStub.reauthErr = nil
+		seedStepupDayEntry(t, fixture)
+
+		startResponse := postErasureStepupStart(t, fixture, "/api/v1/users/current/data-wipe/step-up")
+		defer func() { _ = startResponse.Body.Close() }()
+		if startResponse.StatusCode != http.StatusOK {
+			t.Fatalf("expected 200 from the clear-data step-up start, got %d", startResponse.StatusCode)
+		}
+
+		stepupCookie := readStepupCookie(t, startResponse)
+		state := extractStepupCallbackState(t, fixture, stepupCookie)
+
+		callbackResponse, auditLog := captureStepupCallbackAudit(t, fixture, stepupCookie, state)
+		defer func() { _ = callbackResponse.Body.Close() }()
+
+		if got := countStepupDayEntries(t, fixture); got != 0 {
+			t.Fatalf("expected the callback to erase the diary, day entries = %d", got)
+		}
+		assertHealthDataMutationAudited(t, auditLog, "settings.clear_data", "success", "account_data")
+		assertSecurityEventNamesActor(t, auditLog, "settings.clear_data", "success", fixture.user.ID)
+	})
+
+	t.Run("local password setup", func(t *testing.T) {
+		t.Parallel()
+
+		fixture := newOIDCStepupFixtureWithAudit(t, "stepup-audit-password@example.com", true)
+		fixture.oidcStub.reauthErr = nil
+
+		startResponse := fixture.postStart(t, "EvenStronger2", "EvenStronger2")
+		defer func() { _ = startResponse.Body.Close() }()
+		if startResponse.StatusCode != http.StatusOK {
+			t.Fatalf("expected 200 from the password step-up start, got %d", startResponse.StatusCode)
+		}
+
+		stepupCookie := readStepupCookie(t, startResponse)
+		state := extractStepupCallbackState(t, fixture, stepupCookie)
+
+		callbackResponse, auditLog := captureStepupCallbackAudit(t, fixture, stepupCookie, state)
+		defer func() { _ = callbackResponse.Body.Close() }()
+
+		assertSecurityEventNamesActor(t, auditLog, "auth.local_password_setup.callback", "success", fixture.user.ID)
+	})
 }
 
 // assertHealthDataMutationAudited pins the three fields the typed mutation

--- a/internal/api/settings_oidc_local_password_setup_test.go
+++ b/internal/api/settings_oidc_local_password_setup_test.go
@@ -36,15 +36,24 @@ type oidcStepupFixture struct {
 
 func newOIDCStepupFixture(t *testing.T, email string) *oidcStepupFixture {
 	t.Helper()
+	return newOIDCStepupFixtureWithAudit(t, email, false)
+}
+
+// newOIDCStepupFixtureWithAudit builds the same fixture with the audit stream
+// switchable, so an attribution regression can read the security-event lines
+// the step-up callbacks emit.
+func newOIDCStepupFixtureWithAudit(t *testing.T, email string, auditLogEnabled bool) *oidcStepupFixture {
+	t.Helper()
 
 	stub := newStubOIDCWorkflowService(true)
 	stub.localPublicAuthEnabled = true
 	stub.reauthURL = "https://id.example.com/authorize?prompt=login"
 
 	app, database := newOnboardingTestAppWithOptions(t, onboardingTestAppOptions{
-		enableCSRF:   true,
-		cookieSecure: true,
-		oidcService:  stub,
+		enableCSRF:      true,
+		cookieSecure:    true,
+		oidcService:     stub,
+		auditLogEnabled: auditLogEnabled,
 	})
 
 	user := models.User{


### PR DESCRIPTION
## What is wrong

`emitSecurityEvent` resolves the actor from the request context (`contextUserKey`), and only `AuthRequired` published it there. Both OIDC step-up **completion** handlers resolve their session by calling `authenticateRequest` directly, because `/auth/oidc/callback` cannot carry `AuthRequired` — ordinary sign-in has to work for a visitor with no session.

Every security event those handlers emitted was therefore unattributed, including the health-data mutation that records an erasure:

```
security event: action="settings.clear_data" outcome="success" method="POST"
  path="/auth/oidc/callback" format="json" domain="health_data" target="account_data"
```

No `user_id`, no `role`. The password-gated route emits the same line **with** both fields. An instance may host several independent owners, so the two most destructive operations in the product left a record that does not say whose data they touched — while `docs/security/logging.md` promises `user_id` for authenticated requests.

This is not new with the erasure step-up: the local-password-setup callback has emitted unattributed events since it landed. The gap belongs to the shared resolver, so it is fixed there rather than at either call site.

## The fix

`authenticateRequest` publishes the actor for the whole request, next to the auth-session claims it already publishes.

`AuthRequired` keeps its own assignment. The repository treats layered auth checks as defense-in-depth rather than transitive (`OwnerOnly` is required even where `AuthRequired` already rejects), and a later change to the resolver should not silently drop attribution on every authenticated route.

**Blast radius checked, not assumed.** Six call sites resolve a session this way. The consumers that branch on the actor (`currentUserOrRedirectToLogin`, `currentUserOrUnauthorized`, `OwnerOnly`) all sit behind `AuthRequired`, which published the actor already, so no authorization decision changes. The remaining callers — the not-found handler, the auth pages, the public pages — either publish the actor themselves today or take it as a return value; none of them consults the context key afterwards. What changes is that events emitted on those paths are now attributed, which is the point.

## Regression

`TestStepupCallbacksAuditTheOwnerTheyActFor` drives both step-up purposes end to end through the real callback and asserts on the **specific** audit line rather than the buffer: a request emits several events, and a buffer-wide search for `user_id` passes as long as any one of them is attributed.

Proof on the original defect (required for a security fix) — with the publish removed, both halves fail and name the culprit:

```
--- FAIL: TestStepupCallbacksAuditTheOwnerTheyActFor/erasure
    security event: action="settings.clear_data" outcome="success" must name the owner it
    acted for, got "... domain=\"health_data\" target=\"account_data\""
--- FAIL: TestStepupCallbacksAuditTheOwnerTheyActFor/local_password_setup
    security event: action="auth.local_password_setup.callback" outcome="success" must name
    the owner it acted for, got "... format=\"json\""
```

## Checks

`go build ./...`, `go vet ./internal/api/`, full `go test ./internal/api/` green (262s). Patch-coverage gate run **after** committing, with the profile generated in the same invocation: every modified coverable line covered.