### PR TITLE
docs(openapi): match the recovery-code pattern to what the server accepts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`docs/openapi.yaml` described a recovery code almost no real code could
+  pass.** `ForgotPasswordRequest.recovery_code` declared
+  `pattern: "^OVUM-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}$"` — hex digits only —
+  while `GenerateRecoveryCode` draws each of the 12 random characters from a
+  32-symbol Crockford-style alphabet (`A`–`Z` without the visually-ambiguous
+  `I`/`O`, plus `2`–`9`), of which only 14 symbols are also hex digits: a real
+  code matched the documented pattern with probability `(14/32)^12 ≈ 4.9e-5`
+  — roughly 1 in 20,000. Recovery is the last path back into a locked-out
+  owner's account, so a client that validates a request against the published
+  spec before sending it — the same failure class as the `2fa-challenge`
+  content-type gap documented elsewhere in this list — could not complete it
+  for all but a vanishing fraction of real codes.
+
+  The pattern now documents the class the server actually accepts
+  (`ValidateRecoveryCodeFormat`, `[A-Z0-9]`) rather than the hex subset, or
+  the generator's own narrower alphabet — the server deliberately accepts a
+  wider class than it generates, so pinning the pattern to the generator's
+  exact alphabet would have reproduced the same defect in milder form.
+  `TestOpenAPIRecoveryCodePatternAcceptsGeneratedCodes` pins the documented
+  pattern against both real generated codes and the server validator's
+  accepted character class, with a proof-on-defect regression against the
+  original hex-only pattern.
+
+  The same sweep, run across every `pattern`, `enum`, and numeric bound in
+  the spec, found three more entries narrower than what the server accepts:
+  the language enum on `InterfaceSettings.language` and `POST /lang` was
+  missing `it`, a fully supported locale; `POST /lang` additionally
+  documented its form field as `language`, while the handler reads `lang` —
+  so a client sending the documented field name could not set the language
+  to any value, not only `it`; and `OnboardingStep2Request.cycle_length`
+  declared `14`–`60` where the server accepts `15`–`90`, understating
+  onboarding's real cycle-length range. All three are description-only
+  fixes — no application behavior changed.
+
 - **The language switch is rate-limited.** `POST /lang` is the one
   unauthenticated route outside `/api` that reads a request body, so the `/api`
   budget's path prefix never reached it and it was the only body-reading

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,40 +138,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   drills are now specified against a populated stack: an empty target is the one
   case where a broken restore procedure still looks correct.
 
-- **`docs/openapi.yaml` described a recovery code almost no real code could
-  pass.** `ForgotPasswordRequest.recovery_code` declared
-  `pattern: "^OVUM-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}$"` — hex digits only —
-  while `GenerateRecoveryCode` draws each of the 12 random characters from a
-  32-symbol Crockford-style alphabet (`A`–`Z` without the visually-ambiguous
-  `I`/`O`, plus `2`–`9`), of which only 14 symbols are also hex digits: a real
-  code matched the documented pattern with probability `(14/32)^12 ≈ 4.9e-5`
-  — roughly 1 in 20,000. Recovery is the last path back into a locked-out
-  owner's account, so a client that validates a request against the published
-  spec before sending it — the same failure class as the `2fa-challenge`
-  content-type gap documented elsewhere in this list — could not complete it
-  for all but a vanishing fraction of real codes.
-
-  The pattern now documents the class the server actually accepts
-  (`ValidateRecoveryCodeFormat`, `[A-Z0-9]`) rather than the hex subset, or
-  the generator's own narrower alphabet — the server deliberately accepts a
-  wider class than it generates, so pinning the pattern to the generator's
-  exact alphabet would have reproduced the same defect in milder form.
-  `TestOpenAPIRecoveryCodePatternAcceptsGeneratedCodes` pins the documented
-  pattern against both real generated codes and the server validator's
-  accepted character class, with a proof-on-defect regression against the
-  original hex-only pattern.
-
-  The same sweep, run across every `pattern`, `enum`, and numeric bound in
-  the spec, found three more entries narrower than what the server accepts:
-  the language enum on `InterfaceSettings.language` and `POST /lang` was
-  missing `it`, a fully supported locale; `POST /lang` additionally
-  documented its form field as `language`, while the handler reads `lang` —
-  so a client sending the documented field name could not set the language
-  to any value, not only `it`; and `OnboardingStep2Request.cycle_length`
-  declared `14`–`60` where the server accepts `15`–`90`, understating
-  onboarding's real cycle-length range. All three are description-only
-  fixes — no application behavior changed.
-
 - **The language switch is rate-limited.** `POST /lang` is the one
   unauthenticated route outside `/api` that reads a request body, so the `/api`
   budget's path prefix never reached it and it was the only body-reading
