### PR TITLE
fix(docs): the register spec documents the consent field it always required

### DIFF
--- a/changelog.d/docs-openapi-register-consent-required.md
+++ b/changelog.d/docs-openapi-register-consent-required.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- **`POST /api/v1/users` documents the `consent` field it has always required.** `RegisterRequest`
+  declared `required: [email, password, confirm_password]` next to `additionalProperties: false`,
+  while the handler refuses any body whose `consent` is not truthy — so a client generated from the
+  spec was refused for omitting a field the same document forbade it to send. The field is published
+  with its accepted spellings (`1`, `true`, `on`, `yes`, case-insensitive, trimmed) and the refusal
+  it produces. Found on the load stand, where the harness could not register until it sent `consent`.
+  A new contract test reads the required set out of `docs/openapi.yaml` and lets the endpoint judge
+  it: a body carrying exactly the declared required fields must not be refused as invalid, so a
+  field the server starts demanding without documenting it fails the suite.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -368,7 +368,7 @@ components:
 
     RegisterRequest:
       type: object
-      required: [email, password, confirm_password]
+      required: [email, password, confirm_password, consent]
       properties:
         email:
           type: string
@@ -382,6 +382,9 @@ components:
         confirm_password:
           type: string
           format: password
+        consent:
+          type: string
+          description: Explicit consent to store health data, required for every registration. Truthy spellings, compared case-insensitively after trimming — `1`, `true`, `on`, `yes`. Any other value, and an absent field, are refused with 400 and `error_detail.key` `consent required`.
       additionalProperties: false
 
     LoginRequest:

--- a/internal/api/openapi_contract_test.go
+++ b/internal/api/openapi_contract_test.go
@@ -522,6 +522,123 @@ func openAPISchemaPropertyBounds(t *testing.T, specPath string) map[string]map[s
 	return bounds
 }
 
