### PR TITLE
docs(openapi): declare the input bounds the server actually enforces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -369,6 +369,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   failure that happens after it is open, and the error reported to the operator
   is still the migration failure that caused it.
 
+- **`docs/openapi.yaml` promised input bounds wider than the ones the server
+  actually enforces.** `ProfileSettings.display_name` declared `maxLength: 80`
+  against a 64-rune cap; `CycleSettings.cycle_length` declared `minimum: 1`
+  and no maximum against an accepted range of 15–90;
+  `CycleSettings.period_length` declared no maximum against 1–14; and
+  `SymptomPayload.name` and `.icon` declared no length bound at all against
+  caps of 40 and 16 runes. The settings form has shipped the real limits as
+  `maxlength` attributes all along — only the published document disagreed.
+
+  A spec looser than the server blocks nothing, which is why this went
+  unnoticed, but it is untrue in the direction a client cannot recover from:
+  it cannot tell in advance that a value will be refused, so a 65-character
+  display name or a 41-character symptom label validates cleanly against the
+  published document and is only rejected on send. That is a round trip spent
+  discovering a limit the spec was supposed to state, and for a form that
+  submits a whole settings section at once it is a rejection a client has to
+  explain after the fact rather than prevent.
+
+  Each bound is now declared at the value its endpoint enforces, and the
+  string bounds say what they are measured on: the server counts **runes**,
+  not bytes, and counts them after normalization (trimming for a display name
+  or icon, whitespace collapsing for a symptom name), so a client validating
+  by character count agrees with it. Two constraints no numeric bound can
+  express are stated in prose instead of left invisible — `period_length` must
+  also be at most `cycle_length` minus 10, and the identically-named fields on
+  `OnboardingStep2Request` are clamped into range rather than rejected, so
+  those two schemas stay separate even where their numbers agree.
+  Description-only: no validator and no accepted request changed.
+
+  `TestOpenAPIDeclaredBoundsMatchTheServersOwnLimits` now sweeps every one of
+  these bounds and restates none of them — it reads the number out of the spec
+  and makes the endpoint judge it, requiring the declared bound to be the
+  acceptance boundary itself rather than merely close to it. Each member was
+  proven against its original defect: with the loose values restored the sweep
+  fails naming the field, the keyword, and the direction of the drift.
+
 - **An erasure confirmed through SSO now names the owner it erased.** The audit
   stream takes the actor from the request context, and only the authenticated-
   route middleware published it there. The two step-up completion handlers

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -484,10 +484,24 @@ components:
       properties:
         name:
           type: string
-          description: User-visible symptom label.
+          maxLength: 40
+          description: >-
+            User-visible symptom label. The server caps it at 40 **runes**
+            (Unicode code points), not bytes, and measures the value after
+            collapsing internal whitespace runs and trimming
+            (`normalizeSymptomNameInput` in
+            `internal/services/symptom_name_policy.go`), so a name whose
+            normalized form fits is accepted even when the raw string is
+            longer. Markup (`<`, `>`) and control characters are rejected,
+            not stripped.
         icon:
           type: string
-          description: Single emoji or short symbol shown next to the name in the UI.
+          maxLength: 16
+          description: >-
+            Single emoji or short symbol shown next to the name in the UI.
+            Capped at 16 **runes** after trimming
+            (`normalizeSymptomIconInput`) — wide enough for a multi-codepoint
+            emoji sequence. Omitted or blank falls back to the default icon.
         color:
           type: string
           pattern: "^#[0-9A-Fa-f]{6}$"
@@ -644,10 +658,25 @@ components:
       properties:
         cycle_length:
           type: integer
-          minimum: 1
+          minimum: 15
+          maximum: 90
+          description: >-
+            Rejected with a validation error outside 15–90
+            (`ValidateCycleSettings` in
+            `internal/services/settings_cycle_policy.go`) — unlike the
+            identically-named field on `OnboardingStep2Request`, which is
+            clamped into range instead.
         period_length:
           type: integer
           minimum: 1
+          maximum: 14
+          description: >-
+            Rejected with a validation error outside 1–14. A cross-field rule
+            the numeric bounds cannot express applies on top: the server also
+            requires `period_length` to be at most `cycle_length` minus 10
+            (still capped at 14), so a payload valid against both bounds on
+            its own — say `cycle_length: 15`, `period_length: 14` — is still
+            refused.
         auto_period_fill: { type: boolean }
         irregular_cycle: { type: boolean }
         unpredictable_cycle: { type: boolean }
@@ -690,7 +719,15 @@ components:
       properties:
         display_name:
           type: string
