### PR TITLE
fix(a11y): every navigation entry declares the current section

### DIFF
--- a/changelog.d/fix-nav-aria-current.md
+++ b/changelog.d/fix-nav-aria-current.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- **Every navigation entry says which page you are on.** Today, Calendar, Insights and the
+  bottom bar's settings icon marked the current section with a fill and a weight only, so a
+  screen reader read the entries out with nothing to distinguish the page already open. The
+  desktop section links and the mobile tab bar now carry `aria-current="page"` alongside that
+  fill, exactly one entry per navigation.

--- a/internal/api/dashboard_navigation_regressions_test.go
+++ b/internal/api/dashboard_navigation_regressions_test.go
@@ -279,8 +279,26 @@ func TestDesktopHeaderOffersASingleSettingsEntry(t *testing.T) {
 // aria-current="page" semantics that make the marking readable to assistive
 // technology.
 func navLinkIsActive(node *html.Node, activeClass string) bool {
-	return slices.Contains(strings.Fields(htmlAttr(node, "class")), activeClass) &&
+	styled, current := navActiveMarking(node, activeClass)
+	return styled && current
+}
+
+// navActiveMarking splits an active-state marking into its two halves: the fill
+// a sighted reader sees and the aria-current="page" a screen reader hears. Both
+// are asserted separately because either one alone is the defect — a class with
+// no attribute marks the current section for eyes only, an attribute with no
+// class announces a page that does not look current.
+func navActiveMarking(node *html.Node, activeClass string) (styled, current bool) {
+	return slices.Contains(strings.Fields(htmlAttr(node, "class")), activeClass),
 		htmlAttr(node, "aria-current") == "page"
+}
+
+// navCurrentEntries lists, in document order, the elements under root that
+// declare themselves the current page.
+func navCurrentEntries(root *html.Node) []*html.Node {
+	return htmlFindElements(root, func(node *html.Node) bool {
+		return node.Type == html.ElementNode && htmlAttr(node, "aria-current") == "page"
+	})
 }
 
 // TestDesktopSettingsEntryMarksSettingsAsTheCurrentSection covers a loss that
@@ -336,6 +354,108 @@ func TestDesktopSettingsEntryMarksSettingsAsTheCurrentSection(t *testing.T) {
 				"%s: the mobile menu account chip must stay unmarked — the bottom tab bar marks the current section on a phone, and two markings read as two current pages",
 				path,
 			)
+		}
+	}
+}
+
+// navEntrySection names the section a navigation entry leads to. Section links
+// carry the stable data-nav-link hook; the desktop account chip is the header's
+// only route to settings and is identified by its element id instead.
+func navEntrySection(node *html.Node) string {
+	if hook := htmlAttr(node, "data-nav-link"); hook != "" {
+		return hook
+	}
+	if htmlAttr(node, "id") == "nav-user-chip-desktop" {
+		return "settings"
+	}
+	return ""
+}
+
+// assertNavMarking pins both halves of one navigation entry's active state
+// against what the requested page expects of it.
+func assertNavMarking(t *testing.T, path, entry string, node *html.Node, activeClass string, want bool) {
+	t.Helper()
+
+	styled, current := navActiveMarking(node, activeClass)
+	if styled != want || current != want {
+		t.Errorf(
+			"%s: the %s reports styled=%t aria-current=%t, expected %t for both (class=%q aria-current=%q)",
+			path, entry, styled, current, want, htmlAttr(node, "class"), htmlAttr(node, "aria-current"),
+		)
+	}
+}
+
+// TestNavigationMarksTheCurrentSectionForAssistiveTechnology extends to the rest
+// of the navigation the marking the desktop account chip already carried. Today,
+// Calendar and Insights announced their own page through nav-link-active in the
+// header and mobile-tabbar-link-active in the bottom bar, and the tab bar's
+// settings icon through the latter alone — a fill and a weight, with nothing
+// behind them, so a screen reader reading the four entries out had no way to say
+// which page it was already on. Each landmark now marks exactly one entry, marks
+// it both ways, and leaves the other three unmarked in both ways: an attribute
+// left on an inactive link announces a second current page.
+func TestNavigationMarksTheCurrentSectionForAssistiveTechnology(t *testing.T) {
+	app, database := newOnboardingTestApp(t)
+	user := createOnboardingTestUser(t, database, "nav-aria-current@example.com", "StrongPass1", true)
+	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
+
+	for _, current := range []struct{ path, section string }{
+		{"/dashboard", "today"},
+		{"/calendar", "calendar"},
+		{"/stats", "insights"},
+		{"/settings", "settings"},
+	} {
+		document := mustParseHTMLDocument(t, fetchPageBody(t, app, current.path, authCookie))
+
+		desktop := desktopPrimaryNavigation(document)
+		if desktop == nil {
+			t.Fatalf("%s: expected the desktop primary navigation to render", current.path)
+		}
+		tabbar := htmlElementByTagAndClass(document, "nav", "mobile-tabbar")
+		if tabbar == nil {
+			t.Fatalf("%s: expected the bottom tab bar to render", current.path)
+		}
+
+		for _, landmark := range []struct {
+			name string
+			root *html.Node
+		}{
+			{"desktop navigation", desktop},
+			{"bottom tab bar", tabbar},
+		} {
+			marked := navCurrentEntries(landmark.root)
+			if len(marked) != 1 {
+				t.Errorf(
+					"%s: the %s marks %d entries with aria-current=\"page\", expected exactly one",
+					current.path, landmark.name, len(marked),
+				)
+				continue
+			}
+			if got := navEntrySection(marked[0]); got != current.section {
+				t.Errorf(
+					"%s: the %s marks the %q entry as the current page, expected %q",
+					current.path, landmark.name, got, current.section,
+				)
+			}
+		}
+
+		// Desktop reaches settings through the account chip, which
+		// TestDesktopSettingsEntryMarksSettingsAsTheCurrentSection pins; its
+		// section links are the three page destinations.
+		for _, section := range []string{"today", "calendar", "insights"} {
+			link := htmlElementByAttr(desktop, "data-nav-link", section)
+			if link == nil {
+				t.Fatalf("%s: expected the desktop %s section link to render", current.path, section)
+			}
+			assertNavMarking(t, current.path, "desktop "+section+" link", link, "nav-link-active", section == current.section)
+		}
+
+		for _, section := range []string{"today", "calendar", "insights", "settings"} {
+			link := htmlElementByAttr(tabbar, "data-nav-link", section)
+			if link == nil {
+				t.Fatalf("%s: expected the tab bar %s link to render", current.path, section)
+			}
+			assertNavMarking(t, current.path, "tab bar "+section+" link", link, "mobile-tabbar-link-active", section == current.section)
 		}
 	}
 }

