### PR TITLE
probe: what does the required `test` context report when test-go fails?

### DIFF
--- a/changelog.d/probe-test-gate-cascade.md
+++ b/changelog.d/probe-test-gate-cascade.md
@@ -1,0 +1,3 @@
+### Internal
+
+none — throwaway measurement branch, never merged.

--- a/internal/httpx/probe_gate_test.go
+++ b/internal/httpx/probe_gate_test.go
@@ -1,0 +1,11 @@
+package httpx
+
+import "testing"
+
+// TestProbeGateCascade is a deliberate failure, pushed on a throwaway branch to
+// measure one thing: what branch protection reports for the required `test`
+// context when `test-go` fails and `test` is therefore skipped through its
+// `needs` edge. It is never merged and the branch is deleted after the reading.
+func TestProbeGateCascade(t *testing.T) {
+	t.Fatal("deliberate failure: measuring the required-check cascade")
+}


### PR DESCRIPTION
Throwaway measurement, never to be merged. A deliberately failing Go test makes `test-go` fail; the thin `test` gate job then skips through its `needs` edge. The question is what branch protection reports for the required `test` context, and whether `mergeStateStatus` stays BLOCKED. Closed and deleted as soon as the reading is taken.