-          maxLength: 80
+          maxLength: 64
+          description: >-
+            Capped at 64 **runes** (Unicode code points), not bytes, and
+            measured after trimming surrounding whitespace
+            (`NormalizeDisplayName` in
+            `internal/services/settings_profile_policy.go`), so a padded value
+            whose trimmed form fits is accepted. Markup (`<`, `>`) and control
+            characters are rejected, not stripped. An empty value clears the
+            display name.
 
     InterfaceSettings:
       type: object

--- a/internal/api/openapi_contract_test.go
+++ b/internal/api/openapi_contract_test.go
@@ -1,9 +1,14 @@
 package api
 
 import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -144,4 +149,263 @@ func difference(a, b map[string]struct{}) []string {
 	}
 	sort.Strings(only)
 	return only
+}
+
+// openAPIBoundKeywords are the numeric validation keywords this file reads out
+// of the spec. Values are plain integers in every declaration, so a failed
+// Atoi means the line is not one of ours and is skipped.
+var openAPIBoundKeywords = map[string]struct{}{
+	"minimum": {}, "maximum": {}, "minLength": {}, "maxLength": {},
+}
+
+// openAPISchemaPropertyBounds extracts the numeric validation keywords declared
+// under components.schemas.<Schema>.properties.<property>, keyed
+// "<Schema>.<property>". It extends openAPIV1Routes' indentation scan from the
+// paths section to the components section rather than pulling in a YAML
+// library, matching this file's dependency-free convention: schema names sit at
+// 4-space indent, "properties:" at 6, property names at 8, and their keywords
+// at 10. A property written as an inline map (`id: { type: integer }`) carries
+// no bounds and is skipped; if one ever needs a bound, the sweep below fails
+// loudly with "declares no <keyword>" rather than passing silently.
+func openAPISchemaPropertyBounds(t *testing.T, specPath string) map[string]map[string]int {
+	t.Helper()
+	data, err := os.ReadFile(specPath)
+	if err != nil {
+		t.Fatalf("read openapi spec: %v", err)
+	}
+
+	bounds := make(map[string]map[string]int)
+	inComponents, inSchemas, inProperties := false, false, false
+	schema, property := "", ""
+	for _, raw := range strings.Split(string(data), "\n") {
+		line := strings.TrimRight(raw, "\r")
+		text := strings.TrimSpace(line)
+		if text == "" || strings.HasPrefix(text, "#") {
+			continue
+		}
+
+		if !strings.HasPrefix(line, " ") {
+			inComponents = strings.HasPrefix(line, "components:")
+			inSchemas, inProperties = false, false
+			schema, property = "", ""
+			continue
+		}
+		if !inComponents {
+			continue
+		}
+
+		switch indent := len(line) - len(strings.TrimLeft(line, " ")); {
+		case indent == 2:
+			// components holds parameters/responses/securitySchemes too;
+			// only the schemas subtree carries property bounds.
+			inSchemas = text == "schemas:"
+			inProperties = false
+			schema, property = "", ""
+		case indent == 4 && inSchemas && strings.HasSuffix(text, ":"):
+			schema = strings.TrimSuffix(text, ":")
+			inProperties = false
+			property = ""
+		case indent == 6 && schema != "":
+			inProperties = text == "properties:"
+			property = ""
+		case indent == 8 && inProperties && strings.HasSuffix(text, ":"):
+			property = strings.TrimSuffix(text, ":")
+		case indent == 10 && property != "":
+			keyword, value, found := strings.Cut(text, ":")
+			if !found {
+				continue
+			}
+			if _, ok := openAPIBoundKeywords[keyword]; !ok {
+				continue
+			}
+			parsed, err := strconv.Atoi(strings.TrimSpace(value))
+			if err != nil {
+				continue
+			}
+			key := schema + "." + property
+			if bounds[key] == nil {
+				bounds[key] = make(map[string]int)
+			}
+			bounds[key][keyword] = parsed
+		}
+	}
+	return bounds
+}
+
+// openAPIDeclaredBound is one (schema, property, keyword) triple whose declared
+// value must sit exactly where the running server draws its line. The bound is
+// never restated here: the spec supplies the number and the endpoint judges it,
+// so neither side can drift without the sweep going red.
+type openAPIDeclaredBound struct {
+	schema   string
+	property string
+	keyword  string
+	method   string
+	path     string
+	okStatus int
+	// body builds a request payload that is valid in every respect except
+	// the field under probe, which carries `value` — an integer field's
+	// value directly, a string field's length in runes.
+	body func(value int) map[string]any
+}
+
+// openAPIBoundProbeRune is deliberately multi-byte: a length bound the server
+// measured in bytes rather than runes would refuse a value the spec's
+// character-counted maxLength permits, and the in-bounds probe would catch it.
+const openAPIBoundProbeRune = "ж"
+
+func openAPIBoundProbeText(runes int) string {
+	return strings.Repeat(openAPIBoundProbeRune, runes)
+}
+
+// openAPIDeclaredBounds enumerates the request-shape bounds the /api/v1 surface
+// enforces per field. Each entry names the endpoint that owns the check, so the
+// oracle is the shipped request contract itself rather than a service-internal
+// constant — several of these limits live in package-private policy functions
+// that no exported symbol reveals.
+//
+// Decision (2026-07-28): OnboardingStep2Request stays out of this sweep even
+// though it declares bounds on identically-named fields. POST
+// /api/v1/onboarding/steps/2 CLAMPS an out-of-range cycle or period length into
+// the accepted window (SanitizeOnboardingCycleAndPeriod) instead of refusing
+// it, the way ReminderSettings.reminder_lead_days does, so the "one past the
+// bound must be refused" probe below does not describe that endpoint at all —
+// it would fail against correct behavior. Sharing one schema between the two is
+// wrong for the same reason: they can carry the same numbers and still disagree
+// on what happens when you exceed them. Any later attempt to cover the clamping
+// endpoints needs its own oracle — assert the stored value came back inside the
+// window — not an entry here.
+var openAPIDeclaredBounds = []openAPIDeclaredBound{
+	{
+		schema: "ProfileSettings", property: "display_name", keyword: "maxLength",
+		method: http.MethodPatch, path: "/api/v1/users/current/profile", okStatus: http.StatusOK,
+		body: func(value int) map[string]any {
+			return map[string]any{"display_name": openAPIBoundProbeText(value)}
+		},
+	},
+	{
+		schema: "CycleSettings", property: "cycle_length", keyword: "minimum",
+		method: http.MethodPatch, path: "/api/v1/users/current/cycle", okStatus: http.StatusOK,
+		body: func(value int) map[string]any {
+			return map[string]any{"cycle_length": value, "period_length": 1}
+		},
+	},
+	{
+		schema: "CycleSettings", property: "cycle_length", keyword: "maximum",
+		method: http.MethodPatch, path: "/api/v1/users/current/cycle", okStatus: http.StatusOK,
+		body: func(value int) map[string]any {
+			return map[string]any{"cycle_length": value, "period_length": 1}
+		},
+	},
+	{
+		schema: "CycleSettings", property: "period_length", keyword: "minimum",
+		method: http.MethodPatch, path: "/api/v1/users/current/cycle", okStatus: http.StatusOK,
+		// The longest cycle keeps the cross-field rule (period_length <=
+		// cycle_length-10, capped at 14) out of the way, so only the bound
+		// under probe decides the outcome.
+		body: func(value int) map[string]any {
+			return map[string]any{"cycle_length": 90, "period_length": value}
+		},
+	},
+	{
+		schema: "CycleSettings", property: "period_length", keyword: "maximum",
+		method: http.MethodPatch, path: "/api/v1/users/current/cycle", okStatus: http.StatusOK,
+		body: func(value int) map[string]any {
+			return map[string]any{"cycle_length": 90, "period_length": value}
+		},
+	},
+	{
+		schema: "SymptomPayload", property: "name", keyword: "maxLength",
+		method: http.MethodPost, path: "/api/v1/symptoms", okStatus: http.StatusCreated,
+		body: func(value int) map[string]any {
+			return map[string]any{"name": openAPIBoundProbeText(value)}
+		},
+	},
+	{
+		schema: "SymptomPayload", property: "icon", keyword: "maxLength",
+		method: http.MethodPost, path: "/api/v1/symptoms", okStatus: http.StatusCreated,
+		// Symptom names are unique per owner, so each icon probe needs its
+		// own name; the name itself is well inside its own bound.
+		body: func(value int) map[string]any {
+			return map[string]any{"name": "icon probe " + strconv.Itoa(value), "icon": openAPIBoundProbeText(value)}
+		},
+	},
+}
+
+// TestOpenAPIDeclaredBoundsMatchTheServersOwnLimits sweeps every request-shape
+// bound the /api/v1 surface enforces and requires docs/openapi.yaml to declare
+// it at exactly the value the server uses. A spec looser than the server — a
+// declared maximum above the real cap, or no bound at all where one is
+// enforced — does not block anything, but it makes the document untrue in the
+// direction a client cannot recover from: it cannot tell in advance that a
+// value will be refused, so the rejection can only be discovered by sending it.
+// It is the mirror image of a spec narrower than the server, which blocks a
+// legitimate request outright and is therefore found quickly; this direction is
+// found only when someone compares the two by hand, which is what this sweep
+// replaces.
+//
+// Each member is checked the same way, and the expected limits appear nowhere
+// in this file: the spec supplies the number, the endpoint judges it. The value
+// the spec calls legal must be accepted, and the first value past it must be
+// refused — so the declared bound has to be the acceptance boundary itself, not
+// merely somewhere near it. Both directions matter: dropping only the negative
+// probe would let a spec that understates the cap pass, and dropping only the
+// positive one would let a spec that overstates it pass.
+//
+// The spec previously declared maxLength 80 for display_name where the server
+// caps at 64, minimum 1 and no maximum for cycle_length where the server
+// accepts 15-90, no maximum for period_length where it accepts 1-14, and no
+// length bound at all for a symptom's name or icon (40 and 16 runes).
+func TestOpenAPIDeclaredBoundsMatchTheServersOwnLimits(t *testing.T) {
+	bounds := openAPISchemaPropertyBounds(t, filepath.Join("..", "..", "docs", "openapi.yaml"))
+	if len(bounds) == 0 {
+		t.Fatal("no schema property bounds parsed from openapi.yaml; parser or spec is wrong")
+	}
+
+	app, database := newOnboardingTestApp(t)
+	const email, password = "openapi-bounds@example.com", "StrongPass1"
+	createOnboardingTestUser(t, database, email, password, true)
+	authCookie := loginAndExtractAuthCookie(t, app, email, password)
+
+	for _, bound := range openAPIDeclaredBounds {
+		field := bound.schema + "." + bound.property
+		t.Run(field+"/"+bound.keyword, func(t *testing.T) {
+			declared, ok := bounds[field][bound.keyword]
+			if !ok {
+				t.Fatalf("docs/openapi.yaml declares no %s for %s, but %s %s enforces one: a client validating against the spec cannot tell the value will be refused",
+					bound.keyword, field, bound.method, bound.path)
+			}
+
+			inBounds, outOfBounds := declared, declared+1
+			if bound.keyword == "minimum" || bound.keyword == "minLength" {
+				outOfBounds = declared - 1
+			}
+
+			if status := openAPIProbeBound(t, app, authCookie, bound, inBounds); status != bound.okStatus {
+				t.Fatalf("%s declares %s: %d, but %s %s answered %d for a value the spec calls legal (want %d): the spec is looser than the server",
+					field, bound.keyword, declared, bound.method, bound.path, status, bound.okStatus)
+			}
+			if status := openAPIProbeBound(t, app, authCookie, bound, outOfBounds); status < 400 || status > 499 {
+				t.Fatalf("%s declares %s: %d, but %s %s answered %d for %d, one past the declared bound (want a 4xx refusal): the spec is tighter than the server",
+					field, bound.keyword, declared, bound.method, bound.path, status, outOfBounds)
+			}
+		})
+	}
+}
+
+// openAPIProbeBound sends one JSON request built from the bound's body builder
+// and returns the status the endpoint answered with.
+func openAPIProbeBound(t *testing.T, app *fiber.App, authCookie string, bound openAPIDeclaredBound, value int) int {
+	t.Helper()
+
+	payload, err := json.Marshal(bound.body(value))
+	if err != nil {
+		t.Fatalf("marshal probe body for %s.%s: %v", bound.schema, bound.property, err)
+	}
+	request := httptest.NewRequest(bound.method, bound.path, bytes.NewReader(payload))
+	request.Header.Set("Content-Type", fiber.MIMEApplicationJSON)
+	request.Header.Set("Accept", fiber.MIMEApplicationJSON)
+	request.Header.Set("Cookie", authCookie)
+
+	return mustAppResponse(t, app, request).StatusCode
 }


