### PR TITLE
deploy(compose): pass through the five settings the baseline omitted

### DIFF
--- a/changelog.d/deploy-compose-baseline-env-vars.md
+++ b/changelog.d/deploy-compose-baseline-env-vars.md
@@ -1,0 +1,9 @@
+### Added
+
+- **The baseline `docker-compose.yml` now lists the five settings it was omitting.**
+  `RATE_LIMIT_CALENDAR_FEED_MAX` (`20`), `RATE_LIMIT_CALENDAR_FEED_WINDOW` (`1m`),
+  `WEBHOOK_BLOCK_PRIVATE_ADDRESSES` (`false`), `REMINDER_SCHEDULER_ENABLED` (`false`) and
+  `REMINDER_SCHEDULER_HOUR` (`9`) are read at boot and documented as supported knobs, but reached
+  the container only through `.env`, unlike every other knob the file spells out with its default.
+  Each new entry carries that same loader default, so a stack started from the baseline behaves
+  exactly as before.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,10 +36,19 @@ services:
       - RATE_LIMIT_LOGOUT_WINDOW=${RATE_LIMIT_LOGOUT_WINDOW:-15m}
       - RATE_LIMIT_API_MAX=${RATE_LIMIT_API_MAX:-300}
       - RATE_LIMIT_API_WINDOW=${RATE_LIMIT_API_WINDOW:-1m}
+      # Calendar feed: deliberately far below the API budget — every request costs a
+      # bcrypt compare, so this bounds CPU rather than request count.
+      - RATE_LIMIT_CALENDAR_FEED_MAX=${RATE_LIMIT_CALENDAR_FEED_MAX:-20}
+      - RATE_LIMIT_CALENDAR_FEED_WINDOW=${RATE_LIMIT_CALENDAR_FEED_WINDOW:-1m}
       - AUDIT_LOG_ENABLED=${AUDIT_LOG_ENABLED:-false}
       - TRUST_PROXY_ENABLED=${TRUST_PROXY_ENABLED:-false}
       - PROXY_HEADER=${PROXY_HEADER:-X-Forwarded-For}
       - TRUSTED_PROXIES=${TRUSTED_PROXIES:-127.0.0.1,::1}
+      # Webhook reminders: the built-in daily scheduler ships off, and delivery is
+      # not restricted to public targets, so a LAN ntfy/Gotify endpoint works.
+      - WEBHOOK_BLOCK_PRIVATE_ADDRESSES=${WEBHOOK_BLOCK_PRIVATE_ADDRESSES:-false}
+      - REMINDER_SCHEDULER_ENABLED=${REMINDER_SCHEDULER_ENABLED:-false}
+      - REMINDER_SCHEDULER_HOUR=${REMINDER_SCHEDULER_HOUR:-9}
     init: true
     security_opt:
       - no-new-privileges:true


### PR DESCRIPTION
## What

The baseline `docker-compose.yml` now lists five settings the config loader has always read and
`docs/self-hosted.md` has always documented, but which the shipped stack never named:

| Variable | Value in the file | Source of the default |
| --- | --- | --- |
| `RATE_LIMIT_CALENDAR_FEED_MAX` | `20` | `cmd/ovumcy/config.go:150` |
| `RATE_LIMIT_CALENDAR_FEED_WINDOW` | `1m` | `cmd/ovumcy/config.go:151` |
| `WEBHOOK_BLOCK_PRIVATE_ADDRESSES` | `false` | `cmd/ovumcy/config.go:155` (and `commands.go:127` for the `notify` CLI) |
| `REMINDER_SCHEDULER_ENABLED` | `false` | `cmd/ovumcy/config.go:157` |
| `REMINDER_SCHEDULER_HOUR` | `9` | `cmd/ovumcy/config.go:160` |

Addition only: nothing was removed or renamed. The calendar-feed pair sits with the other
`RATE_LIMIT_*` entries in the order `README.md` already uses; the webhook/scheduler trio is
appended after the proxy settings.

## Why the values are these

Every entry carries the loader's own default in the same `${VAR:-default}` form the rest of the
file uses, so an operator copying the baseline gets today's behaviour, not a changed one — the
feed budget stays 20 requests per minute, private-address egress blocking stays off (the common
case is a LAN ntfy/Gotify target), and the built-in reminder scheduler stays off, with 09:00 local
as the run hour it would use once switched on. Each default is safe to state explicitly: both
booleans ship off, the scheduler hour is inert while the scheduler is off, and the two rate-limit
values are already published in `README.md` and `docs/security/auth-policy-and-rate-limits.md`.

The calendar-feed pair carries a one-line comment for the same reason the `README.md` env sample
does: a budget of 20 next to the API budget of 300 invites a "correction", and the small budget is
what bounds the bcrypt compare every feed request pays.

## Verification

- `go build ./...`
- `go test ./scripts/...` — all six packages pass. `scripts/examplecompose` only asserts the
  postgres data-volume mount under `docs/examples/**`; it neither generates nor validates the root
  compose file, so no script expectation needed updating.
- `docker compose -f docker-compose.yml config` — parses; all five resolve to the values above.
  Nothing was started. Run with `--project-directory` pointing at a scratch directory holding a
  placeholder `.env`, since the repo ships none.
- `go run ./scripts/changelogd check` — OK.

## Not changed

`docs/self-hosted.md` already documents all five knobs with these defaults (advanced-knobs
bullets); its wording stays correct, since leaving a variable out of `.env` still yields the
default. `README.md`'s env sample and `docs/notifications.md` are likewise already consistent.
