### PR TITLE
ci: gate pull requests on changelog.d fragments

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,41 @@
+name: Changelog
+
+on:
+  pull_request:
+  # Merge-queue validation runs: every workflow that owns a required status
+  # check must also report on merge_group, or a queued merge waits forever.
+  merge_group:
+
+permissions:
+  contents: read
+
+jobs:
+  # The job id is the status-check context name; keep it stable.
+  changelog-fragment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pass on merge queue runs
+        if: github.event_name == 'merge_group'
+        run: echo "Fragment presence was already enforced on the pull request run."
+
+      - name: Checkout
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The gate diffs the branch against its base, so it needs history.
+          fetch-depth: 0
+
+      - name: Setup Go
+        if: github.event_name == 'pull_request'
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Check changelog fragment
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: origin/${{ github.event.pull_request.base.ref }}
+        run: |
+          git fetch --no-tags origin ${{ github.event.pull_request.base.ref }}
+          go run ./scripts/changelogd check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+*New entries accumulate as per-pull-request fragments in [changelog.d/](changelog.d/) and are assembled here at release.*
+
 ### Added
 
 - **A readiness probe, `GET /readyz`, that actually checks storage.** The whole

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,37 @@ spots, kept as shipped:
 
 If you are scripting against `/api/v1/*` from outside the bundled UI, pin to a specific image tag and re-validate on every upgrade — `v1.x.y` minor bumps are safe; major bumps surface in [CHANGELOG.md](CHANGELOG.md) with the breaking entries called out.
 
+## Changelog Fragments
+
+Every pull request adds one changelog fragment, `changelog.d/<branch-name>.md`, instead of editing
+[CHANGELOG.md](CHANGELOG.md). Several pull requests inserting an entry at the same anchor in the
+`[Unreleased]` section was this repository's only recurring merge conflict, and rebasing replays the
+earlier commit straight back into the contested spot; a file per branch has no shared anchor.
+
+A fragment holds exactly the text that used to go under `[Unreleased]` — a Keep a Changelog section
+header plus the entry:
+
+```markdown
+### Fixed
+
+- **Short summary.** What changed, and what an operator or a user notices.
+```
+
+- Valid headers are the Keep a Changelog sections — `### Added`, `### Changed`, `### Deprecated`,
+  `### Removed`, `### Fixed`, `### Security` — plus the two this changelog has always carried after
+  them, `### Internal` and `### Dependencies`. Several sections may appear in one fragment; assembly
+  puts them in that order.
+- A pull request with no user-visible change adds a fragment whose first line is exactly `none`;
+  anything below that line is ignored, so the reason can be written underneath it.
+- `CHANGELOG.md` itself is edited directly only by release assembly and by corrections to text that
+  has already been released. At release time,
+  `go run ./scripts/changelogd assemble -version X.Y.Z` merges the accumulated fragments (and
+  anything still frozen under `[Unreleased]`) into a new released section in Keep a Changelog order
+  and deletes the consumed fragments.
+- The `changelog-fragment` CI check enforces this: it fails a pull request that adds neither a valid
+  fragment nor a new `## [` heading in `CHANGELOG.md`, and it names the file and the problem when a
+  fragment has an unknown section header or no entry text.
+
 ## Commit Style
 
 Use imperative commit messages, e.g.:

--- a/changelog.d/ci-changelog-fragments.md
+++ b/changelog.d/ci-changelog-fragments.md
@@ -1,0 +1,8 @@
+### Changed
+
+- **Changelog entries now accumulate as per-pull-request fragments.** Each pull
+  request adds one file under `changelog.d/` instead of editing the
+  `[Unreleased]` section of `CHANGELOG.md`; a CI check enforces the fragment and
+  `go run ./scripts/changelogd assemble` folds the accumulated fragments into
+  `CHANGELOG.md` when a release is cut. Entries written before this change stay
+  under `[Unreleased]` until the next release consumes them.

