### PR TITLE
feat(ui): the goal about timing carries the ovulation estimate and the temperature

### DIFF
--- a/changelog.d/design-w2-ttc-frame.md
+++ b/changelog.d/design-w2-ttc-frame.md
@@ -1,0 +1,11 @@
+### Changed
+
+- **The dashboard frames timing for the goal that is about it.** An account
+  whose usage goal is trying to conceive now reads the ovulation estimate in the
+  status line beside the next-period one, and logs the morning temperature from
+  the journal's visible tier instead of opening "More details" for it — the two
+  things that goal is about. The estimate keeps the wording and the disclaimer
+  every prediction surface carries, and follows the next-period gating exactly:
+  an unpredictable cycle or a paused prediction suppresses it as before. The
+  other goals read the page unchanged, and the disclosure stops counting a
+  temperature that is no longer behind it.

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -10,6 +10,7 @@ import {
 import { cancelConfirmDialog, mutatingRequestsDuring } from './support/confirm-dialog-helpers';
 import {
   dashboardMoreDisclosure,
+  dashboardStatusLine,
   openDashboardMoreFields,
   saveDashboardEntry,
 } from './support/dashboard-helpers';
@@ -794,6 +795,46 @@ test.describe('Dashboard: today editor', () => {
     await expect(
       page.locator('#settings-cycle input[name="usage_goal"][value="avoid_pregnancy"]')
     ).toBeChecked();
+  });
+
+  test('the goal about timing gets the ovulation estimate and the temperature in the open', async ({
+    page,
+  }) => {
+    await registerOwnerOnDashboard(page, 'dashboard-timing-frame');
+    await enableBBTTracking(page);
+
+    const statusLine = dashboardStatusLine(page);
+    const ovulation = statusLine.locator('[data-dashboard-ovulation]');
+    const bbtInput = page.locator('#dashboard-bbt');
+
+    // The default goal is the neutral one: no timing line, temperature folded
+    // away with the other rare fields.
+    await expect(ovulation).toHaveCount(0);
+    await expect(bbtInput).toBeHidden();
+
+    await page.locator('[data-usage-goal-chip]').click();
+    await page.locator('[data-usage-goal-choice="trying_to_conceive"]').click();
+    await expect(page.locator('[data-usage-goal-summary]')).toHaveAttribute(
+      'data-usage-goal-label-key',
+      'settings.goal.trying'
+    );
+
+    // What the goal promised at onboarding, on the next load of the page.
+    await page.reload();
+    await expect(statusLine).toContainText(localeText('en', 'dashboard.ovulation'));
+    await expect(ovulation).toHaveCount(1);
+    await expect(bbtInput).toBeVisible();
+    await expect(dashboardMoreDisclosure(page).locator('#dashboard-bbt')).toHaveCount(0);
+
+    // A field in the visible tier still saves itself, and what was recorded
+    // reads back from the same place.
+    await saveToday(page, async () => {
+      await bbtInput.fill('36.60');
+      await bbtInput.blur();
+    });
+    await page.reload();
+    await expect(page.locator('#dashboard-bbt')).toHaveValue('36.60');
+    await expect(dashboardMoreDisclosure(page).locator('#dashboard-bbt')).toHaveCount(0);
   });
 
   test('closing the page runs beforeunload autosave for dirty notes', async ({ page, context }) => {

--- a/internal/api/dashboard_journal_regressions_test.go
+++ b/internal/api/dashboard_journal_regressions_test.go
@@ -548,6 +548,110 @@ func TestDashboardJournalMoreDisclosureOpensForDataItHolds(t *testing.T) {
 	})
 }
 
+// TestDashboardFramesTimingForTheGoalThatIsAboutIt pins the goal-aware timing
+// frame promised at onboarding. An account trying to conceive reads the page
+// for timing, so the status line also carries the ovulation estimate and the
+// morning temperature sits in the journal's visible tier; the disclosure then
+// stops counting a recorded temperature, which is no longer behind it. Every
+// other goal keeps the line and the two tiers it had.
+func TestDashboardFramesTimingForTheGoalThatIsAboutIt(t *testing.T) {
+	for name, testCase := range map[string]struct {
+		goal   string
+		framed bool
+	}{
+		"trying to conceive": {goal: models.UsageGoalTrying, framed: true},
+		"general health":     {goal: models.UsageGoalHealth, framed: false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			app, database := newOnboardingTestApp(t)
+			user := createOnboardingTestUser(t, database, "dashboard-timing-"+testCase.goal+"@example.com", "StrongPass1", true)
+			enableDashboardMeasurementTracking(t, database, user.ID)
+			seedDashboardStableCycleForGoal(t, database, user.ID, testCase.goal)
+			seedDashboardTodayLog(t, database, user.ID, func(entry *models.DailyLog) {
+				entry.BBT = new(36.6)
+			})
+
+			authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
+			document := mustParseHTMLDocument(t, mustRenderDashboard(t, app, authCookie, "en"))
+
+			statusLine := dashboardElementByDataAttr(document, "data-dashboard-status-line")
+			if statusLine == nil {
+				t.Fatal("expected the dashboard status line")
+			}
+			if got := htmlFindElement(statusLine, htmlNodeHasAttr("data-dashboard-ovulation")) != nil; got != testCase.framed {
+				t.Fatalf("expected the ovulation estimate in the status line=%v, got %v", testCase.framed, got)
+			}
+			if dashboardElementByDataAttr(document, "data-dashboard-prediction-disclaimer") == nil {
+				t.Fatal("expected the prediction disclaimer beside a prediction surface")
+			}
+
+			form := dashboardSaveForm(t, document)
+			more := dashboardMoreDisclosure(t, form)
+			temperature := htmlFindElement(form, htmlNodeAttrEquals("id", "dashboard-bbt"))
+			if temperature == nil {
+				t.Fatal("expected the temperature field in the journal")
+			}
+			if got := htmlNodeContains(more, temperature); got == testCase.framed {
+				t.Fatalf("expected the temperature field inside the disclosure=%v, got %v", !testCase.framed, got)
+			}
+			if got := htmlHasAttr(more, "open"); got == testCase.framed {
+				t.Fatalf("expected today's temperature to open the disclosure=%v, got %v", !testCase.framed, got)
+			}
+		})
+	}
+}
+
+// TestDashboardTimingFrameKeepsSuppressedPredictionsSuppressed is the safety
+// half: the goal reframes what a prediction is called, never whether one is
+// made. An account that turned predictions off sees no ovulation estimate
+// whatever its goal, while the field placement — which no prediction feeds —
+// stays as the goal asked.
+func TestDashboardTimingFrameKeepsSuppressedPredictionsSuppressed(t *testing.T) {
+	app, database := newOnboardingTestApp(t)
+	user := createOnboardingTestUser(t, database, "dashboard-timing-suppressed@example.com", "StrongPass1", true)
+	enableDashboardMeasurementTracking(t, database, user.ID)
+	seedDashboardStableCycleForGoal(t, database, user.ID, models.UsageGoalTrying)
+	if err := database.Model(&models.User{}).Where("id = ?", user.ID).Update("unpredictable_cycle", true).Error; err != nil {
+		t.Fatalf("enable unpredictable cycle: %v", err)
+	}
+
+	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
+	document := mustParseHTMLDocument(t, mustRenderDashboard(t, app, authCookie, "en"))
+
+	statusLine := dashboardElementByDataAttr(document, "data-dashboard-status-line")
+	if statusLine == nil {
+		t.Fatal("expected the dashboard status line")
+	}
+	if htmlFindElement(statusLine, htmlNodeHasAttr("data-dashboard-ovulation")) != nil {
+		t.Fatal("did not expect an ovulation estimate while predictions are suppressed")
+	}
+
+	form := dashboardSaveForm(t, document)
+	temperature := htmlFindElement(form, htmlNodeAttrEquals("id", "dashboard-bbt"))
+	if temperature == nil {
+		t.Fatal("expected the temperature field in the journal")
+	}
+	if htmlNodeContains(dashboardMoreDisclosure(t, form), temperature) {
+		t.Fatal("expected the temperature field to stay in the visible tier for this goal")
+	}
+}
+
+// seedDashboardStableCycleForGoal gives the account a cycle context predictions
+// can be made from, under the usage goal the case is about.
+func seedDashboardStableCycleForGoal(t *testing.T, database *gorm.DB, userID uint, goal string) {
+	t.Helper()
+
+	today := services.DateAtLocation(time.Now().UTC(), time.UTC)
+	if err := database.Model(&models.User{}).Where("id = ?", userID).Updates(map[string]any{
+		"usage_goal":        goal,
+		"cycle_length":      28,
+		"period_length":     5,
+		"last_period_start": today.AddDate(0, 0, -2),
+	}).Error; err != nil {
+		t.Fatalf("seed cycle context for %s: %v", goal, err)
+	}
+}
+
 // enableDashboardMeasurementTracking switches on the two tracking-gated fields
 // the journal's disclosure holds (BBT and cervical mucus); the rest are on by
 // default.

