### PR TITLE
docs(scripts): make the mutation and readmeversion comments true

### DIFF
--- a/changelog.d/docs-script-comment-truth.md
+++ b/changelog.d/docs-script-comment-truth.md
@@ -1,0 +1,17 @@
+### Internal
+
+- **`scripts/mutation.sh`'s header comment now describes the script that
+  ships.** It documented a `merge-api-shards` subcommand (the real one is
+  `merge-shards <base>`), claimed `verify-shards` proves the `internal/api`
+  partition alone (it proves every entry in `SHARDED_PKGS`, and
+  `internal/services` has been registered there since it was sharded too), and
+  named two identifiers that do not exist — `API_SHARD_COUNT` and
+  `api_shard_files`, against the live `SHARDED_PKGS` and `shard_files`. It also
+  called `internal/api` the largest mutation target; `internal/services` is
+  larger (11,555 source lines against 8,099), while `internal/api` remains the
+  slowest, which is the fact the budgeting advice actually rests on.
+- **`scripts/readmeversion/main_test.go` no longer names a release tag in its
+  own doc comment.** It said "currently v1.8.0" while the latest tag is v1.9.2.
+  The assertions are version-agnostic, so the version was dropped rather than
+  bumped: a comment that has to be updated on every release is the drift this
+  test exists to catch.

--- a/scripts/mutation.sh
+++ b/scripts/mutation.sh
@@ -13,40 +13,43 @@
 #                   and a committed score summary under .mutation/.
 #   diff [ref]      Mutate only code changed vs <ref> (default origin/main).
 #                   Fast enough for CI. Advisory: never fails the build.
-#   verify-shards   Proves the internal/api shard partition is exact: every
-#                   non-test .go file lands in exactly one shard, no gaps, no
-#                   overlaps. No gremlins/network dependency — pure file-listing
-#                   arithmetic, safe to run in any CI job or locally.
-#   merge-api-shards [in-dir] [out-file]
-#                   Combines the internal_api_1..N shard JSON reports (once
-#                   downloaded from their CI artifacts) into one
-#                   internal_api.json, via scripts/mutationmerge (go run).
+#   verify-shards   Proves every registered shard partition is exact — for each
+#                   entry in SHARDED_PKGS, every non-test .go file lands in
+#                   exactly one shard, no gaps, no overlaps. No gremlins/network
+#                   dependency — pure file-listing arithmetic, safe to run in any
+#                   CI job or locally.
+#   merge-shards <base> [in-dir] [out-file]
+#                   Combines a registered package's <base>_1..N shard JSON
+#                   reports (once downloaded from their CI artifacts) into one
+#                   <base>.json, via scripts/mutationmerge (go run).
 #
 # The test-suite auditor consumes the JSON output
 # to triage survivors into "real test gap" vs "equivalent mutant".
 #
 # Mutation testing is scoped to business-logic + security + transport packages.
-# internal/api is the largest package (~8.5k source lines) and carries heavy
-# integration tests against a real database, so it is by far the slowest target
-# here — budget accordingly (see MUTATION_WORKERS below and the weekly CI job).
+# internal/services is the largest of them (11.5k source lines against
+# internal/api's 8.1k), but internal/api is the slowest: it carries heavy
+# integration tests against a real database, and each mutant re-runs them. Both
+# are sharded for that reason — budget accordingly (see MUTATION_WORKERS below
+# and the weekly CI job).
 #
-# internal/api sharding (issue #161): a single unsharded internal_api run blew
+# Sharding (issue #161): a single unsharded internal_api run blew
 # past the 3h CI timeout (manual run 28741574692: killed at 3h0m16s, having
 # reached only ~85% of the package's files with a steady, non-decelerating
-# mutant rate — internal/services, a comparably-sized target, finished its
+# mutant rate — internal/services, at least as large a target, finished its
 # *whole* run in 1h53m, so internal/api's heavier DB-integration tests are the
 # bottleneck, not raw file count). gremlins has no package-subdivision or
 # --include-files flag, but `unleash` does support repeatable --exclude-files
 # <regexp> (matched against each candidate file's basename within the target
 # package). That is the only file-subset mechanism the installed gremlins
-# v0.6.0 exposes, so sharding partitions internal/api's own non-test .go files
-# into API_SHARD_COUNT groups and, for shard N, excludes every file that is NOT
-# in group N. The partition is computed at run time from a live directory
-# listing (never a hardcoded file list) so it self-heals as files are
-# added/removed — see api_shard_files below. Round-robin assignment (file
-# index modulo shard count over the sorted file list) balances shard weight
-# better than contiguous alphabetical blocks, since large handler_* files
-# cluster together mid-alphabet.
+# v0.6.0 exposes, so sharding partitions a registered package's own non-test .go
+# files into the shard count SHARDED_PKGS declares for it and, for shard N,
+# excludes every file that is NOT in group N. The partition is computed at run
+# time from a live directory listing (never a hardcoded file list) so it
+# self-heals as files are added/removed — see shard_files below. Round-robin
+# assignment (file index modulo shard count over the sorted file list) balances
+# shard weight better than contiguous alphabetical blocks, since large handler_*
+# files cluster together mid-alphabet.
 
 set -euo pipefail
 

--- a/scripts/readmeversion/main_test.go
+++ b/scripts/readmeversion/main_test.go
@@ -1,5 +1,5 @@
 // Package readmeversion guards README.md against release-tag drift: the
-// current release tag (currently v1.8.0) is hardcoded in several places
+// current release tag is hardcoded in several places
 // (intro blurb, Docker quick start image tag, cosign/attestation/SBOM
 // verification examples, and the Releases section) with no single source of
 // truth, so a release bump that updates one occurrence and misses another


### PR DESCRIPTION
Grooming wave G3 (decision 74), the script-comment cluster. Comment-only; no executable line changes.

## `scripts/mutation.sh` — four claims that describe a script that no longer exists

| Header says | What ships |
|---|---|
| `merge-api-shards [in-dir] [out-file]` | `merge-shards <base> [in-dir] [out-file]` (`:96` usage, `:297` dispatch, `mutation.yml:159`) |
| `verify-shards` proves "the internal/api shard partition" | it iterates `SHARDED_PKGS` and proves every registered package — `internal/services` has been one since it was sharded too |
| partitions into `API_SHARD_COUNT` groups, "see `api_shard_files`" | neither identifier exists; the live ones are `SHARDED_PKGS` (`:72`) and `shard_files` (`:112`) |
| "internal/api is the largest package (~8.5k source lines)" | `internal/services` is larger — 11,555 non-blank non-comment source lines against `internal/api`'s 8,099 |

The last one is worth a sentence rather than a swap. The paragraph's purpose is budgeting advice, and the fact it rests on is not size but cost per mutant: `internal/api` is the *slowest* target because each mutant re-runs its DB-integration tests, which is exactly what the `#161` paragraph below it measured. The comment now says that, and notes that both packages are sharded.

## `scripts/readmeversion/main_test.go`

Its doc comment said "currently v1.8.0"; the latest tag is v1.9.2 (`README.md:30`). The version is **dropped rather than bumped** — the assertions are version-agnostic, and a comment that must be touched on every release is the drift this test exists to catch.

## Verification

- `bash -n scripts/mutation.sh` clean.
- `bash scripts/mutation.sh verify-shards` → OK for both `internal_api` and `internal_services` (no gaps, no overlaps).
- `go vet ./scripts/readmeversion/` clean.

## Risk

Low. Comments only; no behaviour, no public contract, no schema.