--- a/scripts/changelogd/main.go
+++ b/scripts/changelogd/main.go
@@ -1,0 +1,443 @@
+// Command changelogd keeps changelog entries out of CHANGELOG.md until a
+// release is cut. Every pull request adds one fragment file under changelog.d/
+// instead of editing the "## [Unreleased]" section, which is the only spot in
+// the tree several branches reliably contend for: two pull requests inserting
+// an entry at the same anchor conflict in the merge queue, and rebasing replays
+// the earlier commit straight back into the contested spot.
+//
+// Two subcommands:
+//
+//	changelogd check
+//	    CI gate for pull requests. Env BASE_REF (default origin/main) names the
+//	    base to diff against. Passes when the branch adds at least one valid
+//	    fragment under changelog.d/, or when it edits CHANGELOG.md itself in a
+//	    way only release assembly and post-release corrections do (adding a
+//	    "## [" heading). Exit 0 when the gate passes, 1 when it fails.
+//
+//	changelogd assemble -version X.Y.Z [-date YYYY-MM-DD]
+//	    Run by hand at release time. Folds every accumulated fragment, plus
+//	    whatever is still frozen under "## [Unreleased]", into a new released
+//	    section and deletes the consumed fragments.
+//
+// Exit codes follow scripts/patchcov: 0 pass, 1 the gate itself failing, 2 for
+// tool breakage (git unavailable, unreadable files, bad flags).
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+// pointerLine replaces the entries that used to accumulate under
+// "## [Unreleased]". Assembly rewrites the Unreleased body down to this single
+// line, and strips it from the frozen backlog before merging.
+const pointerLine = "*New entries accumulate as per-pull-request fragments in [changelog.d/](changelog.d/) and are assembled here at release.*"
+
+// fragmentDir holds one markdown fragment per pull request.
+const fragmentDir = "changelog.d"
+
+// changelogFile is written by release assembly and by corrections to text that
+// has already been released — never by an ordinary pull request.
+const changelogFile = "CHANGELOG.md"
+
+// noneMarker is the whole content a pull request with no user-visible change
+// puts in its fragment (the rest of such a file is ignored).
+const noneMarker = "none"
+
+// sectionOrder is the order every assembled release follows: the Keep a
+// Changelog sections, then the two this changelog has always carried after them
+// ("### Internal" since 1.4.0, "### Dependencies" since 1.8.0). The list is
+// closed on purpose — a typo'd or invented header is what the check rejects.
+var sectionOrder = []string{
+	"### Added",
+	"### Changed",
+	"### Deprecated",
+	"### Removed",
+	"### Fixed",
+	"### Security",
+	"### Internal",
+	"### Dependencies",
+}
+
+var versionPattern = regexp.MustCompile(`^\d+\.\d+\.\d+$`)
+
+func main() {
+	if len(os.Args) < 2 {
+		fatalf("usage: changelogd <check|assemble> [flags]")
+	}
+	switch os.Args[1] {
+	case "check":
+		failure, err := check(".", envOr("BASE_REF", "origin/main"), gitOutput)
+		if err != nil {
+			fatalf("changelog fragment check: %v", err)
+		}
+		if failure != "" {
+			fmt.Fprintln(os.Stderr, failure)
+			os.Exit(1)
+		}
+		fmt.Println("changelog fragment check OK.")
+	case "assemble":
+		summary, err := assembleCommand(".", os.Args[2:])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "changelog assembly FAILED: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println(summary)
+	default:
+		fatalf("unknown subcommand %q (expected check or assemble)", os.Args[1])
+	}
+}
+
+// gitRunner runs git in dir and returns its standard output.
+type gitRunner func(dir string, args ...string) (string, error)
+
+func gitOutput(dir string, args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("git %s: %v: %s", strings.Join(args, " "), err, strings.TrimSpace(stderr.String()))
+	}
+	return string(out), nil
+}
+
+// check reports whether the branch satisfies the fragment rule. It returns an
+// empty string when the gate passes, the failure text when it fails, and an
+// error only when the check itself could not be carried out.
+func check(root, baseRef string, git gitRunner) (string, error) {
+	nameStatus, err := git(root, "diff", "--name-status", "--no-color", baseRef+"...HEAD")
+	if err != nil {
+		return "", fmt.Errorf("diff against %s: %w", baseRef, err)
+	}
+
+	if fragments := addedFragments(nameStatus); len(fragments) > 0 {
+		var problems []string
+		for _, fragment := range fragments {
+			data, readErr := os.ReadFile(filepath.Join(root, filepath.FromSlash(fragment)))
+			if readErr != nil {
+				return "", fmt.Errorf("read fragment %s: %w", fragment, readErr)
+			}
+			if err := validateFragment(fragment, string(data)); err != nil {
+				problems = append(problems, "  "+err.Error())
+			}
+		}
+		if len(problems) > 0 {
+			return "changelog fragment check FAILED:\n" + strings.Join(problems, "\n") + "\n\n" + fragmentFormatHelp(), nil
+		}
+		return "", nil
+	}
+
+	changelogDiff, err := git(root, "diff", "--unified=0", "--no-color", baseRef+"...HEAD", "--", changelogFile)
+	if err != nil {
+		return "", fmt.Errorf("diff %s against %s: %w", changelogFile, baseRef, err)
+	}
+	if addsReleaseHeading(changelogDiff) {
+		return "", nil
+	}
+	return missingFragmentHelp(), nil
+}
+
+// addedFragments returns the changelog.d/*.md paths this branch adds, taken
+// from `git diff --name-status` output. Only status A counts: an edit to a
+// fragment another branch already landed is not this branch's entry. A missing
+// changelog.d/ directory simply yields nothing.
+func addedFragments(nameStatus string) []string {
+	var added []string
+	for _, line := range strings.Split(nameStatus, "\n") {
+		fields := strings.Split(strings.TrimRight(line, "\r"), "\t")
+		if len(fields) < 2 || fields[0] != "A" {
+			continue
+		}
+		path := fields[len(fields)-1]
+		if strings.HasPrefix(path, fragmentDir+"/") && strings.HasSuffix(path, ".md") {
+			added = append(added, path)
+		}
+	}
+	sort.Strings(added)
+	return added
+}
+
+// addsReleaseHeading reports whether a CHANGELOG.md diff adds a "## [" heading,
+// which is what release assembly and a correction to an already-released
+// section look like — and what an ordinary entry never looks like.
+func addsReleaseHeading(diff string) bool {
+	for _, line := range strings.Split(diff, "\n") {
+		if !strings.HasPrefix(line, "+") || strings.HasPrefix(line, "+++") {
+			continue
+		}
+		if strings.HasPrefix(strings.TrimSpace(line[1:]), "## [") {
+			return true
+		}
+	}
+	return false
+}
+
+// validateFragment accepts either the "none" marker or a fragment whose first
+// non-empty line is a known section header, whose every "### " line is a known
+// section header, and which carries at least one line of entry text.
+func validateFragment(name, content string) error {
+	if isNoneMarker(content) {
+		return nil
+	}
+	sections, err := parseSections(name, content)
+	if err != nil {
+		return err
+	}
+	if len(sections) == 0 {
+		return fmt.Errorf("%s: no changelog entry found (expected a %q header followed by entry text, or the single line %q)", name, sectionOrder[0], noneMarker)
+	}
+	return nil
+}
+
+// isNoneMarker reports whether the file's first non-empty line is exactly the
+// no-user-visible-change marker. The rest of such a file is ignored, so an
+// author may explain the "none" underneath it.
+func isNoneMarker(content string) bool {
+	for _, line := range strings.Split(content, "\n") {
+		if trimmed := strings.TrimSpace(line); trimmed != "" {
+			return trimmed == noneMarker
+		}
+	}
+	return false
+}
+
+// parseSections splits changelog text into one body per section header,
+// preserving each body verbatim (multi-paragraph entries and their indentation
+// survive a round trip). Repeated headers in one source are concatenated.
+func parseSections(name, content string) (map[string]string, error) {
+	sections := map[string]string{}
+	current := ""
+	var buf []string
+
+	flush := func() {
+		body := strings.Trim(strings.Join(buf, "\n"), "\n")
+		buf = nil
+		if current == "" || body == "" {
+			return
+		}
+		if existing := sections[current]; existing != "" {
+			body = existing + "\n\n" + body
+		}
+		sections[current] = body
+	}
+
+	for _, raw := range strings.Split(content, "\n") {
+		line := strings.TrimRight(raw, " \t\r")
+		if strings.HasPrefix(line, "### ") {
+			if !isKnownSection(line) {
+				return nil, fmt.Errorf("%s: unknown section header %q (expected one of: %s)", name, line, strings.Join(sectionOrder, ", "))
+			}
+			flush()
+			current = line
+			continue
+		}
+		if current == "" {
+			if strings.TrimSpace(line) != "" {
+				return nil, fmt.Errorf("%s: text before the first section header: %q (a fragment starts with a %q header, or with the single line %q)", name, strings.TrimSpace(line), sectionOrder[0], noneMarker)
+			}
+			continue
+		}
+		buf = append(buf, line)
+	}
+	flush()
+	return sections, nil
+}
+
+func isKnownSection(line string) bool {
+	for _, section := range sectionOrder {
+		if line == section {
+			return true
+		}
+	}
+	return false
+}
+
+func fragmentFormatHelp() string {
+	return "A fragment holds the entry text that would previously have gone under \"## [Unreleased]\":\n" +
+		"\n" +
+		"    ### Fixed\n" +
+		"\n" +
+		"    - **Short summary.** What changed, and what an operator or a user notices.\n" +
+		"\n" +
+		"Known section headers: " + strings.Join(sectionOrder, ", ") + ".\n" +
+		"Several sections may appear in one fragment.\n" +
+		"\n" +
+		"A pull request with no user-visible change writes a fragment whose first line is:\n" +
+		"\n" +
+		"    none\n"
+}
+
+func missingFragmentHelp() string {
+	return "changelog fragment check FAILED: this branch adds no fragment under " + fragmentDir + "/.\n" +
+		"\n" +
+		"Add " + fragmentDir + "/<branch-name>.md and put the changelog entry there instead of in\n" +
+		changelogFile + ", which is rewritten only by release assembly\n" +
+		"(go run ./scripts/changelogd assemble -version X.Y.Z) and by corrections to already-released text.\n" +
+		"\n" + fragmentFormatHelp()
+}
+
+// assembleCommand parses the assemble flags and folds the accumulated
+// fragments into CHANGELOG.md.
+func assembleCommand(root string, args []string) (string, error) {
+	flags := flag.NewFlagSet("assemble", flag.ContinueOnError)
+	version := flags.String("version", "", "release version to assemble, as X.Y.Z")
+	date := flags.String("date", "", "release date as YYYY-MM-DD (default: today, UTC)")
+	if err := flags.Parse(args); err != nil {
+		return "", err
+	}
+	return assemble(root, *version, *date)
+}
+
+func assemble(root, version, date string) (string, error) {
+	if !versionPattern.MatchString(version) {
+		return "", fmt.Errorf("invalid -version %q (expected X.Y.Z)", version)
+	}
+	if date == "" {
+		date = time.Now().UTC().Format("2006-01-02")
+	} else if _, err := time.Parse("2006-01-02", date); err != nil {
+		return "", fmt.Errorf("invalid -date %q (expected YYYY-MM-DD)", date)
+	}
+
+	fragments, err := filepath.Glob(filepath.Join(root, fragmentDir, "*.md"))
+	if err != nil {
+		return "", fmt.Errorf("list fragments: %w", err)
+	}
+	sort.Strings(fragments)
+
+	changelogPath := filepath.Join(root, changelogFile)
+	content, err := os.ReadFile(changelogPath)
+	if err != nil {
+		return "", fmt.Errorf("read %s: %w", changelogFile, err)
+	}
+	head, unreleased, tail, err := splitChangelog(string(content))
+	if err != nil {
+		return "", err
+	}
+
+	merged := map[string][]string{}
+	frozen, err := parseSections(changelogFile+" [Unreleased]", strings.Join(stripPointerLine(unreleased), "\n"))
+	if err != nil {
+		return "", err
+	}
+	for section, body := range frozen {
+		merged[section] = append(merged[section], body)
+	}
+
+	consumed := 0
+	for _, fragment := range fragments {
+		name := filepath.ToSlash(fragment)
+		data, err := os.ReadFile(fragment)
+		if err != nil {
+			return "", fmt.Errorf("read fragment %s: %w", name, err)
+		}
+		consumed++
+		if isNoneMarker(string(data)) {
+			continue
+		}
+		sections, err := parseSections(name, string(data))
+		if err != nil {
+			return "", err
+		}
+		for _, section := range sectionOrder {
+			if body := sections[section]; body != "" {
+				merged[section] = append(merged[section], body)
+			}
+		}
+	}
+
+	if len(merged) == 0 {
+		return "", fmt.Errorf("nothing to release: no fragments in %s/ and no entries frozen under \"## [Unreleased]\" in %s", fragmentDir, changelogFile)
+	}
+
+	out := renderChangelog(head, tail, merged, version, date)
+	if err := os.WriteFile(changelogPath, []byte(out), 0o644); err != nil {
+		return "", fmt.Errorf("write %s: %w", changelogFile, err)
+	}
+	for _, fragment := range fragments {
+		if err := os.Remove(fragment); err != nil {
+			return "", fmt.Errorf("remove consumed fragment %s: %w", filepath.ToSlash(fragment), err)
+		}
+	}
+
+	return fmt.Sprintf("assembled ## [%s] - %s into %s (%d fragment(s) consumed)", version, date, changelogFile, consumed), nil
+}
+
+// splitChangelog cuts CHANGELOG.md into everything through the
+// "## [Unreleased]" heading, the body of that section, and everything from the
+// next "## " heading onwards.
+func splitChangelog(content string) (head, unreleased, tail []string, err error) {
+	lines := strings.Split(content, "\n")
+	start := -1
+	for i, line := range lines {
+		if strings.TrimSpace(line) == "## [Unreleased]" {
+			start = i
+			break
+		}
+	}
+	if start < 0 {
+		return nil, nil, nil, fmt.Errorf("%s has no \"## [Unreleased]\" section", changelogFile)
+	}
+	end := len(lines)
+	for i := start + 1; i < len(lines); i++ {
+		if strings.HasPrefix(lines[i], "## ") {
+			end = i
+			break
+		}
+	}
+	return lines[:start+1], lines[start+1 : end], lines[end:], nil
+}
+
+// stripPointerLine drops the pointer that stands in for the entries assembly
+// moved out, leaving the frozen backlog.
+func stripPointerLine(body []string) []string {
+	kept := make([]string, 0, len(body))
+	for _, line := range body {
+		if strings.TrimSpace(line) == pointerLine {
+			continue
+		}
+		kept = append(kept, line)
+	}
+	return kept
+}
+
+// renderChangelog rebuilds the file: the Unreleased body shrinks to the pointer
+// line, the new release section follows it, and everything below is untouched.
+func renderChangelog(head, tail []string, merged map[string][]string, version, date string) string {
+	out := make([]string, 0, len(head)+len(tail)+16)
+	out = append(out, head...)
+	out = append(out, "", pointerLine, "")
+	out = append(out, fmt.Sprintf("## [%s] - %s", version, date), "")
+	for _, section := range sectionOrder {
+		bodies := merged[section]
+		if len(bodies) == 0 {
+			continue
+		}
+		out = append(out, section, "")
+		out = append(out, strings.Split(strings.Join(bodies, "\n\n"), "\n")...)
+		out = append(out, "")
+	}
+	out = append(out, tail...)
+	return strings.Join(out, "\n")
+}
+
+func envOr(key, fallback string) string {
+	if v := strings.TrimSpace(os.Getenv(key)); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func fatalf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(2)
+}

