### PR TITLE
fix(dashboard): an overdue cycle shows no next-period window

### DIFF
--- a/changelog.d/fix-overdue-prediction-window.md
+++ b/changelog.d/fix-overdue-prediction-window.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- **An overdue cycle no longer gets a confident next-period window.** The projection rolls forward a
+  whole cycle at a time, so it always produced a future date: on cycle day 45 with a 28-day
+  reference the dashboard named the anchor plus 56 days as firmly as it names tomorrow, and the
+  reminder banner counted down to it. Once a cycle runs past the reference length by more than a
+  week — the same threshold that raises the late-cycle notice — no next-period window, ovulation
+  estimate or reminder banner is shown at all; one line says the estimate returns with the next
+  cycle start. The cycle day, the late-cycle notice and its actions stay exactly as they were.

--- a/e2e/dashboard-late-cycle-notice.spec.ts
+++ b/e2e/dashboard-late-cycle-notice.spec.ts
@@ -26,11 +26,16 @@ import {
  * The notice is addressed exclusively through the hooks the policy owns —
  * `[data-dashboard-cycle-warnings]`, `[data-dashboard-cycle-day-warning]`,
  * `data-late-cycle-key`, `data-late-cycle-tone` — and never through the status
- * header above it, so a redesign of the header (#429) cannot move this spec.
+ * header above it, so a redesign of the header (#429) cannot move this spec. The
+ * one deliberate exception is the beyond-range test, which also reads the
+ * header's next-period slot: the same threshold that raises this notice withholds
+ * the projected window, and "the notice appeared" is worth little if a confident
+ * date is still sitting one line above it.
  */
 const BEYOND_RANGE_KEY = 'dashboard.late_cycle.beyond_range';
 const WITHIN_RANGE_KEY = 'dashboard.late_cycle.within_range';
 const NO_PERSONAL_RANGE_KEY = 'dashboard.late_cycle.no_personal_range';
+const ESTIMATE_PAUSED_KEY = 'dashboard.next_period_estimate_paused';
 
 /** Whole calendar days from `fromISO` to `toISO`, DST-proof (UTC arithmetic). */
 function isoDaysBetween(fromISO: string, toISO: string): number {
@@ -105,6 +110,14 @@ test.describe('Dashboard late-cycle notice', () => {
         excessDays,
       ])
     );
+
+    // The other half of the same threshold: no next-period window is rendered at
+    // all. The projection would happily roll forward to the anchor plus another
+    // whole cycle, so the assertion is the slot's absence, not its contents.
+    await expect(page.locator('[data-dashboard-next-period]')).toHaveCount(0);
+    const pausedEstimate = page.locator('[data-dashboard-next-period-paused]');
+    await expect(pausedEstimate).toBeVisible();
+    await expect(pausedEstimate).toHaveText(localeText('en', ESTIMATE_PAUSED_KEY));
   });
 
   test('a long cycle still inside the recorded range names both bounds', async ({ page }) => {

--- a/internal/api/dashboard_journal_regressions_test.go
+++ b/internal/api/dashboard_journal_regressions_test.go
@@ -636,6 +636,53 @@ func TestDashboardTimingFrameKeepsSuppressedPredictionsSuppressed(t *testing.T) 
 	}
 }
 
+// TestDashboardTimingFrameDropsTheOvulationEstimateForAnOverdueCycle is the same
+// safety half against the other suppression signal. Once a cycle runs past its
+// reference length by more than a week the dashboard withholds the projected
+// window; the ovulation estimate is derived from that same projection, so an
+// account trying to conceive must not be the one cohort still reading a slot
+// where the window used to be. The field placement is a property of the goal
+// alone — a late cycle is when a morning reading matters most — so the
+// temperature stays in the visible tier.
+func TestDashboardTimingFrameDropsTheOvulationEstimateForAnOverdueCycle(t *testing.T) {
+	app, database := newOnboardingTestApp(t)
+	user := createOnboardingTestUser(t, database, "dashboard-timing-overdue@example.com", "StrongPass1", true)
+	enableDashboardMeasurementTracking(t, database, user.ID)
+	seedDashboardStableCycleForGoal(t, database, user.ID, models.UsageGoalTrying)
+	// Cycle day 37 against the 28-day reference: past 28 + 7.
+	today := services.DateAtLocation(time.Now().UTC(), time.UTC)
+	if err := database.Model(&models.User{}).Where("id = ?", user.ID).
+		Update("last_period_start", today.AddDate(0, 0, -36)).Error; err != nil {
+		t.Fatalf("seed overdue cycle context: %v", err)
+	}
+
+	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
+	document := mustParseHTMLDocument(t, mustRenderDashboard(t, app, authCookie, "en"))
+
+	statusLine := dashboardElementByDataAttr(document, "data-dashboard-status-line")
+	if statusLine == nil {
+		t.Fatal("expected the dashboard status line")
+	}
+	if htmlFindElement(statusLine, htmlNodeHasAttr("data-dashboard-ovulation")) != nil {
+		t.Fatal("did not expect an ovulation estimate for a cycle past the late threshold")
+	}
+	if htmlFindElement(statusLine, htmlNodeHasAttr("data-dashboard-next-period")) != nil {
+		t.Fatal("did not expect a next-period estimate for a cycle past the late threshold")
+	}
+	if htmlFindElement(statusLine, htmlNodeHasAttr("data-dashboard-next-period-paused")) == nil {
+		t.Fatal("expected the withheld-estimate line in place of the two estimates")
+	}
+
+	form := dashboardSaveForm(t, document)
+	temperature := htmlFindElement(form, htmlNodeAttrEquals("id", "dashboard-bbt"))
+	if temperature == nil {
+		t.Fatal("expected the temperature field in the journal")
+	}
+	if htmlNodeContains(dashboardMoreDisclosure(t, form), temperature) {
+		t.Fatal("expected the temperature field to stay in the visible tier for this goal")
+	}
+}
+
 // seedDashboardStableCycleForGoal gives the account a cycle context predictions
 // can be made from, under the usage goal the case is about.
 func seedDashboardStableCycleForGoal(t *testing.T, database *gorm.DB, userID uint, goal string) {

--- a/internal/api/dashboard_status_header_regression_test.go
+++ b/internal/api/dashboard_status_header_regression_test.go
@@ -61,6 +61,60 @@ func TestDashboardStatusHeaderCarriesTheSegmentedRingForStableCycleContext(t *te
 	}
 }
 
+// TestDashboardStatusHeaderDropsTheNextPeriodSlotForAnOverdueCycle pins the
+// structural half of the withheld window: once the running cycle is past the
+// reference length by more than a week, the status line carries no next-period
+// estimate at all — not a softened one — while the late-cycle notice below it,
+// which is what the state actually justifies saying, still renders.
+func TestDashboardStatusHeaderDropsTheNextPeriodSlotForAnOverdueCycle(t *testing.T) {
+	app, database, _ := newOnboardingTestAppWithLocation(t, time.UTC)
+	user := createOnboardingTestUser(t, database, "dashboard-overdue-window@example.com", "StrongPass1", true)
+	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
+
+	today := services.DateAtLocation(time.Now().UTC(), time.UTC)
+	// Cycle day 37 against the 28-day reference: past 28 + 7.
+	if err := database.Model(&models.User{}).Where("id = ?", user.ID).Updates(map[string]any{
+		"cycle_length":      28,
+		"period_length":     5,
+		"last_period_start": today.AddDate(0, 0, -36),
+	}).Error; err != nil {
+		t.Fatalf("update overdue cycle context: %v", err)
+	}
+
+	request := httptest.NewRequest(http.MethodGet, "/dashboard", nil)
+	request.Header.Set("Accept-Language", "en")
+	request.Header.Set("Cookie", authCookie)
+
+	response := mustAppResponse(t, app, request)
+	assertStatusCode(t, response, http.StatusOK)
+	document := mustParseHTMLDocument(t, mustReadBodyString(t, response.Body))
+	header := dashboardElementByDataAttr(document, "data-dashboard-status-header")
+	if header == nil {
+		t.Fatal("expected the dashboard status header for an overdue cycle")
+	}
+	if htmlFindElement(header, func(node *html.Node) bool {
+		return node.Type == html.ElementNode && htmlHasAttr(node, "data-dashboard-next-period")
+	}) != nil {
+		t.Fatal("did not expect a next-period estimate for a cycle past the late threshold")
+	}
+	if dashboardElementByDataAttr(header, "data-dashboard-next-period-paused") == nil {
+		t.Fatal("expected the withheld-estimate line in place of the next-period slot")
+	}
+	if dashboardElementByDataAttr(header, "data-dashboard-reminder-banner") != nil {
+		t.Fatal("did not expect a reminder banner summarizing a withheld estimate")
+	}
+	warnings := dashboardElementByDataAttr(header, "data-dashboard-cycle-warnings")
+	if warnings == nil {
+		t.Fatal("expected the cycle warnings block for an overdue cycle")
+	}
+	if dashboardElementByDataAttr(warnings, "data-dashboard-cycle-day-warning") == nil {
+		t.Fatal("expected the late-cycle notice to keep carrying the state")
+	}
+	if dashboardElementByDataAttr(header, "data-dashboard-cycle-day") == nil {
+		t.Fatal("expected the cycle day to stay visible for an overdue cycle")
+	}
+}
+
 // TestDashboardStatusHeaderDropsRingSegmentsWhenPredictionsAreDisabled is the
 // other half: the header still renders in unpredictable mode, but nothing draws
 // phase segments the account's data cannot support.

--- a/internal/api/page_view_data_helpers.go
+++ b/internal/api/page_view_data_helpers.go
@@ -41,6 +41,7 @@ func (handler *Handler) buildDashboardViewData(ctx context.Context, user *models
 		"DisplayOvulationNeedsData":             viewData.CycleContext.DisplayOvulationNeedsData,
 		"DisplayOvulationExact":                 viewData.CycleContext.DisplayOvulationExact,
 		"DisplayOvulationImpossible":            viewData.CycleContext.DisplayOvulationImpossible,
+		"NextPeriodEstimatePaused":              viewData.CycleContext.NextPeriodEstimatePaused,
 		"NextPeriodInPast":                      viewData.CycleContext.NextPeriodInPast,
 		"OvulationInPast":                       viewData.CycleContext.OvulationInPast,
 		"ShowReminderBanner":                    viewData.ReminderBanner.Show,

--- a/internal/i18n/locales/de.json
+++ b/internal/i18n/locales/de.json
@@ -390,6 +390,7 @@
   "dashboard.next_period_need_cycles": "Für einen verlässlichen Bereich werden 3 Zyklen benötigt",
   "dashboard.next_period_prompt": "Geben Sie das Startdatum Ihres letzten Zyklus ein",
   "dashboard.next_period_unknown": "unbekannt",
+  "dashboard.next_period_estimate_paused": "Die Schätzung für die nächste Periode kehrt mit dem Beginn Ihres nächsten Zyklus zurück.",
   "prediction.explainer.unpredictable_compact": "Vorhersagen aus",
   "prediction.explainer.unpredictable": "Im Modus für unvorhersehbare Zyklen sind Vorhersagen deaktiviert. Ovumcy zeigt nur aufgezeichnete Fakten an.",
   "prediction.explainer.irregular_ranges": "Im Modus für unregelmäßige Zyklen werden Bereiche statt exakter Vorhersagedaten verwendet.",

--- a/internal/i18n/locales/en.json
+++ b/internal/i18n/locales/en.json
@@ -390,6 +390,7 @@
   "dashboard.next_period_need_cycles": "3 cycles are needed for a reliable range",
   "dashboard.next_period_prompt": "Enter the start date of your last cycle",
   "dashboard.next_period_unknown": "unknown",
+  "dashboard.next_period_estimate_paused": "The next-period estimate returns with your next cycle start.",
   "prediction.explainer.unpredictable_compact": "Predictions off",
   "prediction.explainer.unpredictable": "Predictions are off in unpredictable cycle mode. Ovumcy shows recorded facts only.",
   "prediction.explainer.irregular_ranges": "Irregular cycle mode uses ranges instead of exact prediction dates.",

--- a/internal/i18n/locales/es.json
+++ b/internal/i18n/locales/es.json
@@ -390,6 +390,7 @@
   "dashboard.next_period_need_cycles": "se necesitan 3 ciclos para un rango fiable",
   "dashboard.next_period_prompt": "Indica la fecha de inicio de tu último ciclo",
   "dashboard.next_period_unknown": "desconocido",
+  "dashboard.next_period_estimate_paused": "La estimación del próximo periodo volverá cuando empiece tu próximo ciclo.",
   "prediction.explainer.unpredictable_compact": "Predicciones desactivadas",
   "prediction.explainer.unpredictable": "Las predicciones están desactivadas en el modo de ciclo impredecible. Ovumcy muestra solo hechos registrados.",
   "prediction.explainer.irregular_ranges": "El modo de ciclo irregular usa rangos en lugar de fechas exactas de predicción.",

--- a/internal/i18n/locales/fr.json
+++ b/internal/i18n/locales/fr.json
@@ -504,6 +504,7 @@
   "dashboard.next_period_need_cycles": "3 cycles sont nécessaires pour obtenir une plage fiable",
   "dashboard.next_period_prompt": "Saisissez la date de début de votre dernier cycle",
   "dashboard.next_period_unknown": "inconnu",
+  "dashboard.next_period_estimate_paused": "L'estimation des prochaines règles reviendra au début de votre prochain cycle.",
 
   "prediction.explainer.unpredictable_compact": "Prédictions désactivées",
   "prediction.explainer.unpredictable": "Les prédictions sont désactivées en mode cycle imprévisible. Ovumcy affiche uniquement les faits enregistrés.",

--- a/internal/i18n/locales/it.json
+++ b/internal/i18n/locales/it.json
@@ -390,6 +390,7 @@
   "dashboard.next_period_need_cycles": "Sono necessari 3 cicli per un intervallo affidabile",
   "dashboard.next_period_prompt": "Inserisci la data di inizio del tuo ultimo ciclo",
   "dashboard.next_period_unknown": "sconosciuto",
+  "dashboard.next_period_estimate_paused": "La stima del prossimo ciclo mestruale tornerà con l'inizio del prossimo ciclo.",
   "prediction.explainer.unpredictable_compact": "Previsioni disattivate",
   "prediction.explainer.unpredictable": "Le previsioni sono disattivate in modalità ciclo imprevedibile. Ovumcy mostra solo i fatti registrati.",
   "prediction.explainer.irregular_ranges": "La modalità ciclo irregolare usa intervalli invece di date esatte di previsione.",

--- a/internal/i18n/locales/ru.json
+++ b/internal/i18n/locales/ru.json
@@ -392,6 +392,7 @@
   "dashboard.next_period_need_cycles": "нужно 3 цикла для надёжного диапазона",
   "dashboard.next_period_prompt": "Укажите дату начала последнего цикла",
   "dashboard.next_period_unknown": "неизвестно",
+  "dashboard.next_period_estimate_paused": "Оценка следующих месячных вернётся с началом следующего цикла.",
   "prediction.explainer.unpredictable_compact": "Прогнозы выключены",
   "prediction.explainer.unpredictable": "В режиме непредсказуемого цикла прогнозы отключены. Ovumcy показывает только записанные факты.",
   "prediction.explainer.irregular_ranges": "В режиме нерегулярного цикла Ovumcy показывает диапазоны вместо точных дат прогноза.",

--- a/internal/services/dashboard_cycle.go
+++ b/internal/services/dashboard_cycle.go
@@ -7,6 +7,14 @@ import (
 	"github.com/ovumcy/ovumcy-web/internal/models"
 )
 
+// DashboardCycleContext is the dashboard's cycle state.
+//
+// NextPeriodEstimatePaused reports that the running cycle is long enough
+// (DashboardCycleDayLooksLong: past the reference length by more than a week)
+// that no next-period window is shown at all: every Display* field it would have
+// filled is cleared, and the surfaces derived from them — the status header slot,
+// the reminder banner — say so instead of naming a date. The cycle day and the
+// late-cycle notice carry the state on their own.
 type DashboardCycleContext struct {
 	CycleDayReference           int
 	CycleDayWarning             bool
@@ -28,6 +36,7 @@ type DashboardCycleContext struct {
 	DisplayOvulationNeedsData   bool
 	DisplayOvulationExact       bool
 	DisplayOvulationImpossible  bool
+	NextPeriodEstimatePaused    bool
 	NextPeriodInPast            bool
 	OvulationInPast             bool
 }
@@ -47,6 +56,7 @@ type dashboardPredictionDisplay struct {
 	ovulationNeedsData   bool
 	ovulationExact       bool
 	ovulationImpossible  bool
+	estimatePaused       bool
 }
 
 func DashboardPredictionDisabled(user *models.User) bool {
@@ -93,6 +103,24 @@ func DashboardProjectionCycleLength(user *models.User, stats CycleStats) int {
 		return user.CycleLength
 	}
 	return models.DefaultCycleLength
+}
+
+// DashboardCycleOverdue reports that the running cycle has passed the account's
+// own reference length by more than a week. It is the reference+7 rule of
+// DashboardCycleDayLooksLong — the one the late-cycle notice already states —
+// resolved against DashboardCycleReferenceLength, so the threshold keeps living
+// in exactly one place and no surface may re-derive it.
+//
+// This is the third medical-safety suppression signal, beside
+// DashboardPredictionDisabled(user) and stats.PregnancyPaused: past this point a
+// projection can only roll a whole cycle forward at a time (ProjectCycleStart),
+// so every date it yields is manufactured rather than estimated, and presenting
+// one as a window is the estimate-presented-as-fact the medical-safety invariant
+// forbids. Every surface that shows a projected window gates on all three —
+// dashboard display and reminder banner here; the calendar grid, the webhook
+// reminder and the .ics feed are the remaining callers of that pair.
+func DashboardCycleOverdue(user *models.User, stats CycleStats) bool {
+	return DashboardCycleDayLooksLong(stats.CurrentCycleDay, DashboardCycleReferenceLength(user, stats))
 }
 
 func DashboardCycleDayLooksLong(currentDay int, referenceLength int) bool {
@@ -273,11 +301,16 @@ func BuildDashboardCycleContext(user *models.User, stats CycleStats, today time.
 		DisplayOvulationNeedsData:   display.ovulationNeedsData,
 		DisplayOvulationExact:       display.ovulationExact,
 		DisplayOvulationImpossible:  display.ovulationImpossible,
+		NextPeriodEstimatePaused:    display.estimatePaused,
 		NextPeriodInPast:            dashboardNextPeriodInPast(display, today),
 		OvulationInPast:             dashboardOvulationInPast(display, today),
 	}
 }
 
+// buildDashboardPredictionDisplay turns the projected cycle into the fields the
+// dashboard renders, withholding the whole projected window once
+// DashboardCycleOverdue reports the cycle is past its reference length by more
+// than a week.
 func buildDashboardPredictionDisplay(user *models.User, stats CycleStats, today time.Time, location *time.Location) dashboardPredictionDisplay {
 	prediction := DashboardUpcomingPredictions(
 		stats,
@@ -299,7 +332,31 @@ func buildDashboardPredictionDisplay(user *models.User, stats CycleStats, today 
 	if display.nextPeriodPrompt || display.nextPeriodNeedsData {
 		return finalizeDashboardPredictionDisplay(display)
 	}
+	if DashboardCycleOverdue(user, stats) {
+		return pauseDashboardPredictionDisplay(display)
+	}
 	return finalizeDashboardPredictionDisplay(applyDashboardPredictionRanges(display, user, stats, location))
+}
+
+// pauseDashboardPredictionDisplay withholds the projected window once the
+// running cycle is past the reference length by more than a week.
+//
+// DashboardUpcomingPredictions rolls the projection forward one whole cycle at a
+// time (ProjectCycleStart), so it always yields a strictly future date: at cycle
+// day 45 with a 28-day reference the header used to name the anchor plus 56 days
+// as confidently as it names tomorrow. A cycle that is already overdue carries no
+// evidence about when the next one starts, and presenting the roll-forward as a
+// window is exactly the estimate-presented-as-fact the medical-safety invariant
+// forbids. Both halves of the phantom projection go — the window and the
+// ovulation date derived from it — while ovulationNeedsData and
+// ovulationImpossible survive: they describe the account's data, not this
+// projection, and other surfaces gate on them.
+func pauseDashboardPredictionDisplay(display dashboardPredictionDisplay) dashboardPredictionDisplay {
+	return dashboardPredictionDisplay{
+		ovulationNeedsData:  display.ovulationNeedsData,
+		ovulationImpossible: display.ovulationImpossible,
+		estimatePaused:      true,
+	}
 }
 
 func dashboardNeedsNextPeriodData(user *models.User, stats CycleStats, nextPeriodStart time.Time) bool {

--- a/internal/services/dashboard_cycle_test.go
+++ b/internal/services/dashboard_cycle_test.go
@@ -77,21 +77,21 @@ func TestBuildDashboardCycleContext(t *testing.T) {
 		LastPeriodStart: &userStart,
 	}
 	stats := CycleStats{
-		CurrentCycleDay:     36,
+		CurrentCycleDay:     30,
 		LastPeriodStart:     mustParseDashboardDay(t, "2026-02-10"),
 		MedianCycleLength:   28,
 		AveragePeriodLength: 5,
 		NextPeriodStart:     mustParseDashboardDay(t, "2026-03-10"),
 		OvulationDate:       mustParseDashboardDay(t, "2026-02-24"),
 	}
-	today := mustParseDashboardDay(t, "2026-03-14")
+	today := mustParseDashboardDay(t, "2026-03-11")
 
 	context := BuildDashboardCycleContext(user, stats, today, time.UTC)
 	if context.CycleDayReference != 28 {
 		t.Fatalf("expected cycle day reference 28, got %d", context.CycleDayReference)
 	}
-	if !context.CycleDayWarning {
-		t.Fatalf("expected cycle day warning for long cycle day")
+	if context.CycleDayWarning {
+		t.Fatalf("did not expect a cycle day warning two days past the reference length")
 	}
 	if !context.CycleDataStale {
 		t.Fatalf("expected stale cycle data flag")
@@ -104,6 +104,129 @@ func TestBuildDashboardCycleContext(t *testing.T) {
 	}
 	if got := context.DisplayNextPeriodEnd.Format("2006-01-02"); got != "2026-04-11" {
 		t.Fatalf("expected exact next period end 2026-04-11, got %s", got)
+	}
+}
+
+// TestBuildDashboardCycleContextWithholdsTheWindowOnceTheCycleIsOverdue pins the
+// state a rolled-forward projection used to hide. DashboardUpcomingPredictions
+// advances the projection a whole cycle at a time, so it always returns a
+// strictly future date: on cycle day 36 against a 28-day reference the dashboard
+// named the anchor plus 56 days — a window nothing in the account's data
+// supports — with the same confidence it names tomorrow's. Past reference + 7
+// there is no window to show, and the cycle day plus the late-cycle notice carry
+// the state on their own.
+//
+// The stats below would otherwise produce a ±2-day uncertainty range (five
+// completed cycles, SD 2.4), so this also pins that the range fields go with the
+// single date rather than surviving as a softer version of the same claim.
+func TestBuildDashboardCycleContextWithholdsTheWindowOnceTheCycleIsOverdue(t *testing.T) {
+	userStart := mustParseDashboardDay(t, "2026-02-10")
+	user := &models.User{
+		CycleLength:     28,
+		PeriodLength:    5,
+		LastPeriodStart: &userStart,
+	}
+	stats := CycleStats{
+		CurrentCycleDay:     36,
+		LastPeriodStart:     mustParseDashboardDay(t, "2026-02-10"),
+		MedianCycleLength:   28,
+		AverageCycleLength:  28.4,
+		AveragePeriodLength: 5,
+		CompletedCycleCount: 5,
+		CycleLengthStdDev:   2.4,
+		NextPeriodStart:     mustParseDashboardDay(t, "2026-03-10"),
+		OvulationDate:       mustParseDashboardDay(t, "2026-02-24"),
+		OvulationExact:      true,
+	}
+	today := mustParseDashboardDay(t, "2026-03-17")
+
+	context := BuildDashboardCycleContext(user, stats, today, time.UTC)
+	if context.CycleDayReference != 28 {
+		t.Fatalf("expected cycle day reference 28, got %d", context.CycleDayReference)
+	}
+	if !context.CycleDayWarning {
+		t.Fatalf("expected cycle day 36 against a 28-day reference to read as long")
+	}
+	if !context.NextPeriodEstimatePaused {
+		t.Fatalf("expected an overdue cycle to pause the next-period estimate")
+	}
+	if !context.LateCycle.Visible {
+		t.Fatalf("expected the late-cycle notice to keep carrying the state")
+	}
+	if !context.DisplayNextPeriodStart.IsZero() || !context.DisplayNextPeriodEnd.IsZero() {
+		t.Fatalf(
+			"expected no projected next-period window, got %s — %s",
+			context.DisplayNextPeriodStart.Format("2006-01-02"),
+			context.DisplayNextPeriodEnd.Format("2006-01-02"),
+		)
+	}
+	if context.DisplayNextPeriodUseRange ||
+		!context.DisplayNextPeriodRangeStart.IsZero() ||
+		!context.DisplayNextPeriodRangeEnd.IsZero() {
+		t.Fatalf("expected no projected next-period range either")
+	}
+	if !context.DisplayOvulationDate.IsZero() || context.DisplayOvulationUseRange || context.DisplayOvulationExact {
+		t.Fatalf("expected the ovulation estimate derived from the same projection to go with it")
+	}
+	if context.DisplayNextPeriodPrompt || context.DisplayNextPeriodNeedsData {
+		t.Fatalf("expected an overdue cycle to stay out of the prompt and needs-data branches")
+	}
+	if context.NextPeriodInPast || context.OvulationInPast {
+		t.Fatalf("expected no in-the-past warning about a window that is not shown")
+	}
+
+	banner := BuildDashboardReminderBanner(context, today, 0)
+	if banner.Show {
+		t.Fatalf("expected no reminder banner for a withheld estimate, got %q", banner.TitleKey)
+	}
+}
+
+// TestBuildDashboardCycleContextKeepsTheWindowAtExactlyTheLateThreshold is the
+// other side of the boundary: DashboardCycleDayLooksLong fires strictly past
+// reference + 7, so day 35 against a 28-day reference still shows its window.
+// Same account as the test above, one day earlier.
+func TestBuildDashboardCycleContextKeepsTheWindowAtExactlyTheLateThreshold(t *testing.T) {
+	userStart := mustParseDashboardDay(t, "2026-02-10")
+	user := &models.User{
+		CycleLength:     28,
+		PeriodLength:    5,
+		LastPeriodStart: &userStart,
+	}
+	stats := CycleStats{
+		CurrentCycleDay:     35,
+		LastPeriodStart:     mustParseDashboardDay(t, "2026-02-10"),
+		MedianCycleLength:   28,
+		AverageCycleLength:  28.4,
+		AveragePeriodLength: 5,
+		CompletedCycleCount: 5,
+		CycleLengthStdDev:   2.4,
+		NextPeriodStart:     mustParseDashboardDay(t, "2026-03-10"),
+		OvulationDate:       mustParseDashboardDay(t, "2026-02-24"),
+		OvulationExact:      true,
+	}
+	today := mustParseDashboardDay(t, "2026-03-16")
+
+	context := BuildDashboardCycleContext(user, stats, today, time.UTC)
+	if context.CycleDayWarning {
+		t.Fatalf("expected cycle day 35 against a 28-day reference to stay inside the threshold")
+	}
+	if context.NextPeriodEstimatePaused {
+		t.Fatalf("did not expect the estimate to pause at exactly reference + 7")
+	}
+	if !context.DisplayNextPeriodUseRange {
+		t.Fatalf("expected the uncertainty range to survive at exactly reference + 7")
+	}
+	if got := context.DisplayNextPeriodRangeStart.Format("2006-01-02"); got != "2026-04-05" {
+		t.Fatalf("expected range start 2026-04-05, got %s", got)
+	}
+	if got := context.DisplayNextPeriodRangeEnd.Format("2006-01-02"); got != "2026-04-09" {
+		t.Fatalf("expected range end 2026-04-09, got %s", got)
+	}
+	if got := context.DisplayNextPeriodStart.Format("2006-01-02"); got != "2026-04-07" {
+		t.Fatalf("expected next period start 2026-04-07, got %s", got)
+	}
+	if context.DisplayOvulationDate.IsZero() {
+		t.Fatalf("expected the ovulation estimate to survive at exactly reference + 7")
 	}
 }
 

--- a/internal/services/dashboard_reminder_banner.go
+++ b/internal/services/dashboard_reminder_banner.go
@@ -107,6 +107,11 @@ type DashboardReminderBanner struct {
 //
 // The banner is suppressed (Show=false) whenever:
 //   - predictions are disabled or paused (PredictionDisabled),
+//   - the next-period estimate is withheld because the cycle is overdue
+//     (NextPeriodEstimatePaused). The cleared Display* fields already suppress
+//     the banner through the zero-date branch below; the explicit check keeps the
+//     rule readable at the surface that would otherwise announce "period in ~N
+//     days" for a window the dashboard itself refuses to show,
 //   - the cycle context has no single-date estimate to summarize (needs more
 //     data, ovulation is impossible, or the corresponding date is zero),
 //   - the context is showing an uncertainty *range* instead of a single date
@@ -121,7 +126,7 @@ type DashboardReminderBanner struct {
 // When both the next period and ovulation fall inside the window on the same
 // request, the period reminder is returned (see DashboardReminderBannerKindPeriod).
 func BuildDashboardReminderBanner(cycleContext DashboardCycleContext, today time.Time, leadDays int) DashboardReminderBanner {
-	if cycleContext.PredictionDisabled {
+	if cycleContext.PredictionDisabled || cycleContext.NextPeriodEstimatePaused {
 		return DashboardReminderBanner{}
 	}
 	windowDays := dashboardReminderBannerWindowDays(leadDays)

--- a/internal/services/dashboard_view_service.go
+++ b/internal/services/dashboard_view_service.go
@@ -236,13 +236,19 @@ type dashboardTimingFrame struct {
 // resolveDashboardTimingFrame decides that frame from the resolved usage goal.
 // The ovulation estimate follows the next-period item's gating exactly: a
 // suppressed prediction (unpredictable cycle, pregnancy pause) stays suppressed
-// here too, and BBT keeps existing only where the tracking settings grant it.
+// here too, and so does a cycle overdue enough that the next-period window is
+// withheld (NextPeriodEstimatePaused) — the ovulation estimate is derived from
+// the same projection, so an account trying to conceive would otherwise be the
+// one cohort still reading a placeholder where the window used to be. BBT keeps
+// existing only where the tracking settings grant it, and its placement is a
+// property of the goal alone: a late cycle is when a morning reading matters
+// most, so nothing about the cycle demotes the field.
 func resolveDashboardTimingFrame(user *models.User, cycleContext DashboardCycleContext, visibility dashboardOwnerVisibility) dashboardTimingFrame {
 	if !IsOwnerUser(user) || NormalizeUsageGoal(user.UsageGoal) != models.UsageGoalTrying {
 		return dashboardTimingFrame{}
 	}
 	return dashboardTimingFrame{
-		ShowOvulationEstimate: !cycleContext.PredictionDisabled,
+		ShowOvulationEstimate: !cycleContext.PredictionDisabled && !cycleContext.NextPeriodEstimatePaused,
 		BBTInVisibleTier:      visibility.ShowBBTField,
 	}
 }

--- a/internal/services/dashboard_view_service_test.go
+++ b/internal/services/dashboard_view_service_test.go
@@ -374,6 +374,46 @@ func TestFirstMissingTrackedDayFindsTrackedGap(t *testing.T) {
 	}
 }
 
+// TestResolveDashboardTimingFrameGatesTheOvulationEstimateOnEverySuppression
+// pins which cycle states the goal-aware ovulation item survives. The frame
+// answers a question about the goal, but the estimate it adds is a prediction:
+// it must disappear wherever the next-period window does — an unpredictable
+// cycle, a pregnancy pause, and a cycle overdue past reference + 7, where the
+// projection has nothing left to say. The temperature's placement answers the
+// goal question alone and is unmoved by any of them.
+func TestResolveDashboardTimingFrameGatesTheOvulationEstimateOnEverySuppression(t *testing.T) {
+	user := &models.User{Role: models.RoleOwner, UsageGoal: models.UsageGoalTrying}
+	visibility := dashboardOwnerVisibility{ShowBBTField: true}
+
+	for name, testCase := range map[string]struct {
+		cycleContext DashboardCycleContext
+		wantEstimate bool
+	}{
+		"stable cycle": {
+			cycleContext: DashboardCycleContext{},
+			wantEstimate: true,
+		},
+		"predictions suppressed": {
+			cycleContext: DashboardCycleContext{PredictionDisabled: true},
+			wantEstimate: false,
+		},
+		"cycle overdue": {
+			cycleContext: DashboardCycleContext{NextPeriodEstimatePaused: true},
+			wantEstimate: false,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			frame := resolveDashboardTimingFrame(user, testCase.cycleContext, visibility)
+			if frame.ShowOvulationEstimate != testCase.wantEstimate {
+				t.Fatalf("expected ovulation estimate=%v, got %v", testCase.wantEstimate, frame.ShowOvulationEstimate)
+			}
+			if !frame.BBTInVisibleTier {
+				t.Fatalf("expected the temperature field to stay in the visible tier for this goal")
+			}
+		})
+	}
+}
+
 func mustParseDashboardServiceDay(t *testing.T, raw string) time.Time {
 	t.Helper()
 	parsed, err := time.ParseInLocation("2006-01-02", raw, time.UTC)

--- a/internal/templates/dashboard.html
+++ b/internal/templates/dashboard.html
@@ -58,6 +58,9 @@
             </span>
             {{end}}
             <span class="dashboard-status-separator" aria-hidden="true">·</span>
+            {{if .NextPeriodEstimatePaused}}
+            <span class="dashboard-status-item journal-muted" data-dashboard-next-period-paused data-next-period-paused-key="dashboard.next_period_estimate_paused">{{t .Messages "dashboard.next_period_estimate_paused"}}</span>
+            {{else}}
             <span class="dashboard-status-item">{{t .Messages "dashboard.next_period"}}:
               <span data-dashboard-next-period>
                 {{if .DisplayNextPeriodUseRange}}
@@ -73,10 +76,12 @@
                 {{end}}
               </span>
             </span>
+            {{end}}
             {{/* The goal decides how timing is framed: an account tracking to
                  conceive is here for the fertile window, so the same status line
                  also names the ovulation estimate. It rides the next-period
-                 item's gating — a suppressed prediction never reaches this
+                 item's gating — a suppressed prediction, and a cycle overdue
+                 enough that the window above is withheld, never reach this
                  branch — and stays an estimate in its own wording. */}}
             {{if .ShowOvulationEstimate}}
             <span class="dashboard-status-separator" aria-hidden="true">·</span>


### PR DESCRIPTION
Wave 2 design pass, review finding: overdue cycles kept a confident window.

## The defect

`DashboardUpcomingPredictions` advances the projection a whole cycle at a time
(`ProjectCycleStart`: `elapsed % length < length`), so it always returns a
strictly future start date, no matter how late the running cycle is. On cycle day
45 against a 28-day reference the status header named the anchor plus 56 days
with the same confidence it names tomorrow, and the reminder banner counted down
to that fabricated date. `DashboardCycleDayLooksLong` — the reference+7 rule —
existed already, but fed only the late-cycle notice and gated nothing about
display. `NextPeriodInPast` cannot cover this cohort either: it needs
`DisplayNextPeriodUseRange`, which is false on the SD==0 path.

Presenting that window is the estimate-presented-as-fact the medical-safety
invariant forbids.

## The change

- `services.DashboardCycleOverdue(user, stats)` states the rule once, resolved
  from `DashboardCycleDayLooksLong` against `DashboardCycleReferenceLength` — no
  surface re-derives +7. It is the third medical-safety suppression signal beside
  `DashboardPredictionDisabled(user)` and `stats.PregnancyPaused`.
- `buildDashboardPredictionDisplay` withholds the whole projected window when it
  fires: next-period start/end, both range bounds, and the ovulation estimate
  derived from the same projection. `ovulationNeedsData` / `ovulationImpossible`
  survive — they describe the account's data, not this projection — and the
  prompt / needs-data branches return before the gate, so their semantics are
  unchanged.
- The reminder banner is suppressed on the same signal
  (`NextPeriodEstimatePaused`), so an overdue account no longer gets "period in
  ~N days" for a window the dashboard itself refuses to show.
- The status header renders one calm line in place of the next-period slot —
  `dashboard.next_period_estimate_paused`, new in all six catalogues (plain key,
  no plural forms). The cycle day, the late-cycle notice, its actions and the
  medical disclaimer are untouched; no new panel.
- Rebased onto the goal-aware timing frame (#444), which lands on the same status
  line. `resolveDashboardTimingFrame` now withholds the ovulation item on this
  signal too, so an account trying to conceive is not left as the one cohort
  reading a placeholder where the window used to be. The temperature field's
  placement answers the goal question alone — a late cycle is when a morning
  reading matters most — so nothing about the cycle moves it out of the visible
  tier.

## Scope boundary

The same phantom projection reaches three egress/rendering surfaces that gate on
`DashboardPredictionDisabled(user) || stats.PregnancyPaused` today —
`calendar_days.go:84`, `webhook_reminder.go:150`, `calendar_feed_ics.go:122`.
A follow-up change owns them; they are deliberately untouched here, and
`DashboardCycleOverdue` is exported and takes `(user, stats)` so they can consume
it unchanged, as a third disjunct.

## Tests

- `TestBuildDashboardCycleContext` **was green about the defect**: it seeded cycle
  day 36 against a 28-day reference — already past reference+7 — and asserted the
  rolled-forward `2026-04-07 — 2026-04-11` window as the expected output. It now
  seeds a cycle inside the threshold and keeps its original assertions there.
- `TestBuildDashboardCycleContextWithholdsTheWindowOnceTheCycleIsOverdue`
  (reference+8, five completed cycles with SD 2.4, so a ±2-day range would
  otherwise render): every `DisplayNextPeriod*` / `DisplayOvulation*` field
  cleared, banner suppressed, late-cycle notice still visible.
- `TestBuildDashboardCycleContextKeepsTheWindowAtExactlyTheLateThreshold`
  (reference+7 exactly, same account one day earlier): window and range unchanged.
- `TestDashboardStatusHeaderDropsTheNextPeriodSlotForAnOverdueCycle` — rendered
  HTML: `data-dashboard-next-period` absent, `data-dashboard-next-period-paused`
  and `data-dashboard-cycle-day-warning` present, no reminder banner.
- `e2e/dashboard-late-cycle-notice.spec.ts` beyond-range test also asserts the
  next-period slot is absent and the paused line carries the catalogue copy.
- `TestResolveDashboardTimingFrameGatesTheOvulationEstimateOnEverySuppression`
  and `TestDashboardTimingFrameDropsTheOvulationEstimateForAnOverdueCycle` cover
  the meeting point with #444: trying + overdue renders no ovulation item and no
  next-period item, and the temperature field stays in the visible tier.

Proof on defect: with the display gate removed, the service test fails on
"expected an overdue cycle to pause the next-period estimate" and the API test on
"did not expect a next-period estimate for a cycle past the late threshold"; with
the timing-frame gate removed, the trying + overdue test fails on "did not expect
an ovulation estimate for a cycle past the late threshold". The reference+7
boundary test stays green throughout.

## Verification

`go build ./...`, `go test ./...`, `golangci-lint run ./...` (0 issues),
`npm run lint`, `npm run test:unit` (62 pass), the `dashboard` and
`dashboard-late-cycle-notice` Playwright specs through `npm run e2e` (24 passed
after the rebase), `go run ./scripts/patchcov` after committing (OK). `web/src`
untouched, so no asset rebuild.

Rollback: revert the commit. No data, schema or contract change is involved.
