### PR TITLE
fix(ui): the desktop header keeps a single route to settings

### DIFF
--- a/changelog.d/design-w1b-single-settings-entry.md
+++ b/changelog.d/design-w1b-single-settings-entry.md
@@ -1,0 +1,8 @@
+### Changed
+
+- **The desktop header now offers one route to settings instead of two.** A gear icon sat beside
+  the account chip in the same header navigation and both opened the settings page, so the row
+  asked twice for the same destination and neither control said which one to use. The gear is
+  gone; the account chip stays, because it also shows the account name (or invites you to add
+  one) and it lands directly on the account section of settings. The phone layout is untouched —
+  the bottom tab bar keeps its settings tab, and the header menu keeps the same account entries.

--- a/internal/api/dashboard_navigation_regressions_test.go
+++ b/internal/api/dashboard_navigation_regressions_test.go
@@ -204,6 +204,76 @@ func navSectionHooks(root *html.Node) []string {
 	return hooks
 }
 
+// desktopPrimaryNavigation returns the header's desktop navigation landmark —
+// the only <nav> that holds the account actions block.
+func desktopPrimaryNavigation(root *html.Node) *html.Node {
+	return htmlFindElement(root, func(node *html.Node) bool {
+		if node.Type != html.ElementNode || node.Data != "nav" {
+			return false
+		}
+		return htmlFindElement(node, func(candidate *html.Node) bool {
+			return candidate.Type == html.ElementNode && htmlHasAttr(candidate, "data-nav-account-actions")
+		}) != nil
+	})
+}
+
+// settingsHrefTargets lists, in document order, the href values under root that
+// lead to the settings page. A bare path, a query and a section fragment are
+// the same destination as far as a reader of the navigation is concerned.
+func settingsHrefTargets(root *html.Node) []string {
+	links := htmlFindElements(root, func(node *html.Node) bool {
+		if node.Type != html.ElementNode || !htmlHasAttr(node, "href") {
+			return false
+		}
+		path, _, _ := strings.Cut(htmlAttr(node, "href"), "#")
+		path, _, _ = strings.Cut(path, "?")
+		return path == "/settings" || strings.HasPrefix(path, "/settings/")
+	})
+	targets := make([]string, 0, len(links))
+	for _, link := range links {
+		targets = append(targets, htmlAttr(link, "href"))
+	}
+	return targets
+}
+
+// TestDesktopHeaderOffersASingleSettingsEntry pins the one-entry contract for
+// the desktop header. It used to carry a gear icon link and the account
+// identity chip side by side — two controls in the same navigation landmark
+// leading to the same page, with the gear adding nothing the chip does not
+// already offer. The chip is the survivor: it reaches settings and names the
+// account, so it must keep an accessible name of its own (its avatar glyph is
+// decorative and stays out of the accessibility tree).
+func TestDesktopHeaderOffersASingleSettingsEntry(t *testing.T) {
+	app, database := newOnboardingTestApp(t)
+	user := createOnboardingTestUser(t, database, "single-settings-entry@example.com", "StrongPass1", true)
+	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
+
+	for _, path := range []string{"/dashboard", "/calendar", "/stats", "/settings"} {
+		document := mustParseHTMLDocument(t, fetchPageBody(t, app, path, authCookie))
+
+		desktop := desktopPrimaryNavigation(document)
+		if desktop == nil {
+			t.Fatalf("%s: expected the desktop primary navigation to render", path)
+		}
+
+		targets := settingsHrefTargets(desktop)
+		if len(targets) != 1 {
+			t.Errorf(
+				"%s: the desktop header offers %d controls leading to settings (%v); exactly one must",
+				path, len(targets), targets,
+			)
+		}
+
+		entry := htmlElementByID(desktop, "nav-user-chip-desktop")
+		if entry == nil {
+			t.Fatalf("%s: the surviving desktop settings entry must be the account identity chip", path)
+		}
+		if got := strings.TrimSpace(htmlAttr(entry, "aria-label")); got == "" {
+			t.Errorf("%s: the account identity chip must carry an accessible name", path)
+		}
+	}
+}
+
 // TestMobileHeaderMenuCarriesOnlyAccountEntries pins the single-navigation
 // contract for mobile: the header menu used to repeat Today / Calendar /
 // Insights / Settings, so a phone carried two navigations to the same four
