### PR TITLE
docs(ci): the e2e job no longer cascades to skipped, and its comment says so

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -453,11 +453,14 @@ jobs:
     # job-level skips were believed to leave the required check unsatisfied —
     # that is not how GitHub behaves today (a skipped job reports as a
     # satisfied required check; the unit/race battery above and the sibling
-    # repos rely on it). The step-gated shape is kept as-is; note that on a
-    # docs-only pull request — and now on a docs-only merge-queue run — this
-    # job cascades to skipped anyway, because its `test` dependency skips
-    # first, so the RUN_E2E step guards matter only if the two allowlists in
-    # `changes` ever diverge. Those guards carry the battery's fail-safe form
+    # repos rely on it). The step-gated shape is kept as-is, and it is now the
+    # thing that does the work: this job used to cascade to skipped on a
+    # docs-only change because its `test` dependency skipped first, but `test`
+    # judges its halves rather than disappearing, so on a docs-only pull request
+    # — or merge-queue run — it reports success and this job RUNS with every
+    # step gated off. The RUN_E2E guards are therefore load-bearing on the
+    # ordinary path, not only if the two allowlists in `changes` ever diverge.
+    # Those guards carry the battery's fail-safe form
     # (`!= 'false'`): an absent output must not silently green a job that ran.
     env:
       RUN_E2E: ${{ needs.changes.outputs.run_e2e }}

--- a/changelog.d/docs-e2e-cascade-comment-truth.md
+++ b/changelog.d/docs-e2e-cascade-comment-truth.md
@@ -1,0 +1,3 @@
+### Internal
+
+none — a comment in the CI workflow corrected to match the gate it describes.


### PR DESCRIPTION
Promised follow-up to #400 and #402, held back until both landed because the queue rebases and all three touch the same hunk.

The comment described the shape those two replaced: this job cascaded to skipped on a docs-only change because its `test` dependency skipped first. `test` now judges its halves instead of disappearing, so it reports success and `e2e` runs with every step gated off by `RUN_E2E`. Those guards are load-bearing on the ordinary path now, not a hedge against the two allowlists in `changes` diverging.

Comment only — no job, gate or allowlist changes.