@@ -247,6 +213,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   far outside any legitimate request including a full-size import), and one that
   outlives its budget answers `503` with the stable key `request_timeout` instead
   of whatever internal `500` the domain that caught the expiry happened to map.
+
+- **`docs/openapi.yaml` described a recovery code almost no real code could
+  pass.** `ForgotPasswordRequest.recovery_code` declared
+  `pattern: "^OVUM-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}$"` — hex digits only —
+  while `GenerateRecoveryCode` draws each of the 12 random characters from a
+  32-symbol Crockford-style alphabet (`A`–`Z` without the visually-ambiguous
+  `I`/`O`, plus `2`–`9`), of which only 14 symbols are also hex digits: a real
+  code matched the documented pattern with probability `(14/32)^12 ≈ 4.9e-5`
+  — roughly 1 in 20,000. Recovery is the last path back into a locked-out
+  owner's account, so a client that validates a request against the published
+  spec before sending it — the same failure class as the `2fa-challenge`
+  content-type gap documented elsewhere in this list — could not complete it
+  for all but a vanishing fraction of real codes.
+
+  The pattern now documents the class the server actually accepts
+  (`ValidateRecoveryCodeFormat`, `[A-Z0-9]`) rather than the hex subset, or
+  the generator's own narrower alphabet — the server deliberately accepts a
+  wider class than it generates, so pinning the pattern to the generator's
+  exact alphabet would have reproduced the same defect in milder form.
+  `TestOpenAPIRecoveryCodePatternAcceptsGeneratedCodes` pins the documented
+  pattern against both real generated codes and the server validator's
+  accepted character class, with a proof-on-defect regression against the
+  original hex-only pattern.
+
+  The same sweep, run across every `pattern`, `enum`, and numeric bound in
+  the spec, found three more entries narrower than what the server accepts:
+  the language enum on `InterfaceSettings.language` and `POST /lang` was
+  missing `it`, a fully supported locale; `POST /lang` additionally
+  documented its form field as `language`, while the handler reads `lang` —
+  so a client sending the documented field name could not set the language
+  to any value, not only `it`; and `OnboardingStep2Request.cycle_length`
+  declared `14`–`60` where the server accepts `15`–`90`, understating
+  onboarding's real cycle-length range. All three are description-only
+  fixes — no application behavior changed.
 
 - **`ovumcy reset-password` can be run without an interactive terminal.** It is
   the operator's documented way back in for an owner locked out by a

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -352,8 +352,19 @@ components:
           format: email
         recovery_code:
           type: string
-          pattern: "^OVUM-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}$"
-          description: Single-use recovery code minted at registration or by `POST /api/v1/users/current/recovery-code`.
+          pattern: "^OVUM-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}$"
+          description: >-
+            Single-use recovery code minted at registration or by `POST
+            /api/v1/users/current/recovery-code`. The pattern documents the
+            server's accepted request shape (`ValidateRecoveryCodeFormat` in
+            `internal/services/auth_input_policy.go`), which is deliberately
+            wider than the alphabet `GenerateRecoveryCode`
+            (`internal/services/auth_reset_policy.go`) actually emits —
+            Crockford-style base32 excluding `I`/`O`/`0`/`1` to avoid
+            visually-ambiguous characters. Narrowing this pattern to the
+            generator's exact alphabet would reintroduce the same defect this
+            fixes in milder form: a spec-following client would reject some
+            fraction of codes the server would otherwise accept.
       additionalProperties: false
 
     ResetPasswordRequest:
@@ -697,7 +708,7 @@ components:
       properties:
         language:
           type: string
-          enum: [en, ru, es, fr, de]
+          enum: [en, ru, es, fr, de, it]
         theme:
           type: string
 
@@ -863,8 +874,8 @@ components:
       properties:
         cycle_length:
           type: integer
-          minimum: 14
-          maximum: 60
+          minimum: 15
+          maximum: 90
         period_length:
           type: integer
           minimum: 1
