### PR TITLE
test(e2e): the dashboard specs seed a backdated cycle through one helper

### DIFF
--- a/changelog.d/test-hoist-onboarding-helper.md
+++ b/changelog.d/test-hoist-onboarding-helper.md
@@ -1,0 +1,7 @@
+none
+
+Tests only: the register-and-onboard-with-an-explicit-cycle-start seeding used by
+the dashboard specs moves into a single shared e2e helper instead of three
+hand-rolled copies, keeping each spec's seeding semantics — including the
+explicit `Origin` header the HTTPS posture requires on a direct API call — and
+its assertions unchanged. No product code.

--- a/changelog.d/test-hoist-onboarding-helper.md
+++ b/changelog.d/test-hoist-onboarding-helper.md
@@ -1,7 +1,7 @@
 none
 
 Tests only: the register-and-onboard-with-an-explicit-cycle-start seeding used by
-the dashboard specs moves into a single shared e2e helper instead of three
-hand-rolled copies, keeping each spec's seeding semantics — including the
+the dashboard and stats specs moves into a single shared e2e helper instead of
+five hand-rolled copies, keeping each spec's seeding semantics — including the
 explicit `Origin` header the HTTPS posture requires on a direct API call — and
 its assertions unchanged. No product code.

--- a/e2e/dashboard-late-cycle-notice.spec.ts
+++ b/e2e/dashboard-late-cycle-notice.spec.ts
@@ -1,17 +1,12 @@
 import { expect, test, type Page } from '@playwright/test';
-import {
-  apiOriginHeader,
-  continueFromRecoveryCode,
-  createCredentials,
-  expectInlineRegisterRecoveryStep,
-  readRecoveryCode,
-  registerOwnerViaUI,
-} from './support/auth-helpers';
 import { saveSettingsLanguage } from './support/language-helpers';
 import { localeText, localeTextByLocale, type Locale } from './support/locale-helpers';