--- a/internal/api/page_view_data_helpers.go
+++ b/internal/api/page_view_data_helpers.go
@@ -70,6 +70,8 @@ func (handler *Handler) buildDashboardViewData(ctx context.Context, user *models
 		"ShowCycleFactors":                      viewData.ShowCycleFactors,
 		"ShowNotesField":                        viewData.ShowNotesField,
 		"MoreFieldsOpen":                        viewData.MoreFieldsOpen,
+		"ShowOvulationEstimate":                 viewData.ShowOvulationEstimate,
+		"ShowBBTInVisibleTier":                  viewData.ShowBBTInVisibleTier,
 		"TemperatureUnit":                       bbtView.Unit,
 		"TemperatureUnitSymbol":                 bbtView.Symbol,
 		"TemperatureInputMin":                   bbtView.Min,

--- a/internal/i18n/locales/de.json
+++ b/internal/i18n/locales/de.json
@@ -403,6 +403,7 @@
   "dashboard.fertility_badge_positive": "Fruchtbare Phase, beste Zeit",
   "dashboard.ovulation": "Eisprung",
   "dashboard.ovulation_range": "%s — %s",
+  "dashboard.ovulation_estimate": "etwa %s",
   "dashboard.ovulation_need_cycles": "3 abgeschlossene Zyklen sind erforderlich, bevor Ovumcy einen Bereich für den Eisprung anzeigen kann",
   "dashboard.ovulation_approximate": "(ungefähr)",
   "dashboard.prediction_disclaimer": "Dies sind Schätzungen, keine medizinische Beratung und keine Verhütungsmethode.",

--- a/internal/i18n/locales/en.json
+++ b/internal/i18n/locales/en.json
@@ -403,6 +403,7 @@
   "dashboard.fertility_badge_positive": "Fertile period, best timing",
   "dashboard.ovulation": "Ovulation",
   "dashboard.ovulation_range": "%s — %s",
+  "dashboard.ovulation_estimate": "around %s",
   "dashboard.ovulation_need_cycles": "3 completed cycles are needed before Ovumcy shows an ovulation range",
   "dashboard.ovulation_approximate": "(approximate)",
   "dashboard.prediction_disclaimer": "These are estimates, not medical advice or a method of contraception.",

--- a/internal/i18n/locales/es.json
+++ b/internal/i18n/locales/es.json
@@ -403,6 +403,7 @@
   "dashboard.fertility_badge_positive": "Fase fértil, mejor momento",
   "dashboard.ovulation": "Ovulación",
   "dashboard.ovulation_range": "%s — %s",
+  "dashboard.ovulation_estimate": "aproximadamente %s",
   "dashboard.ovulation_need_cycles": "se necesitan 3 ciclos completos antes de que Ovumcy muestre un rango de ovulación",
   "dashboard.ovulation_approximate": "(aproximada)",
   "dashboard.prediction_disclaimer": "Son estimaciones, no consejo médico ni un método anticonceptivo.",

--- a/internal/i18n/locales/fr.json
+++ b/internal/i18n/locales/fr.json
@@ -519,6 +519,7 @@
   "dashboard.fertility_badge_positive": "Période fertile, meilleur moment",
   "dashboard.ovulation": "Ovulation",
   "dashboard.ovulation_range": "%s — %s",
+  "dashboard.ovulation_estimate": "vers le %s",
   "dashboard.ovulation_need_cycles": "3 cycles terminés sont nécessaires avant qu'Ovumcy affiche une plage d'ovulation",
   "dashboard.ovulation_approximate": "(approximatif)",
   "dashboard.prediction_disclaimer": "Ce sont des estimations, pas un avis médical ni une méthode de contraception.",

--- a/internal/i18n/locales/it.json
+++ b/internal/i18n/locales/it.json
@@ -403,6 +403,7 @@
   "dashboard.fertility_badge_positive": "Periodo fertile, momento migliore",
   "dashboard.ovulation": "Ovulazione",
   "dashboard.ovulation_range": "%s — %s",
+  "dashboard.ovulation_estimate": "intorno al %s",
   "dashboard.ovulation_need_cycles": "Sono necessari 3 cicli completati prima che Ovumcy mostri un intervallo di ovulazione",
   "dashboard.ovulation_approximate": "(approssimativo)",
   "dashboard.prediction_disclaimer": "Queste sono stime, non consigli medici né un metodo contraccettivo.",

--- a/internal/i18n/locales/ru.json
+++ b/internal/i18n/locales/ru.json
@@ -405,6 +405,7 @@
   "dashboard.fertility_badge_positive": "Фертильный период — лучшее время",
   "dashboard.ovulation": "Овуляция",
   "dashboard.ovulation_range": "%s — %s",
+  "dashboard.ovulation_estimate": "ориентировочно %s",
   "dashboard.ovulation_need_cycles": "нужно 3 завершённых цикла, чтобы Ovumcy показал диапазон овуляции",
   "dashboard.ovulation_approximate": "(приблизительно)",
   "dashboard.prediction_disclaimer": "Это оценки, а не медицинский совет и не метод контрацепции.",

--- a/internal/services/dashboard_view_service.go
+++ b/internal/services/dashboard_view_service.go
@@ -62,6 +62,8 @@ type DashboardViewData struct {
 	ShowCycleFactors                  bool
 	ShowNotesField                    bool
 	MoreFieldsOpen                    bool
+	ShowOvulationEstimate             bool
+	ShowBBTInVisibleTier              bool
 	AllowManualCycleStart             bool
 	ManualCycleStartPolicy            ManualCycleStartPolicy
 	ShowHighFertilityBadge            bool
@@ -153,6 +155,7 @@ func (service *DashboardViewService) BuildDashboardViewData(ctx context.Context,
 		hasCycleFactorExplanation,
 	)
 	visibility := dashboardOwnerVisibilityState(user, today, now, location)
+	timingFrame := resolveDashboardTimingFrame(user, cycleContext, visibility)
 	showHighFertilityBadge := dashboardHighFertilityBadge(user, todayLog)
 	showSpottingCycleWarning := dashboardSpottingCycleWarning(logs, todayLog, today, location)
 	reminderBanner := DashboardReminderBanner{}
@@ -183,7 +186,9 @@ func (service *DashboardViewService) BuildDashboardViewData(ctx context.Context,
 		ShowCervicalMucus:                 visibility.ShowCervicalMucus,
 		ShowCycleFactors:                  visibility.ShowCycleFactors,
 		ShowNotesField:                    visibility.ShowNotesField,
-		MoreFieldsOpen:                    dashboardMoreFieldsHoldData(todayLog, visibility),
+		MoreFieldsOpen:                    dashboardMoreFieldsHoldData(todayLog, visibility, timingFrame.BBTInVisibleTier),
+		ShowOvulationEstimate:             timingFrame.ShowOvulationEstimate,
+		ShowBBTInVisibleTier:              timingFrame.BBTInVisibleTier,
 		AllowManualCycleStart:             visibility.AllowManualCycleStart,
 		ManualCycleStartPolicy:            cycleStart.Policy,
 		ShowHighFertilityBadge:            showHighFertilityBadge,
@@ -218,13 +223,40 @@ type dashboardOwnerVisibility struct {
 	AllowManualCycleStart bool
 }
 
+// dashboardTimingFrame is the goal-aware half of the dashboard. An account
+// tracking to conceive is on the page for timing, so the status header carries
+// the ovulation estimate beside the next-period one and the morning temperature
+// such an account records daily sits in the journal's visible tier instead of
+// behind the "More" disclosure. Every other goal reads the page unchanged.
+type dashboardTimingFrame struct {
+	ShowOvulationEstimate bool
+	BBTInVisibleTier      bool
+}
+
+// resolveDashboardTimingFrame decides that frame from the resolved usage goal.
+// The ovulation estimate follows the next-period item's gating exactly: a
+// suppressed prediction (unpredictable cycle, pregnancy pause) stays suppressed
+// here too, and BBT keeps existing only where the tracking settings grant it.
+func resolveDashboardTimingFrame(user *models.User, cycleContext DashboardCycleContext, visibility dashboardOwnerVisibility) dashboardTimingFrame {
+	if !IsOwnerUser(user) || NormalizeUsageGoal(user.UsageGoal) != models.UsageGoalTrying {
+		return dashboardTimingFrame{}
+	}
+	return dashboardTimingFrame{
+		ShowOvulationEstimate: !cycleContext.PredictionDisabled,
+		BBTInVisibleTier:      visibility.ShowBBTField,
+	}
+}
+
 // dashboardMoreFieldsHoldData answers whether the journal's "More" disclosure
 // must render open: it does exactly when today already holds one of the values
 // that live behind it. A field the owner's tracking settings hide is not
 // rendered at all, so a value left behind in its column cannot open the
 // disclosure over a control that does not exist — the visibility flags gate
 // every clause. The pregnancy test has no tracking toggle and is always there.
-func dashboardMoreFieldsHoldData(entry models.DailyLog, visibility dashboardOwnerVisibility) bool {
+// BBT is counted only while it is behind the disclosure: for a goal that lifts
+// it into the visible tier a recorded temperature is already in the open, and
+// opening the disclosure over it would fold nothing.
+func dashboardMoreFieldsHoldData(entry models.DailyLog, visibility dashboardOwnerVisibility, bbtInVisibleTier bool) bool {
 	if visibility.ShowSexChip && NormalizeDaySexActivity(entry.SexActivity) != models.SexActivityNone {
 		return true
 	}
@@ -234,7 +266,7 @@ func dashboardMoreFieldsHoldData(entry models.DailyLog, visibility dashboardOwne
 	if NormalizeDayPregnancyTest(entry.PregnancyTest) != models.PregnancyTestNone {
 		return true
 	}
-	if visibility.ShowBBTField && entry.BBT != nil && IsValidDayBBT(entry.BBT) {
+	if visibility.ShowBBTField && !bbtInVisibleTier && entry.BBT != nil && IsValidDayBBT(entry.BBT) {
 		return true
 	}
 	if visibility.ShowCycleFactors && len(DayCycleFactorKeySet(entry.CycleFactorKeys)) > 0 {

--- a/internal/templates/dashboard.html
+++ b/internal/templates/dashboard.html
@@ -73,6 +73,29 @@
                 {{end}}
               </span>
             </span>
+            {{/* The goal decides how timing is framed: an account tracking to
+                 conceive is here for the fertile window, so the same status line
+                 also names the ovulation estimate. It rides the next-period
+                 item's gating — a suppressed prediction never reaches this
+                 branch — and stays an estimate in its own wording. */}}
+            {{if .ShowOvulationEstimate}}
+            <span class="dashboard-status-separator" aria-hidden="true">·</span>
+            <span class="dashboard-status-item">{{t .Messages "dashboard.ovulation"}}:
+              <span data-dashboard-ovulation>
+                {{if .DisplayOvulationImpossible}}
+                  {{t .Messages "dashboard.ovulation_unavailable"}}
+                {{else if .DisplayOvulationUseRange}}
+                  {{printf (t .Messages "dashboard.ovulation_range") (formatLocalizedDate .Lang .DisplayOvulationRangeStart "display") (formatLocalizedDate .Lang .DisplayOvulationRangeEnd "display")}}
+                {{else if .DisplayOvulationNeedsData}}
+                  {{t .Messages "dashboard.ovulation_need_cycles"}}
+                {{else if .DisplayOvulationDate.IsZero}}
+                  {{.NoDataLabel}}
+                {{else}}
+                  {{printf (t .Messages "dashboard.ovulation_estimate") (formatLocalizedDate .Lang .DisplayOvulationDate "display")}}{{if not .DisplayOvulationExact}} <span class="journal-muted">{{t .Messages "dashboard.ovulation_approximate"}}</span>{{end}}
+                {{end}}
+              </span>
+            </span>
+            {{end}}
             {{if .CycleHero.Approximate}}
             <span class="dashboard-status-separator" aria-hidden="true">·</span>
             <span class="dashboard-status-item journal-muted" data-dashboard-estimate-qualifier>{{t .Messages "dashboard.cycle_hero_estimated"}}</span>
@@ -267,6 +290,24 @@
           {{template "symptom_options" (dict "Messages" .Messages "PrimarySymptoms" .PrimarySymptoms "ExtraSymptoms" .ExtraSymptoms "HasExtraSymptoms" .HasExtraSymptoms "SelectedSymptomID" .SelectedSymptomID "Lang" .Lang "Compact" false "IncludePreviewHooks" false)}}
         </fieldset>
 
+        {{/* One temperature field, placed by the goal the server resolved: a
+             morning reading is part of the daily routine while trying to
+             conceive, so it stays in the open there and waits behind "More"
+             for every other goal. */}}
+        {{$bbtField := dict
+          "Messages" .Messages
+          "FieldID" "dashboard-bbt"
+          "Value" (displayBBT .TodayEntry.BBT .TemperatureUnit)
+          "TemperatureUnit" .TemperatureUnit
+          "TemperatureInputMin" .TemperatureInputMin
+          "TemperatureInputMax" .TemperatureInputMax
+          "TemperatureRangeError" .TemperatureRangeError
+          "TemperatureUnitSymbol" .TemperatureUnitSymbol
+          "TemperatureRangeHint" .TemperatureRangeHint}}
+        {{if and .ShowBBTField .ShowBBTInVisibleTier}}
+        {{template "temperature_input_field" $bbtField}}
+        {{end}}
+
         {{/* One tap is enough on this screen, so the tier above holds only what
              a day is usually logged with. Everything rarer waits behind one
              disclosure — and the disclosure renders open whenever today already
@@ -304,17 +345,8 @@
               {{template "pregnancy_test_options" (dict "Messages" .Messages "SelectedPregnancyTest" .TodayEntry.PregnancyTest "Compact" false)}}
             </fieldset>
 
-            {{if .ShowBBTField}}
-            {{template "temperature_input_field" (dict
-              "Messages" .Messages
-              "FieldID" "dashboard-bbt"
-              "Value" (displayBBT .TodayEntry.BBT .TemperatureUnit)
-              "TemperatureUnit" .TemperatureUnit
-              "TemperatureInputMin" .TemperatureInputMin
-              "TemperatureInputMax" .TemperatureInputMax
-              "TemperatureRangeError" .TemperatureRangeError
-              "TemperatureUnitSymbol" .TemperatureUnitSymbol
-              "TemperatureRangeHint" .TemperatureRangeHint)}}
+            {{if and .ShowBBTField (not .ShowBBTInVisibleTier)}}
+            {{template "temperature_input_field" $bbtField}}
             {{end}}
 
             {{if .ShowCycleFactors}}


### PR DESCRIPTION
Wave 2 design pass, goal-aware timing frame (review finding, simulated design review 2026-08-12).

Onboarding promises (#420, `usage_goal.ui_only_hint`) that the usage goal changes how timing is
framed in the interface. For an account whose goal is trying to conceive, nothing on the dashboard
kept that promise: the status header named no ovulation estimate, and the morning temperature — a
daily field for that goal — waited behind the "More details" disclosure.

## What changes

- **Status line, one item added.** When the resolved goal is trying to conceive, the status line
  carries the ovulation estimate beside the next-period one, on that item's gating exactly: an
  unpredictable cycle or a paused prediction suppresses it, ranges/needs-data/impossible follow the
  view data the dashboard already computes. It renders as an estimate ("around <date>", plus the
  approximate qualifier where the projection is not exact) under the standing prediction
  disclaimer. Other goals see the line unchanged.
- **Visible tier, goal-aware.** For a trying-to-conceive account whose tracking settings grant BBT,
  the temperature field renders in the journal's visible tier instead of inside "More"; every other
  goal keeps it inside. `TrackingVisibility` still decides whether the field exists at all.
- **The disclosure stops counting BBT where BBT is not behind it** — a recorded temperature is
  already in the open there, so it no longer opens a disclosure over fields it does not hold.

The decision is made server-side beside the existing More open-condition
(`resolveDashboardTimingFrame`, `internal/services/dashboard_view_service.go`) and reaches the
template as two view flags; no goal logic enters the markup, so switching the mode from the
dashboard chip reframes the page on its next load with no extra wiring.

Copy: the ovulation display keys already shipped in all six catalogues are reused; only
`dashboard.ovulation_estimate` ("around %s", mirroring `dashboard.next_period_estimate`) is new,
added to all six with no plural categories.

Restraint rules of the wave hold: one line added to an existing surface, no new card or panel.

## Tests

- `TestDashboardFramesTimingForTheGoalThatIsAboutIt` — both goals, one table: the ovulation hook in
  the status line, the temperature field's tier, and the disclosure's open state on a day that
  holds a temperature.
- `TestDashboardTimingFrameKeepsSuppressedPredictionsSuppressed` — the goal reframes what a
  prediction is called, never whether one is made: unpredictable mode keeps the estimate off while
  the field placement stays.
- `e2e/dashboard.spec.ts` — the default goal shows no ovulation item and a folded temperature
  field; after switching the mode from the dashboard chip the line and the visible field appear,
  and a temperature saved from the visible tier reads back after a reload.

## Verification

`go test ./...`, `golangci-lint run ./...` (0 issues), `npm run lint`, `npm run test:unit`,
`npm run e2e -- e2e/dashboard.spec.ts` (21 passed) and `e2e/dashboard-fertility.spec.ts`
(3 passed, the other spec that drives this goal). `web/src` is untouched; a fresh Tailwind build
is byte-identical to the committed bundle. Patch coverage gate: every modified coverable line
covered.