@@ -925,11 +936,12 @@ paths:
           application/x-www-form-urlencoded:
             schema:
               type: object
-              required: [language, csrf_token]
+              required: [lang, csrf_token]
               properties:
-                language:
+                lang:
                   type: string
-                  enum: [en, ru, es, fr, de]
+                  enum: [en, ru, es, fr, de, it]
+                  description: Form field name is `lang` (the handler reads `c.FormValue("lang")`) — distinct from the `language` JSON field on `PATCH /api/v1/users/current/interface`.
                 csrf_token: { type: string }
       responses:
         '200':

--- a/internal/api/openapi_contract_test.go
+++ b/internal/api/openapi_contract_test.go
@@ -3,11 +3,13 @@ package api
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"testing"
 
 	"github.com/gofiber/fiber/v3"
+	"github.com/ovumcy/ovumcy-web/internal/services"
 )
 
 // TestOpenAPIContractMatchesRegisteredRoutes is the route↔spec contract guard:
@@ -144,4 +146,87 @@ func difference(a, b map[string]struct{}) []string {
 	}
 	sort.Strings(only)
 	return only
+}
+
+// openAPIRecoveryCodePatternLine finds the `pattern: "^OVUM-..."` line
+// declared for ForgotPasswordRequest.recovery_code. It is the only `pattern:`
+// line in the spec starting with "^OVUM-", so a plain line scan identifies it
+// unambiguously without needing to track YAML nesting.
+var openAPIRecoveryCodePatternLine = regexp.MustCompile(`(?m)^\s*pattern:\s*"(\^OVUM-[^"]*)"\s*$`)
+
+// openAPIRecoveryCodePattern extracts and compiles the `pattern` declared for
+// ForgotPasswordRequest.recovery_code in the OpenAPI spec. Like
+// openAPIV1Routes above, it scans the raw text rather than pulling in a YAML
+// library, matching this file's dependency-free convention.
+func openAPIRecoveryCodePattern(t *testing.T, specPath string) *regexp.Regexp {
+	t.Helper()
+	data, err := os.ReadFile(specPath)
+	if err != nil {
+		t.Fatalf("read openapi spec: %v", err)
+	}
+
+	match := openAPIRecoveryCodePatternLine.FindSubmatch(data)
+	if match == nil {
+		t.Fatalf(`docs/openapi.yaml: no recovery_code pattern line found (expected pattern: "^OVUM-...")`)
+	}
+
+	compiled, err := regexp.Compile(string(match[1]))
+	if err != nil {
+		t.Fatalf("docs/openapi.yaml recovery_code pattern %q does not compile: %v", match[1], err)
+	}
+	return compiled
+}
+
+// TestOpenAPIRecoveryCodePatternAcceptsGeneratedCodes pins the recovery-code
+// request-contract class: docs/openapi.yaml declares a `pattern` for
+// ForgotPasswordRequest.recovery_code, and that pattern must accept every
+// code services.GenerateRecoveryCode can actually mint, and must classify
+// input exactly as services.ValidateRecoveryCodeFormat does — the server's
+// own request-shape check (internal/services/auth_input_policy.go), which
+// password_reset_service.go runs on every /api/v1/password-resets request. A
+// pattern narrower than either rejects a legitimate password-reset attempt
+// for any client that validates requests against the spec before sending
+// them — the last path back into a locked-out owner's account.
+//
+// The spec previously declared "^OVUM-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}$"
+// (hex digits only), which a real generated code — drawn from a 32-symbol
+// Crockford-style alphabet, only 14 of whose symbols are also hex digits —
+// matched with probability (14/32)^12 ~= 4.9e-5, i.e. roughly 1 in 20,000.
+func TestOpenAPIRecoveryCodePatternAcceptsGeneratedCodes(t *testing.T) {
+	specPattern := openAPIRecoveryCodePattern(t, filepath.Join("..", "..", "docs", "openapi.yaml"))
+
+	// Every code the generator can actually mint must pass both the
+	// documented pattern and the server's own validator. A single sample
+	// is not enough: the generator draws independently per character from
+	// its alphabet, so a pattern that rejects only some characters can
+	// still pass on a lucky draw. Enough iterations make that negligible.
+	for i := 0; i < 500; i++ {
+		code, err := services.GenerateRecoveryCode()
+		if err != nil {
+			t.Fatalf("services.GenerateRecoveryCode: %v", err)
+		}
+		if !specPattern.MatchString(code) {
+			t.Fatalf("docs/openapi.yaml recovery_code pattern %q rejects a real generated code %q", specPattern.String(), code)
+		}
+		if err := services.ValidateRecoveryCodeFormat(code); err != nil {
+			t.Fatalf("services.ValidateRecoveryCodeFormat rejected a real generated code %q: %v", code, err)
+		}
+	}
+
+	// The documented pattern must also agree with the server's validator on
+	// the accepted character class itself, not only on generator output:
+	// ValidateRecoveryCodeFormat deliberately accepts a wider class
+	// ([A-Z0-9]) than the generator emits (it excludes ambiguous I/O/0/1),
+	// so the spec must mirror the SERVER's accepted class, not the
+	// generator's narrower alphabet. Check every alphanumeric character in
+	// each of the three 4-character groups.
+	for _, r := range "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789" {
+		group := strings.Repeat(string(r), 4)
+		sample := "OVUM-" + group + "-2222-3333"
+		specAccepts := specPattern.MatchString(sample)
+		serverAccepts := services.ValidateRecoveryCodeFormat(sample) == nil
+		if specAccepts != serverAccepts {
+			t.Fatalf("docs/openapi.yaml recovery_code pattern disagrees with services.ValidateRecoveryCodeFormat for character %q: spec accepts=%v, server accepts=%v (sample %q)", r, specAccepts, serverAccepts, sample)
+		}
+	}
 }

