### PR TITLE
chore(tests): stale static-analysis findings leave the tree

### DIFF
--- a/changelog.d/cleanup-gopls-findings.md
+++ b/changelog.d/cleanup-gopls-findings.md
@@ -1,0 +1,5 @@
+none
+
+Static-analysis debt only: inferable type arguments dropped, an unused test-helper
+parameter and a dead write removed, a dead constant and an unused parameter deleted.
+No behavior change.

--- a/internal/api/auth_reset_token_one_time_regressions_test.go
+++ b/internal/api/auth_reset_token_one_time_regressions_test.go
@@ -392,10 +392,7 @@ func TestShowResetPasswordPageWithValidForcedTokenShowsForcedNoticeAndForm(t *te
 // error must surface that error key on the GET page via the
 // data-auth-server-error / data-error-key hooks the front-end keys off.
 func TestShowResetPasswordPageSurfacesFlashAuthErrorThroughDataKey(t *testing.T) {
-	handler := &Handler{
-		secretKey:    []byte(testHandlerSecretKey),
-		cookieSecure: true,
-	}
+	handler := &Handler{secretKey: []byte(testHandlerSecretKey)}
 	codec, err := newSecureCookieCodec(handler.secretKey)
 	if err != nil {
 		t.Fatalf("newSecureCookieCodec: %v", err)

--- a/internal/api/fullpage_fallback_regressions_test.go
+++ b/internal/api/fullpage_fallback_regressions_test.go
@@ -77,7 +77,7 @@ func newFullPageFallbackApp(t *testing.T, options onboardingTestAppOptions) (*fi
 		return c.JSON(fiber.Map{"state": state.State})
 	})
 	app.Get("/__seed/oidc-stepup", func(c fiber.Ctx) error {
-		userID := uint(fiber.Query[int](c, "user_id", 0))
+		userID := uint(fiber.Query(c, "user_id", 0))
 		state, stateErr := newOIDCStepupState(time.Now(), oidcStepupPurposeLocalPasswordSetup, userID, "prepared-hash")
 		if stateErr != nil {
 			return c.Status(fiber.StatusInternalServerError).SendString(stateErr.Error())
@@ -88,7 +88,7 @@ func newFullPageFallbackApp(t *testing.T, options onboardingTestAppOptions) (*fi
 		return c.SendStatus(fiber.StatusOK)
 	})
 	app.Get("/__seed/link-pending", func(c fiber.Ctx) error {
-		userID := uint(fiber.Query[int](c, "user_id", 0))
+		userID := uint(fiber.Query(c, "user_id", 0))
 		payload, payloadErr := newOIDCLinkPendingPayload(time.Now(), userID, "https://issuer.example.com", "subject-1", c.Query("email", ""))
 		if payloadErr != nil {
 			return c.Status(fiber.StatusInternalServerError).SendString(payloadErr.Error())

--- a/internal/api/security_event_logging_mutation_regression_test.go
+++ b/internal/api/security_event_logging_mutation_regression_test.go
@@ -337,7 +337,7 @@ func TestStepupCallbacksAuditTheOwnerTheyActFor(t *testing.T) {
 		}
 
 		stepupCookie := readStepupCookie(t, startResponse)
-		state := extractStepupCallbackState(t, fixture, stepupCookie)
+		state := extractStepupCallbackState(t, fixture)
 
 		callbackResponse, auditLog := captureStepupCallbackAudit(t, fixture, stepupCookie, state)
 		defer func() { _ = callbackResponse.Body.Close() }()
@@ -362,7 +362,7 @@ func TestStepupCallbacksAuditTheOwnerTheyActFor(t *testing.T) {
 		}
 
 		stepupCookie := readStepupCookie(t, startResponse)
-		state := extractStepupCallbackState(t, fixture, stepupCookie)
+		state := extractStepupCallbackState(t, fixture)
 
 		callbackResponse, auditLog := captureStepupCallbackAudit(t, fixture, stepupCookie, state)
 		defer func() { _ = callbackResponse.Body.Close() }()

--- a/internal/api/settings_erasure_stepup_flow_test.go
+++ b/internal/api/settings_erasure_stepup_flow_test.go
@@ -86,7 +86,7 @@ func TestErasureStepupClearsDataOnlyAfterAFreshReauth(t *testing.T) {
 	}
 
 	stepupCookie := readStepupCookie(t, startResponse)
-	state := extractStepupCallbackState(t, fixture, stepupCookie)
+	state := extractStepupCallbackState(t, fixture)
 
 	callbackResponse := postOIDCStepupCallback(t, fixture, stepupCookie, state, "callback-code")
 	defer func() { _ = callbackResponse.Body.Close() }()
@@ -124,7 +124,7 @@ func TestErasureStepupDeletesAccountOnlyAfterAFreshReauth(t *testing.T) {
 	}
 
 	stepupCookie := readStepupCookie(t, startResponse)
-	state := extractStepupCallbackState(t, fixture, stepupCookie)
+	state := extractStepupCallbackState(t, fixture)
 
 	callbackResponse := postOIDCStepupCallback(t, fixture, stepupCookie, state, "callback-code")
 	defer func() { _ = callbackResponse.Body.Close() }()
@@ -164,7 +164,7 @@ func TestErasureStepupKeepsDataWhenTheReauthIsRefused(t *testing.T) {
 			startResponse := postErasureStepupStart(t, fixture, "/api/v1/users/current/data-wipe/step-up")
 			defer func() { _ = startResponse.Body.Close() }()
 			stepupCookie := readStepupCookie(t, startResponse)
-			state := extractStepupCallbackState(t, fixture, stepupCookie)
+			state := extractStepupCallbackState(t, fixture)
 
 			// Refuse only at the exchange, so the request reaches the same place
 			// the successful case does and diverges exactly at the verdict.
@@ -262,7 +262,7 @@ func TestErasureStepupCallbackRefusesAForeignSession(t *testing.T) {
 	startResponse := postErasureStepupStart(t, fixture, "/api/v1/users/current/data-wipe/step-up")
 	defer func() { _ = startResponse.Body.Close() }()
 	stepupCookie := readStepupCookie(t, startResponse)
-	state := extractStepupCallbackState(t, fixture, stepupCookie)
+	state := extractStepupCallbackState(t, fixture)
 
 	// A second owner on the same instance — the household case.
 	intruder := models.User{
@@ -304,7 +304,7 @@ func TestErasureStepupCallbackRefusesOnceALocalPasswordExists(t *testing.T) {
 	startResponse := postErasureStepupStart(t, fixture, "/api/v1/users/current/data-wipe/step-up")
 	defer func() { _ = startResponse.Body.Close() }()
 	stepupCookie := readStepupCookie(t, startResponse)
-	state := extractStepupCallbackState(t, fixture, stepupCookie)
+	state := extractStepupCallbackState(t, fixture)
 
 	if err := fixture.database.Model(&models.User{}).Where("id = ?", fixture.user.ID).
 		Update("local_auth_enabled", true).Error; err != nil {
@@ -330,7 +330,7 @@ func TestErasureStepupCallbackRefusesAProviderError(t *testing.T) {
 	startResponse := postErasureStepupStart(t, fixture, "/api/v1/users/current/data-wipe/step-up")
 	defer func() { _ = startResponse.Body.Close() }()
 	stepupCookie := readStepupCookie(t, startResponse)
-	state := extractStepupCallbackState(t, fixture, stepupCookie)
+	state := extractStepupCallbackState(t, fixture)
 
 	form := url.Values{"state": {state}, "code": {""}, "error": {"access_denied"}}
 	request := httptest.NewRequest(http.MethodPost, "/auth/oidc/callback", strings.NewReader(form.Encode()))
@@ -366,7 +366,7 @@ func TestErasureStepupCallbackSurvivesAStorageFailure(t *testing.T) {
 			startResponse := postErasureStepupStart(t, fixture, testCase.path)
 			defer func() { _ = startResponse.Body.Close() }()
 			stepupCookie := readStepupCookie(t, startResponse)
-			state := extractStepupCallbackState(t, fixture, stepupCookie)
+			state := extractStepupCallbackState(t, fixture)
 
 			// Both erasure transactions start at daily_logs, so dropping it fails
 			// them while leaving the users table the auth middleware reads intact.

--- a/internal/api/settings_mutation_handlers_test.go
+++ b/internal/api/settings_mutation_handlers_test.go
@@ -437,7 +437,7 @@ func newSettingsMutationStepupApp(t *testing.T, stub *stubOIDCWorkflowService) (
 	app := fiber.New()
 	app.Use(handler.LanguageMiddleware)
 	app.Get("/__seed/stepup", func(c fiber.Ctx) error {
-		userID := uint(fiber.Query[int](c, "user_id", 0))
+		userID := uint(fiber.Query(c, "user_id", 0))
 		state, stateErr := newOIDCStepupState(time.Now(), oidcStepupPurposeLocalPasswordSetup, userID, "prepared-hash")
 		if stateErr != nil {
 			return c.Status(fiber.StatusInternalServerError).SendString(stateErr.Error())

--- a/internal/api/settings_oidc_local_password_error_path_test.go
+++ b/internal/api/settings_oidc_local_password_error_path_test.go
@@ -152,7 +152,7 @@ func TestOIDCCompleteLocalPasswordSetupProviderErrorParam(t *testing.T) {
 	startResponse := fixture.postStart(t, "EvenStronger2", "EvenStronger2")
 	defer func() { _ = startResponse.Body.Close() }()
 	stepupCookie := readStepupCookie(t, startResponse)
-	state := extractStepupCallbackState(t, fixture, stepupCookie)
+	state := extractStepupCallbackState(t, fixture)
 
 	form := url.Values{
 		"state": {state},

--- a/internal/api/settings_oidc_local_password_setup_test.go
+++ b/internal/api/settings_oidc_local_password_setup_test.go
@@ -145,7 +145,7 @@ func decodeStepupRedirectJSON(t *testing.T, body []byte) string {
 	return target
 }
 
-func extractStepupCallbackState(t *testing.T, fixture *oidcStepupFixture, stepupCookieHeader string) string {
+func extractStepupCallbackState(t *testing.T, fixture *oidcStepupFixture) string {
 	t.Helper()
 	// We only need the State value that the stub recorded — the cookie is
 	// opaque to the test code but the stub captured the same string the
@@ -284,7 +284,7 @@ func TestOIDCCompleteLocalPasswordSetupFinalizesOnFreshReauth(t *testing.T) {
 	startResponse := fixture.postStart(t, "EvenStronger2", "EvenStronger2")
 	defer func() { _ = startResponse.Body.Close() }()
 	stepupCookie := readStepupCookie(t, startResponse)
-	state := extractStepupCallbackState(t, fixture, stepupCookie)
+	state := extractStepupCallbackState(t, fixture)
 
 	callbackResponse := postOIDCStepupCallback(t, fixture, stepupCookie, state, "callback-code")
 	defer func() { _ = callbackResponse.Body.Close() }()
@@ -323,7 +323,7 @@ func TestOIDCCompleteLocalPasswordSetupRejectsStaleReauth(t *testing.T) {
 	startResponse := fixture.postStart(t, "EvenStronger2", "EvenStronger2")
 	defer func() { _ = startResponse.Body.Close() }()
 	stepupCookie := readStepupCookie(t, startResponse)
-	state := extractStepupCallbackState(t, fixture, stepupCookie)
+	state := extractStepupCallbackState(t, fixture)
 
 	callbackResponse := postOIDCStepupCallback(t, fixture, stepupCookie, state, "callback-code")
 	defer func() { _ = callbackResponse.Body.Close() }()
@@ -353,7 +353,7 @@ func TestOIDCCompleteLocalPasswordSetupRejectsIdentityMismatch(t *testing.T) {
 	startResponse := fixture.postStart(t, "EvenStronger2", "EvenStronger2")
 	defer func() { _ = startResponse.Body.Close() }()
 	stepupCookie := readStepupCookie(t, startResponse)
-	state := extractStepupCallbackState(t, fixture, stepupCookie)
+	state := extractStepupCallbackState(t, fixture)
 
 	callbackResponse := postOIDCStepupCallback(t, fixture, stepupCookie, state, "callback-code")
 	defer func() { _ = callbackResponse.Body.Close() }()

--- a/internal/api/totp_cookies_test.go
+++ b/internal/api/totp_cookies_test.go
@@ -24,8 +24,8 @@ func newTOTPCookieTestApp(t *testing.T, secretKey []byte) (*fiber.App, *Handler)
 	handler := &Handler{secretKey: secretKey, cookieSecure: false}
 	app := fiber.New()
 	app.Get("/seal-pending", func(c fiber.Ctx) error {
-		userID := uint(fiber.Query[int](c, "user_id", 0))
-		remember := fiber.Query[bool](c, "remember_me", false)
+		userID := uint(fiber.Query(c, "user_id", 0))
+		remember := fiber.Query(c, "remember_me", false)
 		if err := handler.setTOTPPendingCookie(c, userID, remember); err != nil {
 			return c.Status(fiber.StatusInternalServerError).SendString(err.Error())
 		}
@@ -42,7 +42,7 @@ func newTOTPCookieTestApp(t *testing.T, secretKey []byte) (*fiber.App, *Handler)
 	// can seal for one owner and parse as another, the way two independent
 	// owners on one household instance would.
 	app.Get("/seal-setup", func(c fiber.Ctx) error {
-		userID := uint(fiber.Query[int](c, "user_id", 0))
+		userID := uint(fiber.Query(c, "user_id", 0))
 		raw := c.Query("raw_secret", "")
 		if err := handler.setTOTPSetupCookie(c, userID, raw); err != nil {
 			return c.Status(fiber.StatusInternalServerError).SendString(err.Error())
@@ -50,7 +50,7 @@ func newTOTPCookieTestApp(t *testing.T, secretKey []byte) (*fiber.App, *Handler)
 		return c.SendStatus(fiber.StatusOK)
 	})
 	app.Get("/parse-setup", func(c fiber.Ctx) error {
-		sessionUserID := uint(fiber.Query[int](c, "user_id", 0))
+		sessionUserID := uint(fiber.Query(c, "user_id", 0))
 		raw, err := handler.parseTOTPSetupCookie(c, sessionUserID)
 		if err != nil {
 			return c.Status(fiber.StatusBadRequest).SendString(err.Error())

--- a/internal/services/calendar_days.go
+++ b/internal/services/calendar_days.go
@@ -37,7 +37,7 @@ func BuildCalendarDayStates(user *models.User, monthStart time.Time, logs []mode
 		weekStart = NormalizeWeekStart(user.WeekStartsOn)
 	}
 	gridStart, gridEnd := calendarGridBounds(monthStart, weekStart)
-	latestLogByDate, hasDataMap := buildCalendarLogMaps(logs, location)
+	latestLogByDate, hasDataMap := buildCalendarLogMaps(logs)
 	predictedPeriodMap, preFertileMap, fertilityEdgeMap, fertilityPeakMap, ovulationMap, tentativeOvulationMap := buildCalendarPredictionMaps(user, logs, stats, gridEnd, now, location)
 
 	todayKey := DateAtLocation(now, location).Format("2006-01-02")
@@ -59,7 +59,7 @@ func calendarGridBounds(monthStart time.Time, weekStart string) (time.Time, time
 	return gridStart, gridEnd
 }
 
-func buildCalendarLogMaps(logs []models.DailyLog, location *time.Location) (map[string]models.DailyLog, map[string]bool) {
+func buildCalendarLogMaps(logs []models.DailyLog) (map[string]models.DailyLog, map[string]bool) {
 	latestLogByDate := make(map[string]models.DailyLog)
 	hasDataMap := make(map[string]bool)
 	for _, logEntry := range logs {

--- a/internal/services/cycles.go
+++ b/internal/services/cycles.go
@@ -39,13 +39,12 @@ type detectedCycle struct {
 }
 
 const (
-	cyclePredictionWindow      = 6
-	irregularCycleSpreadDays   = 7
-	irregularCycleFallbackSpan = 7
-	defaultLutealPhaseDays     = 14
-	minLutealPhaseDays         = 10
-	minOvulationCycleDay       = 5
-	minCycleReserveDays        = 10
+	cyclePredictionWindow    = 6
+	irregularCycleSpreadDays = 7
+	defaultLutealPhaseDays   = 14
+	minLutealPhaseDays       = 10
+	minOvulationCycleDay     = 5
+	minCycleReserveDays      = 10
 )
 
 func BuildCycleStats(logs []models.DailyLog, now time.Time) CycleStats {


### PR DESCRIPTION
## What

Long-standing informational static-analysis findings, style debt only — build and tests were green before and after.

- Inferable type arguments drop from the `fiber.Query` test seams (`totp_cookies_test.go`, `fullpage_fallback_regressions_test.go`, `settings_mutation_handlers_test.go`) — the untyped default argument already fixes the type parameter.
- `extractStepupCallbackState` loses the `stepupCookieHeader` parameter it never read (the state comes from the stub's recording, as its comment says); thirteen call sites updated.
- A dead `cookieSecure: true` write leaves a handler literal that exists only to feed `newSecureCookieCodec` its key — the request in that test goes through the shared app, so the field was never read, and the test asserts flash rendering, not cookie attributes.
- The never-referenced `irregularCycleFallbackSpan` constant and the unused `location` parameter of `buildCalendarLogMaps` are deleted (the map builder keys days through `CalendarDayKey`, which is location-free by the repo's date-only convention).

No behavior change. `gofmt` clean, full `go test ./...` green, patch-coverage gate OK.