-import { selectOnboardingStartDate } from './support/onboarding-helpers';
-import { shiftISODate } from './support/stats-helpers';
-import { setRequestTimezoneFromBrowser } from './support/timezone-helpers';
+import {
+  isoToday,
+  markCycleStartViaAPI,
+  registerAndOnboardWithStartDaysAgo,
+  shiftISODate,
+} from './support/stats-helpers';
 
 /**
  * The three late-cycle notice states, rendered.
@@ -36,15 +31,6 @@ import { setRequestTimezoneFromBrowser } from './support/timezone-helpers';
 const BEYOND_RANGE_KEY = 'dashboard.late_cycle.beyond_range';
 const WITHIN_RANGE_KEY = 'dashboard.late_cycle.within_range';
 const NO_PERSONAL_RANGE_KEY = 'dashboard.late_cycle.no_personal_range';
-
-function isoToday(): string {
-  const date = new Date();
-  date.setHours(0, 0, 0, 0);
-  const yyyy = date.getFullYear();
-  const mm = String(date.getMonth() + 1).padStart(2, '0');
-  const dd = String(date.getDate()).padStart(2, '0');
-  return `${yyyy}-${mm}-${dd}`;
-}
 
 /** Whole calendar days from `fromISO` to `toISO`, DST-proof (UTC arithmetic). */
 function isoDaysBetween(fromISO: string, toISO: string): number {
@@ -89,59 +75,6 @@ function formatCounts(pattern: string, counts: number[]): string {
 
 function lateCycleNotice(page: Page) {
   return page.locator('[data-dashboard-cycle-warnings] [data-dashboard-cycle-day-warning]');
-}
-
-/**
- * Registers an owner and onboards with an explicit last-period-start date,
- * returning that date.
- *
- * Onboarding's own picker is the only way to set the baseline in step 1, and its
- * MinDate is the later of (Jan 1 of the current year) and (today - 60 days), so
- * every anchor below stays inside that window and older cycle starts are added
- * afterwards through the cycle-start endpoint, which has no past-date bound.
- */
-async function registerAndOnboardWithStartDaysAgo(
-  page: Page,
-  prefix: string,
-  startDaysAgo: number
-): Promise<string> {
-  const credentials = createCredentials(prefix);
-  await registerOwnerViaUI(page, credentials);
-  await expectInlineRegisterRecoveryStep(page);
-  await readRecoveryCode(page);
-  await continueFromRecoveryCode(page);
-
-  const startISO = shiftISODate(isoToday(), -startDaysAgo);
-  await selectOnboardingStartDate(page, startISO);
-  await page.locator('form[hx-post="/api/v1/onboarding/steps/1"] button[type="submit"]').click();
-
-  const stepTwoForm = page.locator('form[hx-post="/api/v1/onboarding/steps/2"]');
-  await expect(stepTwoForm).toBeVisible();
-  await Promise.all([
-    page.waitForURL(/\/dashboard(?:\?.*)?$/, { timeout: 15000 }),
-    stepTwoForm.locator('[data-onboarding-step2-submit]').click(),
-  ]);
-
-  await setRequestTimezoneFromBrowser(page);
-  return startISO;
-}
-
-/**
- * Backdates one cycle start. `page.request` sends no Origin of its own and the
- * CSRF middleware validates it on every mutating request under the HTTPS
- * posture, so the header is explicit here.
- */
-async function markCycleStartViaAPI(page: Page, isoDate: string): Promise<void> {
-  const csrf = (await page.locator('meta[name="csrf-token"]').getAttribute('content')) ?? '';
-  const response = await page.request.post(`/api/v1/days/${isoDate}/cycle-start`, {
-    headers: {
-      ...apiOriginHeader(page),
-      'X-CSRF-Token': csrf,
-      'Content-Type': 'application/x-www-form-urlencoded',
-    },
-    form: { replace_existing: 'true' },
-  });
-  expect(response.status(), `mark cycle start at ${isoDate}`).toBeLessThan(400);
 }
 
 test.describe('Dashboard late-cycle notice', () => {

--- a/e2e/dashboard-prediction-range.spec.ts
+++ b/e2e/dashboard-prediction-range.spec.ts
@@ -1,65 +1,12 @@
-import { expect, test, type Page } from '@playwright/test';
-import {
-  continueFromRecoveryCode,
-  createCredentials,
-  expectInlineRegisterRecoveryStep,
-  readRecoveryCode,
-  registerOwnerViaUI,
-  apiOriginHeader,
-} from './support/auth-helpers';
+import { expect, test } from '@playwright/test';
 import { displayDatesIn } from './support/date-field-helpers';
-import { selectOnboardingStartDate } from './support/onboarding-helpers';
 import { dashboardNextPeriodText } from './support/dashboard-helpers';
-import { setRequestTimezoneFromBrowser } from './support/timezone-helpers';
-import { shiftISODate } from './support/stats-helpers';
-
-function isoDateDaysAgo(days: number): string {
-  const date = new Date();
-  date.setHours(0, 0, 0, 0);
-  date.setDate(date.getDate() - days);
-  const yyyy = date.getFullYear();
-  const mm = String(date.getMonth() + 1).padStart(2, '0');
-  const dd = String(date.getDate()).padStart(2, '0');
-  return `${yyyy}-${mm}-${dd}`;
-}
-
-async function registerAndOnboardWithStartDaysAgo(
-  page: Page,
-  prefix: string,
-  startDaysAgo: number
-): Promise<void> {
-  const credentials = createCredentials(prefix);
-  await registerOwnerViaUI(page, credentials);
-  await expectInlineRegisterRecoveryStep(page);
-  await readRecoveryCode(page);
-  await continueFromRecoveryCode(page);
-
-  const startISO = isoDateDaysAgo(startDaysAgo);
-  await selectOnboardingStartDate(page, startISO);
-  await page.locator('form[hx-post="/api/v1/onboarding/steps/1"] button[type="submit"]').click();
-
-  const stepTwoForm = page.locator('form[hx-post="/api/v1/onboarding/steps/2"]');
-  await expect(stepTwoForm).toBeVisible();
-  await Promise.all([
-    page.waitForURL(/\/dashboard(?:\?.*)?$/, { timeout: 15000 }),
-    stepTwoForm.locator('[data-onboarding-step2-submit]').click(),
-  ]);
-
-  await setRequestTimezoneFromBrowser(page);
-}
-
-async function markCycleStartViaAPI(page: Page, isoDate: string): Promise<void> {
-  const csrf = (await page.locator('meta[name="csrf-token"]').getAttribute('content')) ?? '';
-  const response = await page.request.post(`/api/v1/days/${isoDate}/cycle-start`, {
-    headers: {
-      ...apiOriginHeader(page),
-      'X-CSRF-Token': csrf,
-      'Content-Type': 'application/x-www-form-urlencoded',
-    },
-    form: { replace_existing: 'true' },
-  });
-  expect(response.status(), `mark cycle start at ${isoDate}`).toBeLessThan(400);
-}
+import {
+  isoToday,
+  markCycleStartViaAPI,
+  registerAndOnboardWithStartDaysAgo,
+  shiftISODate,
+} from './support/stats-helpers';
 
 test.describe('Dashboard prediction range', () => {
   // Regular (non-irregular) users with at least three completed cycles and
@@ -76,7 +23,7 @@ test.describe('Dashboard prediction range', () => {
     // cycle anchor and add the subsequent cycle starts.
     await registerAndOnboardWithStartDaysAgo(page, 'dashboard-prediction-range', 60);
 
-    const today = isoDateDaysAgo(0);
+    const today = isoToday();
     // Cycle starts: today-90, today-60 (onboarding anchor), today-35, today-5.
     // Completed cycle lengths: 30, 25, 30. Population StdDev ≈ 2.36 → span
     // = 2 days. Max-min spread = 5, below the IsIrregularCycleSpread

--- a/e2e/dashboard-reminder-banner.spec.ts
+++ b/e2e/dashboard-reminder-banner.spec.ts
@@ -1,57 +1,14 @@
-import { expect, test, type Page } from '@playwright/test';
-import {
-  continueFromRecoveryCode,
-  createCredentials,
-  expectInlineRegisterRecoveryStep,
-  readRecoveryCode,
-  registerOwnerViaUI,
-} from './support/auth-helpers';
-import { selectOnboardingStartDate } from './support/onboarding-helpers';
-import { setRequestTimezoneFromBrowser } from './support/timezone-helpers';
+import { expect, test } from '@playwright/test';
+import { registerAndOnboardWithStartDaysAgo } from './support/stats-helpers';
 
 // Onboarding seeds a single cycle (last_period_start + the default 28-day
 // cycle length, models.DefaultCycleLength), enough for the dashboard to show a
 // single-date next-period estimate. With the default 3-day reminder window
 // (services.DashboardReminderBannerWindowDays), a start N days ago places the
 // next period at (28 - N) days out: 26 -> in 2 days (plural "~N days" copy),
-// 27 -> tomorrow (the fixed non-plural copy).
-function isoDateDaysAgo(days: number): string {
-  const date = new Date();
-  date.setHours(0, 0, 0, 0);
-  date.setDate(date.getDate() - days);
-  const yyyy = date.getFullYear();
-  const mm = String(date.getMonth() + 1).padStart(2, '0');
-  const dd = String(date.getDate()).padStart(2, '0');
-  return `${yyyy}-${mm}-${dd}`;
-}
-
-async function registerAndOnboardWithStartDaysAgo(
-  page: Page,
-  prefix: string,
-  startDaysAgo: number
-): Promise<void> {
-  const credentials = createCredentials(prefix);
-  await registerOwnerViaUI(page, credentials);
-  await expectInlineRegisterRecoveryStep(page);
-  await readRecoveryCode(page);
-  await continueFromRecoveryCode(page);
-
-  const startISO = isoDateDaysAgo(startDaysAgo);
-  await selectOnboardingStartDate(page, startISO);
-  await page.locator('form[hx-post="/api/v1/onboarding/steps/1"] button[type="submit"]').click();
-
-  const stepTwoForm = page.locator('form[hx-post="/api/v1/onboarding/steps/2"]');
-  await expect(stepTwoForm).toBeVisible();
-  await Promise.all([
-    page.waitForURL(/\/dashboard(?:\?.*)?$/, { timeout: 15000 }),
-    stepTwoForm.locator('[data-onboarding-step2-submit]').click(),
-  ]);
-
-  // Pin "today" to the browser timezone so the day-count baked into the banner
-  // copy matches the offsets computed above regardless of the server's zone.
-  await setRequestTimezoneFromBrowser(page);
-}
-
+// 27 -> tomorrow (the fixed non-plural copy). registerAndOnboardWithStartDaysAgo
+// pins "today" to the browser timezone, so those day counts hold whatever zone
+// the server runs in.
 test.describe('Dashboard reminder banner', () => {
   // testing.md keeps the backend HTML regressions on the data-reminder-banner-key
   // hook only; the rendered visible copy — including the day count interpolated

--- a/e2e/dashboard-warnings.spec.ts
+++ b/e2e/dashboard-warnings.spec.ts
@@ -8,10 +8,14 @@ import {
   registerOwnerViaUI,
   apiOriginHeader,
 } from './support/auth-helpers';
-import { selectOnboardingStartDate } from './support/onboarding-helpers';
 import { localeText } from './support/locale-helpers';
 import { setRequestTimezoneFromBrowser } from './support/timezone-helpers';
-import { openCalendarDayEditor, shiftISODate, todayISOFromDashboard } from './support/stats-helpers';
+import {
+  openCalendarDayEditor,
+  registerAndOnboardWithStartDaysAgo,
+  shiftISODate,
+  todayISOFromDashboard,
+} from './support/stats-helpers';
 
 async function registerAndOnboardDefault(page: Page, prefix: string): Promise<void> {
   const credentials = createCredentials(prefix);
@@ -20,45 +24,6 @@ async function registerAndOnboardDefault(page: Page, prefix: string): Promise<vo
   await readRecoveryCode(page);
   await continueFromRecoveryCode(page);
   await completeOnboardingIfPresent(page);
-  await setRequestTimezoneFromBrowser(page);
-}
-
-function isoDateDaysAgo(days: number): string {
-  const date = new Date();
-  date.setHours(0, 0, 0, 0);
-  date.setDate(date.getDate() - days);
-  const yyyy = date.getFullYear();
-  const mm = String(date.getMonth() + 1).padStart(2, '0');
-  const dd = String(date.getDate()).padStart(2, '0');
-  return `${yyyy}-${mm}-${dd}`;
-}
-
-async function registerAndOnboardWithStartDaysAgo(
-  page: Page,
-  prefix: string,
-  startDaysAgo: number,
-): Promise<void> {
-  // completeOnboardingIfPresent hardcodes today-3 as the period start, which
-  // makes today an auto-period-fill day. Spotting-warning + future-cycle-
-  // start scenarios need today to sit outside the onboarding period cluster,
-  // so we run a custom onboarding flow that submits an explicit older date.
-  const credentials = createCredentials(prefix);
-  await registerOwnerViaUI(page, credentials);
-  await expectInlineRegisterRecoveryStep(page);
-  await readRecoveryCode(page);
-  await continueFromRecoveryCode(page);
-
-  const startISO = isoDateDaysAgo(startDaysAgo);
-  await selectOnboardingStartDate(page, startISO);
-  await page.locator('form[hx-post="/api/v1/onboarding/steps/1"] button[type="submit"]').click();
-
-  const stepTwoForm = page.locator('form[hx-post="/api/v1/onboarding/steps/2"]');
-  await expect(stepTwoForm).toBeVisible();
-  await Promise.all([
-    page.waitForURL(/\/dashboard(?:\?.*)?$/, { timeout: 15000 }),
-    stepTwoForm.locator('[data-onboarding-step2-submit]').click(),
-  ]);
-
   await setRequestTimezoneFromBrowser(page);
 }
 

--- a/e2e/stats-insights.spec.ts
+++ b/e2e/stats-insights.spec.ts
@@ -1,54 +1,12 @@
 import { test, expect, type Page } from '@playwright/test';
-import { selectOnboardingStartDate } from './support/onboarding-helpers';
+import { apiOriginHeader } from './support/auth-helpers';
 import {
-  continueFromRecoveryCode,
-  createCredentials,
-  expectInlineRegisterRecoveryStep,
-  readRecoveryCode,
-  registerOwnerViaUI,
-  apiOriginHeader,
-} from './support/auth-helpers';
-import { setRequestTimezoneFromBrowser } from './support/timezone-helpers';
-import { shiftISODate } from './support/stats-helpers';
+  isoToday,
+  markCycleStartViaAPI,
+  registerAndOnboardWithStartDaysAgo,
+  shiftISODate,
+} from './support/stats-helpers';
 import { localeText } from './support/locale-helpers';
-
-function isoDateDaysAgo(days: number): string {
-  const date = new Date();
-  date.setHours(0, 0, 0, 0);
-  date.setDate(date.getDate() - days);
-  const yyyy = date.getFullYear();
-  const mm = String(date.getMonth() + 1).padStart(2, '0');
-  const dd = String(date.getDate()).padStart(2, '0');
-  return `${yyyy}-${mm}-${dd}`;
-}
-
-async function registerAndOnboardWithStartDaysAgo(
-  page: Page,
-  prefix: string,
-  startDaysAgo: number
-): Promise<string> {
-  const credentials = createCredentials(prefix);
-  await registerOwnerViaUI(page, credentials);
-  await expectInlineRegisterRecoveryStep(page);
-  await readRecoveryCode(page);
-  await continueFromRecoveryCode(page);
-
-  // Replicate completeOnboardingIfPresent's UI flow but with a custom
-  // start_date so the cycle window is wide enough for the BBT chart.
-  const startISO = isoDateDaysAgo(startDaysAgo);
-  await selectOnboardingStartDate(page, startISO);
-  await page.locator('form[hx-post="/api/v1/onboarding/steps/1"] button[type="submit"]').click();
-
-  const stepTwoForm = page.locator('form[hx-post="/api/v1/onboarding/steps/2"]');
-  await expect(stepTwoForm).toBeVisible();
-  await Promise.all([
-    page.waitForURL(/\/dashboard(?:\?.*)?$/, { timeout: 15000 }),
-    stepTwoForm.locator('[data-onboarding-step2-submit]').click(),
-  ]);
-
-  await setRequestTimezoneFromBrowser(page);
-  return startISO;
-}
 
 async function csrfToken(page: Page): Promise<string> {
   return (await page.locator('meta[name="csrf-token"]').getAttribute('content')) ?? '';
@@ -81,23 +39,6 @@ async function savePeriodDay(page: Page, isoDate: string): Promise<void> {
   expect(response.status(), `save period on ${isoDate}`).toBeLessThan(400);
 }
 
-async function markCycleStartViaAPI(page: Page, isoDate: string): Promise<void> {
-  // POST /api/v1/days/{date}/cycle-start sets IsPeriod=true AND CycleStart=true
-  // on the day, then triggers auto-period-fill. Setting CycleStart explicitly
-  // is what makes latestExplicitCycleStartBeforeOrOn pick the day up; a plain
-  // is_period upsert without the explicit flag leaves stats.LastPeriodStart
-  // anchored to user.LastPeriodStart from onboarding.
-  const response = await page.request.post(`/api/v1/days/${isoDate}/cycle-start`, {
-    headers: {
-      ...apiOriginHeader(page),
-      'X-CSRF-Token': await csrfToken(page),
-      'Content-Type': 'application/x-www-form-urlencoded',
-    },
-    form: { replace_existing: 'true' },
-  });
-  expect(response.status(), `mark cycle start at ${isoDate}`).toBeLessThan(400);
-}
-
 test.describe('Stats: BBT chart', () => {
   test('logging 5+ BBT values within the current cycle renders the BBT chart section', async ({
     page,
@@ -116,7 +57,7 @@ test.describe('Stats: BBT chart', () => {
     // today-30 (cycle 2 start) and today-7 (cycle 3 start, the current
     // cycle). Layer the BBT samples on today-5..today.
     await registerAndOnboardWithStartDaysAgo(page, 'stats-bbt-chart', 60);
-    const today = isoDateDaysAgo(0);
+    const today = isoToday();
 
     await savePeriodDay(page, shiftISODate(today, -30));
     await savePeriodDay(page, shiftISODate(today, -7));
@@ -180,7 +121,7 @@ test.describe('Stats: BBT chart', () => {
     // so the bare { bbt: ... } JSON payloads never wipe an is_period flag we
     // care about.
     await registerAndOnboardWithStartDaysAgo(page, 'stats-bbt-marker', 60);
-    const today = isoDateDaysAgo(0);
+    const today = isoToday();
 
     await markCycleStartViaAPI(page, shiftISODate(today, -30));
     await markCycleStartViaAPI(page, shiftISODate(today, -14));
@@ -254,7 +195,7 @@ test.describe('Stats: symptom patterns', () => {
     // and trip the short-gap confirmation requirement. 18 days leaves
     // headroom regardless of the boundary direction.
     await registerAndOnboardWithStartDaysAgo(page, 'stats-symptom-pattern', 60);
-    const today = isoDateDaysAgo(0);
+    const today = isoToday();
 
     await markCycleStartViaAPI(page, shiftISODate(today, -42));
     await markCycleStartViaAPI(page, shiftISODate(today, -24));
@@ -334,7 +275,7 @@ test.describe('Stats: cycle range', () => {
     // MinCycleLength / MaxCycleLength from cycleLengths(observedStarts), and
     // the Range card prints stats.cycle_range_summary when MinCycleLength>0.
     await registerAndOnboardWithStartDaysAgo(page, 'stats-cycle-range', 60);
-    const today = isoDateDaysAgo(0);
+    const today = isoToday();
 
     await markCycleStartViaAPI(page, shiftISODate(today, -40));
     await markCycleStartViaAPI(page, shiftISODate(today, -15));

--- a/e2e/support/stats-helpers.ts
+++ b/e2e/support/stats-helpers.ts
@@ -1,5 +1,6 @@
 import { expect, type Locator, type Page, type Request } from '@playwright/test';
 import {
+  apiOriginHeader,
   completeOnboardingIfPresent,
   continueFromRecoveryCode,
   createCredentials,
@@ -7,6 +8,7 @@ import {
   readRecoveryCode,
   registerOwnerViaUI,
 } from './auth-helpers';
+import { selectOnboardingStartDate } from './onboarding-helpers';
 import { setRequestTimezoneFromBrowser } from './timezone-helpers';
 
 export function shiftISODate(iso: string, days: number): string {
@@ -16,6 +18,21 @@ export function shiftISODate(iso: string, days: number): string {
   const yyyy = shifted.getFullYear();
   const mm = String(shifted.getMonth() + 1).padStart(2, '0');
   const dd = String(shifted.getDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+/**
+ * Today by the runner's own clock, as an ISO date. Distinct from
+ * `todayISOFromDashboard`, which reads the date the *server* rendered: use this
+ * one to compute the dates a scenario seeds, and that one when the assertion is
+ * about the day the app itself thinks it is.
+ */
+export function isoToday(): string {
+  const date = new Date();
+  date.setHours(0, 0, 0, 0);
+  const yyyy = date.getFullYear();
+  const mm = String(date.getMonth() + 1).padStart(2, '0');
+  const dd = String(date.getDate()).padStart(2, '0');
   return `${yyyy}-${mm}-${dd}`;
 }
 
@@ -40,6 +57,46 @@ export async function registerOwnerAndEnableIrregularMode(
   await cycleForm.locator('input[name="irregular_cycle"]').check();
   await cycleForm.locator('button[data-save-button]').click();
   await expect(page.locator('#settings-cycle-status .status-ok')).toBeVisible();
+}
+
+/**
+ * Registers an owner and onboards with an explicit last-period-start date,
+ * `startDaysAgo` days back, returning that date.
+ *
+ * `completeOnboardingIfPresent` hardcodes today-3, which makes today an
+ * auto-period-fill day and leaves the account inside the onboarding period
+ * cluster; every scenario that needs today to sit outside it, or that needs a
+ * baseline old enough to carry completed cycles, seeds through here instead.
+ *
+ * Step 1 holds exactly one mechanism for the value — the month picker — and its
+ * MinDate is the later of (Jan 1 of the current year) and (today - 60 days), so an
+ * anchor stays inside that window and older cycle starts are added afterwards
+ * through `markCycleStartViaAPI`, which has no past-date bound.
+ */
+export async function registerAndOnboardWithStartDaysAgo(
+  page: Page,
+  prefix: string,
+  startDaysAgo: number
+): Promise<string> {
+  const credentials = createCredentials(prefix);
+  await registerOwnerViaUI(page, credentials);
+  await expectInlineRegisterRecoveryStep(page);
+  await readRecoveryCode(page);
+  await continueFromRecoveryCode(page);
+
+  const startISO = shiftISODate(isoToday(), -startDaysAgo);
+  await selectOnboardingStartDate(page, startISO);
+  await page.locator('form[hx-post="/api/v1/onboarding/steps/1"] button[type="submit"]').click();
+
+  const stepTwoForm = page.locator('form[hx-post="/api/v1/onboarding/steps/2"]');
+  await expect(stepTwoForm).toBeVisible();
+  await Promise.all([
+    page.waitForURL(/\/dashboard(?:\?.*)?$/, { timeout: 15000 }),
+    stepTwoForm.locator('[data-onboarding-step2-submit]').click(),
+  ]);
+
+  await setRequestTimezoneFromBrowser(page);
+  return startISO;
 }
 
 export async function todayISOFromDashboard(page: Page): Promise<string> {
@@ -88,6 +145,32 @@ export async function markCycleStart(page: Page, isoDate: string): Promise<void>
   // markCycleStart/openCalendarDayEditor navigation, so let that fetch settle
   // before returning or it competes with the next page.goto.
   await page.waitForLoadState('networkidle');
+}
+
+/**
+ * Backdates one cycle start through the API, replacing whatever start the date
+ * already carries.
+ *
+ * The counterpart to `markCycleStart` above: that one drives the calendar's own
+ * manual-start button and is the right tool when the button is the subject, this
+ * one is pure seeding and has no past-date bound, so it reaches the anchors
+ * onboarding's picker cannot.
+ *
+ * `page.request` sends no Origin of its own and the CSRF middleware validates it
+ * on every mutating request under the HTTPS posture, so the header is explicit
+ * here (`apiOriginHeader`).
+ */
+export async function markCycleStartViaAPI(page: Page, isoDate: string): Promise<void> {
+  const csrf = (await page.locator('meta[name="csrf-token"]').getAttribute('content')) ?? '';
+  const response = await page.request.post(`/api/v1/days/${isoDate}/cycle-start`, {
+    headers: {
+      ...apiOriginHeader(page),
+      'X-CSRF-Token': csrf,
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    form: { replace_existing: 'true' },
+  });
+  expect(response.status(), `mark cycle start at ${isoDate}`).toBeLessThan(400);
 }
 
 export async function openCalendarDayEditor(page: Page, isoDate: string): Promise<Locator> {

--- a/e2e/support/stats-helpers.ts
+++ b/e2e/support/stats-helpers.ts
@@ -72,6 +72,10 @@ export async function registerOwnerAndEnableIrregularMode(
  * MinDate is the later of (Jan 1 of the current year) and (today - 60 days), so an
  * anchor stays inside that window and older cycle starts are added afterwards
  * through `markCycleStartViaAPI`, which has no past-date bound.
+ *
+ * Onboarding done, "today" is pinned to the browser's timezone, so a day count a
+ * caller computes from the returned anchor matches the one the app renders
+ * whatever zone the server runs in.
  */
 export async function registerAndOnboardWithStartDaysAgo(
   page: Page,
@@ -155,6 +159,12 @@ export async function markCycleStart(page: Page, isoDate: string): Promise<void>
  * manual-start button and is the right tool when the button is the subject, this
  * one is pure seeding and has no past-date bound, so it reaches the anchors
  * onboarding's picker cannot.
+ *
+ * The endpoint sets `IsPeriod=true` AND `CycleStart=true` on the day, then runs
+ * auto-period-fill. The explicit flag is the point: it is what
+ * `latestExplicitCycleStartBeforeOrOn` picks up, where a plain `is_period` day
+ * upsert would leave `stats.LastPeriodStart` anchored to the `user.LastPeriodStart`
+ * onboarding wrote.
  *
  * `page.request` sends no Origin of its own and the CSRF middleware validates it
  * on every mutating request under the HTTPS posture, so the header is explicit


### PR DESCRIPTION
Builds on #432 (`test-late-cycle-locale-keys`, which adds one of the duplication sites) and should merge after it — the diff against `main` will otherwise show that spec twice.

## Why

Five specs each carried their own copy of the same seeding flow: register an owner, walk onboarding's step-1 picker to an explicit last-period-start date instead of the today-3 that `completeOnboardingIfPresent` hardcodes, then backdate the older cycle starts through `POST /api/v1/days/<date>/cycle-start`, the only path with no past-date bound. The copies had begun to drift (three returned nothing, two returned the anchor date the assertions need), and each restated the explicit `Origin` header a direct `page.request` call needs — so a sixth spec would have had to rediscover that requirement rather than inherit it.

## What

- `e2e/support/stats-helpers.ts` gains `registerAndOnboardWithStartDaysAgo` (returns the anchor date), `markCycleStartViaAPI` and the `isoToday` the seeded dates are computed from. They sit beside the existing `markCycleStart`, which drives the calendar's manual-start button, so the choice between the UI path and the seeding path is visible at the point of reading. The doc comments carry what the copies knew and nothing else did: the picker's `MinDate` window, the `Origin`/CSRF reason, that the cycle-start endpoint sets `CycleStart=true` and not merely `is_period` (which is what `latestExplicitCycleStartBeforeOrOn` picks up, where a day upsert leaves `stats.LastPeriodStart` on the onboarding date), and that onboarding pins "today" to the browser timezone.
- `e2e/dashboard-warnings.spec.ts`, `e2e/dashboard-prediction-range.spec.ts`, `e2e/dashboard-late-cycle-notice.spec.ts`, `e2e/dashboard-reminder-banner.spec.ts` and `e2e/stats-insights.spec.ts` drop their local copies and import the shared ones. Two commits: the three dashboard specs first, then the remaining two.

Behaviour-preserving: no locator, no assertion and no product code changed. The only in-test edits beyond deleting the copies are `isoDateDaysAgo(0)` → `isoToday()` (five call sites), the same computation under the shared name.

## Verification

- `npm run e2e -- <the five specs>` — 13 passed.
- The three specs that seed through the API again with `E2E_USE_HTTPS_PROXY=true` — 8 passed. That is the posture where the hoisted `Origin` header is load-bearing: without it the middleware answers 403, and over plain HTTP its absence would go unnoticed.

## Scope

The sweep is complete: no spec under `e2e/` still hand-rolls this flow. One private `isoDateDaysAgo` stays in `e2e/support/auth-helpers.ts` on purpose — `auth-helpers` cannot import `stats-helpers`, which imports it.

Changelog: `changelog.d/test-hoist-onboarding-helper.md` (`none` — test-only).
