### PR TITLE
docs(self-hosted): route the remaining restore paths to the real verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -638,6 +638,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [docs/security/known-disclosures.md](docs/security/known-disclosures.md). Field
   reference: [docs/security/logging.md](docs/security/logging.md#logging-policy).
 
+- **The restore paths that still ended at "it started" now route to the
+  verification that can fail.** *Post-Restore Verification* says in its own text
+  that every up-signal above step 4 stays green on an empty database, and the
+  backup-contract bullet and the named-volume restore step were corrected to
+  defer to it — but two other passages still let a restore be signed off without
+  reading any data back. The Postgres runbook ended on "prints no `ERROR:`
+  lines, exits `0`", which a truncated or empty dump satisfies exactly, because
+  it replays into a freshly dropped schema without an error and leaves the stack
+  healthy and blank. The safe-upgrade procedure's rollback step said to restore
+  from backup with the procedure's own confirmation — the container healthcheck
+  and one page load — sitting above it as steps 4-5.
+
+  Both now point at [docs/self-hosted.md](docs/self-hosted.md) *Post-Restore
+  Verification* and name why the quick signals cannot close a restore out. The
+  checklist itself is unchanged and stays the single home of the procedure.
+
 ### Security
 
 - **A two-factor cookie the server refuses is now cleared instead of left in the

--- a/docs/self-hosted.md
+++ b/docs/self-hosted.md
@@ -357,6 +357,8 @@ Without both, the restore's outcome depends on the state of the target database,
 
 With the drop step and `ON_ERROR_STOP=1`, the same restore prints no `ERROR:` lines, exits `0`, and leaves an export byte-identical to the one taken when the dump was made.
 
+A clean exit now means the two commands ran, not that the data came back: a truncated or empty dump replays into a freshly dropped schema without a single error and exits `0` just the same, leaving the stack healthy and blank. Finish through [Post-Restore Verification](#post-restore-verification) — `/readyz` and a normal page load stay green on an empty database, so neither closes out a Postgres restore either.
+
 Keep the SQL dump and `.env` / application-secret backup separate, just as you would for the SQLite baseline.
 
 The same rule applies to the public Postgres reverse-proxy stacks. Back up PostgreSQL with `pg_dump` or your platform-native Postgres snapshot tooling; do not try to apply the SQLite file-copy runbook to those stacks. The two restore requirements above — empty the target first, and run `psql` under `-v ON_ERROR_STOP=1` — are properties of `pg_dump` and `psql` rather than of the bundled stack, so they hold wherever you replay a plain dump.
@@ -438,7 +440,7 @@ Use this sequence for routine upgrades:
 3. Pull the new image and restart the service.
 4. Wait for the container healthcheck to report healthy.
 5. Confirm `/healthz` through the correct deployment-mode health check and open the main UI once to confirm the app is responding.
-6. If the new version fails to start cleanly, roll back to the previous image tag and restore from backup if needed.
+6. If the new version fails to start cleanly, roll back to the previous image tag and restore from backup if needed. Confirm such a restore through [Post-Restore Verification](#post-restore-verification) rather than by repeating steps 4-5: the container healthcheck and the main UI stay green on an empty database, so they say the rollback booted, not that the data is back.
 
 Migrations apply automatically on every boot: there is no `-migrate` flag or manual step to run (unlike tools such as Miniflux). Starting the new binary or image runs any pending embedded migrations against the database before the server accepts traffic, in order, forward-only, with no down-migration path — this is why step 2 (backup before restart) is mandatory rather than optional.
 


### PR DESCRIPTION
## What

Two operator-facing passages in `docs/self-hosted.md` still allowed a restore to be signed off on signals that stay green on an empty database. Both now defer to *Post-Restore Verification* and say why those signals cannot close a restore out.

- **Postgres restore path** (*Backup and Restore Contract*). The runbook ended on "prints no `ERROR:` lines, exits `0`" — which a truncated or empty dump satisfies exactly, because it replays into a freshly dropped schema without a single error and leaves the stack healthy and blank. Added after that sentence: a clean exit means the two commands ran, not that the data came back, then a pointer to the checklist.
- **Safe Upgrade Procedure, step 6.** The rollback step said to restore from backup while the procedure's own confirmation — the container healthcheck and one page load — stood above it as steps 4-5. The step now says to confirm that restore through *Post-Restore Verification* instead of repeating steps 4-5.

## Why

`/readyz`, a healthy container and a rendering page do not distinguish a restore that brought the data back from one that restored nothing into an empty database. The checklist says this in its own text; these two passages contradicted it, and they are what an operator reads while running the restore rather than afterwards.

## Scope

The full procedure keeps one home: *Post-Restore Verification* is untouched, and the new text defers to it rather than restating it. Swept the tracked docs (`docs/**`, `README*`, `SECURITY.md`, `TESTING.md`, `CONTRIBUTING.md`, the example stacks) for other passages that state how to confirm a restore succeeded; the backup-contract bullet, the named-volume restore step and the restore-drill bullet were already corrected earlier and are left as they are. `docs/gdpr.md` *Backup Restore and the Calendar Feed* is a containment re-check after a restore, not a success signal, so it stays unchanged.

Docs and CHANGELOG only; no code paths touched.