### PR DESCRIPTION
## What

`docs/openapi.yaml` declared four input bounds **wider** than the ones the server
enforces. The spec's own preamble makes it descriptive but true, and in this
direction it was not: a client validating a request against the published
document cannot tell that a value will be refused, so it discovers the real
limit only by sending it and reading the rejection.

| Schema · property | Declared | Server enforces | Measured by |
| --- | --- | --- | --- |
| `ProfileSettings.display_name` | `maxLength: 80` | 64 | `NormalizeDisplayName` — `utf8.RuneCountInString` after `TrimSpace` |
| `CycleSettings.cycle_length` | `minimum: 1`, no maximum | 15–90, **rejected** outside | `IsValidOnboardingCycleLength` via `ValidateCycleSettings` |
| `CycleSettings.period_length` | `minimum: 1`, no maximum | 1–14, **rejected** outside | `IsValidOnboardingPeriodLength` via `ValidateCycleSettings` |
| `SymptomPayload.name` | no bound | 40 | `normalizeSymptomNameInput` — `utf8.RuneCountInString` after whitespace collapsing |
| `SymptomPayload.icon` | no bound | 16 | `normalizeSymptomIconInput` — `utf8.RuneCountInString` after `TrimSpace` |

Every one of these is counted in **runes**, never bytes, which matters because
OpenAPI's `maxLength` is also a character count — the two agree for a non-ASCII
display name only because the server does not count bytes. Each is also counted
on the **normalized** value, so the descriptions say so rather than leaving a
padded or double-spaced input ambiguous.

