### PR TITLE
ci: exempt dependabot from the changelog-fragment gate

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -13,27 +13,39 @@ jobs:
   # The job id is the status-check context name; keep it stable.
   changelog-fragment:
     runs-on: ubuntu-latest
+    env:
+      # The gate runs on pull requests only, and not on dependency bumps: the
+      # bot cannot write a fragment, and a bump has never carried one here —
+      # the "### Dependencies" section is written at release assembly from the
+      # bumps that merged. Keyed on the pull request's author rather than
+      # github.actor, so the verdict does not change when a human re-runs the
+      # check or pushes to the branch.
+      RUN_GATE: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]' }}
     steps:
       - name: Pass on merge queue runs
         if: github.event_name == 'merge_group'
         run: echo "Fragment presence was already enforced on the pull request run."
 
+      - name: Pass on dependency updates
+        if: github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]'
+        run: echo "Dependency bumps carry no fragment; the release's Dependencies section is assembled from the bumps that merged."
+
       - name: Checkout
-        if: github.event_name == 'pull_request'
+        if: env.RUN_GATE == 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # The gate diffs the branch against its base, so it needs history.
           fetch-depth: 0
 
       - name: Setup Go
-        if: github.event_name == 'pull_request'
+        if: env.RUN_GATE == 'true'
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache: true
 
       - name: Check changelog fragment
-        if: github.event_name == 'pull_request'
+        if: env.RUN_GATE == 'true'
         env:
           BASE_REF: origin/${{ github.event.pull_request.base.ref }}
         run: |

--- a/changelog.d/ci-changelog-fragment-dependabot-exemption.md
+++ b/changelog.d/ci-changelog-fragment-dependabot-exemption.md
@@ -1,0 +1,8 @@
+### Internal
+
+- **The changelog-fragment gate now passes dependency bumps without a fragment.**
+  The check stays required for every pull request and keeps its `merge_group`
+  trigger; it returns success immediately when the pull request's author is
+  `dependabot[bot]`, which cannot write a fragment. Dependency updates therefore
+  no longer reach `changelog.d/`, and a release's `### Dependencies` section is
+  assembled from the bumps that merged rather than from fragments.


### PR DESCRIPTION
## What

Dependabot cannot write a `changelog.d/` fragment, so every dependency bump fails the required
`changelog-fragment` check and sits blocked. On #374–#377 it is the **only** failing context.

The job keeps its shape: still required for every pull request, still carrying its `merge_group`
trigger, so the merge queue continues to get a report and cannot deadlock. It now short-circuits
to success when the pull request's author is `dependabot[bot]`.

## Why this form

Least privilege. Nothing is pushed to a pull request branch and the workflow gains no write
scope — `permissions` stays `contents: read`, which matters in a repository holding
special-category health data.

The condition is keyed on `github.event.pull_request.user.login`, not on `github.actor`, so the
verdict does not flip when a human re-runs the check or pushes to the bot's branch. The literal
was verified against the API payload of #374 and #377: `user.login == "dependabot[bot]"`,
`type: Bot`, `id: 49699333`.

Recorded 2026-08-02 in the decision log, together with the alternatives rejected:

- generating the fragment in CI and committing it to the branch — keeps the changelog complete,
  but hands a workflow `contents: write`;
- exempting by changed paths instead of author — actor-agnostic, but any pull request shaped
  like a dependency bump inherits the exemption;
- dropping the requirement for the `deps` type — simplest, but it moves "what counts as deps"
  into the changelog config and makes the requirement non-uniform.

## Consequence to carry

Dependency bumps no longer reach `changelog.d/`. A release's `### Dependencies` section is
assembled from the bumps that merged rather than from fragments.

## Verification

- Every event path has exactly one step that runs, so no path leaves the job with all steps
  skipped: `merge_group` → the queue pass step; a `dependabot[bot]` pull request → the new pass
  step; any other pull request → checkout, setup-go, and the gate.
- `go test ./scripts/changelogd/` passes.
- The gate run against this branch reports `changelog fragment check OK.` — the exemption does
  not weaken the check for ordinary pull requests, and this pull request carries its own fragment.
- Workflow YAML parses; triggers (`pull_request`, `merge_group`) and `permissions` are unchanged.

The real confirmation is #374–#377 turning green once this lands.