--- a/internal/templates/base.html
+++ b/internal/templates/base.html
@@ -76,17 +76,24 @@
       </div>
 
       {{if and .CurrentUser (not .HideNavigation)}}
+      <!-- One condition per section, bound to a variable, so the active fill and the
+           aria-current="page" that makes it readable to assistive technology can never
+           drift apart: a class alone marks the current section for sighted eyes only. -->
+      {{- $todayActive := or (isActiveRoute .CurrentPath "/dashboard") (isActiveRoute .CurrentPath "/")}}
+      {{- $calendarActive := isActiveRoute .CurrentPath "/calendar"}}
+      {{- $insightsActive := isActiveRoute .CurrentPath "/stats"}}
+      {{- $settingsActive := isActiveRoute .CurrentPath "/settings"}}
       <div class="container-main pb-4">
         <nav class="hidden items-center gap-2 sm:flex" aria-label="{{t .Messages "a11y.nav.primary"}}">
-          <a href="/dashboard" class="nav-link {{if isActiveRoute .CurrentPath "/dashboard"}}nav-link-active{{else if isActiveRoute .CurrentPath "/"}}nav-link-active{{end}}" data-nav-link="today" data-nav-link-key="nav.today">{{t .Messages "nav.today"}}</a>
-          <a href="/calendar" class="nav-link {{if isActiveRoute .CurrentPath "/calendar"}}nav-link-active{{end}}" data-nav-link="calendar" data-nav-link-key="nav.calendar">{{t .Messages "nav.calendar"}}</a>
-          <a href="/stats" class="nav-link {{if isActiveRoute .CurrentPath "/stats"}}nav-link-active{{end}}" data-nav-link="insights" data-nav-link-key="nav.insights">{{t .Messages "nav.insights"}}</a>
+          <a href="/dashboard" class="nav-link {{if $todayActive}}nav-link-active{{end}}" data-nav-link="today" data-nav-link-key="nav.today" {{if $todayActive}}aria-current="page"{{end}}>{{t .Messages "nav.today"}}</a>
+          <a href="/calendar" class="nav-link {{if $calendarActive}}nav-link-active{{end}}" data-nav-link="calendar" data-nav-link-key="nav.calendar" {{if $calendarActive}}aria-current="page"{{end}}>{{t .Messages "nav.calendar"}}</a>
+          <a href="/stats" class="nav-link {{if $insightsActive}}nav-link-active{{end}}" data-nav-link="insights" data-nav-link-key="nav.insights" {{if $insightsActive}}aria-current="page"{{end}}>{{t .Messages "nav.insights"}}</a>
 
           <!-- Settings is reached through the account chip alone: a gear beside it led to the same page.
                Being the only desktop route to settings, the chip also carries the section's active
                state, computed with the same isActiveRoute call the three section links use. -->
           <div class="nav-account-actions" data-nav-account-actions>