The settings form has shipped `maxlength="64"` and `maxlength="40"` all along
(`internal/templates/components/settings_account.html`,
`components/settings_symptoms.html`) — only the published spec disagreed.

Two constraints that no numeric keyword can express are now stated in prose
instead of being invisible:

- `period_length` must additionally be at most `cycle_length` minus 10, so
  `{cycle_length: 15, period_length: 14}` satisfies both declared ranges and is
  still refused (`IsCompatibleCycleAndPeriod`).
- `OnboardingStep2Request.cycle_length` / `.period_length` carry the same
  numbers but **clamp** out-of-range input instead of rejecting it
  (`SanitizeOnboardingCycleAndPeriod`), so the two schemas are deliberately not
  merged.

**Description-only.** No validator, and nothing in what the application accepts,
was changed.

## Test

`TestOpenAPIDeclaredBoundsMatchTheServersOwnLimits` in
`internal/api/openapi_contract_test.go` sweeps all seven (schema, property,
keyword) triples and **restates none of the limits**: it reads the number out of
the spec and makes the endpoint judge it. The value the spec calls legal must be
accepted, and the first value past it must be refused, so the declared bound has
to be the acceptance boundary itself rather than merely close to it. A bound
declared where none is enforced, one missing where the server has one, and drift
on either side all fail. Length probes use a two-byte rune, so a byte-counting
validator would fail the in-bounds probe.

