### PR TITLE
test(e2e): bind the 2FA login wait to its own POST, drop the webkit skip

### DIFF
--- a/changelog.d/e2e-auth-2fa-webkit-unskip.md
+++ b/changelog.d/e2e-auth-2fa-webkit-unskip.md
@@ -1,0 +1,6 @@
+### Internal
+
+- **The 2FA login-redirect e2e test runs on WebKit again.** Its wait now binds to the click's own
+  `POST /api/v1/sessions` and asserts the `303 → /auth/2fa` the server answers, instead of polling
+  only for the landed URL. That race was the whole reason the test carried a permanent WebKit skip,
+  so the skip is gone and every browser project covers the challenge redirect.

--- a/e2e/auth-2fa.spec.ts
+++ b/e2e/auth-2fa.spec.ts
@@ -72,13 +72,7 @@ test.describe('Auth: TOTP two-factor authentication', () => {
     expect(setupCookie).toBeFalsy();
   });
 
-  test('login after enrollment redirects to 2FA challenge page', async ({
-    page,
-    context,
-    browserName,
-  }) => {
-    test.skip(browserName === 'webkit', 'flaky redirect timing on webkit; covered in chromium');
-
+  test('login after enrollment redirects to 2FA challenge page', async ({ page, context }) => {
     const creds = createCredentials('2fa-login-redirect');
     await registerOwnerViaUI(page, creds);
     await continueFromRecoveryCode(page);
@@ -99,11 +93,28 @@ test.describe('Auth: TOTP two-factor authentication', () => {
     // Log out (must be DELETE+CSRF; GET to /api/v1/sessions/current is rejected).
     await logoutViaAPI(page);
 
-    // Log back in — should hit challenge page
+    // Log back in — should hit challenge page. The wait binds to this click's own
+    // POST /api/v1/sessions and reads its answer: the 303 to /auth/2fa is what
+    // "the challenge was demanded" actually means, and it is settled on the server
+    // before any navigation starts. Polling only the landed URL made the assertion
+    // race the redirect, which is what kept this test permanently skipped on webkit.
     await page.goto('/login');
     await page.locator('input[name="email"]').fill(creds.email);
     await page.locator('input[name="password"]').fill(creds.password);
-    await page.locator('form[action="/api/v1/sessions"] button[type="submit"]').click();
+    const [loginRequest] = await Promise.all([
+      page.waitForRequest(
+        (candidate) =>
+          candidate.method() === 'POST' && new URL(candidate.url()).pathname === '/api/v1/sessions'
+      ),
+      page.locator('form[action="/api/v1/sessions"] button[type="submit"]').click(),
+    ]);
+    const loginResponse = await loginRequest.response();
+    expect(loginResponse, 'expected a response for POST /api/v1/sessions').not.toBeNull();
+    expect(
+      loginResponse!.status(),
+      `POST /api/v1/sessions answered ${loginResponse!.status()}, want a 303 redirect`
+    ).toBe(303);
+    expect(loginResponse!.headers()['location']).toBe('/auth/2fa');
 
     await expect(page).toHaveURL('/auth/2fa', { timeout: 5_000 });
 


### PR DESCRIPTION
## Why

`e2e/auth-2fa.spec.ts › login after enrollment redirects to 2FA challenge page` carried a
permanent `test.skip(browserName === 'webkit', ...)`. The skip existed only because the test
clicked the login submit and then waited on live page state — `expect(page).toHaveURL('/auth/2fa')`
— rather than on a concrete signal, so the assertion raced the redirect and WebKit lost that race
most often. A skip on one project is not coverage: nothing checked that WebKit demands the TOTP
challenge instead of issuing a session.

## What changed

The wait now binds to the click's own request and reads its answer, the pattern the browser-e2e
guidance already prescribes for save helpers:

- `page.waitForRequest` for `POST /api/v1/sessions`, raced with the click (`Promise.all`), then
  `request.response()`;
- assert `303` with `Location: /auth/2fa` — settled on the server before any navigation starts, and
  the actual meaning of "the challenge was demanded" (`internal/api/handlers_auth_session_login.go:116`);
- the original landed-URL check and both cookie assertions stay, now behind a deterministic anchor;
- `test.skip` and the unused `browserName` fixture are gone.

Nothing else in the spec is touched; the neighbouring tests keep their existing waits.

## Verification

Run through the repo runner (never `npx playwright test` directly), one spec at a time, `workers=1`.
Installing the WebKit build for the pinned Playwright 1.62.1 was a prerequisite — the local cache
had `webkit-2311`, the pinned version wants `webkit-2336`, and the first attempt failed with
`Executable doesn't exist … webkit-2336`, not with a test failure:

```
node node_modules/@playwright/test/cli.js install webkit
  -> WebKit 26.5 (playwright webkit v2336) downloaded

node ./scripts/run-e2e.mjs --mode=ci --project=webkit e2e/auth-2fa.spec.ts
  -> 6 passed (1.1m), 0 skipped

node ./scripts/run-e2e.mjs --mode=ci --project=chromium e2e/auth-2fa.spec.ts
  -> 6 passed (31.4s)

node ./scripts/run-e2e.mjs --mode=ci --project=webkit --repeat-each=5 \
  -g "login after enrollment redirects to 2FA challenge page" e2e/auth-2fa.spec.ts
  -> 5 passed (1.2m)
```

`go run ./scripts/changelogd check` → OK.

Not run locally: the `firefox` project. Its binary for the pinned version (`firefox-1538`) is not in
the local cache either, and the run failed on `browserType.launch` before any test executed. The
change is browser-agnostic — a redirect status read off the request the click issued — but Firefox
is covered only by CI here, not by an observed local pass.
