### PR TITLE
probe(ci): fragment-less pull request must be blocked

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -184,3 +184,5 @@ The pushed image is a shell-free `FROM scratch` runtime built from the repo-root
 build-provenance attestation and an SBOM. Publication waits for the commit's own
 CI run and scans the exact image before pushing it, so a tag or `:latest` never
 reaches the registry ahead of the checks for the commit it was built from.
+
+<!-- probe: changelog-fragment gate; this pull request is closed without merging -->


### PR DESCRIPTION
Probe for the `changelog-fragment` required status check: this pull request deliberately adds no `changelog.d/` fragment, so the check must fail and block the merge. Closed without merging once the red state is recorded.