### PR TITLE
docs(changelog): the screenshots directory has two outbound assets

### DIFF
--- a/changelog.d/docs-drop-dead-login-screenshot.md
+++ b/changelog.d/docs-drop-dead-login-screenshot.md
@@ -2,6 +2,7 @@
 
 - **Removed `docs/screenshots/login.png`** (307 KB), which nothing referenced.
   The README shows six screenshots and the login screen is not among them, and
-  the file sits outside the reusable asset set `docs/hero-demo.md` defines. Every
-  other file in that directory is either rendered by the README or listed in that
-  contract.
+  the file sits outside the reusable asset set `docs/hero-demo.md` defines. The
+  directory's other screenshots are all rendered by the README; the two files that
+  are not, `ovumcy-promo-card.svg` and `ovumcy-social-preview.png`, are outbound
+  assets consumed outside the repository and carry no in-repo reference by design.

--- a/changelog.d/docs-screenshot-asset-claim.md
+++ b/changelog.d/docs-screenshot-asset-claim.md
@@ -1,0 +1,7 @@
+none
+
+Corrects an unreleased changelog fragment, not the product: the entry for the
+removed login screenshot claimed every remaining file in `docs/screenshots/` is
+rendered by the README or listed in `docs/hero-demo.md`, which two outbound
+assets falsify. Nothing user-visible changes, and the released CHANGELOG never
+carried the claim.


### PR DESCRIPTION
Last item of the docs grooming pass, and the one it created itself.

The fragment written for the removed login screenshot ended on a claim wider than
the evidence behind it: that every other file in `docs/screenshots/` is either
rendered by the README or listed in `docs/hero-demo.md`'s six-shot contract. Two
files falsify it — `ovumcy-promo-card.svg` and `ovumcy-social-preview.png`, both
with zero references anywhere in the tree.

Both files stay. Their lack of an in-repo reference is their normal state rather
than evidence of death: the social preview is uploaded in the repository's own
settings and the promo card is a source for posts, so neither can be reached from
a link inside the tree. The closing sentence now says exactly that, which is a
claim a reader can check.

The fragment has not been assembled into `CHANGELOG.md` yet, so the released text
never carried the wrong sentence and nothing user-visible changes here. The
accompanying fragment for this branch is therefore `none`, with the reason under
it.
