### PR TITLE
build(deps): lift brace-expansion to 5.0.9

### DIFF
--- a/changelog.d/deps-brace-expansion-5-0-9.md
+++ b/changelog.d/deps-brace-expansion-5-0-9.md
@@ -1,0 +1,8 @@
+### Internal
+
+- **`brace-expansion` lifted to 5.0.9 in the lockfile**, closing CVE-2026-69152
+  (HIGH) and turning the required `trivy-fs` check green again. The package is a
+  transitive dev-only dependency of the build toolchain and is not part of any
+  shipped artifact, so no running instance was exposed. The `overrides` entry
+  stays the floor `^5.0.8` — 5.0.9 satisfies it, so only `package-lock.json`
+  changed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1320,9 +1320,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## What

`CVE-2026-69152` (HIGH) covers `brace-expansion` 5.0.8, which the lockfile held. The advisory
reached Trivy's database today between the morning scheduled scan of `main` (green at 06:45Z on
85257c1) and the afternoon's pull request runs — so the required `trivy-fs` check started failing
on **every** pull request, including the blocked dependency bumps #374–#377 and the changelog-gate
change in #378.

Fixed versions are 1.1.18, 2.1.4, 3.0.6 and 5.0.9; this takes 5.0.9.

## Why only the lockfile

The `overrides` entry is already the floor `^5.0.8`, and 5.0.9 satisfies it — so `npm update
brace-expansion --package-lock-only` lifts it with `package.json` untouched. Three lines, one
package, no other dependency churn.

Keeping the caret is the point, and it is the lesson the previous `brace-expansion` incident left:
an `overrides` entry pins a floor, not a point, and an exact pin added to close an advisory becomes
the finding itself the day the next advisory covers that version. (`npm install brace-expansion@5.0.9`
is refused outright with `EOVERRIDE` — the override has to be satisfied, not crossed.)

## Exposure

None for a running instance. `brace-expansion` is a transitive **dev-only** dependency of the build
toolchain (`dev: true` in the lockfile; the project declares no runtime npm dependencies at all), so
it is not part of any shipped artifact. `trivy-fs` scans `--include-dev-deps`, which is why a
dev-only path still blocks the queue.

## Verification

- `npm ci` → `npm run lint` clean, `npm run test:unit` 41/41, `npm run build` succeeds.
- Working tree after the build shows only `package-lock.json` — no asset churn.
- Trivy's own SARIF from the failing run listed exactly one finding, this package; 5.0.9 is on its
  fixed-version list.

## Known remaining, not in scope here

`npm audit` still reports `undici` 7.0.0–7.28.0 (HIGH, GHSA-8xcm-r25x-g524 / GHSA-4cwx-7wf7-3272).
Trivy does not currently flag it, so it is not blocking the queue and is left for its own change
rather than widened into this one.
