### PR TITLE
docs(api): declare the 400 the server sends, not a 422 it never sends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -347,6 +347,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the file from being moved or deleted. The connection is now released on any
   failure that happens after it is open, and the error reported to the operator
   is still the migration failure that caused it.
+- **The API specification published a `422` the server never sends.** Nineteen
+  operations in [docs/openapi.yaml](docs/openapi.yaml) declared `422
+  Unprocessable Entity` for a rejected payload, while every validation refusal
+  the app produces is a `400` — there is no `422` branch anywhere in the server.
+  A client written against the document was therefore branching on a status it
+  could never receive, and met the real refusal in whichever branch it kept for
+  something else. The document now says `400`. Nothing in the server changed:
+  moving the app to `422` would have broken every client already reading `400`,
+  in exchange for a distinction the response envelope already carries in
+  `error_detail.category`, where `validation` is its own stable value.
+
+  Sweeping the remaining statuses the same way closed the opposite gap. The
+  `409` that a duplicate symptom name — or a cycle start that would overwrite an
+  existing one — really answers with was documented nowhere in the file, nor was
+  the `404` for a symptom that does not exist. Five shared error examples showed
+  a bare `{ "error": ... }` that the `ApiError` schema above them forbids, two of
+  them naming keys (`too many attempts`, `internal error`) the server has never
+  emitted; each now shows the full envelope with a key the server really sends.
 
 ### Security
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -153,31 +153,68 @@ components:
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
-          example: { error: "unauthorized" }
+          example:
+            error: "unauthorized"
+            error_detail: { key: "unauthorized", category: "unauthorized", target: "global" }
     Forbidden:
       description: Session is valid but the caller lacks the required role (typically owner-only) or CSRF validation failed.
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
-          example: { error: "forbidden" }
+          example:
+            error: "forbidden"
+            error_detail: { key: "forbidden", category: "forbidden", target: "global" }
     ValidationError:
-      description: Request body or query parameters failed validation.
+      description: |
+        Request body, path, or query parameters failed validation. The server
+        answers `400` — it has no `422` branch, and a client that needs to tell a
+        validation refusal apart from any other `400` reads
+        `error_detail.category`, which is `validation` for every response using
+        this component. `error_detail.target` follows the surface: `global` for
+        programmatic endpoints, `auth_form` or `settings_form` where the
+        rejection belongs inside a rendered form.
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
-          example: { error: "invalid input" }
+          example:
+            error: "invalid input"
+            error_detail: { key: "invalid input", category: "validation", target: "global" }
+    NotFound:
+      description: The addressed resource does not exist for the authenticated account.
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/ApiError' }
+          example:
+            error: "symptom not found"
+            error_detail: { key: "symptom not found", category: "not_found", target: "settings_form" }
+    Conflict:
+      description: |
+        The request collides with state the account already holds — a duplicate
+        symptom name, or a cycle start that would overwrite an existing one. The
+        envelope carries `error_detail.category: "conflict"`; the collision is
+        resolvable by the client (rename, or resend with `replace_existing`).
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/ApiError' }
+          example:
+            error: "symptom name already exists"
+            error_detail: { key: "symptom name already exists", category: "conflict", target: "settings_form" }
     RateLimited:
       description: Rate limit exceeded.
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
-          example: { error: "too many attempts" }
+          example:
+            error: "too many requests"
+            error_detail: { key: "too many requests", category: "rate_limited", target: "global" }
     InternalError:
       description: Unexpected server error.
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
-          example: { error: "internal error" }
+          example:
+            error: "internal_error"
+            error_detail: { key: "internal_error", category: "internal", target: "global" }
 
   schemas:
     ApiError:
@@ -959,7 +996,7 @@ paths:
       responses:
         '303':
           description: Redirect to `/register/welcome` with the sealed pickup cookie. Shape is identical for new and duplicate emails.
-        '422':
+        '400':
           $ref: '#/components/responses/ValidationError'
         '429':
           $ref: '#/components/responses/RateLimited'
@@ -1108,7 +1145,7 @@ paths:
       responses:
         '303':
           description: Redirect to `/login` after success.
-        '422':
+        '400':
           $ref: '#/components/responses/ValidationError'
 
   # =========================================================================
@@ -1130,7 +1167,7 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/OkResponse' }
         '401': { $ref: '#/components/responses/Unauthorized' }