+// TestOpenAPIRequiredRegistrationFieldsAreEnoughToRegister is the request-BODY
+// half of the route↔spec contract, and it exists because the document described a
+// registration no generated client could perform. `RegisterRequest` declared
+// required [email, password, confirm_password] together with
+// `additionalProperties: false`, while Register refuses every body whose
+// `consent` is not truthy — so a client built from the spec was refused for
+// omitting a field the same document forbade it to send. Measured on the soak
+// stand, where the harness could not register until it added `consent`.
+//
+// Route presence, declared bounds, statuses and error categories were each
+// pinned; required request fields were not, which is the same gap that let the
+// 2FA challenge declare `application/json` for a handler reading form values.
+//
+// The area rule's shape: the constraint is READ from the spec and the endpoint
+// judges it. The body carries exactly the declared required properties and
+// nothing else, so a field the handler starts demanding without documenting it
+// fails here — and so does a required field the spec gains that this test has no
+// sample for, which is precisely when someone has to decide what a client would
+// actually send.
+func TestOpenAPIRequiredRegistrationFieldsAreEnoughToRegister(t *testing.T) {
+	app, _ := newOnboardingTestApp(t)
+
+	specPath := filepath.Join("..", "..", "docs", "openapi.yaml")
+	required := openAPISchemaRequired(t, specPath, "RegisterRequest")
+	if len(required) == 0 {
+		t.Fatal("RegisterRequest declares no required properties in docs/openapi.yaml; parser or spec is wrong")
+	}
+
+	// What a client generated from the spec would put in each documented field:
+	// values that satisfy every OTHER published constraint, so the only thing
+	// this test can fail on is the completeness of the required set itself.
+	samples := map[string]string{
+		"email":            "spec-required-fields@example.com",
+		"password":         "StrongPass1",
+		"confirm_password": "StrongPass1",
+		"consent":          "true",
+	}
+	body := make(map[string]string, len(required))
+	for _, field := range required {
+		value, ok := samples[field]
+		if !ok {
+			t.Fatalf("docs/openapi.yaml requires %q on RegisterRequest and this test carries no value for it — "+
+				"add one a client could plausibly send, then let the endpoint judge it", field)
+		}
+		body[field] = value
+	}
+
+	payload, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal register body: %v", err)
+	}
+	request := httptest.NewRequest(http.MethodPost, "/api/v1/users", bytes.NewReader(payload))
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Accept", "application/json")
+
+	response := mustAppResponse(t, app, request)
+	if response.StatusCode == http.StatusBadRequest {
+		envelope := map[string]any{}
+		_ = json.NewDecoder(response.Body).Decode(&envelope)
+		key := ""
+		if detail, ok := envelope["error_detail"].(map[string]any); ok {
+			key, _ = detail["key"].(string)
+		}
+		t.Fatalf("a body carrying exactly the spec's required fields %v was refused with 400 %q — "+
+			"the document describes a registration no client written to it can perform", required, key)
+	}
+}
+
+// openAPISchemaRequired reads one component schema's `required` list, which the
+// spec writes inline (`required: [a, b, c]`). Line-based like every other reader
+// here, for the same reason: the repo's minimal-dependency posture, and a YAML
+// library would be pulled in for four lines of parsing.
+func openAPISchemaRequired(t *testing.T, specPath, schema string) []string {
+	t.Helper()
+	data, err := os.ReadFile(specPath)
+	if err != nil {
+		t.Fatalf("read openapi spec: %v", err)
+	}
+
+	inComponents, inSchemas, inSchema := false, false, false
+	for _, raw := range strings.Split(string(data), "\n") {
+		line := strings.TrimRight(raw, "\r")
+		text := strings.TrimSpace(line)
+		if text == "" || strings.HasPrefix(text, "#") {
+			continue
+		}
+		if !strings.HasPrefix(line, " ") {
+			inComponents = strings.HasPrefix(line, "components:")
+			inSchemas, inSchema = false, false
+			continue
+		}
+		if !inComponents {
+			continue
+		}
+		switch indent := len(line) - len(strings.TrimLeft(line, " ")); {
+		case indent == 2:
+			inSchemas = text == "schemas:"
+			inSchema = false
+		case indent == 4 && inSchemas && strings.HasSuffix(text, ":"):
+			inSchema = strings.TrimSuffix(text, ":") == schema
+		case indent == 6 && inSchema:
+			list, found := strings.CutPrefix(text, "required:")
+			if !found {
+				continue
+			}
+			names := []string{}
+			for _, name := range strings.Split(strings.Trim(strings.TrimSpace(list), "[]"), ",") {
+				if trimmed := strings.TrimSpace(name); trimmed != "" {
+					names = append(names, trimmed)
+				}
+			}
+			return names
+		}
+	}
+	return nil
+}
+
 // openAPIDeclaredBound is one (schema, property, keyword) triple whose declared
 // value must sit exactly where the running server draws its line. The bound is
 // never restated here: the spec supplies the number and the endpoint judges it,


### PR DESCRIPTION
`RegisterRequest` declared `required: [email, password, confirm_password]` next to
`additionalProperties: false`, while `Register` refuses every body whose `consent` is not truthy.
A client generated from `docs/openapi.yaml` was therefore refused for omitting a field the same
document forbade it to send — the spec did not merely omit `consent`, it closed the object against
it. Found on the load stand, where the harness could not register until it added the field.

## What changes

- `consent` is published on `RegisterRequest`: in `required`, and as a string property carrying the
  spellings the server accepts (`1`, `true`, `on`, `yes` — compared case-insensitively after
  trimming) plus the refusal a wrong value produces (400, `error_detail.key` `consent required`).
- `TestOpenAPIRequiredRegistrationFieldsAreEnoughToRegister` pins the request-body half of the
  route↔spec contract, which nothing pinned before: route presence, declared bounds, statuses and
  error categories each had a guard, required request fields did not. That is the same gap that let
  the 2FA challenge declare `application/json` for a handler reading form values.

No runtime code changes — the server behaves identically before and after.

## How the test is built

It follows the area rule for published constraints: the value is read out of the spec and the
endpoint judges it. The test parses `RegisterRequest`'s own `required` list, sends a body carrying
exactly those fields and nothing else, and fails if the server answers 400. So a field the handler
starts demanding without documenting it fails the suite, and a required field the spec gains
without a plausible client value fails it too, naming the field.

Proved in both directions: with the `consent` entry removed from the spec the test fails with
`a body carrying exactly the spec's required fields [email password confirm_password] was refused
with 400 "consent required"`.

## Verification

`go test ./...` green across every package.
