### PR TITLE
ci: drop config entries that can no longer match

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -35,14 +35,11 @@ profile.cov
 .idea/
 .vscode/
 
-.tmp_*/
 .tmp*/
 
-docker/
 web/src/
 scripts/
 package.json
 package-lock.json
-tailwind.config.js
 eslint.config.mjs
 playwright.config.ts

--- a/.gitattributes
+++ b/.gitattributes
@@ -9,4 +9,6 @@ web/static/css/tailwind.css linguist-generated=true
 web/static/js/app.js linguist-generated=true
 web/static/js/settings-export.js linguist-generated=true
 web/static/js/settings-import.js linguist-generated=true
+web/static/js/theme-bootstrap.js linguist-generated=true
+web/static/js/timezone-bootstrap.js linguist-generated=true
 web/static/js/htmx.min.js linguist-vendored=true

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,6 @@
 /internal/db/ @terraincognita07
 /migrations/ @terraincognita07
 /docker-compose.yml @terraincognita07
-/docker/ @terraincognita07
 /.env.example @terraincognita07
 /docs/self-hosted.md @terraincognita07
 /docs/examples/ @terraincognita07

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -99,10 +99,12 @@ jobs:
         run: bash scripts/mutation.sh baseline "${{ matrix.slug }}"
 
       - name: Verify mutation output was produced
-        # Silent-failure guard: if the step above died partway (OOM, disk
-        # exhaustion, timeout) without gremlins ever writing its report, fail
-        # the job loudly instead of leaving .mutation/<slug>.md permanently
-        # reading "pending first weekly CI run".
+        # Silent-failure guard. The step above is continue-on-error and the
+        # upload below is if-no-files-found: ignore, so a shard that died
+        # partway (OOM, disk exhaustion, timeout) without gremlins ever writing
+        # its report would pass green having published nothing, and the merge
+        # job — which runs if: always() — would fold that hole into a combined
+        # report indistinguishable from a complete one. Fail the shard instead.
         run: |
           out=".tmp/mutation/${{ matrix.slug }}.json"
           if [ ! -s "$out" ]; then

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -128,7 +128,7 @@ jobs:
           image: ${{ env.TRIVY_IMAGE }}
 
       - name: Run Trivy filesystem scan
-        run: docker run --rm -v "${{ github.workspace }}:/work" -w /work "${{ env.TRIVY_IMAGE }}" fs --scanners vuln --skip-version-check --severity HIGH,CRITICAL --ignore-unfixed --include-dev-deps --skip-dirs .tmp --skip-dirs .tmp_docker_ctx --skip-dirs web/static --format sarif --output .tmp/security/trivy-fs.sarif --exit-code 1 .
+        run: docker run --rm -v "${{ github.workspace }}:/work" -w /work "${{ env.TRIVY_IMAGE }}" fs --scanners vuln --skip-version-check --severity HIGH,CRITICAL --ignore-unfixed --include-dev-deps --skip-dirs .tmp --skip-dirs web/static --format sarif --output .tmp/security/trivy-fs.sarif --exit-code 1 .
 
       - name: Upload Trivy filesystem SARIF
         if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)

--- a/.gitignore
+++ b/.gitignore
@@ -54,7 +54,6 @@ Thumbs.db
 *.swo
 
 # Local and generated artifacts
-.tmp_*/
 .tmp*/
 .local/
 test-results/

--- a/changelog.d/ci-drop-dead-config-lines.md
+++ b/changelog.d/ci-drop-dead-config-lines.md
@@ -1,0 +1,13 @@
+### Internal
+
+- **Config entries that can no longer match anything are gone.** Trivy's filesystem scan skipped a
+  `.tmp_docker_ctx` directory nothing has ever created; `.dockerignore` and `.github/CODEOWNERS`
+  still named a `docker/` tree removed in `90d85a4`; `.dockerignore` excluded a
+  `tailwind.config.js` that Tailwind v4 does not use; and both ignore files carried `.tmp_*/`
+  alongside the `.tmp*/` that already subsumes it.
+- **Two build outputs are now marked generated.** `web/static/js/theme-bootstrap.js` and
+  `timezone-bootstrap.js` are written by `scripts/build-js.mjs` from `web/src/js/`, and were the
+  only build products missing `linguist-generated` in `.gitattributes`.
+- **The mutation shard guard's comment now describes the failure it prevents.** It cited a
+  `.mutation/<slug>.md` "pending first weekly CI run" state that exists in no file and under no
+  slug spelling; what the guard actually stops is a shard passing green having uploaded nothing.


### PR DESCRIPTION
Grooming wave G4 (decision 74): configuration entries that can no longer match anything. Every one was verified dead against the tree before removal, so none of them changes a build, a scan, or a review assignment.

## Removed

| Where | Entry | Why it is dead |
| --- | --- | --- |
| `.github/workflows/security.yml:131` | `--skip-dirs .tmp_docker_ctx` | no such directory is created anywhere; `git log -S '.tmp_docker_ctx'` returns only the commit that added the flag. The adjacent `--skip-dirs .tmp` is a different path and stays |
| `.dockerignore`, `.github/CODEOWNERS` | `docker/`, `/docker/` | the tree was removed in `90d85a4`. The CODEOWNERS rule was assigning review of a path that cannot exist |
| `.dockerignore` | `tailwind.config.js` | impossible under Tailwind v4 — configuration is CSS-side, and the CSS build passes only `-i`/`-o`/`--minify` |
| `.dockerignore`, `.gitignore` | `.tmp_*/` | a strict subset of the `.tmp*/` on the very next line, in both pattern dialects |

## Added

**`.gitattributes` marks two more build outputs `linguist-generated`.** `web/static/js/theme-bootstrap.js` and `timezone-bootstrap.js` are written by `scripts/build-js.mjs` from `web/src/js/`, and were the only build products under `web/static/js/` left unmarked. `chart-lite.js` stays unmarked and that is correct — it has no source under `web/src/js/` and no writer in `build-js.mjs`, so it is hand-written.

## Corrected

**The mutation shard guard's comment.** It justified itself by a `.mutation/<slug>.md` file "permanently reading `pending first weekly CI run`". That string appears in no file but the comment, and the filename could not exist under any slug: the committed reports are hyphenated (`internal-api.md`, `internal-security.md`, `internal-services.md`) while matrix slugs are underscored (`internal_api_3`).

The guard itself is right and untouched. Its comment now names the failure it actually prevents — the shard step is `continue-on-error`, the upload below is `if-no-files-found: ignore`, and the merge job runs `if: always()`, so a shard that dies to OOM or a timeout would pass green having published nothing and have its hole folded into a combined report indistinguishable from a complete one.

## Proposed by the inventory, deliberately not done

**`.github/actions/docker-pull-retry`'s `attempts` input stays.** It is genuinely unused — all five call sites take the default — but an action input with a documented default is an interface affordance, not a dead line. Removing it hardcodes `3` into the retry loop, and the first job that needs a different bound has to re-add the input. This is the difference between the rest of the list, which names paths that cannot exist, and a knob nobody has needed yet.

The `.dockerignore` removals do widen what a build context could pick up *if* one of those paths came back. That is accepted: an ignore file kept in step with the tree is the point of the wave, and if `docker/` ever returns its entry returns with it.

## Verification

- `go run ./scripts/changelogd check` passes.
- No test or script reads the edited files. The only in-repo references to `.dockerignore` are two comments about it excluding `.git` (`cmd/ovumcy/version.go:35`, `main_test.go:2863`), which this does not touch.
- This PR touches `.github/`, so `changes` runs the full battery rather than the docs-only path.
