### PR TITLE
ci: the test gate reports a verdict instead of disappearing when a half fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,10 +153,40 @@ jobs:
     needs:
       - test-go
       - test-frontend
+    # WITHOUT AN `if`, A FAILED DEPENDENCY SKIPS THIS JOB — and a skipped
+    # required check counts as satisfied, so a failing Go suite left no required
+    # context red at all. Measured 2026-08-08 on a throwaway branch carrying one
+    # deliberately failing test: `test-go` failed, and `test`, `e2e` and
+    # `patch-coverage` — three of the fourteen required contexts — all reported
+    # SKIPPED. `race` gates on `changes` rather than on this job, so it ran and
+    # passed, and nothing else covered the unit suite.
+    #
+    # `!cancelled()` makes this job RUN whatever its dependencies did, and the
+    # step below turns their results into this context's verdict. A cancelled
+    # run is still excluded: a superseded PR run must not report a failure.
+    if: ${{ !cancelled() }}
     permissions:
       contents: read
     steps:
-      - run: echo "test-go and test-frontend passed."
+      - name: Judge the two unit halves
+        env:
+          GO_RESULT: ${{ needs.test-go.result }}
+          FRONTEND_RESULT: ${{ needs.test-frontend.result }}
+        run: |
+          set -euo pipefail
+          echo "test-go=$GO_RESULT test-frontend=$FRONTEND_RESULT"
+          # `skipped` is a PASS here and only here: the `changes` job judged the
+          # diff irrelevant to the battery, which is a decision not to run, not
+          # a failure to run. Anything else — failure, cancelled, or a state
+          # this gate has never seen — is this context's failure, because the
+          # whole point of the job is to have a verdict to report.
+          for result in "$GO_RESULT" "$FRONTEND_RESULT"; do
+            case "$result" in
+              success|skipped) ;;
+              *) echo "::error::a unit half reported \"$result\""; exit 1 ;;
+            esac
+          done
+          echo "test-go and test-frontend passed."
 
   race:
     runs-on: ubuntu-latest

--- a/changelog.d/ci-test-gate-judges-its-halves.md
+++ b/changelog.d/ci-test-gate-judges-its-halves.md
@@ -1,0 +1,11 @@
+### Internal
+
+- **The `test` gate reports a verdict instead of disappearing when a unit half fails.** The job had
+  no `if`, so a failed dependency skipped it — and GitHub reports a skipped job as a satisfied
+  required check. Measured on a throwaway branch carrying one deliberately failing Go test:
+  `test-go` failed, and `test`, `e2e` and `patch-coverage` — three of the fourteen required
+  contexts — all reported SKIPPED. `race` gates on the `changes` job rather than on `test`, so it
+  ran and passed, and nothing else covered the unit suite. The job now runs under `!cancelled()`
+  and turns its two dependencies' results into its own verdict: `success` and `skipped` pass —
+  the latter is the docs-only decision not to run the battery — and anything else fails the
+  context, so a failing unit suite is red where branch protection looks.


### PR DESCRIPTION
The thin `test` job — the one branch protection's required context is pinned to by name — carried no `if`, so a failed dependency skipped it. GitHub reports a skipped job as a satisfied required check, which is the property the battery's docs-only skip is built on, and here it worked the wrong way round.

**Measured** on a throwaway branch carrying one deliberately failing Go test, twice, identically: `test-go` failed, and `test`, `e2e` and `patch-coverage` — three of the fourteen required contexts — all reported SKIPPED through their needs edges. `race` gates on the `changes` job rather than on `test`, so it ran; nothing among the required contexts covered the unit suite. A CLEAN mergeable state was not observed directly: main moved under an active merge queue and the probe branch turned BEHIND before `race` settled, both times. The second leg — that a skipped required check is satisfied — is what the docs-only skip already depends on, and docs-only pull requests do merge.

The job now runs under `!cancelled()` and turns its dependencies' results into its own verdict. `success` and `skipped` pass, and only there: a skip is the `changes` job's decision that the diff is irrelevant to the battery, not a failure to run it. Anything else fails the context.

**Downstream:** on a docs-only change `test` now reports success rather than skipping, so `e2e` and `e2e-postgres-smoke` spin their jobs up instead of cascading to skipped. Their work is already gated per step on `RUN_E2E`, so they do nothing and stay green.

The gate script was exercised offline over six result pairs: both success, both skipped, either one failing, cancelled, and an unrecognised state — exit 0, 0, 1, 1, 1, 1.

Note: the comment in the `e2e` job describing the old cascade is left untouched here on purpose — #400 rewrites that same hunk, and this queue rebases. It gets a one-line follow-up once both have landed.