--- a/scripts/changelogd/main_test.go
+++ b/scripts/changelogd/main_test.go
@@ -1,0 +1,569 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const fixtureChangelog = `# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+` + pointerLine + `
+
+### Fixed
+
+- **A frozen entry.** Written before fragments existed, and still waiting for a
+  release to carry it out.
+
+## [1.0.0] - 2026-01-01
+
+### Added
+
+- **The first release.**
+`
+
+// --- check mode -------------------------------------------------------------
+
+func TestCheckFailsWhenBranchAddsNoFragment(t *testing.T) {
+	dir := initRepo(t)
+	writeFile(t, dir, "internal/app.go", "package app\n")
+	commitAll(t, dir, "feat: something user-visible")
+
+	failure, err := check(dir, "main", gitOutput)
+	if err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	if failure == "" {
+		t.Fatal("expected the gate to fail on a branch with no changelog.d/ fragment")
+	}
+	for _, want := range []string{"adds no fragment", "changelog.d/<branch-name>.md", "### Fixed", "none"} {
+		if !strings.Contains(failure, want) {
+			t.Errorf("failure message does not mention %q:\n%s", want, failure)
+		}
+	}
+}
+
+func TestCheckPassesOnAddedFragment(t *testing.T) {
+	dir := initRepo(t)
+	writeFile(t, dir, "changelog.d/some-branch.md", "### Added\n\n- **A new thing.**\n")
+	commitAll(t, dir, "feat: a new thing")
+
+	failure, err := check(dir, "main", gitOutput)
+	if err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	if failure != "" {
+		t.Fatalf("expected the gate to pass on a valid fragment, got:\n%s", failure)
+	}
+}
+
+func TestCheckPassesOnNoneMarkerFragment(t *testing.T) {
+	dir := initRepo(t)
+	writeFile(t, dir, "changelog.d/chore-branch.md", "none\n\nOnly the CI workflow moved; nothing an operator can observe.\n")
+	commitAll(t, dir, "chore: nothing user-visible")
+
+	failure, err := check(dir, "main", gitOutput)
+	if err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	if failure != "" {
+		t.Fatalf("expected the gate to pass on a none-marker fragment, got:\n%s", failure)
+	}
+}
+
+func TestCheckFailsOnUnknownSectionHeaderAndNamesTheFile(t *testing.T) {
+	dir := initRepo(t)
+	writeFile(t, dir, "changelog.d/bad-branch.md", "### Improved\n\n- **Not a Keep a Changelog section.**\n")
+	commitAll(t, dir, "feat: wrong header")
+
+	failure, err := check(dir, "main", gitOutput)
+	if err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	if !strings.Contains(failure, "changelog.d/bad-branch.md") || !strings.Contains(failure, "### Improved") {
+		t.Fatalf("failure must name the file and the offending header, got:\n%s", failure)
+	}
+}
+
+func TestCheckFailsOnFragmentWithoutEntryText(t *testing.T) {
+	dir := initRepo(t)
+	writeFile(t, dir, "changelog.d/empty-branch.md", "### Added\n\n")
+	commitAll(t, dir, "feat: header only")
+
+	failure, err := check(dir, "main", gitOutput)
+	if err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	if !strings.Contains(failure, "no changelog entry found") {
+		t.Fatalf("expected a header-only fragment to fail, got:\n%s", failure)
+	}
+}
+
+func TestCheckFailsOnFragmentTextBeforeTheFirstHeader(t *testing.T) {
+	dir := initRepo(t)
+	writeFile(t, dir, "changelog.d/loose-branch.md", "- **An entry with no section.**\n")
+	commitAll(t, dir, "feat: no header")
+
+	failure, err := check(dir, "main", gitOutput)
+	if err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	if !strings.Contains(failure, "text before the first section header") {
+		t.Fatalf("expected an unheaded fragment to fail, got:\n%s", failure)
+	}
+}
+
+func TestCheckPassesWhenChangelogGainsAReleaseHeading(t *testing.T) {
+	dir := initRepo(t)
+	writeFile(t, dir, "CHANGELOG.md", strings.Replace(fixtureChangelog,
+		"## [1.0.0] - 2026-01-01",
+		"## [1.1.0] - 2026-02-02\n\n### Added\n\n- **An assembled release.**\n\n## [1.0.0] - 2026-01-01", 1))
+	commitAll(t, dir, "chore: cut 1.1.0")
+
+	failure, err := check(dir, "main", gitOutput)
+	if err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	if failure != "" {
+		t.Fatalf("expected release assembly to pass without a fragment, got:\n%s", failure)
+	}
+}
+
+func TestCheckFailsWhenChangelogGainsAnEntryButNoReleaseHeading(t *testing.T) {
+	dir := initRepo(t)
+	writeFile(t, dir, "CHANGELOG.md", strings.Replace(fixtureChangelog,
+		"### Fixed\n",
+		"### Fixed\n\n- **An entry written straight into Unreleased.**\n", 1))
+	commitAll(t, dir, "fix: edit the changelog by hand")
+
+	failure, err := check(dir, "main", gitOutput)
+	if err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	if failure == "" {
+		t.Fatal("editing the [Unreleased] body by hand must not satisfy the gate")
+	}
+}
+
+func TestCheckIgnoresAnEditToAnExistingFragment(t *testing.T) {
+	dir := initRepo(t)
+	writeFile(t, dir, "changelog.d/landed-earlier.md", "### Added\n\n- **Landed on main already.**\n")
+	commitAll(t, dir, "chore: a fragment already on main")
+	run(t, dir, "checkout", "-q", "main")
+	run(t, dir, "merge", "-q", "--ff-only", "feature")
+	run(t, dir, "checkout", "-q", "-b", "later")
+	writeFile(t, dir, "changelog.d/landed-earlier.md", "### Added\n\n- **Reworded by another branch.**\n")
+	commitAll(t, dir, "docs: reword someone else's fragment")
+
+	failure, err := check(dir, "main", gitOutput)
+	if err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	if failure == "" {
+		t.Fatal("modifying a fragment that is already on main is not this branch's entry")
+	}
+}
+
+func TestCheckReportsAnUnusableBaseRef(t *testing.T) {
+	dir := initRepo(t)
+	if _, err := check(dir, "origin/does-not-exist", gitOutput); err == nil {
+		t.Fatal("expected an error, not a verdict, when the base ref cannot be resolved")
+	}
+}
+
+func TestAddedFragmentsCollectsOnlyAddedMarkdownUnderChangelogD(t *testing.T) {
+	nameStatus := strings.Join([]string{
+		"A\tchangelog.d/second.md",
+		"A\tchangelog.d/first.md",
+		"M\tchangelog.d/existing.md",
+		"D\tchangelog.d/gone.md",
+		"A\tchangelog.d/.gitkeep",
+		"A\tdocs/changelog.d/elsewhere.md",
+		"A\tinternal/api/handler.go",
+		"R100\tchangelog.d/old.md\tchangelog.d/renamed.md",
+		"",
+	}, "\n")
+
+	got := addedFragments(nameStatus)
+	want := []string{"changelog.d/first.md", "changelog.d/second.md"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("addedFragments = %v, want %v", got, want)
+	}
+}
+
+func TestAddsReleaseHeadingReadsAddedLinesOnly(t *testing.T) {
+	cases := map[string]bool{
+		"+++ b/CHANGELOG.md\n+## [1.2.3] - 2026-02-02\n":  true,
+		"+++ b/CHANGELOG.md\n+- **An ordinary entry.**\n": false,
+		"+++ b/CHANGELOG.md\n-## [1.2.3] - 2026-02-02\n":  false,
+		"":                                               false,
+	}
+	for diff, want := range cases {
+		if got := addsReleaseHeading(diff); got != want {
+			t.Errorf("addsReleaseHeading(%q) = %v, want %v", diff, got, want)
+		}
+	}
+}
+
+// --- assemble mode ----------------------------------------------------------
+
+func TestAssembleFoldsFragmentsIntoAReleaseSection(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "CHANGELOG.md", fixtureChangelog)
+	writeFile(t, dir, "changelog.d/.gitkeep", "")
+	writeFile(t, dir, "changelog.d/a-first.md", "### Added\n\n- **A new thing.** It spans\n  two lines.\n")
+	writeFile(t, dir, "changelog.d/b-second.md", "### Fixed\n\n- **A fixed thing.**\n\n### Security\n\n- **A hardened thing.**\n")
+	writeFile(t, dir, "changelog.d/c-quiet.md", "none\n")
+
+	summary, err := assembleCommand(dir, []string{"-version", "1.1.0", "-date", "2026-02-02"})
+	if err != nil {
+		t.Fatalf("assemble: %v", err)
+	}
+	if !strings.Contains(summary, "1.1.0") || !strings.Contains(summary, "3 fragment(s)") {
+		t.Errorf("summary = %q, want the version and the consumed count", summary)
+	}
+
+	want := `# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+` + pointerLine + `
+
+## [1.1.0] - 2026-02-02
+
+### Added
+
+- **A new thing.** It spans
+  two lines.
+
+### Fixed
+
+- **A frozen entry.** Written before fragments existed, and still waiting for a
+  release to carry it out.
+
+- **A fixed thing.**
+
+### Security
+
+- **A hardened thing.**
+
+## [1.0.0] - 2026-01-01
+
+### Added
+
+- **The first release.**
+`
+	got := readFile(t, dir, "CHANGELOG.md")
+	if got != want {
+		t.Fatalf("assembled CHANGELOG.md mismatch:\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+
+	for _, consumed := range []string{"changelog.d/a-first.md", "changelog.d/b-second.md", "changelog.d/c-quiet.md"} {
+		if _, err := os.Stat(filepath.Join(dir, filepath.FromSlash(consumed))); !os.IsNotExist(err) {
+			t.Errorf("%s must be deleted after assembly (stat err = %v)", consumed, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(dir, "changelog.d", ".gitkeep")); err != nil {
+		t.Errorf("changelog.d/.gitkeep must survive assembly: %v", err)
+	}
+}
+
+func TestAssembleWithoutFragmentsStillReleasesTheFrozenBacklog(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "CHANGELOG.md", fixtureChangelog)
+
+	if _, err := assemble(dir, "1.1.0", "2026-02-02"); err != nil {
+		t.Fatalf("assemble: %v", err)
+	}
+	got := readFile(t, dir, "CHANGELOG.md")
+	if !strings.Contains(got, "## [1.1.0] - 2026-02-02\n\n### Fixed\n\n- **A frozen entry.**") {
+		t.Fatalf("frozen backlog was not carried into the release:\n%s", got)
+	}
+	if strings.Count(got, "- **A frozen entry.**") != 1 {
+		t.Fatalf("the frozen entry must move, not duplicate:\n%s", got)
+	}
+	if !strings.Contains(got, "## [Unreleased]\n\n"+pointerLine+"\n\n## [1.1.0]") {
+		t.Fatalf("the Unreleased body must shrink to the pointer line:\n%s", got)
+	}
+}
+
+func TestAssembleDefaultsTheDateToTodayInUTC(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "CHANGELOG.md", fixtureChangelog)
+
+	summary, err := assembleCommand(dir, []string{"-version", "2.0.0"})
+	if err != nil {
+		t.Fatalf("assemble: %v", err)
+	}
+	if !strings.Contains(readFile(t, dir, "CHANGELOG.md"), "## [2.0.0] - ") {
+		t.Fatalf("expected a dated release heading, summary was %q", summary)
+	}
+}
+
+func TestAssembleRefusesBadInput(t *testing.T) {
+	cases := []struct {
+		name    string
+		version string
+		date    string
+		want    string
+	}{
+		{name: "no version", version: "", date: "2026-02-02", want: "invalid -version"},
+		{name: "tag-shaped version", version: "v1.1.0", date: "2026-02-02", want: "invalid -version"},
+		{name: "bad date", version: "1.1.0", date: "02/02/2026", want: "invalid -date"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeFile(t, dir, "CHANGELOG.md", fixtureChangelog)
+			_, err := assemble(dir, c.version, c.date)
+			if err == nil || !strings.Contains(err.Error(), c.want) {
+				t.Fatalf("assemble error = %v, want one mentioning %q", err, c.want)
+			}
+		})
+	}
+}
+
+func TestAssembleRefusesAnEmptyRelease(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "CHANGELOG.md", "# Changelog\n\n## [Unreleased]\n\n"+pointerLine+"\n\n## [1.0.0] - 2026-01-01\n\n### Added\n\n- **The first release.**\n")
+
+	_, err := assemble(dir, "1.1.0", "2026-02-02")
+	if err == nil || !strings.Contains(err.Error(), "nothing to release") {
+		t.Fatalf("assemble error = %v, want one mentioning \"nothing to release\"", err)
+	}
+}
+
+func TestAssembleRefusesAnUnknownSectionInAFragment(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "CHANGELOG.md", fixtureChangelog)
+	writeFile(t, dir, "changelog.d/bad.md", "### Improved\n\n- **Not a Keep a Changelog section.**\n")
+
+	_, err := assemble(dir, "1.1.0", "2026-02-02")
+	if err == nil || !strings.Contains(err.Error(), "bad.md") || !strings.Contains(err.Error(), "### Improved") {
+		t.Fatalf("assemble error = %v, want one naming the fragment and the header", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "changelog.d", "bad.md")); statErr != nil {
+		t.Errorf("a rejected fragment must not be deleted: %v", statErr)
+	}
+}
+
+func TestAssembleRefusesAChangelogWithoutAnUnreleasedSection(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "CHANGELOG.md", "# Changelog\n\n## [1.0.0] - 2026-01-01\n\n### Added\n\n- **The first release.**\n")
+	writeFile(t, dir, "changelog.d/x.md", "### Added\n\n- **A new thing.**\n")
+
+	_, err := assemble(dir, "1.1.0", "2026-02-02")
+	if err == nil || !strings.Contains(err.Error(), "no \"## [Unreleased]\" section") {
+		t.Fatalf("assemble error = %v, want one about the missing Unreleased section", err)
+	}
+}
+
+func TestAssembleReportsAnUnreadableChangelog(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := assemble(dir, "1.1.0", "2026-02-02"); err == nil || !strings.Contains(err.Error(), "read CHANGELOG.md") {
+		t.Fatalf("assemble error = %v, want one about reading CHANGELOG.md", err)
+	}
+}
+
+func TestAssembleCommandRejectsUnknownFlags(t *testing.T) {
+	if _, err := assembleCommand(t.TempDir(), []string{"-nope"}); err == nil {
+		t.Fatal("expected an error on an unknown flag")
+	}
+}
+
+func TestAssembleReleasesTheLastSectionOfTheFile(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "CHANGELOG.md", "# Changelog\n\n## [Unreleased]\n\n"+pointerLine+"\n")
+	writeFile(t, dir, "changelog.d/only.md", "### Added\n\n- **The very first entry.**\n")
+
+	if _, err := assemble(dir, "0.1.0", "2026-02-02"); err != nil {
+		t.Fatalf("assemble: %v", err)
+	}
+	want := "# Changelog\n\n## [Unreleased]\n\n" + pointerLine + "\n\n## [0.1.0] - 2026-02-02\n\n### Added\n\n- **The very first entry.**\n"
+	if got := readFile(t, dir, "CHANGELOG.md"); got != want {
+		t.Fatalf("assembled CHANGELOG.md mismatch:\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}
+
+// TestAssembleOrdersSectionsIncludingTheTwoBeyondKeepAChangelog pins the order
+// released sections have always been written in here: the Keep a Changelog six,
+// then "### Internal", then "### Dependencies".
+func TestAssembleOrdersSectionsIncludingTheTwoBeyondKeepAChangelog(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "CHANGELOG.md", "# Changelog\n\n## [Unreleased]\n\n"+pointerLine+"\n")
+	writeFile(t, dir, "changelog.d/one.md", "### Dependencies\n\n- **Bumped a pin.**\n\n### Internal\n\n- **Moved a helper.**\n\n### Changed\n\n- **Changed a behaviour.**\n")
+
+	if _, err := assemble(dir, "1.1.0", "2026-02-02"); err != nil {
+		t.Fatalf("assemble: %v", err)
+	}
+	want := "# Changelog\n\n## [Unreleased]\n\n" + pointerLine + "\n\n## [1.1.0] - 2026-02-02\n\n" +
+		"### Changed\n\n- **Changed a behaviour.**\n\n" +
+		"### Internal\n\n- **Moved a helper.**\n\n" +
+		"### Dependencies\n\n- **Bumped a pin.**\n"
+	if got := readFile(t, dir, "CHANGELOG.md"); got != want {
+		t.Fatalf("assembled CHANGELOG.md mismatch:\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}
+
+// TestAssembleCarriesTheRepositoryBacklogVerbatim runs assembly over a copy of
+// this repository's own CHANGELOG.md and fragments. The fixture above is small
+// and tidy; the real file carries multi-paragraph entries, nested bullets and
+// indented continuation lines, and those must survive the move into a released
+// section byte for byte.
+func TestAssembleCarriesTheRepositoryBacklogVerbatim(t *testing.T) {
+	root := repoRoot(t)
+	original, err := os.ReadFile(filepath.Join(root, "CHANGELOG.md"))
+	if err != nil {
+		t.Fatalf("read the repository CHANGELOG.md: %v", err)
+	}
+	head, unreleased, tail, err := splitChangelog(string(original))
+	if err != nil {
+		t.Fatalf("split the repository CHANGELOG.md: %v", err)
+	}
+	frozen, err := parseSections("CHANGELOG.md [Unreleased]", strings.Join(stripPointerLine(unreleased), "\n"))
+	if err != nil {
+		t.Fatalf("parse the repository backlog: %v", err)
+	}
+
+	dir := t.TempDir()
+	writeFile(t, dir, "CHANGELOG.md", string(original))
+	fragments, err := filepath.Glob(filepath.Join(root, "changelog.d", "*.md"))
+	if err != nil {
+		t.Fatalf("list the repository fragments: %v", err)
+	}
+	for _, fragment := range fragments {
+		data, readErr := os.ReadFile(fragment)
+		if readErr != nil {
+			t.Fatalf("read %s: %v", fragment, readErr)
+		}
+		writeFile(t, dir, "changelog.d/"+filepath.Base(fragment), string(data))
+	}
+
+	if _, err := assemble(dir, "99.0.0", "2026-12-31"); err != nil {
+		t.Fatalf("assemble: %v", err)
+	}
+
+	got := readFile(t, dir, "CHANGELOG.md")
+	if !strings.HasPrefix(got, strings.Join(head, "\n")+"\n\n"+pointerLine+"\n\n## [99.0.0] - 2026-12-31\n") {
+		t.Fatalf("assembled head is wrong:\n%s", firstLines(got, 12))
+	}
+	if !strings.HasSuffix(got, strings.Join(tail, "\n")) {
+		t.Fatal("everything below the released sections must be untouched")
+	}
+	for section, body := range frozen {
+		if !strings.Contains(got, body) {
+			t.Errorf("the frozen %s body did not survive assembly verbatim", section)
+		}
+	}
+}
+
+func TestParseSectionsConcatenatesRepeatedHeaders(t *testing.T) {
+	sections, err := parseSections("x.md", "### Added\n\n- **One.**\n\n### Added\n\n- **Two.**\n")
+	if err != nil {
+		t.Fatalf("parseSections: %v", err)
+	}
+	if got := sections["### Added"]; got != "- **One.**\n\n- **Two.**" {
+		t.Fatalf("sections[\"### Added\"] = %q", got)
+	}
+}
+
+func TestValidateFragmentAcceptsTheNoneMarkerAndRejectsAnEmptyFile(t *testing.T) {
+	if err := validateFragment("quiet.md", "  none  \n"); err != nil {
+		t.Errorf("a padded none marker must be accepted: %v", err)
+	}
+	if err := validateFragment("empty.md", "\n\n"); err == nil {
+		t.Error("an empty fragment must be rejected")
+	}
+	if err := validateFragment("notquite.md", "nonelike\n"); err == nil {
+		t.Error("only an exact none marker may skip the section rules")
+	}
+}
+
+// --- helpers ----------------------------------------------------------------
+
+// initRepo builds a real one-commit git repository with the fixture changelog
+// on main and leaves a branch checked out, so the check-mode tests exercise the
+// same `git diff` invocations CI runs rather than a canned string.
+func initRepo(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skipf("git is not available: %v", err)
+	}
+	dir := t.TempDir()
+	run(t, dir, "init", "-q", "-b", "main")
+	run(t, dir, "config", "user.email", "changelogd@example.test")
+	run(t, dir, "config", "user.name", "changelogd test")
+	run(t, dir, "config", "commit.gpgsign", "false")
+	writeFile(t, dir, "CHANGELOG.md", fixtureChangelog)
+	commitAll(t, dir, "chore: base")
+	run(t, dir, "checkout", "-q", "-b", "feature")
+	return dir
+}
+
+func commitAll(t *testing.T, dir, message string) {
+	t.Helper()
+	run(t, dir, "add", "-A")
+	run(t, dir, "commit", "-q", "--no-verify", "-m", message)
+}
+
+func run(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	if out, err := gitOutput(dir, args...); err != nil {
+		t.Fatalf("git %s: %v (%s)", strings.Join(args, " "), err, out)
+	}
+}
+
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	path := filepath.Join(dir, filepath.FromSlash(name))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir for %s: %v", name, err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+// repoRoot walks up from the test's working directory to the module root.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("module root (go.mod) not found above the test directory")
+		}
+		dir = parent
+	}
+}
+
+func firstLines(s string, n int) string {
+	lines := strings.Split(s, "\n")
+	if len(lines) > n {
+		lines = lines[:n]
+	}
+	return strings.Join(lines, "\n")
+}
+
+func readFile(t *testing.T, dir, name string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(dir, filepath.FromSlash(name)))
+	if err != nil {
+		t.Fatalf("read %s: %v", name, err)
+	}
+	return string(data)
+}