--- a/internal/api/openapi_contract_test.go
+++ b/internal/api/openapi_contract_test.go
@@ -200,7 +200,7 @@ func TestOpenAPIRecoveryCodePatternAcceptsGeneratedCodes(t *testing.T) {
 	// is not enough: the generator draws independently per character from
 	// its alphabet, so a pattern that rejects only some characters can
 	// still pass on a lucky draw. Enough iterations make that negligible.
-	for i := 0; i < 500; i++ {
+	for range 500 {
 		code, err := services.GenerateRecoveryCode()
 		if err != nil {
 			t.Fatalf("services.GenerateRecoveryCode: %v", err)


### PR DESCRIPTION
## Summary

- `ForgotPasswordRequest.recovery_code` declared `pattern: "^OVUM-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}$"` (hex digits only). `GenerateRecoveryCode` draws each of a code's 12 random characters from a 32-symbol Crockford-style alphabet (`A`-`Z` without the visually-ambiguous `I`/`O`, plus `2`-`9`), of which only 14 symbols are also hex digits, so a real code matched the documented pattern with probability `(14/32)^12 ≈ 4.9e-5` — roughly 1 in 20,000. Recovery is the last path back into a locked-out owner's account, so a client validating requests against the published spec before sending them (as generated clients typically do) could not complete it for almost every real code — the same failure class as the `2fa-challenge` content-type gap (`fix(api) #329` / `docs(openapi) 19d6318`).
- **Chosen fix — the server's accepted class, not the generator's alphabet.** The pattern now reads `^OVUM-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}$`, matching `ValidateRecoveryCodeFormat` (`internal/services/auth_input_policy.go`). The spec describes the **request contract**, and the server intentionally accepts a wider class (`[A-Z0-9]`) than the generator emits. Pinning the pattern to the generator's exact alphabet (excluding `I`/`O`/`0`/`1`) would reproduce the same defect in a milder form: a spec-following client would then reject some recovery-code input the server would actually accept.
- **Full sweep of `docs/openapi.yaml`** — every `pattern:`, `format:`, and enum cross-checked against its actual validation in code:

  | Field | Spec declared | Server accepts | Verdict |
  | --- | --- | --- | --- |
  | `ForgotPasswordRequest.recovery_code` | `^OVUM-[0-9A-F]{4}...` (hex) | `^OVUM-[A-Z0-9]{4}...` (`auth_input_policy.go:16`) | **Fixed** |
  | `TOTPLoginRequest.code` / `TOTPEnrollmentRequest.code` | `^[0-9]{6}$` | Real TOTP codes are always 6 digits (`totp.GenerateCode`) | Verified correct |
  | `SymptomPayload.color` | `^#[0-9A-Fa-f]{6}$` | `hexSymptomColorPattern` (`symptom_name_policy.go:17`) | Verified correct |
  | `format: date` fields | `YYYY-MM-DD` | `ParseDayDate` uses layout `"2006-01-02"` | Verified correct |
  | Password `minLength: 8` | 8+ | `ValidatePasswordStrength`: 8+ code points, ≤72 bytes, upper+lower+digit (`password_policy.go`) | Verified correct |
  | `DayPayload`/`ExportJSONEntry` enums: `flow`, `sex_activity`, `cervical_mucus`, `pregnancy_test` | 4 fixed enums | Exact match to `internal/models/daily_log.go` constants | Verified correct |
  | `age_group`, `usage_goal` enums | fixed sets | Exact match to `internal/models/user.go` constants | Verified correct |
  | `temperature_unit` enum `[c, f]` | fixed set | `TemperatureUnitCelsius`/`Fahrenheit` (`day_tracking.go`) | Verified correct |
  | `InterfaceSettings.language` enum + `POST /lang` enum | `[en, ru, es, fr, de]` | `internal/i18n` supports 6 locales incl. `it` (`requiredLocales`, `.claude/rules/frontend.md`) | **Fixed** — added `it` |
  | `POST /lang` form field name | `language` | Handler reads `c.FormValue("lang")` (`handlers_public_pages.go`) | **Fixed** — renamed to `lang`; every value, not only `it`, was undeliverable under the documented name |
  | `OnboardingStep2Request.cycle_length` | `minimum: 14, maximum: 60` | `IsValidOnboardingCycleLength`: `15`-`90` (`onboarding_service.go:169`) | **Fixed** |

  Other numeric bounds looked at but left alone because the spec is *looser* than the server (does not block a legitimate value, only fails to warn early about an invalid one) rather than narrower — `ProfileSettings.display_name maxLength: 80` (real cap 64), `CycleSettings.cycle_length`/`period_length` (real 15-90 / 1-14, spec under-specifies both), `SymptomPayload.name`/`icon` (no declared `maxLength`, real caps 40/16). Flagged as a follow-up, not fixed here, to keep this PR to the "spec narrower than reality" defect class.

## Regression

`TestOpenAPIRecoveryCodePatternAcceptsGeneratedCodes` (`internal/api/openapi_contract_test.go`) pins the recovery-code pattern class: it extracts the declared `pattern` from `docs/openapi.yaml`, asserts it accepts 500 freshly `GenerateRecoveryCode`-minted codes, and asserts it agrees with `ValidateRecoveryCodeFormat` character-by-character across the full alphanumeric set.

**Proof-on-defect**, run locally before landing the fix:
```
$ (reverted pattern to "^OVUM-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}$")
$ go test ./internal/api/... -run TestOpenAPIRecoveryCodePatternAcceptsGeneratedCodes -v
=== RUN   TestOpenAPIRecoveryCodePatternAcceptsGeneratedCodes
    openapi_contract_test.go:209: docs/openapi.yaml recovery_code pattern "^OVUM-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}$" rejects a real generated code "OVUM-PA29-ZV77-NHUD"
--- FAIL: TestOpenAPIRecoveryCodePatternAcceptsGeneratedCodes (0.00s)
FAIL
$ (fix restored)
$ go test ./internal/api/... -run TestOpenAPI -v
=== RUN   TestOpenAPIContractMatchesRegisteredRoutes
--- PASS: TestOpenAPIContractMatchesRegisteredRoutes (0.15s)
=== RUN   TestOpenAPIRecoveryCodePatternAcceptsGeneratedCodes
--- PASS: TestOpenAPIRecoveryCodePatternAcceptsGeneratedCodes (0.00s)
PASS
```

## Scope

Description and test only. Generator (`GenerateRecoveryCode`), server validator (`ValidateRecoveryCodeFormat`), and every other application behavior are unchanged — this PR touches `docs/openapi.yaml`, `internal/api/openapi_contract_test.go`, and `CHANGELOG.md` only.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/api/... ./internal/services/... ./internal/i18n/...`
- [x] `go test ./...` (full module suite, all green)
- [x] Proof-on-defect: reverted pattern → test fails naming the cause; fix restored → test passes
- [x] Patch coverage gate (`go run ./scripts/patchcov`) — the only `.go` change is a `_test.go` file, which the gate excludes by design