@@ -211,13 +281,17 @@ func navSectionHooks(root *html.Node) []string {
 // tab bar visible underneath it. The four section destinations now live in the
 // tab bar alone; the header menu is the account menu (profile chip + logout)
 // and declares that reduced scope through data-mobile-menu="account". Desktop
-// renders its own full primary navigation and is unaffected.
+// keeps its own primary navigation, unaffected by that reduction.
 func TestMobileHeaderMenuCarriesOnlyAccountEntries(t *testing.T) {
 	app, database := newOnboardingTestApp(t)
 	user := createOnboardingTestUser(t, database, "mobile-single-nav@example.com", "StrongPass1", true)
 	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
 
 	sections := []string{"today", "calendar", "insights", "settings"}
+	// Desktop reaches settings through the account chip (an account control, not
+	// a section link), so its section hooks stop at the three page destinations —
+	// TestDesktopHeaderOffersASingleSettingsEntry pins the settings route itself.
+	desktopSections := []string{"today", "calendar", "insights"}
 
 	for _, path := range []string{"/dashboard", "/calendar", "/stats", "/settings"} {
 		document := mustParseHTMLDocument(t, fetchPageBody(t, app, path, authCookie))
@@ -252,19 +326,15 @@ func TestMobileHeaderMenuCarriesOnlyAccountEntries(t *testing.T) {
 			t.Errorf("%s: the bottom tab bar must remain the mobile route to every section, got %v", path, got)
 		}
 
-		desktop := htmlFindElement(document, func(node *html.Node) bool {
-			if node.Type != html.ElementNode || node.Data != "nav" {
-				return false
-			}
-			return htmlFindElement(node, func(candidate *html.Node) bool {
-				return candidate.Type == html.ElementNode && htmlHasAttr(candidate, "data-nav-account-actions")
-			}) != nil
-		})
+		desktop := desktopPrimaryNavigation(document)
 		if desktop == nil {
 			t.Fatalf("%s: expected the desktop primary navigation to render", path)
 		}
-		if got := navSectionHooks(desktop); !slices.Equal(got, sections) {
+		if got := navSectionHooks(desktop); !slices.Equal(got, desktopSections) {
 			t.Errorf("%s: desktop navigation must keep every section link, got %v", path, got)
+		}
+		if htmlElementByID(desktop, "nav-user-chip-desktop") == nil {
+			t.Errorf("%s: the desktop navigation must keep the account chip, its only route to settings", path)
 		}
 	}
 }

--- a/internal/templates/base.html
+++ b/internal/templates/base.html
@@ -81,10 +81,8 @@
           <a href="/dashboard" class="nav-link {{if isActiveRoute .CurrentPath "/dashboard"}}nav-link-active{{else if isActiveRoute .CurrentPath "/"}}nav-link-active{{end}}" data-nav-link="today" data-nav-link-key="nav.today">{{t .Messages "nav.today"}}</a>
           <a href="/calendar" class="nav-link {{if isActiveRoute .CurrentPath "/calendar"}}nav-link-active{{end}}" data-nav-link="calendar" data-nav-link-key="nav.calendar">{{t .Messages "nav.calendar"}}</a>
           <a href="/stats" class="nav-link {{if isActiveRoute .CurrentPath "/stats"}}nav-link-active{{end}}" data-nav-link="insights" data-nav-link-key="nav.insights">{{t .Messages "nav.insights"}}</a>
-          <a href="/settings" class="nav-link nav-link-icon {{if isActiveRoute .CurrentPath "/settings"}}nav-link-active{{end}}" data-nav-link="settings" data-nav-link-key="nav.settings" aria-label="{{t .Messages "nav.settings"}}" title="{{t .Messages "nav.settings"}}">
-            <span aria-hidden="true">⚙️</span>
-          </a>
 
+          <!-- Settings is reached through the account chip alone: a gear beside it led to the same page. -->
           <div class="nav-account-actions" data-nav-account-actions>
             {{template "nav_user_identity_chip" (dict "CurrentUser" .CurrentUser "Messages" .Messages "ElementID" "nav-user-chip-desktop" "Block" false "SwapOOB" false)}}
             <form action="/logout" method="post" class="nav-logout-form" data-confirm="{{t .Messages "auth.confirm_logout"}}" data-confirm-accept="{{t .Messages "nav.logout"}}">


### PR DESCRIPTION
## The defect

The desktop header navigation carried two controls to the same place: a gear icon link
(`href="/settings"`) and the account identity chip (`href="/settings#settings-account"`), side by
side in the same navigation landmark. The row asked twice for one destination, and neither control
told a reader which of the two to use.

## Which control survives, and why

The **account identity chip** stays and the gear is removed — the smaller change of the two, and the
one that keeps more:

- The chip carries information the gear does not: it renders the display name, or the
  "add your name" hint when none is set, and it lands directly on the account section of settings.
- The gear's accessible purpose was already covered — its `aria-label` was `nav.settings`, the same
  key the mobile tab bar's settings tab still uses, so nothing announced by the gear disappears from
  the product.
- Removing the chip instead would have cost far more: `#nav-user-chip-desktop` is the htmx
  out-of-band swap target that keeps the header name in sync after a profile save
  (`internal/templates/current_user_identity_oob.html:2`), and it is addressed by four browser specs
  and two backend regressions.

Desktop settings is therefore an account control rather than a section link. The desktop navigation
now lists three section destinations (Today / Calendar / Insights) plus the account block (chip +
logout).

## Scope

Desktop header only. The mobile surfaces are untouched: the bottom tab bar keeps its settings tab
(`internal/templates/base.html:142`), and the header menu stays the account menu
(`data-mobile-menu="account"`) introduced in #417.

`nav.settings` is still used by the mobile tab bar and by the privacy breadcrumb
(`internal/services/privacy_page_policy.go:46`), so no locale key became unused.

## Test that fails before the fix

`TestDesktopHeaderOffersASingleSettingsEntry`
(`internal/api/dashboard_navigation_regressions_test.go:246`) finds the desktop navigation landmark
on `/dashboard`, `/calendar`, `/stats` and `/settings`, counts the elements under it whose `href`
resolves to the settings page — bare path, query and section fragment all count as the same
destination — and requires exactly one. It also pins the surviving chip's accessible name, since its
avatar glyph is decorative and carries `aria-hidden="true"`.

Against the pre-fix templates it fails on all four pages and names both culprits:

```
--- FAIL: TestDesktopHeaderOffersASingleSettingsEntry (0.55s)
    dashboard_navigation_regressions_test.go:261: /dashboard: the desktop header offers 2 controls
      leading to settings ([/settings /settings#settings-account]); exactly one must
    ... /calendar, /stats, /settings identically
```

The desktop half of `TestMobileHeaderMenuCarriesOnlyAccountEntries` moves from four expected section
hooks to three and gains an assertion that the account chip — the navigation's only route to
settings — is present; its mobile assertions are unchanged.

## A11y invariants

`TestAuthenticatedPagesNameEveryNavigationLandmark` and
`TestTemplatesKeepDecorativeGlyphsOutOfTheAccessibilityTree` stay green: no `<nav>` changed, and the
removed markup was a decorative `aria-hidden` glyph inside a labelled link.

## Verification

- `go test ./...` — green.
- `golangci-lint run ./internal/... ./scripts/...` — 0 issues.
- `npm run lint:js`, `npm run build` — clean; the bundle is byte-identical, so no asset is committed
  (the removed `nav-link-icon` class had no utility definition).
- `go test ./internal/services/ ./internal/api/ -coverprofile=coverage.out -coverpkg=./internal/...`
  followed by `COVERAGE_FILE=coverage.out BASE_REF=origin/main go run ./scripts/patchcov` — "patch
  coverage gate OK".

Not run: the Playwright suite. No spec addresses the removed gear (`[data-nav-link="settings"]` is
queried only as `.first()` for the `today` hook in `e2e/navigation-language.spec.ts:28`, and the
mobile tab bar still provides the hook), so the browser layer needs no selector update.
