### PR TITLE
docs(api): make the published error contract say what the server sends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -438,7 +438,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `WriteTimeout` and dragged the budget along with it. The two constants are now
   recorded as independent, and the fasthttp behaviour the reasoning rests on is
   pinned by a test that fails on an upgrade moving the deadline.
-
 - **`docs/openapi.yaml` promised input bounds wider than the ones the server
   actually enforces.** `ProfileSettings.display_name` declared `maxLength: 80`
   against a 64-rune cap; `CycleSettings.cycle_length` declared `minimum: 1`
@@ -486,6 +485,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   product left a log line that did not say whose data they touched. The session
   resolver now publishes the actor for the whole request, which covers both
   step-up purposes and any handler that resolves a session the same way later.
+- **The API specification described error responses the server never sends.**
+  Nineteen operations in [docs/openapi.yaml](docs/openapi.yaml) declared `422
+  Unprocessable Entity` for a rejected payload, while every validation refusal
+  the app produces is a `400` — there is no `422` branch anywhere in the server.
+  A client written against the document was therefore branching on a status it
+  could never receive, and met the real refusal in whichever branch it kept for
+  something else. The document now says `400`. Nothing in the server changed:
+  moving the app to `422` would have broken every client already reading `400`,
+  in exchange for a distinction the response envelope already carries in
+  `error_detail.category`, where `validation` is its own stable value.
+
+  The published `error_detail.category` enum had the mirror-image defect, and a
+  worse one — it was **missing** a value the server really sends. The enum is
+  documented as closed and is what the document tells clients to branch on, yet
+  it omitted `too_large`, which every request refused by the 16 MiB body limit
+  and every one refused by the oversized request head carries. A client that
+  trusted the enum did not merely wait for something that could not arrive; it
+  met something it had been told could not exist.
+
+  Decision (2026-07-28): `413` legitimately carries **two** categories, and the
+  document now says so instead of picking one. `category` names the reason, not
+  the status: a body past the byte limit is refused before the request reaches
+  an operation, with nothing about its content examined, and carries
+  `too_large`; a restore payload that parses cleanly but declares more than
+  20 000 entries has failed a content rule after parsing, and carries
+  `validation`. Collapsing them would tell a client "send fewer bytes" and
+  "split this export into several restores" in the same word. The two keys that
+  `413` carries were already documented and deliberate; the two categories are
+  the same distinction one level up.
+
+  Sweeping the remaining statuses the same way closed the opposite gap. The
+  `409` that a duplicate symptom name — or a cycle start that would overwrite an
+  existing one — really answers with was documented nowhere in the file, nor was
+  the `404` for a symptom that does not exist.
+
+  The examples were the same story in miniature: fourteen of them showed a bare
+  `{ "error": ... }` that the `ApiError` schema above them forbids, and three
+  key strings — `too many attempts`, `internal error`, and the
+  `auth.invalid_credentials` that headed the schema itself — belong to no
+  response the server can produce (the real ones are `too many requests`,
+  `internal_error` and `invalid credentials`). Every example in the document now
+  carries a complete envelope whose key, category and target are the ones a
+  client will actually receive.
 
 - **Onboarding and three settings endpoints now appear in the audit stream.**
   With `AUDIT_LOG_ENABLED=true`, both onboarding steps, onboarding completion,

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -154,31 +154,68 @@ components:
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
-          example: { error: "unauthorized" }
+          example:
+            error: "unauthorized"
+            error_detail: { key: "unauthorized", category: "unauthorized", target: "global" }
     Forbidden:
       description: Session is valid but the caller lacks the required role (typically owner-only) or CSRF validation failed.
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
-          example: { error: "forbidden" }
+          example:
+            error: "forbidden"
+            error_detail: { key: "forbidden", category: "forbidden", target: "global" }
     ValidationError:
-      description: Request body or query parameters failed validation.
+      description: |
+        Request body, path, or query parameters failed validation. The server
+        answers `400` — it has no `422` branch, and a client that needs to tell a
+        validation refusal apart from any other `400` reads
+        `error_detail.category`, which is `validation` for every response using
+        this component. `error_detail.target` follows the surface: `global` for
+        programmatic endpoints, `auth_form` or `settings_form` where the
+        rejection belongs inside a rendered form.
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
-          example: { error: "invalid input" }
+          example:
+            error: "invalid input"
+            error_detail: { key: "invalid input", category: "validation", target: "global" }
+    NotFound:
+      description: The addressed resource does not exist for the authenticated account.
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/ApiError' }
+          example:
+            error: "symptom not found"
+            error_detail: { key: "symptom not found", category: "not_found", target: "settings_form" }
+    Conflict:
+      description: |
+        The request collides with state the account already holds — a duplicate
+        symptom name, or a cycle start that would overwrite an existing one. The
+        envelope carries `error_detail.category: "conflict"`; the collision is
+        resolvable by the client (rename, or resend with `replace_existing`).
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/ApiError' }
+          example:
+            error: "symptom name already exists"
+            error_detail: { key: "symptom name already exists", category: "conflict", target: "settings_form" }
     RateLimited:
       description: Rate limit exceeded.
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
-          example: { error: "too many attempts" }
+          example:
+            error: "too many requests"
+            error_detail: { key: "too many requests", category: "rate_limited", target: "global" }
     InternalError:
       description: Unexpected server error.
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
-          example: { error: "internal error" }
+          example:
+            error: "internal_error"
+            error_detail: { key: "internal_error", category: "internal", target: "global" }
 
   schemas:
     ApiError:
@@ -250,7 +287,7 @@ components:
       properties:
         error:
           type: string
-          example: "auth.invalid_credentials"
+          example: "invalid credentials"
         error_detail:
           $ref: '#/components/schemas/ApiErrorDetail'
       additionalProperties: false
@@ -262,11 +299,27 @@ components:
         key:
           type: string
           description: Same value as the top-level `error` string. Duplicated here so a client that consumes only `error_detail` can branch without parsing the parent envelope.
-          example: "auth.invalid_credentials"
+          example: "invalid credentials"
         category:
           type: string
-          enum: [validation, not_found, conflict, unauthorized, forbidden, rate_limited, internal]
-          description: Error class. Stable enum — new values may be added in any release but existing values do not change meaning.
+          enum: [validation, not_found, conflict, unauthorized, forbidden, rate_limited, too_large, internal]
+          description: |
+            Error class. Stable enum — new values may be added in any release
+            but existing values do not change meaning, so treat an unknown
+            category as the generic failure for its status class.
+
+            `category` names the **reason**, not the status, so it is not a
+            function of the status code. `413` is the case where that matters:
+            a body past the 16 MiB limit — measured on the wire and, for a
+            compressed request, on the decompressed stream — is refused before
+            the request reaches any operation and carries `too_large` with the
+            key `request_too_large`, while a restore payload that parses
+            cleanly but declares more than 20 000 day entries has failed a
+            content rule and carries `validation` with the key
+            `import file too large`. Both are `413`; a client that branches on
+            `413` alone cannot tell "send fewer bytes" from "split this export
+            into several restores". `too_large` is likewise what a `431`
+            carries when the request head does not fit the read buffer.
         target:
           type: string
           enum: [global, auth_form, settings_form]
@@ -1020,7 +1073,7 @@ paths:
       responses:
         '303':
           description: Redirect to `/register/welcome` with the sealed pickup cookie. Shape is identical for new and duplicate emails.
-        '422':
+        '400':
           $ref: '#/components/responses/ValidationError'
         '429':
           $ref: '#/components/responses/RateLimited'
@@ -1064,7 +1117,9 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ApiError' }
-              example: { error: "auth.invalid_credentials" }
+              example:
+                error: "invalid credentials"
+                error_detail: { key: "invalid credentials", category: "unauthorized", target: "auth_form" }
         '429':
           $ref: '#/components/responses/RateLimited'
 
@@ -1169,7 +1224,7 @@ paths:
       responses:
         '303':
           description: Redirect to `/login` after success.
-        '422':
+        '400':
           $ref: '#/components/responses/ValidationError'
 
   # =========================================================================
@@ -1191,7 +1246,7 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/OkResponse' }
         '401': { $ref: '#/components/responses/Unauthorized' }
-        '422': { $ref: '#/components/responses/ValidationError' }
+        '400': { $ref: '#/components/responses/ValidationError' }
 
   /api/v1/onboarding/steps/2:
     post:
@@ -1209,7 +1264,7 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/OkResponse' }
         '401': { $ref: '#/components/responses/Unauthorized' }
-        '422': { $ref: '#/components/responses/ValidationError' }
+        '400': { $ref: '#/components/responses/ValidationError' }
 
   /api/v1/onboarding/complete:
     post:
@@ -1242,7 +1297,7 @@ paths:
                 type: array
                 items: { $ref: '#/components/schemas/DailyLog' }
         '401': { $ref: '#/components/responses/Unauthorized' }
-        '422': { $ref: '#/components/responses/ValidationError' }
+        '400': { $ref: '#/components/responses/ValidationError' }
 
   /api/v1/days/{date}:
     parameters:
@@ -1257,7 +1312,7 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/DailyLog' }
         '401': { $ref: '#/components/responses/Unauthorized' }
-        '422': { $ref: '#/components/responses/ValidationError' }
+        '400': { $ref: '#/components/responses/ValidationError' }
     head:
       tags: [days]
       summary: Check whether the day has any persisted data (owner only).