-            {{template "nav_user_identity_chip" (dict "CurrentUser" .CurrentUser "Messages" .Messages "ElementID" "nav-user-chip-desktop" "Block" false "SwapOOB" false "Active" (isActiveRoute .CurrentPath "/settings"))}}
+            {{template "nav_user_identity_chip" (dict "CurrentUser" .CurrentUser "Messages" .Messages "ElementID" "nav-user-chip-desktop" "Block" false "SwapOOB" false "Active" $settingsActive)}}
             <form action="/logout" method="post" class="nav-logout-form" data-confirm="{{t .Messages "auth.confirm_logout"}}" data-confirm-accept="{{t .Messages "nav.logout"}}">
               <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
               <button type="submit" class="nav-link nav-link-logout">{{t .Messages "nav.logout"}}</button>
@@ -135,11 +142,15 @@
     </main>
 
     {{if and .CurrentUser (not .HideNavigation)}}
+    {{- $todayActive := or (isActiveRoute .CurrentPath "/dashboard") (isActiveRoute .CurrentPath "/")}}
+    {{- $calendarActive := isActiveRoute .CurrentPath "/calendar"}}
+    {{- $insightsActive := isActiveRoute .CurrentPath "/stats"}}
+    {{- $settingsActive := isActiveRoute .CurrentPath "/settings"}}
     <nav class="mobile-tabbar sm:hidden" aria-label="{{t .Messages "a11y.nav.tabbar"}}">
-      <a href="/dashboard" class="mobile-tabbar-link {{if isActiveRoute .CurrentPath "/dashboard"}}mobile-tabbar-link-active{{else if isActiveRoute .CurrentPath "/"}}mobile-tabbar-link-active{{end}}" data-nav-link="today" data-nav-link-key="nav.today">{{t .Messages "nav.today"}}</a>
-      <a href="/calendar" class="mobile-tabbar-link {{if isActiveRoute .CurrentPath "/calendar"}}mobile-tabbar-link-active{{end}}" data-nav-link="calendar" data-nav-link-key="nav.calendar">{{t .Messages "nav.calendar"}}</a>
-      <a href="/stats" class="mobile-tabbar-link {{if isActiveRoute .CurrentPath "/stats"}}mobile-tabbar-link-active{{end}}" data-nav-link="insights" data-nav-link-key="nav.insights">{{t .Messages "nav.insights"}}</a>
-      <a href="/settings" class="mobile-tabbar-link mobile-tabbar-icon {{if isActiveRoute .CurrentPath "/settings"}}mobile-tabbar-link-active{{end}}" data-nav-link="settings" data-nav-link-key="nav.settings" aria-label="{{t .Messages "nav.settings"}}" title="{{t .Messages "nav.settings"}}"><span class="mobile-tabbar-icon-glyph" aria-hidden="true">⚙️</span></a>
+      <a href="/dashboard" class="mobile-tabbar-link {{if $todayActive}}mobile-tabbar-link-active{{end}}" data-nav-link="today" data-nav-link-key="nav.today" {{if $todayActive}}aria-current="page"{{end}}>{{t .Messages "nav.today"}}</a>
+      <a href="/calendar" class="mobile-tabbar-link {{if $calendarActive}}mobile-tabbar-link-active{{end}}" data-nav-link="calendar" data-nav-link-key="nav.calendar" {{if $calendarActive}}aria-current="page"{{end}}>{{t .Messages "nav.calendar"}}</a>
+      <a href="/stats" class="mobile-tabbar-link {{if $insightsActive}}mobile-tabbar-link-active{{end}}" data-nav-link="insights" data-nav-link-key="nav.insights" {{if $insightsActive}}aria-current="page"{{end}}>{{t .Messages "nav.insights"}}</a>
+      <a href="/settings" class="mobile-tabbar-link mobile-tabbar-icon {{if $settingsActive}}mobile-tabbar-link-active{{end}}" data-nav-link="settings" data-nav-link-key="nav.settings" aria-label="{{t .Messages "nav.settings"}}" title="{{t .Messages "nav.settings"}}" {{if $settingsActive}}aria-current="page"{{end}}><span class="mobile-tabbar-icon-glyph" aria-hidden="true">⚙️</span></a>
     </nav>
     {{end}}
 


