### PR TITLE
fix(cycle): a competing cycle start on a period's edge day is seen again

### DIFF
--- a/changelog.d/fix-competing-cycle-start-tz.md
+++ b/changelog.d/fix-competing-cycle-start-tz.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- **Marking a new cycle start now offers to replace an earlier start on the first
+  bleeding day of the same period.** Depending on the account's time zone, a start
+  already recorded on the edge day of a period could go unnoticed: no replacement
+  was offered, and confirming one left the old start in place, so the same period
+  carried two cycle starts.

--- a/internal/services/cycle_start_policy.go
+++ b/internal/services/cycle_start_policy.go
@@ -173,7 +173,7 @@ func findCompetingCycleStart(logs []models.DailyLog, day time.Time, location *ti
 		if sameCalendarDay(logDay, day) {
 			continue
 		}
-		if logDay.Before(clusterStart) || logDay.After(clusterEnd) {
+		if !withinPeriodCluster(logDay, clusterStart, clusterEnd) {
 			continue
 		}
 		if conflict.IsZero() || logDay.Before(conflict) {
@@ -189,11 +189,23 @@ func manualCycleStartClusterBounds(logs []models.DailyLog, day time.Time, locati
 	hypotheticalLogs := logsWithSyntheticPeriodDay(logs, targetDay)
 	clusters := buildPeriodClusters(hypotheticalLogs)
 	for _, cluster := range clusters {
-		if !targetDay.Before(cluster.Start) && !targetDay.After(cluster.End) {
+		if withinPeriodCluster(targetDay, cluster.Start, cluster.End) {
 			return cluster.Start, cluster.End, true
 		}
 	}
 	return time.Time{}, time.Time{}, false
+}
+
+// withinPeriodCluster reports whether a calendar day falls inside the bounds
+// buildPeriodClusters produced. Those bounds are UTC-midnight values (dateOnly)
+// while the days compared against them are location-midnight working values, so
+// the day is re-anchored to UTC-midnight first. Comparing the two midnights
+// directly is an instant comparison under a non-zero UTC offset, which places a
+// day on the edge of its own cluster outside it — ahead of UTC the first day,
+// behind UTC the last one (issue #48 class).
+func withinPeriodCluster(day time.Time, clusterStart time.Time, clusterEnd time.Time) bool {
+	canonicalDay := dateOnly(day)
+	return !canonicalDay.Before(clusterStart) && !canonicalDay.After(clusterEnd)
 }
 
 func logsWithSyntheticPeriodDay(logs []models.DailyLog, day time.Time) []models.DailyLog {

--- a/internal/services/cycle_start_policy_boundary_test.go
+++ b/internal/services/cycle_start_policy_boundary_test.go
@@ -144,6 +144,55 @@ func TestResolveManualCycleStartPolicy_ShortGapBoundary(t *testing.T) {
 // it one calendar day backward in UTC-minus locales, inflating the gap by
 // one: a 5-day gap (too early) was reported as a 6-day implantation
 // candidate and a true 12-day gap fell outside the 6..12 window.
+// TestResolveManualCycleStartPolicy_CompetingStartCrossTimezone pins the
+// issue-#48-class fix on the replace-confirmation flow. The period-cluster
+// bounds are UTC-midnight values (buildPeriodClusters via dateOnly) while the
+// days compared against them are rebuilt at location midnight. Those are
+// different instants under a non-zero UTC offset, so the day on the edge of
+// its own cluster fell outside the bounds: ahead of UTC a competing cycle
+// start on the FIRST cluster day went undetected, behind UTC one on the LAST
+// day did. The owner then saw no replace confirmation and kept two cycle
+// starts inside one bleeding cluster. An interior day was detected either way
+// and is the control here.
+func TestResolveManualCycleStartPolicy_CompetingStartCrossTimezone(t *testing.T) {
+	// Europe/Belgrade in early March, and its UTC-minus mirror.
+	belgrade := time.FixedZone("UTC+1", 1*60*60)
+	lima := time.FixedZone("UTC-5", -5*60*60)
+
+	cases := []struct {
+		name      string
+		location  *time.Location
+		competing string
+	}{
+		{"UTC+1 competing start on the first cluster day", belgrade, "2026-03-01"},
+		{"UTC+1 competing start on an interior cluster day", belgrade, "2026-03-04"},
+		{"UTC-5 competing start on the last cluster day", lima, "2026-03-05"},
+		{"UTC-5 competing start on an interior cluster day", lima, "2026-03-02"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			logs := make([]models.DailyLog, 0, 5)
+			for _, day := range []string{"2026-03-01", "2026-03-02", "2026-03-03", "2026-03-04", "2026-03-05"} {
+				logs = append(logs, models.DailyLog{
+					Date:       mustParseCycleStartPolicyDay(t, day),
+					IsPeriod:   true,
+					CycleStart: day == tc.competing,
+				})
+			}
+
+			// The selected day arrives as ParseDayDate leaves it: midnight in
+			// the request location, while the stored logs above are
+			// UTC-midnight date-only values.
+			targetDay := time.Date(2026, 3, 3, 0, 0, 0, 0, tc.location)
+
+			policy := ResolveManualCycleStartPolicy(&models.User{}, logs, targetDay, targetDay, tc.location)
+			if got := CalendarDayKey(policy.ConflictDate); got != tc.competing {
+				t.Fatalf("ResolveManualCycleStartPolicy conflict date = %q, want %q", got, tc.competing)
+			}
+		})
+	}
+}
+
 func TestPotentialImplantationGapDays_CrossTimezone(t *testing.T) {
 	// Same geometry as the window-boundary test: ovulation for a 28-day cycle
 	// starting 2026-02-26 lands on 2026-03-11.

--- a/internal/services/day_service.go
+++ b/internal/services/day_service.go
@@ -705,7 +705,7 @@ func (service *DayService) clearCompetingCycleStarts(ctx context.Context, userID
 		}
 
 		logDay := CalendarDay(logEntry.Date, location)
-		if logDay.Before(clusterStart) || logDay.After(clusterEnd) {
+		if !withinPeriodCluster(logDay, clusterStart, clusterEnd) {
 			continue
 		}
 		if sameCalendarDay(logDay, selectedDay) && logEntry.ID == selectedEntry.ID {

--- a/internal/services/day_service_integration_test.go
+++ b/internal/services/day_service_integration_test.go
@@ -326,6 +326,55 @@ func TestDayServiceMarkCycleStartManuallyPreservesEntryAndMarksExplicitStart(t *
 	}
 }
 
+// The replace confirmation and the clearing it authorizes read the same
+// UTC-midnight period-cluster bounds, so both must re-anchor the days they
+// compare. Ahead of UTC a competing start on the FIRST day of the cluster used
+// to read as sitting before the cluster: the owner confirmed the replacement
+// and the old start survived it, leaving two cycle starts in one bleeding
+// cluster.
+func TestDayServiceMarkCycleStartManuallyClearsAFirstClusterDayStartAheadOfUTC(t *testing.T) {
+	service, database := newDayServiceIntegration(t)
+	user := createDayServiceTestUser(t, database, "manual-cycle-start-replace-tz-service@example.com")
+
+	logs := []models.DailyLog{}
+	for day := 1; day <= 5; day++ {
+		logs = append(logs, models.DailyLog{
+			UserID:     user.ID,
+			Date:       time.Date(2026, time.March, day, 0, 0, 0, 0, time.UTC),
+			IsPeriod:   true,
+			Flow:       models.FlowMedium,
+			CycleStart: day == 1,
+		})
+	}
+	if err := database.Create(&logs).Error; err != nil {
+		t.Fatalf("create logs: %v", err)
+	}
+
+	belgrade := time.FixedZone("UTC+1", 1*60*60)
+	targetDay := time.Date(2026, time.March, 3, 0, 0, 0, 0, belgrade)
+	now := time.Date(2026, time.March, 5, 9, 0, 0, 0, belgrade)
+	// Both confirmations the flow asks for here are granted: the replacement
+	// itself and the short gap to the start being replaced.
+	options := ManualCycleStartOptions{ReplaceExisting: true, MarkUncertain: true}
+	if err := service.MarkCycleStartManually(context.Background(), user.ID, targetDay, now, belgrade, options); err != nil {
+		t.Fatalf("MarkCycleStartManually returned error: %v", err)
+	}
+
+	reloaded := []models.DailyLog{}
+	if err := database.Where("user_id = ?", user.ID).Order("date ASC").Find(&reloaded).Error; err != nil {
+		t.Fatalf("reload logs: %v", err)
+	}
+	starts := []string{}
+	for _, entry := range reloaded {
+		if entry.CycleStart {
+			starts = append(starts, CalendarDayKey(entry.Date))
+		}
+	}
+	if len(starts) != 1 || starts[0] != "2026-03-03" {
+		t.Fatalf("expected 2026-03-03 to be the only cycle start left, got %v", starts)
+	}
+}
+
 func TestDayServiceMarkCycleStartManuallyClearsPreviousExplicitStart(t *testing.T) {
 	service, database := newDayServiceIntegration(t)
 	user := createDayServiceTestUser(t, database, "manual-cycle-start-replace-service@example.com")


### PR DESCRIPTION
## Problem

The replace-confirmation flow for a manual cycle start compares candidate days
against period-cluster bounds, and the two operands carry different midnights:
`buildPeriodClusters` produces UTC-midnight bounds (`dateOnly`,
`internal/services/cycles.go:623`) while `findCompetingCycleStart`
(`internal/services/cycle_start_policy.go:160`) and `clearCompetingCycleStarts`
(`internal/services/day_service.go:695`) rebuild each day at location midnight.

Under a non-zero UTC offset those are different instants, so a day sitting on the
edge of its own cluster compared as outside it — ahead of UTC the first day of the
cluster, behind UTC the last one. An existing cycle start there was neither reported
to the confirmation nor cleared once the owner confirmed the replacement, so the same
bleeding cluster kept two cycle starts. An interior day was handled correctly, which
is why the defect stayed invisible.

## Change

- `withinPeriodCluster` re-anchors the compared day to the bounds' own UTC midnight,
  the same calendar-day discipline `CalendarDay`/`CalendarDaysBetween` already carry;
  the cluster lookup, the conflict search and the clearing pass all use it.
- No other behaviour changes: in UTC the comparison is identical.

## Tests

- `TestResolveManualCycleStartPolicy_CompetingStartCrossTimezone` — competing start on
  the first cluster day at UTC+1 and on the last at UTC-5, each with an interior-day
  control. Both edge cases fail on the pre-fix code (conflict date empty), both
  controls pass before and after.
- `TestDayServiceMarkCycleStartManuallyClearsAFirstClusterDayStartAheadOfUTC` — the
  clearing half of the same flow. With the `day_service.go` line alone reverted it
  fails with `got [2026-03-01 2026-03-03]`, i.e. two starts surviving the confirmed
  replacement.

`go test ./internal/services/...`, `go test ./...`, `golangci-lint run ./internal/services/...`
and the local `patchcov` gate against a freshly regenerated profile are green.

`e2e/dashboard-cycle-start-suggestion.spec.ts` (#433) places its competing start on an
interior day and is deliberately left untouched.