@@ -1292,7 +1347,7 @@ paths:
               schema: { $ref: '#/components/schemas/DailyLog' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
-        '422': { $ref: '#/components/responses/ValidationError' }
+        '400': { $ref: '#/components/responses/ValidationError' }
     delete:
       tags: [days]
       summary: Delete a single day's entry (owner only).
@@ -1342,8 +1397,19 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/OkResponse' }
+        '400': { $ref: '#/components/responses/ValidationError' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
+        '409':
+          description: |
+            The day already carries a cycle start (or data that marking one would
+            overwrite). Resend with `replace_existing=true` to take it.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ApiError' }
+              example:
+                error: "cycle start replace required"
+                error_detail: { key: "cycle start replace required", category: "conflict", target: "global" }
 
   # =========================================================================
   # symptoms
@@ -1377,7 +1443,8 @@ paths:
               schema: { $ref: '#/components/schemas/Symptom' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
-        '422': { $ref: '#/components/responses/ValidationError' }
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '409': { $ref: '#/components/responses/Conflict' }
 
   /api/v1/symptoms/{id}:
     parameters:
@@ -1398,7 +1465,9 @@ paths:
               schema: { $ref: '#/components/schemas/Symptom' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
-        '422': { $ref: '#/components/responses/ValidationError' }
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '409': { $ref: '#/components/responses/Conflict' }
     delete:
       tags: [symptoms]
       summary: Archive (soft-delete) a symptom (owner only).
@@ -1413,8 +1482,10 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/OkResponse' }
+        '400': { $ref: '#/components/responses/ValidationError' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
 
   /api/v1/symptoms/{id}/restore:
     post:
@@ -1428,8 +1499,11 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/OkResponse' }
+        '400': { $ref: '#/components/responses/ValidationError' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '409': { $ref: '#/components/responses/Conflict' }
 
   # =========================================================================
   # stats
@@ -1534,14 +1608,20 @@ paths:
         '413':
           description: |
             Payload exceeds the size or entry-count limit. Two independent caps
-            produce two different keys: `import file too large` from the entry
-            cap (20 000), and `request_too_large` from the 16 MiB body limit,
-            which the server enforces before the handler runs — on the wire body
-            and, when the request is compressed, on its decompressed size.
+            produce two different keys **and two different categories**, because
+            they measure different things at different moments:
+            `import file too large` / `validation` from the entry cap (20 000),
+            counted on a payload that already parsed; and `request_too_large` /
+            `too_large` from the 16 MiB body limit, which the server enforces
+            before the handler runs — on the wire body and, when the request is
+            compressed, on its decompressed size — without looking at the
+            content at all. Branch on `error_detail`, not on the status.
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ApiError' }
-              example: { error: "import file too large" }
+              example:
+                error: "import file too large"
+                error_detail: { key: "import file too large", category: "validation", target: "global" }
 
   # =========================================================================
   # users/current — whoami, settings, and account management
@@ -1582,7 +1662,7 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/OkResponse' }
         '401': { $ref: '#/components/responses/Unauthorized' }
-        '422': { $ref: '#/components/responses/ValidationError' }
+        '400': { $ref: '#/components/responses/ValidationError' }
 
   /api/v1/users/current/profile:
     patch:
@@ -1601,7 +1681,7 @@ paths:
               schema: { $ref: '#/components/schemas/OkResponse' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
-        '422': { $ref: '#/components/responses/ValidationError' }
+        '400': { $ref: '#/components/responses/ValidationError' }
 
   /api/v1/users/current/interface:
     patch:
@@ -1701,7 +1781,9 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ApiError' }
-              example: { error: "invalid webhook url" }
+              example:
+                error: "invalid webhook url"
+                error_detail: { key: "invalid webhook url", category: "validation", target: "settings_form" }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
 
@@ -1738,7 +1820,9 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ApiError' }
-              example: { error: "failed to update calendar feed" }
+              example:
+                error: "failed to update calendar feed"
+                error_detail: { key: "failed to update calendar feed", category: "internal", target: "global" }
     delete:
       tags: [settings]
       summary: Revoke (disable) the calendar (.ics) feed (owner only).
@@ -1760,7 +1844,9 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ApiError' }
-              example: { error: "failed to update calendar feed" }
+              example:
+                error: "failed to update calendar feed"
+                error_detail: { key: "failed to update calendar feed", category: "internal", target: "global" }
 
   /api/v1/users/current/calendar-feed/rotate:
     post:
@@ -1790,7 +1876,9 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ApiError' }
-              example: { error: "failed to update calendar feed" }
+              example:
+                error: "failed to update calendar feed"
+                error_detail: { key: "failed to update calendar feed", category: "internal", target: "global" }
 
   /api/v1/users/current/cycle:
     patch:
@@ -1809,7 +1897,7 @@ paths:
               schema: { $ref: '#/components/schemas/OkResponse' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
-        '422': { $ref: '#/components/responses/ValidationError' }
+        '400': { $ref: '#/components/responses/ValidationError' }
 
   /api/v1/users/current/reminders:
     patch:
@@ -1859,8 +1947,10 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ApiError' }
-              example: { error: "oidc reauth required" }
-        '422': { $ref: '#/components/responses/ValidationError' }
+              example:
+                error: "oidc reauth required"
+                error_detail: { key: "oidc reauth required", category: "forbidden", target: "settings_form" }
+        '400': { $ref: '#/components/responses/ValidationError' }
 
   /api/v1/users/current/password/step-up:
     post:
@@ -1887,7 +1977,7 @@ paths:
           description: "Browser redirect to the provider authorize URL when `Accept: application/json` is not set."
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
-        '422': { $ref: '#/components/responses/ValidationError' }
+        '400': { $ref: '#/components/responses/ValidationError' }
 
   /api/v1/users/current/data-wipe/step-up:
     post:
@@ -1919,7 +2009,9 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ApiError' }
-              example: { error: "invalid settings input" }
+              example:
+                error: "invalid settings input"
+                error_detail: { key: "invalid settings input", category: "validation", target: "settings_form" }
 
   /api/v1/users/current/deletion/step-up:
     post:
@@ -1945,7 +2037,9 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ApiError' }
-              example: { error: "invalid settings input" }
+              example:
+                error: "invalid settings input"
+                error_detail: { key: "invalid settings input", category: "validation", target: "settings_form" }
 
   /api/v1/users/current/recovery-code:
     post:
@@ -1966,7 +2060,7 @@ paths:
           description: Recovery code surface rendered. JSON clients should follow the redirect to `/recovery-code` to pick up the plaintext code (shown exactly once).
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
-        '422': { $ref: '#/components/responses/ValidationError' }
+        '400': { $ref: '#/components/responses/ValidationError' }
 
   /api/v1/users/current/2fa:
     put:
@@ -1986,7 +2080,7 @@ paths:
           description: 2FA enabled.
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
-        '422': { $ref: '#/components/responses/ValidationError' }
+        '400': { $ref: '#/components/responses/ValidationError' }
     delete:
       tags: [settings]
       summary: Disable TOTP 2FA (owner only).
@@ -2003,7 +2097,7 @@ paths:
           description: 2FA disabled.
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
-        '422': { $ref: '#/components/responses/ValidationError' }
+        '400': { $ref: '#/components/responses/ValidationError' }
         '429': { $ref: '#/components/responses/RateLimited' }
 
   /api/v1/users/current/data-wipe/validate:
@@ -2024,7 +2118,7 @@ paths:
         '204':
           description: Same as 200 for non-JSON clients.
         '401': { $ref: '#/components/responses/Unauthorized' }
-        '422': { $ref: '#/components/responses/ValidationError' }
+        '400': { $ref: '#/components/responses/ValidationError' }
 
   /api/v1/users/current/data-wipe:
     post:
@@ -2049,4 +2143,4 @@ paths:
               schema: { $ref: '#/components/schemas/OkResponse' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
-        '422': { $ref: '#/components/responses/ValidationError' }
+        '400': { $ref: '#/components/responses/ValidationError' }

--- a/internal/api/openapi_contract_test.go
+++ b/internal/api/openapi_contract_test.go
@@ -3,10 +3,13 @@ package api
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
+	"io/fs"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -45,6 +48,292 @@ func TestOpenAPIContractMatchesRegisteredRoutes(t *testing.T) {
 	if extra := difference(specRoutes, codeRoutes); len(extra) > 0 {
 		t.Errorf("routes documented in docs/openapi.yaml but not registered in code:\n  %s", strings.Join(extra, "\n  "))
 	}
+}
+
+// TestOpenAPIDeclaresOnlyStatusesTheServerCanEmit is the status half of the
+// route↔spec contract. Route presence is pinned above; this pins the response
+// codes each operation publishes, because a spec can name every route correctly
+// and still describe outcomes the server has no branch for. It did: the document
+// declared '422' on nineteen operations while the app answers every validation
+// refusal with 400 — the distinction clients actually get is
+// error_detail.category, not a second status.
+//
+// The check runs one way on purpose: every status the spec DECLARES must be a
+// status the server can PRODUCE. The opposite direction is not derivable from a
+// source scan — a status appears in the sources without saying which operation
+// answers it, and the document deliberately excludes page routes (the OIDC start
+// redirect's 307) and documents the transport statuses centrally rather than per
+// path. That half is pinned instead by
+// TestOpenAPIDocumentsEveryTransportStatusTheEnvelopeCovers, where a real
+// registry exists to enumerate.
+//
+// "Can produce" is read from the server's own sources: every rejection resolves
+// its status through an APIErrorSpec built with a fiber.Status* constant, and the
+// handful of direct answers use c.Status/SendStatus. Test sources are excluded —
+// what a test can assert is not what the server can send.
+func TestOpenAPIDeclaresOnlyStatusesTheServerCanEmit(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+
+	declared := openAPIDeclaredStatuses(t, filepath.Join(repoRoot, "docs", "openapi.yaml"))
+	if len(declared) == 0 {
+		t.Fatal("no response statuses parsed from openapi.yaml; parser or spec is wrong")
+	}
+	sources := serverSourceText(t, repoRoot)
+
+	statuses := make([]int, 0, len(declared))
+	for status := range declared {
+		statuses = append(statuses, status)
+	}
+	sort.Ints(statuses)
+
+	for _, status := range statuses {
+		identifier := fiberStatusIdentifier(t, status)
+		if regexp.MustCompile(regexp.QuoteMeta(identifier) + `\b`).MatchString(sources) {
+			continue
+		}
+		if regexp.MustCompile(`(?:Status|SendStatus)\(\s*` + fmt.Sprint(status) + `\b`).MatchString(sources) {
+			continue
+		}
+		operations := declared[status]
+		sort.Strings(operations)
+		t.Errorf("docs/openapi.yaml declares %d but no server source emits it (searched for %s and a literal Status(%d)); declared on:\n  %s",
+			status, identifier, status, strings.Join(operations, "\n  "))
+	}
+}
+
+// TestOpenAPIDocumentsEveryTransportStatusTheEnvelopeCovers pins the reverse
+// direction for the one part of the surface that keeps a registry of it. The
+// transport statuses are answered outside any operation — an unroutable request,
+// an undecodable body, an unparseable head — so the spec documents them once in
+// the ApiError schema description instead of per path. That list is prose, which
+// is exactly the kind of text that stops matching the map beside it: a new entry
+// in transportErrorSpecsByStatus, or a renamed key, is invisible until a client
+// meets a status the document never mentions. Both the status and its stable key
+// are asserted, since the key is the whole reason the entry is worth publishing.
+func TestOpenAPIDocumentsEveryTransportStatusTheEnvelopeCovers(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "..", "docs", "openapi.yaml"))
+	if err != nil {
+		t.Fatalf("read openapi spec: %v", err)
+	}
+	spec := string(data)
+
+	statuses := make([]int, 0, len(transportErrorSpecsByStatus))
+	for status := range transportErrorSpecsByStatus {
+		statuses = append(statuses, status)
+	}
+	sort.Ints(statuses)
+
+	for _, status := range statuses {
+		entry := fmt.Sprintf("* `%d` — `%s`", status, transportErrorSpecsByStatus[status].Key)
+		if !strings.Contains(spec, entry) {
+			t.Errorf("transportErrorSpecsByStatus answers %d with key %q, but docs/openapi.yaml never documents it; the ApiError description needs the line %q",
+				status, transportErrorSpecsByStatus[status].Key, entry)
+		}
+	}
+}
+
+// TestOpenAPIPublishesEveryErrorCategoryTheServerCanEmit pins the third half of
+// the envelope contract. The status half is above; this one covers
+// error_detail.category, which the spec publishes as a closed enum and which the
+// spec's own text tells clients to branch on in preference to the key string. A
+// closed enum missing a value the server sends is worse than a status the server
+// never sends: the client is not merely waiting for something that cannot
+// arrive, it is meeting something it was told could not exist. The enum omitted
+// too_large, which every 413 refused by the body limit and every 431 refused by
+// the read buffer carries.
+//
+// The check runs both ways, like the route contract: a constant the enum forgets
+// AND an enum value no constant defines both fail. The constants are read out of
+// their declaration file rather than listed here, so a category added later is
+// swept without editing this test — and the parser is anchored to the compiler
+// below, so a regex that silently stops matching cannot pass as "no categories
+// to check".
+func TestOpenAPIPublishesEveryErrorCategoryTheServerCanEmit(t *testing.T) {
+	declared := declaredErrorCategories(t, filepath.Join("..", "..", "internal", "api", "error_mapping_types.go"))
+	published := openAPIPublishedErrorCategories(t, filepath.Join("..", "..", "docs", "openapi.yaml"))
+
+	// Anchor the source scan against the compiler: these two constants exist by
+	// name here, so a regex that matched nothing (or matched the wrong capture)
+	// fails loudly instead of reporting an empty, trivially satisfied set.
+	for _, anchor := range []APIErrorCategory{APIErrorCategoryValidation, APIErrorCategoryTooLarge} {
+		if _, ok := declared[string(anchor)]; !ok {
+			t.Fatalf("category scan did not find %q in error_mapping_types.go; the scan, not the spec, is broken", anchor)
+		}
+	}
+
+	if missing := difference(declared, published); len(missing) > 0 {
+		t.Errorf("categories the server can emit but docs/openapi.yaml does not publish in ApiErrorDetail.category:\n  %s\n(a client told the enum is closed meets a value it was promised could not exist)",
+			strings.Join(missing, "\n  "))
+	}
+	if extra := difference(published, declared); len(extra) > 0 {
+		t.Errorf("categories published in docs/openapi.yaml but declared by no APIErrorCategory constant:\n  %s",
+			strings.Join(extra, "\n  "))
+	}
+}
+
+// declaredErrorCategories reads the APIErrorCategory constant block and returns
+// the wire values it declares. Go cannot enumerate the members of a constant
+// type at run time, so the declaration file is the only place that holds the
+// whole set; scanning it keeps the sweep allowlist-free, which a hand-written
+// slice here would not be.
+func declaredErrorCategories(t *testing.T, sourcePath string) map[string]struct{} {
+	t.Helper()
+	data, err := os.ReadFile(sourcePath)
+	if err != nil {
+		t.Fatalf("read %s: %v", sourcePath, err)
+	}
+
+	declaration := regexp.MustCompile(`APIErrorCategory\w+\s+APIErrorCategory\s*=\s*"([^"]+)"`)
+	categories := make(map[string]struct{})
+	for _, match := range declaration.FindAllStringSubmatch(string(data), -1) {
+		categories[match[1]] = struct{}{}
+	}
+	return categories
+}
+
+// openAPIPublishedErrorCategories reads the enum declared for
+// ApiErrorDetail.category. The scan tracks the schema nesting rather than
+// matching the first "enum:" it sees, because the sibling `target` property
+// declares one too and confusing the two would compare the wrong sets.
+func openAPIPublishedErrorCategories(t *testing.T, specPath string) map[string]struct{} {
+	t.Helper()
+	data, err := os.ReadFile(specPath)
+	if err != nil {
+		t.Fatalf("read openapi spec: %v", err)
+	}
+
+	inSchema, inCategory := false, false
+	for _, raw := range strings.Split(string(data), "\n") {
+		line := strings.TrimRight(raw, "\r")
+		text := strings.TrimSpace(line)
+		if text == "" || strings.HasPrefix(text, "#") {
+			continue
+		}
+		indent := len(line) - len(strings.TrimLeft(line, " "))
+
+		switch {
+		case indent == 4 && strings.HasSuffix(text, ":"):
+			inSchema = text == "ApiErrorDetail:"
+			inCategory = false
+		case indent == 8 && inSchema && strings.HasSuffix(text, ":"):
+			inCategory = text == "category:"
+		case indent == 10 && inCategory && strings.HasPrefix(text, "enum:"):
+			values := make(map[string]struct{})
+			for _, value := range strings.Split(strings.Trim(strings.TrimSpace(strings.TrimPrefix(text, "enum:")), "[]"), ",") {
+				if trimmed := strings.Trim(strings.TrimSpace(value), `"'`); trimmed != "" {
+					values[trimmed] = struct{}{}
+				}
+			}
+			return values
+		}
+	}
+	t.Fatal("no enum found for ApiErrorDetail.category in docs/openapi.yaml; parser or spec is wrong")
+	return nil
+}
+
+// openAPIDeclaredStatuses returns every response status declared under paths:,
+// mapped to the "METHOD /path" operations that declare it. Statuses live at a
+// fixed depth — path item (2), operation (4), responses (6), status (8) — so the
+// scan tracks that nesting rather than matching three-digit keys anywhere, which
+// would also swallow enum values and example payloads.
+func openAPIDeclaredStatuses(t *testing.T, specPath string) map[int][]string {
+	t.Helper()
+	data, err := os.ReadFile(specPath)
+	if err != nil {
+		t.Fatalf("read openapi spec: %v", err)
+	}
+
+	statusKey := regexp.MustCompile(`^'?(\d{3})'?:`)
+	declared := make(map[int][]string)
+	inPaths := false
+	currentPath := ""
+	currentOperation := ""
+	inResponses := false
+
+	for _, raw := range strings.Split(string(data), "\n") {
+		line := strings.TrimRight(raw, "\r")
+		if strings.TrimSpace(line) == "" || strings.HasPrefix(strings.TrimSpace(line), "#") {
+			continue
+		}
+		if !strings.HasPrefix(line, " ") {
+			inPaths = strings.HasPrefix(line, "paths:")
+			currentPath, currentOperation, inResponses = "", "", false
+			continue
+		}
+		if !inPaths {
+			continue
+		}
+
+		indent := len(line) - len(strings.TrimLeft(line, " "))
+		text := strings.TrimSpace(line)
+
+		switch {
+		case indent == 2 && strings.HasPrefix(text, "/") && strings.HasSuffix(text, ":"):
+			currentPath = strings.TrimSuffix(text, ":")
+			currentOperation, inResponses = "", false
+		case indent == 4:
+			currentOperation = strings.ToUpper(strings.TrimSuffix(text, ":"))
+			inResponses = false
+		case indent == 6:
+			inResponses = text == "responses:"
+		case indent == 8 && inResponses && currentPath != "" && currentOperation != "":
+			match := statusKey.FindStringSubmatch(text)
+			if match == nil {
+				continue
+			}
+			status := 0
+			if _, err := fmt.Sscanf(match[1], "%d", &status); err != nil {
+				t.Fatalf("unparseable status key %q under %s %s", text, currentOperation, currentPath)
+			}
+			declared[status] = append(declared[status], currentOperation+" "+currentPath)
+		}
+	}
+	return declared
+}
+
+// serverSourceText concatenates every non-test Go source under internal/ and
+// cmd/ — the code that can actually put a status on the wire.
+func serverSourceText(t *testing.T, repoRoot string) string {
+	t.Helper()
+	var builder strings.Builder
+	for _, tree := range []string{"internal", "cmd"} {
+		root := filepath.Join(repoRoot, tree)
+		err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if entry.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			data, readErr := os.ReadFile(path)
+			if readErr != nil {
+				return readErr
+			}
+			builder.Write(data)
+			builder.WriteString("\n")
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walk %s: %v", root, err)
+		}
+	}
+	if builder.Len() == 0 {
+		t.Fatalf("no server sources read from %s; test setup is wrong", repoRoot)
+	}
+	return builder.String()
+}
+
+// fiberStatusIdentifier derives the fiber constant a status would be written as.
+// fiber's Status* constants mirror net/http's, whose names are StatusText with
+// the separators removed, so the mapping needs no hand-maintained table that
+// could drift from the spec it is meant to check.
+func fiberStatusIdentifier(t *testing.T, status int) string {
+	t.Helper()
+	text := http.StatusText(status)
+	if text == "" {
+		t.Fatalf("docs/openapi.yaml declares %d, which is not a registered HTTP status", status)
+	}
+	return "fiber.Status" + strings.NewReplacer(" ", "", "-", "").Replace(text)
 }
 
 // registeredV1Routes returns the set of "METHOD /api/v1/..." entries the Fiber


### PR DESCRIPTION
Supersedes #363 — same work, rebased onto `main` after #357 landed and touched
the same test file. Force-push is blocked here, so the rebased history is
published under a new branch; #363 can be closed as replaced.

One theme: **`docs/openapi.yaml` described error responses the server never
sends, and omitted one it does.** Statuses, one category, and the examples.
No Go source outside the test file is modified; no status, key, category or
mapping changes.

## 1. The `422` nineteen operations declared and the server never sends

18 as `$ref: '#/components/responses/ValidationError'`, one
(`POST /api/v1/users`) in expanded form, while the application answers **no
request with 422, ever**:

```
$ grep -rn "StatusUnprocessableEntity" internal/ cmd/
(no matches)
```

Every validation refusal resolves through an `APIErrorSpec` built with
`fiber.StatusBadRequest` — `settingsValidationErrorSpec`, `authValidationErrorSpec`,
`onboardingValidationErrorSpec`, `mapDayUpsertError`, `mapSymptomNameValidationError`
— and the transport catch-all for an undecodable body is
`transportErrorSpecsByStatus[400] = bad_request`. A client written against the
document was branching on a status it could never receive, and met the real
refusal in whichever branch it kept for something else.

Same class as #352 (recovery-code alphabet) and #357 (field bounds).

### Decision (2026-07-28): the spec moves to 400; the application is not touched

The area rule for `internal/api` calls the spec **descriptive but obliged to be
true**. Moving the server to `422` would break every client that branches on
`400` today, and would buy a distinction the application **already publishes in
a better place**: `error_detail.category`, a stable enum in which `validation`
is its own value. A `422` would restate what is already stated, at the cost of a
breaking change.

**Collisions: zero.** The five operations that already declared `'400'`
(`POST /api/v1/imports/json`, `.../timezone`, `.../webhook`,
`.../data-wipe/step-up`, `.../deletion/step-up`) are exactly the five that
carried no `'422'`, so no descriptions had to be merged and no duplicate YAML key
was produced. Verified with a duplicate-key-strict loader.

## 2. The `too_large` category the enum omitted and the server does send

`ApiErrorDetail.category` is published as a **closed** enum, and the document
tells clients to branch on it in preference to the key string. It listed seven
values; `internal/api/error_mapping_types.go` declares eight. The missing one,
`too_large`, is what **every** transport `413` (body past the 16 MiB limit — on
the wire and, for a compressed request, decompressed) and **every** `431`
(request head past the read buffer) carries.

This is worse than a status that never arrives. A client trusting the enum was
not waiting for something that could not come; it was meeting something it had
been told could not exist.

### Decision (2026-07-28): `413` carries two categories, and the document says so

The domain `413` in `error_mapping_import.go` is tagged
`APIErrorCategoryValidation`, not `TooLarge`. That is **intentional and
correct**, and it is now documented rather than smoothed over. `category` names
the **reason**, not the status:

| | transport `413` | import `413` |
| --- | --- | --- |
| raised by | fiber `BodyLimit`, before routing | `ImportService.ImportJSON` |
| measured | wire bytes, and the decompressed stream | `len(payload.Entries) > MaxImportEntries` (20 000) |
| when | before any handler; content never examined | **after** `json.Unmarshal` succeeded |
| key | `request_too_large` | `import file too large` |
| category | `too_large` | `validation` |
| client's move | send fewer bytes | split the export into several restores |

The import cap is a content rule failing on a document that **parsed** — the
same class of judgement as its sibling `invalid import file` (also `validation`,
`400`) in the same mapper. Collapsing the two into one category would tell a
client "send fewer bytes" and "split this export" in the same word.

Two supporting facts checked rather than assumed:

- The repository already documents and intends `413` carrying **two keys** — the
  `/api/v1/imports/json` `413` description has said so since the cap landed. Two
  categories are the same deliberate distinction one level up.
- `api.md`'s "one status keeps one key whichever layer produced it" is not
  violated: its examples (401, 404, 429) are one **condition** surfacing from
  different layers. Here there are two different conditions, which is exactly the
  case that rule leaves room for.

The counter-case, for the record: one could argue the import `413` should be
`too_large` for symmetry with its status. That buys visual tidiness and loses the
only signal separating a byte-count refusal from a record-count refusal, so it is
declined. **No mapping in Go changed either way** — had the analysis gone the
other way, the change would have been a server behaviour decision and out of
scope for this PR.

## 3. Class sweep — every declared status against every emitted one

No other status is declared and never sent. The sweep did find the reverse:

| Status | Declared before | Emitted by the app | Action |
| --- | --- | --- | --- |
| 200 / 201 / 204 / 303 | yes | yes | correct, unchanged |
| 400 | 5 sites | everywhere validation fails | 19 sites restored |
| 401 | 44 sites | `unauthorizedErrorSpec`, auth mappers | correct |
| 403 | 30 sites | owner-only guard, CSRF, OIDC re-auth | correct |
| 404 | 1 site (`HEAD /days/{date}`) | also `symptom not found` on 3 symptom routes | **added** to those 3 |
| 409 | **nowhere** | `symptom name already exists`, `cycle start replace required` | **added** to the 4 routes that emit it |
| 413 | 1 site (`imports/json`) | entry cap + body limit | correct; the two categories are now stated |
| 429 | 6 sites | limiters | correct |
| 500 | 3 sites | any handler's persistence failure | left as is — the `ApiError` description documents it app-wide; per-path would be noise |
| 503 | 1 site (`/readyz`) | readiness + request-budget timeout | correct |
| 405 / 415 / 431 | prose only | transport layer | correct — documented centrally in the `ApiError` description |
| 307 | nowhere | `/auth/oidc` start redirect | correct — a page route, explicitly out of scope for this document |

New `NotFound` and `Conflict` shared responses back the additions.

## 4. The examples

`ApiError` requires `error_detail`. **Fourteen** examples showed a bare
`{ "error": ... }` and so were invalid against the schema printed above them —
five shared components and nine inline. Three key strings named responses the
server cannot produce at all:

| Published | Real |
| --- | --- |
| `too many attempts` | `too many requests` |
| `internal error` | `internal_error` |
| `auth.invalid_credentials` (×3, including the headline example on `ApiError` itself) | `invalid credentials` |

`auth.invalid_credentials` occurs **nowhere** in the codebase — only in this
document, and it was the first example a reader of the schema saw.

Every `ApiError` example in the file (17, including the three added here) now
carries a complete envelope whose `key`, `category` and `target` are the ones a
client actually receives; a walk of the parsed document checks each against
`ApiError.required`, `ApiErrorDetail.required`, both published enums, and
`error_detail.key == error`.

## Tests

Three pins, all in `internal/api/openapi_contract_test.go` next to the existing
route↔spec guard.

- **`TestOpenAPIDeclaresOnlyStatusesTheServerCanEmit`** — every status declared
  under `paths:` must be one the server's non-test sources can produce
  (`fiber.Status*`, or a literal `Status(NNN)`/`SendStatus(NNN)`). The `fiber`
  identifier is derived from `http.StatusText`, so no hand-maintained table can
  drift.
- **`TestOpenAPIDocumentsEveryTransportStatusTheEnvelopeCovers`** — the reverse
  direction for the one part of the surface with a registry:
  `transportErrorSpecsByStatus`. Status **and** stable key are asserted.
- **`TestOpenAPIPublishesEveryErrorCategoryTheServerCanEmit`** — both directions
  between the `APIErrorCategory*` constants and the published enum. The
  constants are read out of their declaration file, not listed in the test, so a
  category added later is swept for free; the scan is anchored to the compiler by
  requiring it to find `APIErrorCategoryValidation` and `APIErrorCategoryTooLarge`
  by name, so a regex that silently stops matching fails loudly instead of
  passing as "nothing to check".

Domain statuses are deliberately **not** checked in the emitted→declared
direction: a source scan cannot say which operation answers a status, and the
document excludes page routes (the OIDC `307`). That half is left to review
rather than faked.

### Proof on defect

`'422'` restored on one operation:

```
=== RUN   TestOpenAPIDeclaresOnlyStatusesTheServerCanEmit
    openapi_contract_test.go:95: docs/openapi.yaml declares 422 but no server source emits it
        (searched for fiber.StatusUnprocessableEntity and a literal Status(422)); declared on:
          DELETE /api/v1/users/current
--- FAIL: TestOpenAPIDeclaresOnlyStatusesTheServerCanEmit (0.03s)
```

One transport key broken (`unsupported_media_type` → `unsupported_media`):

```
=== RUN   TestOpenAPIDocumentsEveryTransportStatusTheEnvelopeCovers
    openapi_contract_test.go:125: transportErrorSpecsByStatus answers 415 with key
        "unsupported_media_type", but docs/openapi.yaml never documents it; the ApiError
        description needs the line "* `415` — `unsupported_media_type`"
--- FAIL: TestOpenAPIDocumentsEveryTransportStatusTheEnvelopeCovers (0.01s)
```

`too_large` removed from the enum — the exact original defect:

```
=== RUN   TestOpenAPIPublishesEveryErrorCategoryTheServerCanEmit
    openapi_contract_test.go:165: categories the server can emit but docs/openapi.yaml does not
        publish in ApiErrorDetail.category:
          too_large
        (a client told the enum is closed meets a value it was promised could not exist)
--- FAIL: TestOpenAPIPublishesEveryErrorCategoryTheServerCanEmit (0.00s)
```

And the reverse arm of the same test, with an invented enum value, so neither
half is dead:

```
=== RUN   TestOpenAPIPublishesEveryErrorCategoryTheServerCanEmit
    openapi_contract_test.go:169: categories published in docs/openapi.yaml but declared by no
        APIErrorCategory constant:
          quota_exceeded
--- FAIL: TestOpenAPIPublishesEveryErrorCategoryTheServerCanEmit (0.00s)
```

All four defects restored; all three tests green.

## Verification

- `go build ./...`, `go vet ./...` — clean.
- Full `go test ./...` — every package green (docs edits are not test-free:
  `scripts/readmeversion` reads shipped docs).
- Spec parsed with a duplicate-key-strict YAML loader: no duplicate keys, all 46
  `$ref`s resolve, all 17 `ApiError` examples valid.
- Patch-coverage gate run after the commit, profile and gate in one invocation:
  `patch coverage gate OK`.
- Rebased onto `origin/main` (`ce54b54c`); `git merge-tree` against `main`
  reports no conflict.



## Why this replaces #366

The merge queue rebases, and after #364/#365 landed their changelog entries in the same section tail, replaying this branch conflicted there. Rebuilt on the current `main`; `docs/openapi.yaml` and `internal/api/openapi_contract_test.go` are unchanged from #366.