-        '422': { $ref: '#/components/responses/ValidationError' }
+        '400': { $ref: '#/components/responses/ValidationError' }
 
   /api/v1/onboarding/steps/2:
     post:
@@ -1148,7 +1185,7 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/OkResponse' }
         '401': { $ref: '#/components/responses/Unauthorized' }
-        '422': { $ref: '#/components/responses/ValidationError' }
+        '400': { $ref: '#/components/responses/ValidationError' }
 
   /api/v1/onboarding/complete:
     post:
@@ -1181,7 +1218,7 @@ paths:
                 type: array
                 items: { $ref: '#/components/schemas/DailyLog' }
         '401': { $ref: '#/components/responses/Unauthorized' }
-        '422': { $ref: '#/components/responses/ValidationError' }
+        '400': { $ref: '#/components/responses/ValidationError' }
 
   /api/v1/days/{date}:
     parameters:
@@ -1196,7 +1233,7 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/DailyLog' }
         '401': { $ref: '#/components/responses/Unauthorized' }
-        '422': { $ref: '#/components/responses/ValidationError' }
+        '400': { $ref: '#/components/responses/ValidationError' }
     head:
       tags: [days]
       summary: Check whether the day has any persisted data (owner only).
@@ -1231,7 +1268,7 @@ paths:
               schema: { $ref: '#/components/schemas/DailyLog' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
-        '422': { $ref: '#/components/responses/ValidationError' }
+        '400': { $ref: '#/components/responses/ValidationError' }
     delete:
       tags: [days]
       summary: Delete a single day's entry (owner only).
@@ -1281,8 +1318,19 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/OkResponse' }
+        '400': { $ref: '#/components/responses/ValidationError' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
+        '409':
+          description: |
+            The day already carries a cycle start (or data that marking one would
+            overwrite). Resend with `replace_existing=true` to take it.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ApiError' }
+              example:
+                error: "cycle start replace required"
+                error_detail: { key: "cycle start replace required", category: "conflict", target: "global" }
 
   # =========================================================================
   # symptoms
@@ -1316,7 +1364,8 @@ paths:
               schema: { $ref: '#/components/schemas/Symptom' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
-        '422': { $ref: '#/components/responses/ValidationError' }
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '409': { $ref: '#/components/responses/Conflict' }
 
   /api/v1/symptoms/{id}:
     parameters:
@@ -1337,7 +1386,9 @@ paths:
               schema: { $ref: '#/components/schemas/Symptom' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
-        '422': { $ref: '#/components/responses/ValidationError' }
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '409': { $ref: '#/components/responses/Conflict' }
     delete:
       tags: [symptoms]
       summary: Archive (soft-delete) a symptom (owner only).
@@ -1352,8 +1403,10 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/OkResponse' }
+        '400': { $ref: '#/components/responses/ValidationError' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
 
   /api/v1/symptoms/{id}/restore:
     post:
@@ -1367,8 +1420,11 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/OkResponse' }
+        '400': { $ref: '#/components/responses/ValidationError' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '409': { $ref: '#/components/responses/Conflict' }
 
   # =========================================================================
   # stats
@@ -1521,7 +1577,7 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/OkResponse' }
         '401': { $ref: '#/components/responses/Unauthorized' }
-        '422': { $ref: '#/components/responses/ValidationError' }
+        '400': { $ref: '#/components/responses/ValidationError' }
 
   /api/v1/users/current/profile:
     patch:
@@ -1540,7 +1596,7 @@ paths:
               schema: { $ref: '#/components/schemas/OkResponse' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
-        '422': { $ref: '#/components/responses/ValidationError' }
+        '400': { $ref: '#/components/responses/ValidationError' }
 
   /api/v1/users/current/interface:
     patch:
@@ -1748,7 +1804,7 @@ paths:
               schema: { $ref: '#/components/schemas/OkResponse' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
-        '422': { $ref: '#/components/responses/ValidationError' }
+        '400': { $ref: '#/components/responses/ValidationError' }
 
   /api/v1/users/current/reminders:
     patch:
@@ -1799,7 +1855,7 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/ApiError' }
               example: { error: "oidc reauth required" }
-        '422': { $ref: '#/components/responses/ValidationError' }
+        '400': { $ref: '#/components/responses/ValidationError' }
 
   /api/v1/users/current/password/step-up:
     post:
@@ -1826,7 +1882,7 @@ paths:
           description: "Browser redirect to the provider authorize URL when `Accept: application/json` is not set."
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
-        '422': { $ref: '#/components/responses/ValidationError' }
+        '400': { $ref: '#/components/responses/ValidationError' }
 
   /api/v1/users/current/data-wipe/step-up:
     post:
@@ -1905,7 +1961,7 @@ paths:
           description: Recovery code surface rendered. JSON clients should follow the redirect to `/recovery-code` to pick up the plaintext code (shown exactly once).
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
-        '422': { $ref: '#/components/responses/ValidationError' }
+        '400': { $ref: '#/components/responses/ValidationError' }
 
   /api/v1/users/current/2fa:
     put:
@@ -1925,7 +1981,7 @@ paths:
           description: 2FA enabled.
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
-        '422': { $ref: '#/components/responses/ValidationError' }
+        '400': { $ref: '#/components/responses/ValidationError' }
     delete:
       tags: [settings]
       summary: Disable TOTP 2FA (owner only).
@@ -1942,7 +1998,7 @@ paths:
           description: 2FA disabled.
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
-        '422': { $ref: '#/components/responses/ValidationError' }
+        '400': { $ref: '#/components/responses/ValidationError' }
         '429': { $ref: '#/components/responses/RateLimited' }
 
   /api/v1/users/current/data-wipe/validate:
@@ -1963,7 +2019,7 @@ paths:
         '204':
           description: Same as 200 for non-JSON clients.
         '401': { $ref: '#/components/responses/Unauthorized' }
-        '422': { $ref: '#/components/responses/ValidationError' }
+        '400': { $ref: '#/components/responses/ValidationError' }
 
   /api/v1/users/current/data-wipe:
     post:
@@ -1988,4 +2044,4 @@ paths:
               schema: { $ref: '#/components/schemas/OkResponse' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
-        '422': { $ref: '#/components/responses/ValidationError' }
+        '400': { $ref: '#/components/responses/ValidationError' }

--- a/internal/api/openapi_contract_test.go
+++ b/internal/api/openapi_contract_test.go
@@ -1,8 +1,12 @@
 package api
 
 import (
+	"fmt"
+	"io/fs"
+	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"testing"
@@ -40,6 +44,193 @@ func TestOpenAPIContractMatchesRegisteredRoutes(t *testing.T) {
 	if extra := difference(specRoutes, codeRoutes); len(extra) > 0 {
 		t.Errorf("routes documented in docs/openapi.yaml but not registered in code:\n  %s", strings.Join(extra, "\n  "))
 	}
+}
+
+// TestOpenAPIDeclaresOnlyStatusesTheServerCanEmit is the status half of the
+// route↔spec contract. Route presence is pinned above; this pins the response
+// codes each operation publishes, because a spec can name every route correctly
+// and still describe outcomes the server has no branch for. It did: the document
+// declared '422' on nineteen operations while the app answers every validation
+// refusal with 400 — the distinction clients actually get is
+// error_detail.category, not a second status.
+//
+// The check runs one way on purpose: every status the spec DECLARES must be a
+// status the server can PRODUCE. The opposite direction is not derivable from a
+// source scan — a status appears in the sources without saying which operation
+// answers it, and the document deliberately excludes page routes (the OIDC start
+// redirect's 307) and documents the transport statuses centrally rather than per
+// path. That half is pinned instead by
+// TestOpenAPIDocumentsEveryTransportStatusTheEnvelopeCovers, where a real
+// registry exists to enumerate.
+//
+// "Can produce" is read from the server's own sources: every rejection resolves
+// its status through an APIErrorSpec built with a fiber.Status* constant, and the
+// handful of direct answers use c.Status/SendStatus. Test sources are excluded —
+// what a test can assert is not what the server can send.
+func TestOpenAPIDeclaresOnlyStatusesTheServerCanEmit(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+
+	declared := openAPIDeclaredStatuses(t, filepath.Join(repoRoot, "docs", "openapi.yaml"))
+	if len(declared) == 0 {
+		t.Fatal("no response statuses parsed from openapi.yaml; parser or spec is wrong")
+	}
+	sources := serverSourceText(t, repoRoot)
+
+	statuses := make([]int, 0, len(declared))
+	for status := range declared {
+		statuses = append(statuses, status)
+	}
+	sort.Ints(statuses)
+
+	for _, status := range statuses {
+		identifier := fiberStatusIdentifier(t, status)
+		if regexp.MustCompile(regexp.QuoteMeta(identifier) + `\b`).MatchString(sources) {
+			continue
+		}
+		if regexp.MustCompile(`(?:Status|SendStatus)\(\s*` + fmt.Sprint(status) + `\b`).MatchString(sources) {
+			continue
+		}
+		operations := declared[status]
+		sort.Strings(operations)
+		t.Errorf("docs/openapi.yaml declares %d but no server source emits it (searched for %s and a literal Status(%d)); declared on:\n  %s",
+			status, identifier, status, strings.Join(operations, "\n  "))
+	}
+}
+
+// TestOpenAPIDocumentsEveryTransportStatusTheEnvelopeCovers pins the reverse
+// direction for the one part of the surface that keeps a registry of it. The
+// transport statuses are answered outside any operation — an unroutable request,
+// an undecodable body, an unparseable head — so the spec documents them once in
+// the ApiError schema description instead of per path. That list is prose, which
+// is exactly the kind of text that stops matching the map beside it: a new entry
+// in transportErrorSpecsByStatus, or a renamed key, is invisible until a client
+// meets a status the document never mentions. Both the status and its stable key
+// are asserted, since the key is the whole reason the entry is worth publishing.
+func TestOpenAPIDocumentsEveryTransportStatusTheEnvelopeCovers(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "..", "docs", "openapi.yaml"))
+	if err != nil {
+		t.Fatalf("read openapi spec: %v", err)
+	}
+	spec := string(data)
+
+	statuses := make([]int, 0, len(transportErrorSpecsByStatus))
+	for status := range transportErrorSpecsByStatus {
+		statuses = append(statuses, status)
+	}
+	sort.Ints(statuses)
+
+	for _, status := range statuses {
+		entry := fmt.Sprintf("* `%d` — `%s`", status, transportErrorSpecsByStatus[status].Key)
+		if !strings.Contains(spec, entry) {
+			t.Errorf("transportErrorSpecsByStatus answers %d with key %q, but docs/openapi.yaml never documents it; the ApiError description needs the line %q",
+				status, transportErrorSpecsByStatus[status].Key, entry)
+		}
+	}
+}
+
+// openAPIDeclaredStatuses returns every response status declared under paths:,
+// mapped to the "METHOD /path" operations that declare it. Statuses live at a
+// fixed depth — path item (2), operation (4), responses (6), status (8) — so the
+// scan tracks that nesting rather than matching three-digit keys anywhere, which
+// would also swallow enum values and example payloads.
+func openAPIDeclaredStatuses(t *testing.T, specPath string) map[int][]string {
+	t.Helper()
+	data, err := os.ReadFile(specPath)
+	if err != nil {
+		t.Fatalf("read openapi spec: %v", err)
+	}
+
+	statusKey := regexp.MustCompile(`^'?(\d{3})'?:`)
+	declared := make(map[int][]string)
+	inPaths := false
+	currentPath := ""
+	currentOperation := ""
+	inResponses := false
+
+	for _, raw := range strings.Split(string(data), "\n") {
+		line := strings.TrimRight(raw, "\r")
+		if strings.TrimSpace(line) == "" || strings.HasPrefix(strings.TrimSpace(line), "#") {
+			continue
+		}
+		if !strings.HasPrefix(line, " ") {
+			inPaths = strings.HasPrefix(line, "paths:")
+			currentPath, currentOperation, inResponses = "", "", false
+			continue
+		}
+		if !inPaths {
+			continue
+		}
+
+		indent := len(line) - len(strings.TrimLeft(line, " "))
+		text := strings.TrimSpace(line)
+
+		switch {
+		case indent == 2 && strings.HasPrefix(text, "/") && strings.HasSuffix(text, ":"):
+			currentPath = strings.TrimSuffix(text, ":")
+			currentOperation, inResponses = "", false
+		case indent == 4:
+			currentOperation = strings.ToUpper(strings.TrimSuffix(text, ":"))
+			inResponses = false
+		case indent == 6:
+			inResponses = text == "responses:"
+		case indent == 8 && inResponses && currentPath != "" && currentOperation != "":
+			match := statusKey.FindStringSubmatch(text)
+			if match == nil {
+				continue
+			}
+			status := 0
+			if _, err := fmt.Sscanf(match[1], "%d", &status); err != nil {
+				t.Fatalf("unparseable status key %q under %s %s", text, currentOperation, currentPath)
+			}
+			declared[status] = append(declared[status], currentOperation+" "+currentPath)
+		}
+	}
+	return declared
+}
+
+// serverSourceText concatenates every non-test Go source under internal/ and
+// cmd/ — the code that can actually put a status on the wire.
+func serverSourceText(t *testing.T, repoRoot string) string {
+	t.Helper()
+	var builder strings.Builder
+	for _, tree := range []string{"internal", "cmd"} {
+		root := filepath.Join(repoRoot, tree)
+		err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if entry.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			data, readErr := os.ReadFile(path)
+			if readErr != nil {
+				return readErr
+			}
+			builder.Write(data)
+			builder.WriteString("\n")
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walk %s: %v", root, err)
+		}
+	}
+	if builder.Len() == 0 {
+		t.Fatalf("no server sources read from %s; test setup is wrong", repoRoot)
+	}
+	return builder.String()
+}
+
+// fiberStatusIdentifier derives the fiber constant a status would be written as.
+// fiber's Status* constants mirror net/http's, whose names are StatusText with
+// the separators removed, so the mapping needs no hand-maintained table that
+// could drift from the spec it is meant to check.
+func fiberStatusIdentifier(t *testing.T, status int) string {
+	t.Helper()
+	text := http.StatusText(status)
+	if text == "" {
+		t.Fatalf("docs/openapi.yaml declares %d, which is not a registered HTTP status", status)
+	}
+	return "fiber.Status" + strings.NewReplacer(" ", "", "-", "").Replace(text)
 }
 
 // registeredV1Routes returns the set of "METHOD /api/v1/..." entries the Fiber


### PR DESCRIPTION
## The defect

`docs/openapi.yaml` declared `'422'` on **19 operations** — 18 as
`$ref: '#/components/responses/ValidationError'`, one (`POST /api/v1/users`) in
expanded form — while the application answers **no request with 422, ever**:

```
$ grep -rn "StatusUnprocessableEntity" internal/ cmd/
(no matches)
```

Every validation refusal resolves through an `APIErrorSpec` built with
`fiber.StatusBadRequest` — `settingsValidationErrorSpec`, `authValidationErrorSpec`,
`onboardingValidationErrorSpec`, `mapDayUpsertError`, `mapSymptomNameValidationError`
— and the transport layer's own catch-all for an undecodable body is
`transportErrorSpecsByStatus[400] = bad_request`. A client written against the
document was branching on a status it could never receive, and met the real
refusal in whichever branch it kept for something else.

Same class as #352 (recovery-code alphabet) and #357 (field bounds): the
published contract disagrees with the execution. Here the disagreement is about
the **response status**.

## Decision (2026-07-28): the spec moves to 400; the application is not touched

The area rule for `internal/api` calls the spec **descriptive but obliged to be
true** — it documents what the server does. Moving the server to `422` instead
would break every client that branches on `400` today, and would buy a
distinction the application **already publishes in a better place**: the error
envelope carries `error_detail.category` with a stable enum in which
`validation` is its own value. A `422` would restate what is already stated, at
the cost of a breaking change.

No Go source is modified by this PR. No status, key, or category changes.

## What changed

**19 status declarations `'422'` → `'400'`.** Of the 19, **zero** collided with
an existing `'400'` in the same operation. The five operations that already
declared `'400'` (`POST /api/v1/imports/json`, `.../timezone`, `.../webhook`,
`.../data-wipe/step-up`, `.../deletion/step-up`) are exactly the five that
carried no `'422'`, so no descriptions had to be merged and no duplicate YAML key
was produced. Verified by parsing the result with a duplicate-key-strict loader
and resolving all 46 `$ref`s.

**The `ValidationError` component** now states the status explicitly, points a
client at `error_detail.category` for the distinction `422` would have carried,
and describes how `target` varies by surface. Its `example` was
`{ error: "invalid input" }` — invalid against its own schema, which requires
`error_detail`. It now shows the full envelope the server really sends
(`invalid input` / `validation` / `global` is the literal response of
`POST /api/v1/onboarding/steps/1` on a malformed body).

**Class sweep — every declared status against every emitted one.** No other
status is declared and never sent. The sweep did find the reverse:

| Status | Declared before | Emitted by the app | Action |
| --- | --- | --- | --- |
| 200 / 201 / 204 / 303 | yes | yes | correct, unchanged |
| 400 | 5 sites | everywhere validation fails | 19 sites restored |
| 401 | 44 sites | `unauthorizedErrorSpec`, auth mappers | correct |
| 403 | 30 sites | owner-only guard, CSRF, OIDC re-auth | correct |
| 404 | 1 site (`HEAD /days/{date}`) | also `symptom not found` on 3 symptom routes | **added** to those 3 |
| 409 | **nowhere** | `symptom name already exists`, `cycle start replace required` | **added** to the 4 routes that emit it |
| 413 | 1 site (`imports/json`) | entry cap + body limit | correct |
| 429 | 6 sites | limiters | correct |
| 500 | 3 sites | any handler's persistence failure | left as is — the `ApiError` description documents it app-wide; per-path would be noise |
| 503 | 1 site (`/readyz`) | readiness + request-budget timeout | correct |
| 405 / 415 / 431 | prose only | transport layer | correct — documented centrally in the `ApiError` description, not per path |
| 307 | nowhere | `/auth/oidc` start redirect | correct — a page route, explicitly out of scope for this document |

New `NotFound` and `Conflict` shared responses back the additions. Four more
component examples (`Unauthorized`, `Forbidden`, `RateLimited`, `InternalError`)
carried the same schema-invalid bare `{ error: ... }`; two of them named keys the
server has never emitted (`too many attempts`, `internal error` — the real ones
are `too many requests` and `internal_error`). All five now show a complete,
real envelope.

## Tests

Both new, both in `internal/api/openapi_contract_test.go` next to the existing
route↔spec guard.

- **`TestOpenAPIDeclaresOnlyStatusesTheServerCanEmit`** — parses every status
  declared under `paths:` and requires each to be a status the server's own
  non-test sources can produce (`fiber.Status*`, or a literal
  `Status(NNN)`/`SendStatus(NNN)`). The `fiber` identifier is derived from
  `http.StatusText`, so there is no hand-maintained table to drift.
- **`TestOpenAPIDocumentsEveryTransportStatusTheEnvelopeCovers`** — the reverse
  direction for the one part of the surface that keeps a registry:
  `transportErrorSpecsByStatus`. Every entry must appear in the `ApiError`
  description with its stable key. The reverse direction is not machine-checkable
  for domain statuses — a source scan cannot say which operation answers a
  status, and the document deliberately omits page routes — so that half is left
  to review rather than faked.

**Proof on defect.** Restoring `'422'` on one operation:

```
=== RUN   TestOpenAPIDeclaresOnlyStatusesTheServerCanEmit
    openapi_contract_test.go:95: docs/openapi.yaml declares 422 but no server source emits it
        (searched for fiber.StatusUnprocessableEntity and a literal Status(422)); declared on:
          DELETE /api/v1/users/current
--- FAIL: TestOpenAPIDeclaresOnlyStatusesTheServerCanEmit (0.03s)
```

And breaking one documented transport key (`unsupported_media_type` →
`unsupported_media`):

```
=== RUN   TestOpenAPIDocumentsEveryTransportStatusTheEnvelopeCovers
    openapi_contract_test.go:125: transportErrorSpecsByStatus answers 415 with key
        "unsupported_media_type", but docs/openapi.yaml never documents it; the ApiError
        description needs the line "* `415` — `unsupported_media_type`"
--- FAIL: TestOpenAPIDocumentsEveryTransportStatusTheEnvelopeCovers (0.01s)
```

Both restored; both green.

## Verification

- `go build ./...`, `go vet ./...` — clean.
- Full `go test ./...` — every package green (docs edits are not test-free:
  `scripts/readmeversion` reads shipped docs).
- Spec parsed with a duplicate-key-strict YAML loader: no duplicate keys, all 46
  `$ref`s resolve, every component example satisfies `ApiError`'s `required`.
- Patch-coverage gate run after the commit, profile and gate in one invocation:
  `patch coverage gate OK`.

## Known, not fixed here

`ApiErrorDetail.category` publishes the enum
`[validation, not_found, conflict, unauthorized, forbidden, rate_limited, internal]`,
but `APIErrorCategoryTooLarge` (`too_large`) is what a transport `413`/`431`
actually carries. That is a category, not a status, so it falls outside this
PR's class; worth its own change.