### PR DESCRIPTION
> Stacked on #434 (`fix-desktop-nav-settings-active`) and should merge after it — this branch takes #434's own "Follow-up, not in scope" note as its scope, so its commit is included below until #434 lands on `main`.

## What

The desktop section links and every mobile tab bar link marked their own page by class alone — `nav-link-active` in the header, `mobile-tabbar-link-active` in the bottom bar. The marking is a fill and a weight, so it reached sighted readers and no one else: a screen reader read Today / Calendar / Insights / Settings out with nothing to say which page was already open. #434 gave the desktop account chip both halves and left the rest as a follow-up; this is that follow-up.

Each active entry now renders `aria-current="page"` beside the active class — three desktop section links (`internal/templates/base.html:88`) and four tab bar links (`internal/templates/base.html:150`).

## Details

- The four route states are bound to template variables per navigation block (`internal/templates/base.html:82`, `internal/templates/base.html:145`), so the fill and the attribute come from one condition each and cannot drift apart. That also collapses Today's `{{if}}/{{else if}}` pair into a single `or`, which renders the same class string it did before.
- The desktop chip now reads `$settingsActive` instead of repeating the `isActiveRoute` call #434 added (`internal/templates/base.html:96`) — same value, one source.
- Attributes only: no class, no copy, no CSS, so `web/src` and `web/static` are untouched and no bundle was rebuilt. Every `<nav>` keeps its distinct localized `aria-label`, and the tab bar's gear glyph keeps `aria-hidden` — both already pinned by `TestAuthenticatedPagesNameEveryNavigationLandmark` and `TestTemplatesKeepDecorativeGlyphsOutOfTheAccessibilityTree`, which stay green.
- The mobile menu account chip stays unmarked, unchanged from #434: on a phone the tab bar is what marks the current section, and two markings read as two current pages.

## Rollback

Template attributes and a test only — no handler, route, schema, CSS or business-logic change. Reverting the commit restores the previous markup exactly; nothing persists and no state migrates.

## Tests

`internal/api/dashboard_navigation_regressions_test.go:397` — for each of `/dashboard`, `/calendar`, `/stats`, `/settings`: the desktop navigation and the bottom tab bar each mark **exactly one** entry with `aria-current="page"`, that entry is the one leading to the current section, and every entry's class and attribute agree — both present on the active link, both absent on the inactive ones. The two halves are asserted separately (`navActiveMarking`) because either alone is the defect: a class with no attribute marks the section for eyes only, an attribute with no class announces a page that does not look current.

Proof on defect — two injected faults, each named by the test:

- Desktop Insights keeps the class and loses the attribute → `/stats: the desktop insights link reports styled=true aria-current=false, expected true for both (class="nav-link nav-link-active" aria-current="")`, plus `/stats: the desktop navigation marks 0 entries with aria-current="page", expected exactly one`.
- The tab bar's Calendar link marks itself unconditionally → `/dashboard: the bottom tab bar marks 2 entries with aria-current="page", expected exactly one` and `/dashboard: the tab bar calendar link reports styled=false aria-current=true, expected false for both`, on the three pages where Calendar is not current and on none where it is.

Run locally: `go test ./internal/api/...` and `go test ./...` (whole suite green), `golangci-lint run ./internal/...` (0 issues). No Playwright spec asserts navigation active state or `aria-current` (`e2e/` carries no reference to either), so no e2e spec was rerun. The patch-coverage gate excludes test files and tooling, and this change adds no production Go lines.