The spec is parsed by extending the existing indentation scan from `paths` to
`components.schemas`, keeping this file dependency-free.

Proof on defect — with the loose values restored, the sweep fails naming each
field, its keyword, and the direction of the drift:

```
--- FAIL: TestOpenAPIDeclaredBoundsMatchTheServersOwnLimits
    --- FAIL: .../ProfileSettings.display_name/maxLength
        ProfileSettings.display_name declares maxLength: 80, but PATCH /api/v1/users/current/profile
        answered 400 for a value the spec calls legal (want 200): the spec is looser than the server
    --- FAIL: .../CycleSettings.cycle_length/minimum
        CycleSettings.cycle_length declares minimum: 1, but PATCH /api/v1/users/current/cycle
        answered 400 for a value the spec calls legal (want 200): the spec is looser than the server
    --- FAIL: .../CycleSettings.cycle_length/maximum
        docs/openapi.yaml declares no maximum for CycleSettings.cycle_length, but PATCH
        /api/v1/users/current/cycle enforces one: a client validating against the spec cannot
        tell the value will be refused
    --- FAIL: .../SymptomPayload.name/maxLength
        docs/openapi.yaml declares no maxLength for SymptomPayload.name, but POST /api/v1/symptoms
        enforces one: a client validating against the spec cannot tell the value will be refused
```

## Verification

`go build ./...`, `go vet ./...`, `staticcheck ./internal/...`,
`golangci-lint run ./internal/...` (0 issues), the full `go test ./...` suite,
and `go run ./scripts/patchcov` against a freshly generated profile.

## Note on overlap

This branch is cut from `origin/main` and does not touch
`OnboardingStep2Request`, whose `cycle_length` bounds (`14`–`60` on `main`,
against a real `15`–`90`) are corrected separately in #352. Once that lands the
two schemas agree on their numbers while keeping their different enforcement —
reject here, clamp there — which is why the description on `CycleSettings`
points at the difference rather than sharing one schema.

The CHANGELOG entry is appended as the **last** item of `[Unreleased] → Fixed`
so it merges cleanly alongside the other spec fixes in flight.



## Why this replaces #357

The merge queue rebases, and after #353 landed its entry in the same tail region of the changelog, replaying this branch conflicted there. This is the same work rebuilt on top of the current `main`: `docs/openapi.yaml` and `internal/api/openapi_contract_test.go` are line-for-line identical to #357 (47 and 266 changed lines respectively), and only the changelog entry moved to a free anchor.
