### PR TITLE
fix(ui): the temperature range and the ru cycle-map note read plainly

### DIFF
--- a/changelog.d/fix-review-copy-nits.md
+++ b/changelog.d/fix-review-copy-nits.md
@@ -1,0 +1,6 @@
+### Changed
+
+- **Calmer wording around the cycle map and the temperature range.** The BBT range hint and its
+  out-of-range error name whole bounds instead of padded decimals (34-43 °C, 93.2-109.4 °F), and the
+  Russian estimate qualifier under the cycle map says the map follows how the cycle usually goes
+  rather than naming baseline parameters.

--- a/e2e/settings-profile-cycle.spec.ts
+++ b/e2e/settings-profile-cycle.spec.ts
@@ -439,7 +439,7 @@ test.describe('Settings: profile and cycle', () => {
     const bbtInput = dashboardForm.locator('#dashboard-bbt');
     await expect(bbtInput).toBeVisible();
     await expect(dashboardForm.locator('.measurement-field-unit')).toContainText('°F');
-    await expect(dashboardForm).toContainText('93.20-109.40 °F');
+    await expect(dashboardForm).toContainText('93.2-109.4 °F');
     await bbtInput.fill('150.0');
     await bbtInput.blur();
     const invalidState = await bbtInput.evaluate((node) => {

--- a/internal/api/page_view_data_helpers.go
+++ b/internal/api/page_view_data_helpers.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/gofiber/fiber/v3"
@@ -174,15 +175,29 @@ func buildBBTFieldViewData(messages map[string]string, unit string) bbtFieldView
 	symbol := services.TemperatureUnitSymbol(resolvedUnit)
 	minLabel := fmt.Sprintf("%.2f", min)
 	maxLabel := fmt.Sprintf("%.2f", max)
+	// The input attributes stay machine-readable at two decimals; the copy the
+	// owner reads drops the padding zeros (34-43 °C, 93.2-109.4 °F).
+	minText := trimTemperatureLabelZeros(minLabel)
+	maxText := trimTemperatureLabelZeros(maxLabel)
 
 	return bbtFieldViewData{
 		Unit:       resolvedUnit,
 		Symbol:     symbol,
 		Min:        minLabel,
 		Max:        maxLabel,
-		RangeHint:  formatBBTLocalizedMessage(messages, "dashboard.bbt_range_hint", "Allowed range: %s-%s %s.", minLabel, maxLabel, symbol),
-		RangeError: formatBBTLocalizedMessage(messages, "dashboard.bbt_range_error", "Enter a value between %s and %s %s.", minLabel, maxLabel, symbol),
+		RangeHint:  formatBBTLocalizedMessage(messages, "dashboard.bbt_range_hint", "Allowed range: %s-%s %s.", minText, maxText, symbol),
+		RangeError: formatBBTLocalizedMessage(messages, "dashboard.bbt_range_error", "Enter a value between %s and %s %s.", minText, maxText, symbol),
 	}
+}
+
+// trimTemperatureLabelZeros drops the padding a fixed two-decimal format adds:
+// "34.00" reads as "34", "93.20" as "93.2". A label without a decimal point is
+// returned untouched, so the trim can never eat an integer's own zeros.
+func trimTemperatureLabelZeros(label string) string {
+	if !strings.Contains(label, ".") {
+		return label
+	}
+	return strings.TrimSuffix(strings.TrimRight(label, "0"), ".")
 }
 
 func formatBBTLocalizedMessage(messages map[string]string, key string, fallback string, min string, max string, symbol string) string {

--- a/internal/api/page_view_data_helpers_mutkill_test.go
+++ b/internal/api/page_view_data_helpers_mutkill_test.go
@@ -3,6 +3,8 @@ package api
 import (
 	"strings"
 	"testing"
+
+	"github.com/ovumcy/ovumcy-web/internal/services"
 )
 
 // Mutation-kill test for formatBBTLocalizedMessage (page_view_data_helpers.go
@@ -37,6 +39,52 @@ func TestFormatBBTLocalizedMessageMutKill(t *testing.T) {
 		got := formatBBTLocalizedMessage(map[string]string{}, key, fallback, "36.00", "38.00", "C")
 		if got != "FALLBACK 36.00-38.00 C" {
 			t.Fatalf("expected fallback formatting for missing translation, got %q", got)
+		}
+	})
+}
+
+// The range copy names the bounds without the padding a fixed two-decimal
+// format adds ("34-43 °C", not "34.00-43.00 °C"), while the input attributes
+// the browser validates against keep the two decimals. Both halves are pinned
+// here: trimming the attributes too would change what `data-temperature-min`
+// carries, and trimming nothing brings the lab-style copy back.
+func TestBuildBBTFieldViewDataTrimsRangeCopyZeros(t *testing.T) {
+	patterns := map[string]string{
+		"dashboard.bbt_range_hint":  "hint %s-%s %s",
+		"dashboard.bbt_range_error": "error %s-%s %s",
+	}
+
+	t.Run("celsius bounds read as whole degrees", func(t *testing.T) {
+		view := buildBBTFieldViewData(patterns, services.TemperatureUnitCelsius)
+		if view.RangeHint != "hint 34-43 °C" {
+			t.Fatalf("expected trimmed celsius hint, got %q", view.RangeHint)
+		}
+		if view.RangeError != "error 34-43 °C" {
+			t.Fatalf("expected trimmed celsius error, got %q", view.RangeError)
+		}
+		if view.Min != "34.00" || view.Max != "43.00" {
+			t.Fatalf("expected the input bounds to keep two decimals, got %q-%q", view.Min, view.Max)
+		}
+	})
+
+	t.Run("fahrenheit bounds keep the decimal they need", func(t *testing.T) {
+		view := buildBBTFieldViewData(patterns, services.TemperatureUnitFahrenheit)
+		if view.RangeHint != "hint 93.2-109.4 °F" {
+			t.Fatalf("expected one-decimal fahrenheit hint, got %q", view.RangeHint)
+		}
+		if view.RangeError != "error 93.2-109.4 °F" {
+			t.Fatalf("expected one-decimal fahrenheit error, got %q", view.RangeError)
+		}
+		if view.Min != "93.20" || view.Max != "109.40" {
+			t.Fatalf("expected the input bounds to keep two decimals, got %q-%q", view.Min, view.Max)
+		}
+	})
+
+	t.Run("a label without a decimal point is untouched", func(t *testing.T) {
+		// Guards the `strings.Contains` branch: without it, TrimRight would eat
+		// the trailing zeros of an integer label such as "100".
+		if got := trimTemperatureLabelZeros("100"); got != "100" {
+			t.Fatalf("expected an integer label to survive the trim, got %q", got)
 		}
 	})
 }

--- a/internal/i18n/locales/ru.json
+++ b/internal/i18n/locales/ru.json
@@ -429,7 +429,7 @@
   "usage_goal.summary.health": "Интерфейс остаётся нейтральным и делает акцент на наблюдении за паттернами со временем.",
   "dashboard.update_cycle_data": "Обновить данные цикла",
   "dashboard.today_editor": "Запись за сегодня",
-  "dashboard.cycle_hero_estimated": "Карта цикла приблизительная и построена по Вашим текущим базовым параметрам цикла.",
+  "dashboard.cycle_hero_estimated": "Карта цикла приблизительная: она построена по тому, как обычно проходит Ваш цикл.",
   "dashboard.period_day": "День месячных",
   "dashboard.period_day_action": "Отметить как день месячных",
   "dashboard.mood": "Настроение",


### PR DESCRIPTION
Two copy findings from the 2026-08-12 design review.

## BBT range hint read lab-style

`buildBBTFieldViewData` formatted both bounds with `%.2f`, so the hint under the temperature field
rendered `Allowed range: 34.00-43.00 °C.` — a padding the constraint does not carry. The copy now
uses trimmed labels:

- `34.00-43.00 °C` -> `34-43 °C`
- `93.20-109.40 °F` -> `93.2-109.4 °F` (Fahrenheit keeps the decimal it needs)

The trim is a formatting change in `internal/api/page_view_data_helpers.go`, not a locale one: every
locale value already carries `%s` placeholders. `data-temperature-min` / `data-temperature-max`, the
attributes the client-side validator parses, keep two decimals — only the two rendered messages
change. The out-of-range error (`dashboard.bbt_range_error`) states the same two bounds in the same
fieldset, so it is trimmed with the hint rather than left stating the range a second way.

`TestBuildBBTFieldViewDataTrimsRangeCopyZeros` pins both halves — the trimmed copy and the untrimmed
input attributes — plus the branch that keeps the trim from eating an integer's own zeros.
`e2e/settings-profile-cycle.spec.ts` asserted the Fahrenheit hint text and is updated to match.

## Russian estimate qualifier named machine parameters

The qualifier under the cycle map (`dashboard.cycle_hero_estimated`) restated the model's inputs
instead of their meaning. English source: *Cycle map is approximate and based on your current
baseline.*

- before: «Карта цикла приблизительная и построена по Вашим текущим базовым параметрам цикла.»
- after: «Карта цикла приблизительная: она построена по тому, как обычно проходит Ваш цикл.»

Value-only, ru alone, so key parity is untouched; formal «Вы» is kept and the estimate qualifier
itself stays, as the medical-safety invariant requires. No Go literal, template or e2e expectation
referenced the old string.

## Validation

- `go test ./...` — clean
- `golangci-lint run ./internal/api/...` — 0 issues
- `npm run e2e -- e2e/settings-profile-cycle.spec.ts` — 14 passed (the spec that reads the hint;
  `e2e/dashboard.spec.ts` references neither touched key)
- `scripts/patchcov` against a profile generated in the same invocation — OK
