### PR TITLE
docs(self-hosted): realign the backup helper's Alpine pin with the Dockerfile

### DIFF
--- a/changelog.d/docs-self-hosted-alpine-pin.md
+++ b/changelog.d/docs-self-hosted-alpine-pin.md
@@ -1,0 +1,10 @@
+### Changed
+
+- **The backup and restore helper in `docs/self-hosted.md` pins the same Alpine release as the
+  runtime image again.** Both were moved to `alpine:3.22.3` in one commit, to clear the OpenSSL
+  findings that failed the image scan; the Dockerfile has since been carried to `alpine:3.24.1` by
+  the automated base-image updates, which read `Dockerfile` and compose manifests but not a fenced
+  command in a Markdown runbook, so the documented helper stayed three minors behind on an image
+  pinned for a security patch. The commands themselves — BusyBox `sh`, `tar czf`/`tar xzf` — need
+  nothing from either release, so the older pin bought an operator nothing but the unpatched
+  packages it was originally raised to escape.

--- a/docs/self-hosted.md
+++ b/docs/self-hosted.md
@@ -383,7 +383,7 @@ docker run --rm \
   -e BACKUP_FILE="$BACKUP_FILE" \
   -v ovumcy_data:/source:ro \
   -v "$PWD/backups:/backup" \
-  alpine:3.22.3 \
+  alpine:3.24.1 \
   sh -c 'cd /source && tar czf "/backup/$BACKUP_FILE" .'
 ```
 
@@ -404,7 +404,7 @@ docker run --rm \
   -e BACKUP_FILE="$BACKUP_FILE" \
   -v ovumcy_data:/target \
   -v "$PWD/backups:/backup:ro" \
-  alpine:3.22.3 \
+  alpine:3.24.1 \
   sh -c 'cd /target && tar xzf "/backup/$BACKUP_FILE"'
 
 docker compose up -d


### PR DESCRIPTION
## What

The Docker named-volume backup and restore helpers in `docs/self-hosted.md` ran `alpine:3.22.3`,
while the Dockerfile's runtime-assets stage is on `alpine:3.24.1`. Both helper invocations now
name `alpine:3.24.1`.

## Why this is drift, not a deliberate split

The two pins were raised together, in one commit: `fc07cfe` "Patch Alpine runtime base for Trivy
findings", whose body names "the runtime image and backup helper examples" and which touches
exactly `Dockerfile` and `docs/self-hosted.md`. They were meant to track each other, and the
reason they moved at all was a scan finding on the older packages.

What broke the pairing is mechanical. The Dockerfile went 3.22.3 → 3.24.0 (#71) → 3.24.1 (#109),
both single-file commits from the automated base-image updates; `.github/dependabot.yml` points
the `docker` and `docker-compose` ecosystems at the Dockerfile and the compose manifests, and
neither can see a pinned tag inside a fenced command in a Markdown runbook. So the documented
helper could only ever be moved by hand, and was not.

Nothing argues for keeping the older tag:

- The helper runs BusyBox `sh` with `tar czf` / `tar xzf`. Neither needs anything a particular
  Alpine release supplies; the commands are unchanged across both.
- No other document or example stack pins a third value for this helper. The other Alpine strings
  in the tree — `postgres:18.4-alpine3.22`, `caddy:2.11.4-alpine`, `nginx:1.28.0-alpine3.21` —
  are upstream images choosing their own bases, not this backup container.
- The old pin's only remaining effect was to hand an operator, in a runbook step that reads a
  volume holding health data, the package set that the pin was originally raised to escape.

## Deliberately left alone

The helper keeps a plain tag instead of the Dockerfile's `tag@sha256:…` form. This command is
copy-pasted by hand into a shell; a digest would turn each routine tag bump into a two-place edit
for a throwaway container whose whole job is one `tar`. The Dockerfile's own pin, the example
stacks' image tags and the Dependabot configuration are untouched — teaching the updater to read
Markdown is a separate change with its own trade-offs.

## Validation

- `go run ./scripts/changelogd check` — OK
- `go build ./...`
- `go test ./scripts/...` — all packages pass, including `scripts/readmeversion`
