### PR TITLE
fix(nav): the mobile header menu stops repeating the tab bar

### DIFF
--- a/changelog.d/design-w1b-single-mobile-nav.md
+++ b/changelog.d/design-w1b-single-mobile-nav.md
@@ -1,0 +1,7 @@
+### Changed
+
+- **A phone now has one navigation, not two.** The header menu repeated Today, Calendar, Insights
+  and Settings — the same four destinations the bottom tab bar already offers — so opening it
+  pushed the page down to show a second copy of the bar that stayed visible underneath. The menu
+  is now the account menu: the profile entry and sign-out, nothing else. Section switching belongs
+  to the bottom bar, and the desktop navigation is unchanged.

--- a/internal/api/dashboard_navigation_regressions_test.go
+++ b/internal/api/dashboard_navigation_regressions_test.go
@@ -5,11 +5,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"regexp"
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/gofiber/fiber/v3"
 	"github.com/ovumcy/ovumcy-web/internal/models"
+	"golang.org/x/net/html"
 )
 
 func TestDashboardLogoutFormsRequireConfirmation(t *testing.T) {
@@ -186,6 +188,84 @@ func TestCalendarSelectedDayLoadsEditModeWhenRequested(t *testing.T) {
 	}
 	if got := htmlAttr(loader, "hx-get"); got != "/calendar/day/2026-03-12?mode=edit" {
 		t.Fatalf("expected the #day-editor lazy-loader to fetch edit mode from /calendar/day/2026-03-12?mode=edit, got hx-get=%q", got)
+	}
+}
+
+// navSectionHooks lists the section destinations a navigation landmark offers,
+// in document order, by their stable data-nav-link hooks.
+func navSectionHooks(root *html.Node) []string {
+	links := htmlFindElements(root, func(node *html.Node) bool {
+		return node.Type == html.ElementNode && htmlHasAttr(node, "data-nav-link")
+	})
+	hooks := make([]string, 0, len(links))
+	for _, link := range links {
+		hooks = append(hooks, htmlAttr(link, "data-nav-link"))
+	}
+	return hooks
+}
+
+// TestMobileHeaderMenuCarriesOnlyAccountEntries pins the single-navigation
+// contract for mobile: the header menu used to repeat Today / Calendar /
+// Insights / Settings, so a phone carried two navigations to the same four
+// destinations — the menu pushed the page down when opened and left the bottom
+// tab bar visible underneath it. The four section destinations now live in the
+// tab bar alone; the header menu is the account menu (profile chip + logout)
+// and declares that reduced scope through data-mobile-menu="account". Desktop
+// renders its own full primary navigation and is unaffected.
+func TestMobileHeaderMenuCarriesOnlyAccountEntries(t *testing.T) {
+	app, database := newOnboardingTestApp(t)
+	user := createOnboardingTestUser(t, database, "mobile-single-nav@example.com", "StrongPass1", true)
+	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
+
+	sections := []string{"today", "calendar", "insights", "settings"}
+
+	for _, path := range []string{"/dashboard", "/calendar", "/stats", "/settings"} {
+		document := mustParseHTMLDocument(t, fetchPageBody(t, app, path, authCookie))
+
+		menu := htmlFindElement(document, func(node *html.Node) bool {
+			return node.Type == html.ElementNode && node.Data == "nav" && htmlHasAttr(node, "data-mobile-menu")
+		})
+		if menu == nil {
+			t.Fatalf("%s: expected the header to render the mobile menu landmark", path)
+		}
+		if got := htmlAttr(menu, "data-mobile-menu"); got != "account" {
+			t.Errorf("%s: mobile menu declares data-mobile-menu=%q, expected \"account\"", path, got)
+		}
+		if hooks := navSectionHooks(menu); len(hooks) != 0 {
+			t.Errorf(
+				"%s: the mobile header menu still lists section destinations %v; the bottom tab bar already covers them, so a phone gets two navigations to the same places",
+				path, hooks,
+			)
+		}
+		if htmlElementByID(menu, "nav-user-chip-mobile") == nil {
+			t.Errorf("%s: the mobile menu must keep the profile entry", path)
+		}
+		if htmlElementByAttr(menu, "action", "/logout") == nil {
+			t.Errorf("%s: the mobile menu must keep the logout form", path)
+		}
+
+		tabbar := htmlElementByTagAndClass(document, "nav", "mobile-tabbar")
+		if tabbar == nil {
+			t.Fatalf("%s: expected the bottom tab bar to stay in place", path)
+		}
+		if got := navSectionHooks(tabbar); !slices.Equal(got, sections) {
+			t.Errorf("%s: the bottom tab bar must remain the mobile route to every section, got %v", path, got)
+		}
+
+		desktop := htmlFindElement(document, func(node *html.Node) bool {
+			if node.Type != html.ElementNode || node.Data != "nav" {
+				return false
+			}
+			return htmlFindElement(node, func(candidate *html.Node) bool {
+				return candidate.Type == html.ElementNode && htmlHasAttr(candidate, "data-nav-account-actions")
+			}) != nil
+		})
+		if desktop == nil {
+			t.Fatalf("%s: expected the desktop primary navigation to render", path)
+		}
+		if got := navSectionHooks(desktop); !slices.Equal(got, sections) {
+			t.Errorf("%s: desktop navigation must keep every section link, got %v", path, got)
+		}
 	}
 }
 

