### PR TITLE
fix(dashboard): the journal names the day it writes to and can switch it

### DIFF
--- a/changelog.d/design-w1c-visible-entry-date.md
+++ b/changelog.d/design-w1c-visible-entry-date.md
@@ -1,0 +1,11 @@
+### Changed
+
+- **The dashboard journal now names the day it is writing to, and offers Today / Yesterday next to
+  it.** Evening entries are routinely made after midnight, and the journal filed them under the new
+  day with nothing on screen to say so — a health record silently gains a day. The header keeps the
+  date visible while the form is filled, in the interface language and in the timezone the request
+  resolves to, and the Today / Yesterday pair beside it switches the entry to that day. The
+  Yesterday jump is no longer hidden once yesterday already holds an entry, which is exactly when a
+  misfiled late-night entry has to be moved. Both are plain links to the screens that already edit
+  those days, so switching writes nothing and never carries half-filled values from one day to
+  another; the accessible name of the pair ships in all six interface languages.

--- a/e2e/bugs.spec.ts
+++ b/e2e/bugs.spec.ts
@@ -262,6 +262,17 @@ test.describe('Bug regressions', () => {
         `date subtitle "${subtitleText}" should name ${expectedToday.weekday}`
       ).toContain(expectedToday.weekday.toLowerCase());
 
+      // The visible journal date carries the ISO day it edits, and the quick
+      // switch offers the request-local yesterday — an evening entry made after
+      // midnight has to be able to see and correct the day it lands on.
+      await expect(page.locator('[data-dashboard-entry-date]').first()).toHaveAttribute(
+        'data-dashboard-entry-date',
+        actualTodayISO
+      );
+      await expect(
+        page.locator('[data-dashboard-entry-date-switch] [data-entry-date-choice="yesterday"]')
+      ).toHaveAttribute('data-entry-date', shiftISODate(actualTodayISO, -1));
+
       const expectedCycleDay = page.evaluate(({ todayISO, startISO }) => {
         const today = new Date(`${todayISO}T00:00:00`);
         const start = new Date(`${startISO}T00:00:00`);

--- a/internal/api/dashboard_journal_regressions_test.go
+++ b/internal/api/dashboard_journal_regressions_test.go
@@ -201,6 +201,174 @@ func TestDashboardOffersAQuickUsageGoalSwitchForOwner(t *testing.T) {
 	}
 }
 
+// TestDashboardJournalHeaderShowsTheEditableEntryDateAndItsQuickSwitch pins the
+// after-midnight contract: the journal header names the date the form writes to
+// — as localized copy carrying the ISO date in its own hook — and offers the
+// Today / Yesterday jumps unconditionally, so an evening entry logged after
+// midnight can be moved to the day it belongs to. Yesterday already holds an
+// entry here, the state that used to hide the only yesterday affordance.
+func TestDashboardJournalHeaderShowsTheEditableEntryDateAndItsQuickSwitch(t *testing.T) {
+	app, database := newOnboardingTestApp(t)
+	user := createOnboardingTestUser(t, database, "dashboard-entry-date@example.com", "StrongPass1", true)
+
+	today := services.DateAtLocation(time.Now().In(time.UTC), time.UTC)
+	yesterday := today.AddDate(0, 0, -1)
+	filledYesterday := models.DailyLog{
+		UserID:   user.ID,
+		Date:     yesterday,
+		IsPeriod: true,
+		Flow:     models.FlowMedium,
+	}
+	if err := database.Create(&filledYesterday).Error; err != nil {
+		t.Fatalf("seed yesterday daily log: %v", err)
+	}
+
+	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
+	document := mustParseHTMLDocument(t, mustRenderDashboard(t, app, authCookie, "en"))
+
+	entryDate := dashboardEntryDateElement(t, document)
+	todayISO := today.Format("2006-01-02")
+	if got := htmlAttr(entryDate, "data-dashboard-entry-date"); got != todayISO {
+		t.Fatalf("expected the journal header to name %q as the editable date, got %q", todayISO, got)
+	}
+	saveForm := htmlFindElement(document, func(node *html.Node) bool {
+		return node.Type == html.ElementNode && htmlHasAttr(node, "data-dashboard-save-form")
+	})
+	if saveForm == nil {
+		t.Fatal("expected the dashboard save form")
+	}
+	if got := htmlAttr(saveForm, "hx-put"); got != "/api/v1/days/"+todayISO {
+		t.Fatalf("expected the header date to be the date the form writes to, got hx-put=%q", got)
+	}
+
+	group := dashboardEntryDateSwitch(t, document)
+	if got := htmlAttr(group, "role"); got != "group" {
+		t.Fatalf("expected the entry-date switch to be a labelled group, got role=%q", got)
+	}
+	if htmlAttr(group, "aria-label") == "" {
+		t.Fatal("expected the entry-date switch group to carry an accessible name")
+	}
+	if htmlFindElement(saveForm, func(node *html.Node) bool {
+		return node.Type == html.ElementNode && htmlHasAttr(node, "data-dashboard-entry-date-switch")
+	}) != nil {
+		t.Fatal("expected the entry-date switch to sit outside the save form, so switching writes nothing")
+	}
+
+	choices := dashboardEntryDateChoices(t, group)
+	todayChoice := choices["today"]
+	if todayChoice == nil {
+		t.Fatal("expected a Today entry-date choice")
+	}
+	if got := htmlAttr(todayChoice, "href"); got != "/dashboard" {
+		t.Fatalf("expected the Today choice to reuse the dashboard route, got href=%q", got)
+	}
+	if got := htmlAttr(todayChoice, "aria-current"); got != "page" {
+		t.Fatalf("expected the Today choice to be marked as the current date, got aria-current=%q", got)
+	}
+	if got := htmlAttr(todayChoice, "data-entry-date"); got != todayISO {
+		t.Fatalf("expected the Today choice to carry %q, got %q", todayISO, got)
+	}
+
+	yesterdayChoice := choices["yesterday"]
+	if yesterdayChoice == nil {
+		t.Fatal("expected a Yesterday entry-date choice even when yesterday already holds an entry")
+	}
+	yesterdayISO := yesterday.Format("2006-01-02")
+	wantHref := "/calendar?month=" + yesterday.Format("2006-01") + "&day=" + yesterdayISO + "&edit=1"
+	if got := htmlAttr(yesterdayChoice, "href"); got != wantHref {
+		t.Fatalf("expected the Yesterday choice to reuse the calendar day-editor route %q, got %q", wantHref, got)
+	}
+	if got := htmlAttr(yesterdayChoice, "data-entry-date"); got != yesterdayISO {
+		t.Fatalf("expected the Yesterday choice to carry %q, got %q", yesterdayISO, got)
+	}
+	if got := htmlAttr(yesterdayChoice, "data-entry-date-empty"); got != "false" {
+		t.Fatalf("expected the Yesterday choice to report the seeded entry, got data-entry-date-empty=%q", got)
+	}
+}
+
+// TestDashboardJournalEntryDateFollowsRequestTimezoneAtUTCBoundary is the
+// timezone half of the same contract: with the server on UTC and the request
+// resolving to a zone whose calendar day differs, the date shown in the journal
+// header — and the day the Yesterday jump targets — follow the request-local
+// zone, never the server's UTC date.
+func TestDashboardJournalEntryDateFollowsRequestTimezoneAtUTCBoundary(t *testing.T) {
+	app, database, _ := newOnboardingTestAppWithLocation(t, time.UTC)
+	user := createOnboardingTestUser(t, database, "dashboard-entry-date-tz@example.com", "StrongPass1", true)
+	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
+
+	nowUTC := time.Now().UTC()
+	timezoneName, location := timezoneWithDifferentCalendarDay(t, nowUTC)
+	localToday := services.DateAtLocation(nowUTC.In(location), location)
+	localTodayISO := localToday.Format("2006-01-02")
+	if serverTodayISO := services.DateAtLocation(nowUTC, time.UTC).Format("2006-01-02"); serverTodayISO == localTodayISO {
+		t.Fatalf("expected %s to sit on another calendar day than UTC, both are %q", timezoneName, localTodayISO)
+	}
+
+	response := dashboardWithTimezoneResponse(t, app, authCookie, timezoneName)
+	document := mustParseHTMLDocument(t, mustReadBodyString(t, response.Body))
+
+	entryDate := dashboardEntryDateElement(t, document)
+	if got := htmlAttr(entryDate, "data-dashboard-entry-date"); got != localTodayISO {
+		t.Fatalf("expected the journal header to name the request-local date %q, got %q", localTodayISO, got)
+	}
+	// The localized copy and the hook must name the same day, or the visible
+	// date and the saved date part company again.
+	if got, want := strings.TrimSpace(htmlNodeText(entryDate)), services.LocalizedDashboardDate("ru", localToday); got != want {
+		t.Fatalf("expected the header copy to follow the request-local date %q, got %q", want, got)
+	}
+
+	choices := dashboardEntryDateChoices(t, dashboardEntryDateSwitch(t, document))
+	if got := htmlAttr(choices["today"], "data-entry-date"); got != localTodayISO {
+		t.Fatalf("expected the Today choice to follow the request-local date %q, got %q", localTodayISO, got)
+	}
+	localYesterdayISO := localToday.AddDate(0, 0, -1).Format("2006-01-02")
+	if got := htmlAttr(choices["yesterday"], "data-entry-date"); got != localYesterdayISO {
+		t.Fatalf("expected the Yesterday choice to follow the request-local date %q, got %q", localYesterdayISO, got)
+	}
+}
+
+func dashboardEntryDateElement(t *testing.T, document *html.Node) *html.Node {
+	t.Helper()
+
+	element := htmlFindElement(document, func(node *html.Node) bool {
+		return node.Type == html.ElementNode && htmlHasAttr(node, "data-dashboard-entry-date")
+	})
+	if element == nil {
+		t.Fatal("expected the journal header to expose the editable date through data-dashboard-entry-date")
+	}
+	return element
+}
+
+func dashboardEntryDateSwitch(t *testing.T, document *html.Node) *html.Node {
+	t.Helper()
+
+	group := htmlFindElement(document, func(node *html.Node) bool {
+		return node.Type == html.ElementNode && htmlHasAttr(node, "data-dashboard-entry-date-switch")
+	})
+	if group == nil {
+		t.Fatal("expected a Today / Yesterday entry-date switch next to the journal date")
+	}
+	return group
+}
+
+func dashboardEntryDateChoices(t *testing.T, group *html.Node) map[string]*html.Node {
+	t.Helper()
+
+	choices := make(map[string]*html.Node)
+	for _, node := range htmlFindElements(group, func(node *html.Node) bool {
+		return node.Type == html.ElementNode && htmlHasAttr(node, "data-entry-date-choice")
+	}) {
+		if node.Data != "a" || htmlAttr(node, "href") == "" {
+			t.Fatalf("expected every entry-date choice to be a plain link, got <%s>", node.Data)
+		}
+		choices[htmlAttr(node, "data-entry-date-choice")] = node
+	}
+	if len(choices) != 2 || choices["today"] == nil || choices["yesterday"] == nil {
+		t.Fatalf("expected exactly the today and yesterday choices, got %d", len(choices))
+	}
+	return choices
+}
+
 func assertDashboardSavedNoteDisclosure(t *testing.T, document *html.Node) {
 	t.Helper()
 

--- a/internal/i18n/locales/de.json
+++ b/internal/i18n/locales/de.json
@@ -449,6 +449,7 @@
   "dashboard.cycle_factors.medication_change": "Änderung der Medikation",
   "dashboard.notes": "Notizen",
   "dashboard.fill_yesterday": "Gestern",
+  "dashboard.entry_date_switch": "Eintragsdatum ändern",
   "dashboard.add_note": "Notiz hinzufügen",
   "dashboard.edit_note": "Notiz bearbeiten",
   "dashboard.hide_note": "Notiz ausblenden",

--- a/internal/i18n/locales/en.json
+++ b/internal/i18n/locales/en.json
@@ -449,6 +449,7 @@
   "dashboard.cycle_factors.medication_change": "Medication change",
   "dashboard.notes": "Notes",
   "dashboard.fill_yesterday": "Yesterday",
+  "dashboard.entry_date_switch": "Change entry date",
   "dashboard.add_note": "Add note",
   "dashboard.edit_note": "Edit note",
   "dashboard.hide_note": "Hide note",

--- a/internal/i18n/locales/es.json
+++ b/internal/i18n/locales/es.json
@@ -449,6 +449,7 @@
   "dashboard.cycle_factors.medication_change": "Cambio de medicación",
   "dashboard.notes": "Notas",
   "dashboard.fill_yesterday": "Ayer",
+  "dashboard.entry_date_switch": "Cambiar la fecha de la entrada",
   "dashboard.add_note": "Añadir nota",
   "dashboard.edit_note": "Editar nota",
   "dashboard.hide_note": "Ocultar nota",

--- a/internal/i18n/locales/fr.json
+++ b/internal/i18n/locales/fr.json
@@ -565,6 +565,7 @@
   "dashboard.cycle_factors.medication_change": "Changement de médicament",
   "dashboard.notes": "Notes",
   "dashboard.fill_yesterday": "Hier",
+  "dashboard.entry_date_switch": "Changer la date de l'entrée",
   "dashboard.add_note": "Ajouter une note",
   "dashboard.edit_note": "Modifier la note",
   "dashboard.hide_note": "Masquer la note",

--- a/internal/i18n/locales/it.json
+++ b/internal/i18n/locales/it.json
@@ -449,6 +449,7 @@
   "dashboard.cycle_factors.medication_change": "Cambio di farmaco",
   "dashboard.notes": "Note",
   "dashboard.fill_yesterday": "Ieri",
+  "dashboard.entry_date_switch": "Cambia la data della voce",
   "dashboard.add_note": "Aggiungi nota",
   "dashboard.edit_note": "Modifica nota",
   "dashboard.hide_note": "Nascondi nota",

--- a/internal/i18n/locales/ru.json
+++ b/internal/i18n/locales/ru.json
@@ -451,6 +451,7 @@
   "dashboard.cycle_factors.medication_change": "Изменение лекарств",
   "dashboard.notes": "Заметки",
   "dashboard.fill_yesterday": "Вчера",
+  "dashboard.entry_date_switch": "Изменить дату записи",
   "dashboard.add_note": "Добавить заметку",
   "dashboard.edit_note": "Изменить заметку",
   "dashboard.hide_note": "Скрыть заметку",

--- a/internal/templates/dashboard.html
+++ b/internal/templates/dashboard.html
@@ -221,10 +221,27 @@
       <div class="mb-5 flex flex-wrap items-center justify-between gap-3">
         <div>
           <h2 class="journal-subtitle">{{t .Messages "dashboard.today_editor"}}</h2>
-          <p class="journal-muted" data-dashboard-date-subtitle>{{.FormattedDate}}</p>
+          <p class="journal-muted" data-dashboard-date-subtitle data-dashboard-entry-date="{{.Today}}">{{.FormattedDate}}</p>
         </div>
-        {{if and .IsOwner .ShowYesterdayJump}}
-        <a href="/calendar?month={{.YesterdayMonth}}&day={{.Yesterday}}&edit=1" class="inline-link text-sm"><span aria-hidden="true">←</span> {{t .Messages "dashboard.fill_yesterday"}}</a>
+        {{if .IsOwner}}
+        <div
+          class="flex flex-wrap items-center gap-2"
+          role="group"
+          aria-label="{{t .Messages "dashboard.entry_date_switch"}}"
+          data-dashboard-entry-date-switch>
+          <a
+            href="/dashboard"
+            class="btn-soft text-sm"
+            aria-current="page"
+            data-entry-date-choice="today"
+            data-entry-date="{{.Today}}">{{t .Messages "nav.today"}}</a>
+          <a
+            href="/calendar?month={{.YesterdayMonth}}&day={{.Yesterday}}&edit=1"
+            class="btn-soft text-sm"
+            data-entry-date-choice="yesterday"
+            data-entry-date="{{.Yesterday}}"
+            data-entry-date-empty="{{if .ShowYesterdayJump}}true{{else}}false{{end}}">{{t .Messages "dashboard.fill_yesterday"}}</a>
+        </div>
         {{end}}
       </div>
 


### PR DESCRIPTION
## The defect

Evening entries are routinely made after midnight. The dashboard journal wrote to the
request-local *today* with nothing on screen tying the form to that day: the card rendered a
localized date, but no hook connected it to the date the form actually saves, and the single
Yesterday affordance was hidden by `ShowYesterdayJump` as soon as yesterday already held an entry —
precisely the state a misfiled late-night entry creates. A health record gained a day with no
visible cause.

## What changed

- The journal header date now carries the ISO day it edits in its own hook,
  `data-dashboard-entry-date`, next to the copy already localized through the shared date policy
  (`internal/templates/dashboard.html:224`).
- A labelled `role="group"` switch sits beside it with two choices: **Today** →
  `/dashboard`, marked `aria-current="page"`, and **Yesterday** → the existing calendar
  day-editor route `/calendar?month=…&day=…&edit=1`, which lazy-loads the day panel in edit mode.
  Both are plain links to routes that already exist; no new endpoint, no new date arithmetic
  (`internal/templates/dashboard.html:226`).
- The switch renders for every owner, no longer only when yesterday is empty. The dropped
  condition stays wired as `data-entry-date-empty` on the Yesterday choice, so the
  "yesterday has no entry" signal is still observable and the view data behind it is still used.
- The group sits **outside** the save form, and its controls are links rather than submits:
  switching the date writes nothing and cannot carry half-filled values from one day to another.

All dates come from the view data already resolved through the request-local timezone resolver
(`X-Ovumcy-Timezone` → `ovumcy_tz` → server fallback); the template only renders `Today` /
`Yesterday` / `YesterdayMonth`, which `BuildDashboardViewData` computes.

## Copy

`nav.today` and `dashboard.fill_yesterday` already ship in all six locales and are reused for the
two labels. One new key, the accessible name of the group — `dashboard.entry_date_switch` — lands
in en/ru/es/fr/de/it (ru uses the formal register).

## Tests

- `TestDashboardJournalHeaderShowsTheEditableEntryDateAndItsQuickSwitch` — the header hook names
  the same ISO day as the form's `hx-put` target, the group is labelled and outside the form, both
  choices are links to the routes above, and the Yesterday choice is present **with yesterday
  already seeded** (the state that used to hide it).
- `TestDashboardJournalEntryDateFollowsRequestTimezoneAtUTCBoundary` — server on UTC, request
  resolving to a zone on another calendar day: the header hook, the header copy and the Yesterday
  target all follow the request-local date, never the server's UTC date.
- Both fail on the pre-change template with
  `expected the journal header to expose the editable date through data-dashboard-entry-date`.
- `e2e/bugs.spec.ts` (BUG-01 request-local date consistency) gains a browser assertion that the
  visible journal date's ISO hook and the Yesterday target match the request timezone.

## Scope

Dashboard journal only. The calendar day panel keeps its own header; the wave-2 rewrite of this
screen is where the two are unified.