### PR DESCRIPTION
## What changes

Changelog entries stop going into `CHANGELOG.md` directly. Each pull request now adds one fragment
file under `changelog.d/`, and a release folds the accumulated fragments into `CHANGELOG.md`.

- `scripts/changelogd` — `check` (the CI gate) and `assemble -version X.Y.Z [-date YYYY-MM-DD]`
  (run by hand at release time).
- `.github/workflows/changelog.yml` — job `changelog-fragment`, running on `pull_request` and
  reporting on `merge_group` so a queued merge cannot wait on it forever.
- `CHANGELOG.md` — the `[Unreleased]` body gains one pointer line; everything already accumulated
  there stays put and is consumed by the first assembly.
- `changelog.d/.gitkeep` plus this pull request's own fragment.
- `CONTRIBUTING.md` — a *Changelog Fragments* section describing the format and the gate.

## Why

`[Unreleased]` is a single anchor every branch inserts at, which makes it this repository's only
recurring merge-queue conflict: rebasing replays the earlier commit straight back into the contested
spot, so the conflict has to be resolved by hand on branch after branch. A file per branch has no
shared anchor, so the class disappears rather than being resolved one instance at a time.

## How the gate goes red

`go run ./scripts/changelogd check` diffs `BASE_REF...HEAD` and collects added `changelog.d/*.md`
paths.

- No added fragment, and no `## [` heading added to `CHANGELOG.md` → exit 1 with the instructive
  message (what file to add, which headers are valid, and the `none` marker for a pull request with
  no user-visible change).
- An added fragment whose first non-empty line is not a known section header, or that carries an
  unknown `### ` header, or that has no entry text → exit 1 naming the file and the problem.
- A pull request that edits `CHANGELOG.md` by adding a `## [` heading passes without a fragment:
  that is release assembly, or a correction to already-released text.

Both red paths were exercised against this branch itself before the fragment was committed, not only
in unit tests.

## At release time

`go run ./scripts/changelogd assemble -version X.Y.Z` merges the frozen `[Unreleased]` backlog and
every fragment (frozen entries first, then fragments in filename order) into a new
`## [X.Y.Z] - DATE` section, shrinks the `[Unreleased]` body back to the pointer line, and deletes
the consumed fragments. Section order is the Keep a Changelog six followed by `### Internal` and
`### Dependencies`, matching every released section in this file. A `none` fragment is skipped and
deleted; an empty release is refused.

## Follow-up

`changelog-fragment` is added to the required status checks of the «Protect main» ruleset after this
pull request merges — the context does not exist until the workflow is on `main`.