--- a/internal/templates/base.html
+++ b/internal/templates/base.html
@@ -94,11 +94,8 @@
           </div>
         </nav>
 
-        <nav id="mobile-menu" data-mobile-menu hidden class="mt-2 space-y-2 sm:hidden" aria-label="{{t .Messages "a11y.nav.mobile_menu"}}">
-          <a href="/dashboard" class="nav-link block {{if isActiveRoute .CurrentPath "/dashboard"}}nav-link-active{{else if isActiveRoute .CurrentPath "/"}}nav-link-active{{end}}" data-nav-link="today" data-nav-link-key="nav.today">{{t .Messages "nav.today"}}</a>
-          <a href="/calendar" class="nav-link block {{if isActiveRoute .CurrentPath "/calendar"}}nav-link-active{{end}}" data-nav-link="calendar" data-nav-link-key="nav.calendar">{{t .Messages "nav.calendar"}}</a>
-          <a href="/stats" class="nav-link block {{if isActiveRoute .CurrentPath "/stats"}}nav-link-active{{end}}" data-nav-link="insights" data-nav-link-key="nav.insights">{{t .Messages "nav.insights"}}</a>
-          <a href="/settings" class="nav-link nav-link-icon block {{if isActiveRoute .CurrentPath "/settings"}}nav-link-active{{end}}" data-nav-link="settings" data-nav-link-key="nav.settings" aria-label="{{t .Messages "nav.settings"}}" title="{{t .Messages "nav.settings"}}"><span aria-hidden="true">⚙️</span></a>
+        <!-- Account menu only: the four section destinations are the bottom tab bar's job on mobile. -->
+        <nav id="mobile-menu" data-mobile-menu="account" hidden class="mt-2 space-y-2 sm:hidden" aria-label="{{t .Messages "a11y.nav.mobile_menu"}}">
           {{template "nav_user_identity_chip" (dict "CurrentUser" .CurrentUser "Messages" .Messages "ElementID" "nav-user-chip-mobile" "Block" true "SwapOOB" false)}}
           <form action="/logout" method="post" data-confirm="{{t .Messages "auth.confirm_logout"}}" data-confirm-accept="{{t .Messages "nav.logout"}}">
             <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">


### PR DESCRIPTION
## Defect

On a phone the app carried two navigations to the same four destinations. The header
menu (`#mobile-menu`) repeated Today / Calendar / Insights / Settings, which the bottom
tab bar already offers; opening it pushed the page content down to reveal a second copy
of the same links while the bar stayed visible underneath.

## Change

The header menu becomes the account menu. It keeps the profile chip and the sign-out
form, drops the four section links, and declares its reduced scope through the stable
hook `data-mobile-menu="account"` (the toggle script matches on the attribute, not its
value, so the open/close binding is unchanged).

Untouched by design: the bottom tab bar and its four links, the desktop primary
navigation, the PWA install prompt, and every locale string — no copy or key changed, so
`a11y.nav.mobile_menu` still names the landmark. The menu keeps at least two entries in
every state, so the named-landmark contract needs no conditional removal.

## Tests

`TestMobileHeaderMenuCarriesOnlyAccountEntries`
(`internal/api/dashboard_navigation_regressions_test.go`) renders `/dashboard`,
`/calendar`, `/stats` and `/settings` as an authenticated owner and asserts the
structural split: the mobile menu declares `data-mobile-menu="account"` and holds zero
`data-nav-link` descendants while keeping `#nav-user-chip-mobile` and the `/logout`
form; the bottom tab bar and the desktop navigation each still expose all four section
hooks in order. Hooks only — no rendered copy is asserted.

Before the template change the test fails on all four pages with
`the mobile header menu still lists section destinations [today calendar insights settings]`.

The existing guards stay green, including `TestAuthenticatedPagesNameEveryNavigationLandmark`,
`TestTemplatesKeepDecorativeGlyphsOutOfTheAccessibilityTree`,
`TestDashboardLogoutFormsRequireConfirmation` and the two navigation identity-chip
regressions.

Run locally: full `go test ./...`, `golangci-lint run ./internal/api/...`,
`npm run lint:js`, `npm run build` (the committed `web/static` bundle is byte-identical —
no class was added or removed), and the patch-coverage gate after committing (`OK`).

No e2e spec drives the header menu — `e2e/navigation-language.spec.ts` addresses
`[data-nav-link]` with `.first()` at the desktop viewport, and the mobile specs read the
tab bar (`nav.mobile-tabbar`) — so no spec needed rerouting.
