### PR TITLE
docs(cycle): the inferred luteal phase discards, it does not clamp

### DIFF
--- a/changelog.d/docs-luteal-sample-filter.md
+++ b/changelog.d/docs-luteal-sample-filter.md
@@ -1,0 +1,7 @@
+### Internal
+
+- **`docs/cycle-prediction.md` now describes what the inferred luteal phase actually does with an
+  out-of-range cycle.** It said the observed length is "clamped to a physiological 10–20 day
+  range"; the code discards such a cycle instead, and falls back to the fixed 14-day default
+  unless at least two cycles survive the filter. The difference is visible to an owner — a clamp
+  would let one implausible reading pull the estimate to 10 or 20, and none does.

--- a/docs/cycle-prediction.md
+++ b/docs/cycle-prediction.md
@@ -106,14 +106,18 @@ These are the exact cases asserted by the reference tests.
 - **Luteal phase** defaults to the fixed 14-day model value, but is refined for
   the owner when their logs carry enough signal: when basal body temperature or
   cervical-mucus entries let the app infer the ovulation-to-next-period length
-  across several cycles, that observed luteal length (clamped to a physiological
-  10–20 day range) replaces the default. The cervical-mucus signal estimates
-  ovulation as the day after the last egg-white (peak-quality) mucus day of the
-  cycle; self-observed peak days can differ from reference ovulation by a day
-  or more, which is another reason the inferred luteal length stays an
-  estimate. With little or no such data the fixed
-  14-day default stands. Individual luteal phases vary (commonly 11–17 days),
-  which is one reason predictions remain estimates.
+  across several cycles, the average of those observed luteal lengths replaces
+  the default. A cycle whose inferred luteal length falls outside a
+  physiological 10–20 day window is **discarded**, not pulled to the nearest
+  edge of it — an implausible inference is treated as a bad reading rather than
+  as a 10 or a 20 — and the refinement needs at least two surviving cycles, so
+  a single odd reading cannot move the estimate on its own. The cervical-mucus
+  signal estimates ovulation as the day after the last egg-white (peak-quality)
+  mucus day of the cycle; self-observed peak days can differ from reference
+  ovulation by a day or more, which is another reason the inferred luteal
+  length stays an estimate. With little or no such data the fixed 14-day
+  default stands. Individual luteal phases vary (commonly 11–17 days), which is
+  one reason predictions remain estimates.
 - For irregular cycles the app widens the prediction into a range rather than a
   single date. The range and variability statistics (shortest/longest cycle and
   the sample standard deviation) are computed over the same recent-cycle window


### PR DESCRIPTION
Grooming wave G3 (decision 74), the one behavioural claim in the doc truth pass. `docs/cycle-prediction.md` only — no Go file is touched.

## The claim

> that observed luteal length (clamped to a physiological 10–20 day range) replaces the default

No clamp of that shape exists. `internal/services/cycle_signals.go`:

- `:48-50` — a cycle whose inferred ovulation-to-next-period length is `< minLutealPhaseDays` or `> 20` hits `continue`. The sample is dropped; nothing is pulled to a boundary.
- `:54-56` — with fewer than two surviving samples the refinement is abandoned and `defaultLutealPhaseDays` (14) is returned with `false`.
- `:57` — the estimate is the rounded mean of the survivors.

## Why this one was not a wording nit

Clamping and discarding diverge exactly where an owner would notice. Under a clamp, one cycle whose BBT shift or peak-mucus day was misread — a 4-day or a 25-day inference — is admitted as a 10 or a 20 and drags the mean, and the luteal estimate feeds every ovulation date, fertile window, and next-period prediction downstream of it. The code refuses that; the doc promised it. The two-cycle minimum, which is the other half of the same protection, was not documented at all and now is.

## Direction of the fix

Doc moves to code, per the grooming brief: the implemented behaviour is the one worth keeping, and changing `internal/services` to match the prose would be a services-layer behaviour change made to satisfy a stale sentence.

## Not touched, deliberately

- **`:39`, "`minLutealPhaseDays` | 10 | Lower clamp for the luteal phase"** — a *different* mechanism. `ResolveLutealPhase` (`internal/services/cycles.go:80-88`) does clamp, at the bottom only, and applies to the owner's **configured** value, not to an inferred one. Correct as written; the edited sentence now says "inferred" so the two cannot be read as one rule.
- **`:96`, the worked example with "luteal clamped"** — same configured-value path, still accurate.
- **The bare `20` at `cycle_signals.go:48`** — the lower bound is the named `minLutealPhaseDays`, the upper bound is a literal. Worth a constant, but that is a code change and not this PR's scope.

## Verification

- `go run ./scripts/changelogd check` passes.
- No reference test pins the edited prose: the doc's worked examples are mirrored by `cycles_reference_test.go`, and this bullet is not one of them — `grep "clamped to a physiological"` over the Go tree returns nothing.
