### PR TITLE
fix(egress): an overdue cycle stops inventing dates outside the dashboard

### DIFF
--- a/changelog.d/fix-overdue-egress.md
+++ b/changelog.d/fix-overdue-egress.md
@@ -1,0 +1,14 @@
+### Fixed
+
+- **Reminders and calendar events stopped inventing dates for a cycle that had not started.** Once a
+  cycle runs past the account's reference length by more than a week, the projection can only roll a
+  whole cycle forward at a time — and three surfaces kept following it. The webhook reminder
+  announced a "period soon" for a date nothing in the account supported, and because its
+  already-sent marker is the predicted date itself, every roll re-armed a new one, repeating about
+  once per cycle for as long as the cycle stayed open. The `.ics` feed pushed up to three cycles of
+  invented period and ovulation events into subscribed calendar clients, where they outlive any
+  correction made in the app. The calendar grid shaded a predicted period in the past — on days that
+  came and went with no period logged — and phantom fertile windows ahead of it. All three now stay
+  quiet for an overdue cycle, exactly as the dashboard already does; logged days, their markers and
+  the calendar subscription itself are untouched. When the new cycle start is finally logged, the
+  next reminder fires once, on time.

--- a/changelog.d/fix-overdue-prediction-window.md
+++ b/changelog.d/fix-overdue-prediction-window.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- **An overdue cycle no longer gets a confident next-period window.** The projection rolls forward a
+  whole cycle at a time, so it always produced a future date: on cycle day 45 with a 28-day
+  reference the dashboard named the anchor plus 56 days as firmly as it names tomorrow, and the
+  reminder banner counted down to it. Once a cycle runs past the reference length by more than a
+  week — the same threshold that raises the late-cycle notice — no next-period window, ovulation
+  estimate or reminder banner is shown at all; one line says the estimate returns with the next
+  cycle start. The cycle day, the late-cycle notice and its actions stay exactly as they were.

--- a/e2e/dashboard-late-cycle-notice.spec.ts
+++ b/e2e/dashboard-late-cycle-notice.spec.ts
@@ -26,11 +26,16 @@ import {
  * The notice is addressed exclusively through the hooks the policy owns —
  * `[data-dashboard-cycle-warnings]`, `[data-dashboard-cycle-day-warning]`,
  * `data-late-cycle-key`, `data-late-cycle-tone` — and never through the status
- * header above it, so a redesign of the header (#429) cannot move this spec.
+ * header above it, so a redesign of the header (#429) cannot move this spec. The
+ * one deliberate exception is the beyond-range test, which also reads the
+ * header's next-period slot: the same threshold that raises this notice withholds
+ * the projected window, and "the notice appeared" is worth little if a confident
+ * date is still sitting one line above it.
  */
 const BEYOND_RANGE_KEY = 'dashboard.late_cycle.beyond_range';
 const WITHIN_RANGE_KEY = 'dashboard.late_cycle.within_range';
 const NO_PERSONAL_RANGE_KEY = 'dashboard.late_cycle.no_personal_range';
+const ESTIMATE_PAUSED_KEY = 'dashboard.next_period_estimate_paused';
 
 /** Whole calendar days from `fromISO` to `toISO`, DST-proof (UTC arithmetic). */
 function isoDaysBetween(fromISO: string, toISO: string): number {
@@ -105,6 +110,14 @@ test.describe('Dashboard late-cycle notice', () => {
         excessDays,
       ])
     );
+
+    // The other half of the same threshold: no next-period window is rendered at
+    // all. The projection would happily roll forward to the anchor plus another
+    // whole cycle, so the assertion is the slot's absence, not its contents.
+    await expect(page.locator('[data-dashboard-next-period]')).toHaveCount(0);
+    const pausedEstimate = page.locator('[data-dashboard-next-period-paused]');
+    await expect(pausedEstimate).toBeVisible();
+    await expect(pausedEstimate).toHaveText(localeText('en', ESTIMATE_PAUSED_KEY));
   });
 
   test('a long cycle still inside the recorded range names both bounds', async ({ page }) => {

--- a/internal/api/calendar_feed_regressions_test.go
+++ b/internal/api/calendar_feed_regressions_test.go
@@ -43,15 +43,20 @@ func armCalendarFeedForUserWithColumns(t *testing.T, database *gorm.DB, userID u
 	if err := repo.SaveCalendarFeedToken(t.Context(), userID, adjust(columns)); err != nil {
 		t.Fatalf("SaveCalendarFeedToken: %v", err)
 	}
-	for _, day := range []string{"2026-01-05", "2026-02-02", "2026-03-02"} {
-		parsed, _ := time.ParseInLocation("2006-01-02", day, time.UTC)
-		if err := database.Create(&models.DailyLog{UserID: userID, Date: parsed, IsPeriod: true}).Error; err != nil {
-			t.Fatalf("seed period log %s: %v", day, err)
+	// Three cycle starts one 28-day cycle apart, anchored to the CURRENT day: the
+	// feed emits no prediction events once a cycle has run past the account's
+	// reference length by more than a week (services.DashboardCycleOverdue), so a
+	// cadence pinned to fixed calendar dates stops producing events as soon as the
+	// clock moves past them. Relative seeding keeps the running cycle on day 3.
+	today := time.Now().UTC().Truncate(24 * time.Hour)
+	starts := []time.Time{today.AddDate(0, 0, -58), today.AddDate(0, 0, -30), today.AddDate(0, 0, -2)}
+	for _, start := range starts {
+		if err := database.Create(&models.DailyLog{UserID: userID, Date: start, IsPeriod: true}).Error; err != nil {
+			t.Fatalf("seed period log %s: %v", start.Format("2006-01-02"), err)
 		}
 	}
 	// Anchor the current cycle to the most recent seeded start.
-	start, _ := time.ParseInLocation("2006-01-02", "2026-03-02", time.UTC)
-	if err := database.Model(&models.User{}).Where("id = ?", userID).Update("last_period_start", start).Error; err != nil {
+	if err := database.Model(&models.User{}).Where("id = ?", userID).Update("last_period_start", starts[len(starts)-1]).Error; err != nil {
 		t.Fatalf("set last_period_start: %v", err)
 	}
 	return token

--- a/internal/api/calendar_ovulation_tag_regression_test.go
+++ b/internal/api/calendar_ovulation_tag_regression_test.go
@@ -12,10 +12,19 @@ import (
 	"github.com/ovumcy/ovumcy-web/internal/models"
 )
 
+// TestCalendarRendersOvulationTagWithoutFertileOverride pins the ovulation
+// marker's rendering: a dot on the ovulation day, never the textual badge, in the
+// running cycle and in the next projected one.
+//
+// The cycle is seeded relative to the CURRENT day (cycle day 5). A fixture pinned
+// to fixed calendar dates would paint nothing at all once the clock moved a week
+// past the account's reference length — the calendar withholds every projected
+// marker for an overdue cycle (services.DashboardCycleOverdue) — so the marker
+// contract has to be measured on an account whose cycle is actually running.
 func TestCalendarRendersOvulationTagWithoutFertileOverride(t *testing.T) {
 	app, database := newOnboardingTestApp(t)
 	user := createOnboardingTestUser(t, database, "calendar-ovulation-tag@example.com", "StrongPass1", true)
-	periodStart := time.Date(2026, time.February, 10, 0, 0, 0, 0, time.UTC)
+	periodStart := time.Now().UTC().Truncate(24 * time.Hour).AddDate(0, 0, -4)
 
 	if err := database.Model(&models.User{}).Where("id = ?", user.ID).Updates(map[string]any{
 		"cycle_length":      28,
@@ -38,19 +47,24 @@ func TestCalendarRendersOvulationTagWithoutFertileOverride(t *testing.T) {
 
 	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
 
-	febRendered := renderCalendarMonthHTML(t, app, authCookie, "2026-02")
-	febDayMarkup := extractCalendarDayMarkup(t, febRendered, "2026-02-23")
-	if !regexp.MustCompile(`calendar-ovulation-dot`).MatchString(febDayMarkup) {
-		t.Fatalf("expected ovulation dot on 2026-02-23 in February calendar")
+	// Ovulation of the running cycle: cycle start + (28 - 14) - 1. The next
+	// projected cycle repeats it one cycle length later.
+	currentOvulation := periodStart.AddDate(0, 0, 13)
+	projectedOvulation := currentOvulation.AddDate(0, 0, 28)
+
+	currentRendered := renderCalendarMonthHTML(t, app, authCookie, currentOvulation.Format("2006-01"))
+	currentDayMarkup := extractCalendarDayMarkup(t, currentRendered, currentOvulation.Format("2006-01-02"))
+	if !regexp.MustCompile(`calendar-ovulation-dot`).MatchString(currentDayMarkup) {
+		t.Fatalf("expected ovulation dot on %s", currentOvulation.Format("2006-01-02"))
 	}
-	if regexp.MustCompile(`calendar-tag-label-full">Ovulation</span>`).MatchString(febDayMarkup) {
-		t.Fatalf("did not expect textual ovulation badge on 2026-02-23")
+	if regexp.MustCompile(`calendar-tag-label-full">Ovulation</span>`).MatchString(currentDayMarkup) {
+		t.Fatalf("did not expect textual ovulation badge on %s", currentOvulation.Format("2006-01-02"))
 	}
 
-	marRendered := renderCalendarMonthHTML(t, app, authCookie, "2026-03")
-	marDayMarkup := extractCalendarDayMarkup(t, marRendered, "2026-03-23")
-	if !regexp.MustCompile(`calendar-ovulation-dot`).MatchString(marDayMarkup) {
-		t.Fatalf("expected projected ovulation dot on 2026-03-23 in March calendar")
+	projectedRendered := renderCalendarMonthHTML(t, app, authCookie, projectedOvulation.Format("2006-01"))
+	projectedDayMarkup := extractCalendarDayMarkup(t, projectedRendered, projectedOvulation.Format("2006-01-02"))
+	if !regexp.MustCompile(`calendar-ovulation-dot`).MatchString(projectedDayMarkup) {
+		t.Fatalf("expected projected ovulation dot on %s", projectedOvulation.Format("2006-01-02"))
 	}
 }
 

--- a/internal/api/dashboard_journal_regressions_test.go
+++ b/internal/api/dashboard_journal_regressions_test.go
@@ -636,6 +636,53 @@ func TestDashboardTimingFrameKeepsSuppressedPredictionsSuppressed(t *testing.T) 
 	}
 }
 
+// TestDashboardTimingFrameDropsTheOvulationEstimateForAnOverdueCycle is the same
+// safety half against the other suppression signal. Once a cycle runs past its
+// reference length by more than a week the dashboard withholds the projected
+// window; the ovulation estimate is derived from that same projection, so an
+// account trying to conceive must not be the one cohort still reading a slot
+// where the window used to be. The field placement is a property of the goal
+// alone — a late cycle is when a morning reading matters most — so the
+// temperature stays in the visible tier.
+func TestDashboardTimingFrameDropsTheOvulationEstimateForAnOverdueCycle(t *testing.T) {
+	app, database := newOnboardingTestApp(t)
+	user := createOnboardingTestUser(t, database, "dashboard-timing-overdue@example.com", "StrongPass1", true)
+	enableDashboardMeasurementTracking(t, database, user.ID)
+	seedDashboardStableCycleForGoal(t, database, user.ID, models.UsageGoalTrying)
+	// Cycle day 37 against the 28-day reference: past 28 + 7.
+	today := services.DateAtLocation(time.Now().UTC(), time.UTC)
+	if err := database.Model(&models.User{}).Where("id = ?", user.ID).
+		Update("last_period_start", today.AddDate(0, 0, -36)).Error; err != nil {
+		t.Fatalf("seed overdue cycle context: %v", err)
+	}
+
+	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
+	document := mustParseHTMLDocument(t, mustRenderDashboard(t, app, authCookie, "en"))
+
+	statusLine := dashboardElementByDataAttr(document, "data-dashboard-status-line")
+	if statusLine == nil {
+		t.Fatal("expected the dashboard status line")
+	}
+	if htmlFindElement(statusLine, htmlNodeHasAttr("data-dashboard-ovulation")) != nil {
+		t.Fatal("did not expect an ovulation estimate for a cycle past the late threshold")
+	}
+	if htmlFindElement(statusLine, htmlNodeHasAttr("data-dashboard-next-period")) != nil {
+		t.Fatal("did not expect a next-period estimate for a cycle past the late threshold")
+	}
+	if htmlFindElement(statusLine, htmlNodeHasAttr("data-dashboard-next-period-paused")) == nil {
+		t.Fatal("expected the withheld-estimate line in place of the two estimates")
+	}
+
+	form := dashboardSaveForm(t, document)
+	temperature := htmlFindElement(form, htmlNodeAttrEquals("id", "dashboard-bbt"))
+	if temperature == nil {
+		t.Fatal("expected the temperature field in the journal")
+	}
+	if htmlNodeContains(dashboardMoreDisclosure(t, form), temperature) {
+		t.Fatal("expected the temperature field to stay in the visible tier for this goal")
+	}
+}
+
 // seedDashboardStableCycleForGoal gives the account a cycle context predictions
 // can be made from, under the usage goal the case is about.
 func seedDashboardStableCycleForGoal(t *testing.T, database *gorm.DB, userID uint, goal string) {

--- a/internal/api/dashboard_status_header_regression_test.go
+++ b/internal/api/dashboard_status_header_regression_test.go
@@ -61,6 +61,60 @@ func TestDashboardStatusHeaderCarriesTheSegmentedRingForStableCycleContext(t *te
 	}
 }
 
+// TestDashboardStatusHeaderDropsTheNextPeriodSlotForAnOverdueCycle pins the
+// structural half of the withheld window: once the running cycle is past the
+// reference length by more than a week, the status line carries no next-period
+// estimate at all — not a softened one — while the late-cycle notice below it,
+// which is what the state actually justifies saying, still renders.
+func TestDashboardStatusHeaderDropsTheNextPeriodSlotForAnOverdueCycle(t *testing.T) {
+	app, database, _ := newOnboardingTestAppWithLocation(t, time.UTC)
+	user := createOnboardingTestUser(t, database, "dashboard-overdue-window@example.com", "StrongPass1", true)
+	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
+
+	today := services.DateAtLocation(time.Now().UTC(), time.UTC)
+	// Cycle day 37 against the 28-day reference: past 28 + 7.
+	if err := database.Model(&models.User{}).Where("id = ?", user.ID).Updates(map[string]any{
+		"cycle_length":      28,
+		"period_length":     5,
+		"last_period_start": today.AddDate(0, 0, -36),
+	}).Error; err != nil {
+		t.Fatalf("update overdue cycle context: %v", err)
+	}
+
+	request := httptest.NewRequest(http.MethodGet, "/dashboard", nil)
+	request.Header.Set("Accept-Language", "en")
+	request.Header.Set("Cookie", authCookie)
+
+	response := mustAppResponse(t, app, request)
+	assertStatusCode(t, response, http.StatusOK)
+	document := mustParseHTMLDocument(t, mustReadBodyString(t, response.Body))
+	header := dashboardElementByDataAttr(document, "data-dashboard-status-header")
+	if header == nil {
+		t.Fatal("expected the dashboard status header for an overdue cycle")
+	}
+	if htmlFindElement(header, func(node *html.Node) bool {
+		return node.Type == html.ElementNode && htmlHasAttr(node, "data-dashboard-next-period")
+	}) != nil {
+		t.Fatal("did not expect a next-period estimate for a cycle past the late threshold")
+	}
+	if dashboardElementByDataAttr(header, "data-dashboard-next-period-paused") == nil {
+		t.Fatal("expected the withheld-estimate line in place of the next-period slot")
+	}
+	if dashboardElementByDataAttr(header, "data-dashboard-reminder-banner") != nil {
+		t.Fatal("did not expect a reminder banner summarizing a withheld estimate")
+	}
+	warnings := dashboardElementByDataAttr(header, "data-dashboard-cycle-warnings")
+	if warnings == nil {
+		t.Fatal("expected the cycle warnings block for an overdue cycle")
+	}
+	if dashboardElementByDataAttr(warnings, "data-dashboard-cycle-day-warning") == nil {
+		t.Fatal("expected the late-cycle notice to keep carrying the state")
+	}
+	if dashboardElementByDataAttr(header, "data-dashboard-cycle-day") == nil {
+		t.Fatal("expected the cycle day to stay visible for an overdue cycle")
+	}
+}
+
 // TestDashboardStatusHeaderDropsRingSegmentsWhenPredictionsAreDisabled is the
 // other half: the header still renders in unpredictable mode, but nothing draws
 // phase segments the account's data cannot support.

--- a/internal/api/page_view_data_helpers.go
+++ b/internal/api/page_view_data_helpers.go
@@ -41,6 +41,7 @@ func (handler *Handler) buildDashboardViewData(ctx context.Context, user *models
 		"DisplayOvulationNeedsData":             viewData.CycleContext.DisplayOvulationNeedsData,
 		"DisplayOvulationExact":                 viewData.CycleContext.DisplayOvulationExact,
 		"DisplayOvulationImpossible":            viewData.CycleContext.DisplayOvulationImpossible,
+		"NextPeriodEstimatePaused":              viewData.CycleContext.NextPeriodEstimatePaused,
 		"NextPeriodInPast":                      viewData.CycleContext.NextPeriodInPast,
 		"OvulationInPast":                       viewData.CycleContext.OvulationInPast,
 		"ShowReminderBanner":                    viewData.ReminderBanner.Show,

--- a/internal/i18n/locales/de.json
+++ b/internal/i18n/locales/de.json
@@ -390,6 +390,7 @@
   "dashboard.next_period_need_cycles": "Für einen verlässlichen Bereich werden 3 Zyklen benötigt",
   "dashboard.next_period_prompt": "Geben Sie das Startdatum Ihres letzten Zyklus ein",
   "dashboard.next_period_unknown": "unbekannt",
+  "dashboard.next_period_estimate_paused": "Die Schätzung für die nächste Periode kehrt mit dem Beginn Ihres nächsten Zyklus zurück.",
   "prediction.explainer.unpredictable_compact": "Vorhersagen aus",
   "prediction.explainer.unpredictable": "Im Modus für unvorhersehbare Zyklen sind Vorhersagen deaktiviert. Ovumcy zeigt nur aufgezeichnete Fakten an.",
   "prediction.explainer.irregular_ranges": "Im Modus für unregelmäßige Zyklen werden Bereiche statt exakter Vorhersagedaten verwendet.",

--- a/internal/i18n/locales/en.json
+++ b/internal/i18n/locales/en.json
@@ -390,6 +390,7 @@
   "dashboard.next_period_need_cycles": "3 cycles are needed for a reliable range",
   "dashboard.next_period_prompt": "Enter the start date of your last cycle",
   "dashboard.next_period_unknown": "unknown",
+  "dashboard.next_period_estimate_paused": "The next-period estimate returns with your next cycle start.",
   "prediction.explainer.unpredictable_compact": "Predictions off",
   "prediction.explainer.unpredictable": "Predictions are off in unpredictable cycle mode. Ovumcy shows recorded facts only.",
   "prediction.explainer.irregular_ranges": "Irregular cycle mode uses ranges instead of exact prediction dates.",

--- a/internal/i18n/locales/es.json
+++ b/internal/i18n/locales/es.json
@@ -390,6 +390,7 @@
   "dashboard.next_period_need_cycles": "se necesitan 3 ciclos para un rango fiable",
   "dashboard.next_period_prompt": "Indica la fecha de inicio de tu último ciclo",
   "dashboard.next_period_unknown": "desconocido",
+  "dashboard.next_period_estimate_paused": "La estimación del próximo periodo volverá cuando empiece tu próximo ciclo.",
   "prediction.explainer.unpredictable_compact": "Predicciones desactivadas",
   "prediction.explainer.unpredictable": "Las predicciones están desactivadas en el modo de ciclo impredecible. Ovumcy muestra solo hechos registrados.",
   "prediction.explainer.irregular_ranges": "El modo de ciclo irregular usa rangos en lugar de fechas exactas de predicción.",

--- a/internal/i18n/locales/fr.json
+++ b/internal/i18n/locales/fr.json
@@ -504,6 +504,7 @@
   "dashboard.next_period_need_cycles": "3 cycles sont nécessaires pour obtenir une plage fiable",
   "dashboard.next_period_prompt": "Saisissez la date de début de votre dernier cycle",
   "dashboard.next_period_unknown": "inconnu",
+  "dashboard.next_period_estimate_paused": "L'estimation des prochaines règles reviendra au début de votre prochain cycle.",
 
   "prediction.explainer.unpredictable_compact": "Prédictions désactivées",
   "prediction.explainer.unpredictable": "Les prédictions sont désactivées en mode cycle imprévisible. Ovumcy affiche uniquement les faits enregistrés.",

--- a/internal/i18n/locales/it.json
+++ b/internal/i18n/locales/it.json
@@ -390,6 +390,7 @@
   "dashboard.next_period_need_cycles": "Sono necessari 3 cicli per un intervallo affidabile",
   "dashboard.next_period_prompt": "Inserisci la data di inizio del tuo ultimo ciclo",
   "dashboard.next_period_unknown": "sconosciuto",
+  "dashboard.next_period_estimate_paused": "La stima del prossimo ciclo mestruale tornerà con l'inizio del prossimo ciclo.",
   "prediction.explainer.unpredictable_compact": "Previsioni disattivate",
   "prediction.explainer.unpredictable": "Le previsioni sono disattivate in modalità ciclo imprevedibile. Ovumcy mostra solo i fatti registrati.",
   "prediction.explainer.irregular_ranges": "La modalità ciclo irregolare usa intervalli invece di date esatte di previsione.",

--- a/internal/i18n/locales/ru.json
+++ b/internal/i18n/locales/ru.json
@@ -392,6 +392,7 @@
   "dashboard.next_period_need_cycles": "нужно 3 цикла для надёжного диапазона",
   "dashboard.next_period_prompt": "Укажите дату начала последнего цикла",
   "dashboard.next_period_unknown": "неизвестно",
+  "dashboard.next_period_estimate_paused": "Оценка следующих месячных вернётся с началом следующего цикла.",
   "prediction.explainer.unpredictable_compact": "Прогнозы выключены",
   "prediction.explainer.unpredictable": "В режиме непредсказуемого цикла прогнозы отключены. Ovumcy показывает только записанные факты.",
   "prediction.explainer.irregular_ranges": "В режиме нерегулярного цикла Ovumcy показывает диапазоны вместо точных дат прогноза.",

--- a/internal/services/calendar_days.go
+++ b/internal/services/calendar_days.go
@@ -81,7 +81,16 @@ func buildCalendarPredictionMaps(user *models.User, logs []models.DailyLog, stat
 	ovulationMap := make(map[string]bool)
 	tentativeOvulationMap := make(map[string]bool)
 
-	if DashboardPredictionDisabled(user) || stats.PregnancyPaused {
+	// Medical-safety suppression gate, the same three signals every projected
+	// surface gates on: unpredictable-cycle mode, a pregnancy pause, or a cycle
+	// running past the account's reference length by more than a week
+	// (DashboardCycleOverdue). Past that point stats.NextPeriodStart is a date the
+	// account's own data no longer supports: appendPredictedCycles chains from it,
+	// so the grid painted a predicted period in the PAST — one that never happened
+	// — and then a phantom window every cycle length after it. Every prediction map
+	// stays empty here; the recorded facts (logged period days, has-data, sex
+	// activity) are read elsewhere and are untouched.
+	if DashboardPredictionDisabled(user) || stats.PregnancyPaused || DashboardCycleOverdue(user, stats) {
 		return predictedPeriodMap, preFertileMap, fertilityEdgeMap, fertilityPeakMap, ovulationMap, tentativeOvulationMap
 	}
 

--- a/internal/services/calendar_days_test.go
+++ b/internal/services/calendar_days_test.go
@@ -186,6 +186,98 @@ func TestBuildCalendarDayStatesSuppressesPredictionsWhenPregnancyPaused(t *testi
 	}
 }
 
+// overdueCalendarLogs is a stable 28-day history ending 2026-02-26: four logged
+// cycle starts a cycle apart, so the observed average and median are both 28 and
+// stats.NextPeriodStart lands on 2026-03-26.
+func overdueCalendarLogs() []models.DailyLog {
+	logs := make([]models.DailyLog, 0, 4)
+	for _, day := range []time.Time{
+		time.Date(2025, time.December, 4, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, time.January, 29, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, time.February, 26, 0, 0, 0, 0, time.UTC),
+	} {
+		logs = append(logs, models.DailyLog{Date: day, IsPeriod: true, CycleStart: true})
+	}
+	return logs
+}
+
+// TestBuildCalendarDayStatesSuppressesPredictionsForOverdueCycle covers the third
+// medical-safety gate on the grid, and the shading it withheld is the strangest
+// of the three surfaces.
+//
+// appendPredictedCycles chains from stats.NextPeriodStart, which is NOT rolled
+// forward: with the last logged cycle start on 2026-02-26 it stays 2026-03-26
+// even once "today" is 2026-04-20. So an overdue account saw a predicted period
+// painted in the PAST — on days that came and went with no period logged — and
+// then a phantom window every cycle length after it, indefinitely. Both are
+// asserted here, in the month each falls in, against a same-account control on a
+// date inside the reference length.
+func TestBuildCalendarDayStatesSuppressesPredictionsForOverdueCycle(t *testing.T) {
+	user := &models.User{Role: models.RoleOwner, CycleLength: 28, PeriodLength: 5, LutealPhase: 14}
+	logs := overdueCalendarLogs()
+	march := time.Date(2026, time.March, 1, 0, 0, 0, 0, time.UTC)
+	april := time.Date(2026, time.April, 1, 0, 0, 0, 0, time.UTC)
+
+	statsAt := func(now time.Time) CycleStats {
+		return NewStatsService(nil, nil).BuildCycleStatsFromLogs(user, logs, now, time.UTC)
+	}
+
+	t.Run("a cycle inside its reference length still paints its prediction", func(t *testing.T) {
+		now := time.Date(2026, time.March, 23, 0, 0, 0, 0, time.UTC)
+		stats := statsAt(now)
+		if DashboardCycleOverdue(user, stats) {
+			t.Fatalf("control must not be overdue: cycle day %d against reference %d",
+				stats.CurrentCycleDay, DashboardCycleReferenceLength(user, stats))
+		}
+
+		days := BuildCalendarDayStates(user, march, logs, stats, now, time.UTC)
+		if !findCalendarDayStateByDateString(t, days, "2026-03-26").IsPredicted {
+			t.Fatalf("expected the predicted period on 2026-03-26 for a cycle inside its reference length")
+		}
+	})
+
+	t.Run("an overdue cycle paints no prediction, past or future", func(t *testing.T) {
+		now := time.Date(2026, time.April, 20, 0, 0, 0, 0, time.UTC)
+		stats := statsAt(now)
+		if !DashboardCycleOverdue(user, stats) {
+			t.Fatalf("test setup expects an overdue cycle: cycle day %d against reference %d",
+				stats.CurrentCycleDay, DashboardCycleReferenceLength(user, stats))
+		}
+		if got := CalendarDayKey(stats.NextPeriodStart); got != "2026-03-26" {
+			t.Fatalf("test setup expects the un-rolled next period start 2026-03-26, got %s", got)
+		}
+
+		// The past-painted period: 2026-03-26 is behind "today" and no period was
+		// ever logged there.
+		marchDays := BuildCalendarDayStates(user, march, logs, stats, now, time.UTC)
+		pastPainted := findCalendarDayStateByDateString(t, marchDays, "2026-03-26")
+		if pastPainted.IsPredicted {
+			t.Fatalf("an overdue cycle must not paint a predicted period in the past, got %#v", pastPainted)
+		}
+		if pastPainted.IsPreFertile || pastPainted.IsFertility || pastPainted.IsOvulation || pastPainted.IsTentativeOvulation {
+			t.Fatalf("an overdue cycle must not paint any prediction state on 2026-03-26, got %#v", pastPainted)
+		}
+
+		// The phantom future window, one projected cycle further on.
+		aprilDays := BuildCalendarDayStates(user, april, logs, stats, now, time.UTC)
+		for _, dateString := range []string{"2026-04-09", "2026-04-23"} {
+			day := findCalendarDayStateByDateString(t, aprilDays, dateString)
+			if day.IsPredicted || day.IsPreFertile || day.IsFertility || day.IsOvulation || day.IsTentativeOvulation {
+				t.Fatalf("an overdue cycle must not paint a projected window on %s, got %#v", dateString, day)
+			}
+		}
+
+		// Recorded facts are untouched: the logged cycle start still reads as a
+		// period day with data.
+		februaryDays := BuildCalendarDayStates(user, time.Date(2026, time.February, 1, 0, 0, 0, 0, time.UTC), logs, stats, now, time.UTC)
+		logged := findCalendarDayStateByDateString(t, februaryDays, "2026-02-26")
+		if !logged.IsPeriod || !logged.HasData {
+			t.Fatalf("suppression must leave recorded facts alone, got %#v", logged)
+		}
+	})
+}
+
 func TestBuildCalendarDayStatesOpensEditDirectlyForFutureEmptyDays(t *testing.T) {
 	monthStart := time.Date(2026, time.March, 1, 0, 0, 0, 0, time.UTC)
 	now := time.Date(2026, time.March, 12, 0, 0, 0, 0, time.UTC)

--- a/internal/services/calendar_feed_ics.go
+++ b/internal/services/calendar_feed_ics.go
@@ -19,10 +19,13 @@ import (
 // Medical-safety invariant (same as the webhook reminder decision): it reuses
 // the EXACT prediction path the dashboard uses (BuildCycleStatsFromLogs →
 // DashboardUpcomingPredictions, gated by DashboardPredictionDisabled /
-// stats.PregnancyPaused). It NEVER fabricates a date the app itself refuses to
-// show — when in-app predictions are suppressed (unpredictable cycle, or a
-// pregnancy pause), it emits ZERO prediction events, so a "fertile window" is
-// never pushed into a pregnant owner's calendar.
+// stats.PregnancyPaused / DashboardCycleOverdue). It NEVER fabricates a date the
+// app itself refuses to show — when in-app predictions are suppressed
+// (unpredictable cycle, a pregnancy pause, or a cycle running past its reference
+// length by more than a week), it emits ZERO prediction events, so neither a
+// "fertile window" is pushed into a pregnant owner's calendar nor three cycles
+// of invented period dates into a calendar client the app itself would not name
+// a single date to.
 //
 // Data-minimization invariant: every VEVENT SUMMARY is the SAME neutral,
 // contentless title (calendarFeedNeutralSummary) — no cycle phase, no date, no
@@ -91,8 +94,9 @@ type calendarFeedEvent struct {
 //   - Build cycle stats from the owner's logs via the SAME path the dashboard
 //     uses (StatsService.BuildCycleStatsFromLogs, which needs no repositories).
 //   - If in-app predictions are suppressed (DashboardPredictionDisabled — the
-//     owner's unpredictable-cycle mode — or stats.PregnancyPaused), emit ZERO
-//     events. This is the hard medical-safety suppression gate.
+//     owner's unpredictable-cycle mode — stats.PregnancyPaused, or
+//     DashboardCycleOverdue), emit ZERO events. This is the hard medical-safety
+//     suppression gate.
 //   - Otherwise project the next calendarFeedProjectionCycles cycles forward from
 //     the owner's last period start, reusing the dashboard's own cycle-start
 //     projection + window helpers, and emit a predicted-next-period event and an
@@ -118,8 +122,12 @@ func calendarFeedEvents(input CalendarFeedICSInput) []calendarFeedEvent {
 	stats := NewStatsService(nil, nil).BuildCycleStatsFromLogs(user, input.Logs, input.Now, input.Location)
 
 	// Medical-safety suppression gate: if the app suppresses predictions, emit
-	// nothing. Pregnancy-pause OR unpredictable-cycle mode both suppress.
-	if DashboardPredictionDisabled(user) || stats.PregnancyPaused {
+	// nothing. Unpredictable-cycle mode, a pregnancy pause, OR an overdue cycle
+	// (DashboardCycleOverdue — past the account's reference length by more than a
+	// week, where the projection can only roll a whole cycle forward) each
+	// suppress on their own. The feed carries prediction events only, so this is
+	// the empty-but-well-formed VCALENDAR path.
+	if DashboardPredictionDisabled(user) || stats.PregnancyPaused || DashboardCycleOverdue(user, stats) {
 		return nil
 	}
 

--- a/internal/services/calendar_feed_ics_test.go
+++ b/internal/services/calendar_feed_ics_test.go
@@ -191,6 +191,63 @@ func TestBuildCalendarFeedICSSuppressesForUnpredictableCycle(t *testing.T) {
 	}
 }
 
+// TestBuildCalendarFeedICSSuppressesForOverdueCycle covers the third
+// medical-safety gate on the feed: an account whose cycle has run past its own
+// reference length by more than a week emits no prediction events.
+//
+// This is the surface where the phantom travelled furthest — the builder projects
+// three cycles ahead, so an overdue account pushed up to six invented all-day
+// events into whatever third-party calendar client holds the subscription, where
+// they outlive any in-app correction. The 2026-03-02 anchor with a 28-day cadence
+// puts "today" = 2026-04-25 on cycle day 55 against a 28-day reference.
+//
+// The first subtest is the positive anchor: the same account, same logs, a date
+// inside the reference length still gets its events, so the suppressed case
+// cannot pass by emitting nothing for an unrelated reason.
+func TestBuildCalendarFeedICSSuppressesForOverdueCycle(t *testing.T) {
+	user := predictableFeedUser(t, "2026-03-02")
+	logs := predictableFeedLogs(t)
+
+	renderFeed := func(now time.Time) string {
+		return string(BuildCalendarFeedICS(CalendarFeedICSInput{
+			User:       user,
+			Logs:       logs,
+			Now:        now,
+			Location:   time.UTC,
+			Disclaimer: "disclaimer",
+		}))
+	}
+
+	t.Run("a cycle inside its reference length still emits events", func(t *testing.T) {
+		body := renderFeed(mustParseDashboardDay(t, "2026-03-20"))
+		if !strings.Contains(body, "BEGIN:VEVENT") {
+			t.Fatalf("expected prediction events inside the reference length, got:\n%s", body)
+		}
+	})
+
+	t.Run("an overdue cycle emits no prediction events", func(t *testing.T) {
+		now := mustParseDashboardDay(t, "2026-04-25")
+
+		stats := NewStatsService(nil, nil).BuildCycleStatsFromLogs(user, logs, now, time.UTC)
+		if !DashboardCycleOverdue(user, stats) {
+			t.Fatalf("test setup expects an overdue cycle: cycle day %d against reference %d",
+				stats.CurrentCycleDay, DashboardCycleReferenceLength(user, stats))
+		}
+
+		body := renderFeed(now)
+		if strings.Contains(body, "BEGIN:VEVENT") {
+			t.Fatalf("an overdue cycle must suppress ALL prediction events, got:\n%s", body)
+		}
+		// The subscription must not break: the feed is prediction-only, so
+		// suppression is the well-formed empty VCALENDAR a client keeps polling.
+		for _, marker := range []string{"BEGIN:VCALENDAR", "VERSION:2.0", "PRODID:" + calendarFeedProductID, "END:VCALENDAR"} {
+			if !strings.Contains(body, marker) {
+				t.Fatalf("expected a well-formed empty VCALENDAR carrying %q, got:\n%s", marker, body)
+			}
+		}
+	})
+}
+
 func TestBuildCalendarFeedICSHandlesNoBaseline(t *testing.T) {
 	// A user with no last period start and no logs yields a valid empty feed,
 	// never a panic or a fabricated event.

--- a/internal/services/dashboard_cycle.go
+++ b/internal/services/dashboard_cycle.go
@@ -7,6 +7,14 @@ import (
 	"github.com/ovumcy/ovumcy-web/internal/models"
 )
 
+// DashboardCycleContext is the dashboard's cycle state.
+//
+// NextPeriodEstimatePaused reports that the running cycle is long enough
+// (DashboardCycleDayLooksLong: past the reference length by more than a week)
+// that no next-period window is shown at all: every Display* field it would have
+// filled is cleared, and the surfaces derived from them — the status header slot,
+// the reminder banner — say so instead of naming a date. The cycle day and the
+// late-cycle notice carry the state on their own.
 type DashboardCycleContext struct {
 	CycleDayReference           int
 	CycleDayWarning             bool
@@ -28,6 +36,7 @@ type DashboardCycleContext struct {
 	DisplayOvulationNeedsData   bool
 	DisplayOvulationExact       bool
 	DisplayOvulationImpossible  bool
+	NextPeriodEstimatePaused    bool
 	NextPeriodInPast            bool
 	OvulationInPast             bool
 }
@@ -47,6 +56,7 @@ type dashboardPredictionDisplay struct {
 	ovulationNeedsData   bool
 	ovulationExact       bool
 	ovulationImpossible  bool
+	estimatePaused       bool
 }
 
 func DashboardPredictionDisabled(user *models.User) bool {
@@ -93,6 +103,24 @@ func DashboardProjectionCycleLength(user *models.User, stats CycleStats) int {
 		return user.CycleLength
 	}
 	return models.DefaultCycleLength
+}
+
+// DashboardCycleOverdue reports that the running cycle has passed the account's
+// own reference length by more than a week. It is the reference+7 rule of
+// DashboardCycleDayLooksLong — the one the late-cycle notice already states —
+// resolved against DashboardCycleReferenceLength, so the threshold keeps living
+// in exactly one place and no surface may re-derive it.
+//
+// This is the third medical-safety suppression signal, beside
+// DashboardPredictionDisabled(user) and stats.PregnancyPaused: past this point a
+// projection can only roll a whole cycle forward at a time (ProjectCycleStart),
+// so every date it yields is manufactured rather than estimated, and presenting
+// one as a window is the estimate-presented-as-fact the medical-safety invariant
+// forbids. Every surface that shows a projected window gates on all three —
+// dashboard display and reminder banner here; the calendar grid, the webhook
+// reminder and the .ics feed are the remaining callers of that pair.
+func DashboardCycleOverdue(user *models.User, stats CycleStats) bool {
+	return DashboardCycleDayLooksLong(stats.CurrentCycleDay, DashboardCycleReferenceLength(user, stats))
 }
 
 func DashboardCycleDayLooksLong(currentDay int, referenceLength int) bool {
@@ -273,11 +301,16 @@ func BuildDashboardCycleContext(user *models.User, stats CycleStats, today time.
 		DisplayOvulationNeedsData:   display.ovulationNeedsData,
 		DisplayOvulationExact:       display.ovulationExact,
 		DisplayOvulationImpossible:  display.ovulationImpossible,
+		NextPeriodEstimatePaused:    display.estimatePaused,
 		NextPeriodInPast:            dashboardNextPeriodInPast(display, today),
 		OvulationInPast:             dashboardOvulationInPast(display, today),
 	}
 }
 
+// buildDashboardPredictionDisplay turns the projected cycle into the fields the
+// dashboard renders, withholding the whole projected window once
+// DashboardCycleOverdue reports the cycle is past its reference length by more
+// than a week.
 func buildDashboardPredictionDisplay(user *models.User, stats CycleStats, today time.Time, location *time.Location) dashboardPredictionDisplay {
 	prediction := DashboardUpcomingPredictions(
 		stats,
@@ -299,7 +332,31 @@ func buildDashboardPredictionDisplay(user *models.User, stats CycleStats, today 
 	if display.nextPeriodPrompt || display.nextPeriodNeedsData {
 		return finalizeDashboardPredictionDisplay(display)
 	}
+	if DashboardCycleOverdue(user, stats) {
+		return pauseDashboardPredictionDisplay(display)
+	}
 	return finalizeDashboardPredictionDisplay(applyDashboardPredictionRanges(display, user, stats, location))
+}
+
+// pauseDashboardPredictionDisplay withholds the projected window once the
+// running cycle is past the reference length by more than a week.
+//
+// DashboardUpcomingPredictions rolls the projection forward one whole cycle at a
+// time (ProjectCycleStart), so it always yields a strictly future date: at cycle
+// day 45 with a 28-day reference the header used to name the anchor plus 56 days
+// as confidently as it names tomorrow. A cycle that is already overdue carries no
+// evidence about when the next one starts, and presenting the roll-forward as a
+// window is exactly the estimate-presented-as-fact the medical-safety invariant
+// forbids. Both halves of the phantom projection go — the window and the
+// ovulation date derived from it — while ovulationNeedsData and
+// ovulationImpossible survive: they describe the account's data, not this
+// projection, and other surfaces gate on them.
+func pauseDashboardPredictionDisplay(display dashboardPredictionDisplay) dashboardPredictionDisplay {
+	return dashboardPredictionDisplay{
+		ovulationNeedsData:  display.ovulationNeedsData,
+		ovulationImpossible: display.ovulationImpossible,
+		estimatePaused:      true,
+	}
 }
 
 func dashboardNeedsNextPeriodData(user *models.User, stats CycleStats, nextPeriodStart time.Time) bool {

--- a/internal/services/dashboard_cycle_test.go
+++ b/internal/services/dashboard_cycle_test.go
@@ -77,21 +77,21 @@ func TestBuildDashboardCycleContext(t *testing.T) {
 		LastPeriodStart: &userStart,
 	}
 	stats := CycleStats{
-		CurrentCycleDay:     36,
+		CurrentCycleDay:     30,
 		LastPeriodStart:     mustParseDashboardDay(t, "2026-02-10"),
 		MedianCycleLength:   28,
 		AveragePeriodLength: 5,
 		NextPeriodStart:     mustParseDashboardDay(t, "2026-03-10"),
 		OvulationDate:       mustParseDashboardDay(t, "2026-02-24"),
 	}
-	today := mustParseDashboardDay(t, "2026-03-14")
+	today := mustParseDashboardDay(t, "2026-03-11")
 
 	context := BuildDashboardCycleContext(user, stats, today, time.UTC)
 	if context.CycleDayReference != 28 {
 		t.Fatalf("expected cycle day reference 28, got %d", context.CycleDayReference)
 	}
-	if !context.CycleDayWarning {
-		t.Fatalf("expected cycle day warning for long cycle day")
+	if context.CycleDayWarning {
+		t.Fatalf("did not expect a cycle day warning two days past the reference length")
 	}
 	if !context.CycleDataStale {
 		t.Fatalf("expected stale cycle data flag")
@@ -104,6 +104,129 @@ func TestBuildDashboardCycleContext(t *testing.T) {
 	}
 	if got := context.DisplayNextPeriodEnd.Format("2006-01-02"); got != "2026-04-11" {
 		t.Fatalf("expected exact next period end 2026-04-11, got %s", got)
+	}
+}
+
+// TestBuildDashboardCycleContextWithholdsTheWindowOnceTheCycleIsOverdue pins the
+// state a rolled-forward projection used to hide. DashboardUpcomingPredictions
+// advances the projection a whole cycle at a time, so it always returns a
+// strictly future date: on cycle day 36 against a 28-day reference the dashboard
+// named the anchor plus 56 days — a window nothing in the account's data
+// supports — with the same confidence it names tomorrow's. Past reference + 7
+// there is no window to show, and the cycle day plus the late-cycle notice carry
+// the state on their own.
+//
+// The stats below would otherwise produce a ±2-day uncertainty range (five
+// completed cycles, SD 2.4), so this also pins that the range fields go with the
+// single date rather than surviving as a softer version of the same claim.
+func TestBuildDashboardCycleContextWithholdsTheWindowOnceTheCycleIsOverdue(t *testing.T) {
+	userStart := mustParseDashboardDay(t, "2026-02-10")
+	user := &models.User{
+		CycleLength:     28,
+		PeriodLength:    5,
+		LastPeriodStart: &userStart,
+	}
+	stats := CycleStats{
+		CurrentCycleDay:     36,
+		LastPeriodStart:     mustParseDashboardDay(t, "2026-02-10"),
+		MedianCycleLength:   28,
+		AverageCycleLength:  28.4,
+		AveragePeriodLength: 5,
+		CompletedCycleCount: 5,
+		CycleLengthStdDev:   2.4,
+		NextPeriodStart:     mustParseDashboardDay(t, "2026-03-10"),
+		OvulationDate:       mustParseDashboardDay(t, "2026-02-24"),
+		OvulationExact:      true,
+	}
+	today := mustParseDashboardDay(t, "2026-03-17")
+
+	context := BuildDashboardCycleContext(user, stats, today, time.UTC)
+	if context.CycleDayReference != 28 {
+		t.Fatalf("expected cycle day reference 28, got %d", context.CycleDayReference)
+	}
+	if !context.CycleDayWarning {
+		t.Fatalf("expected cycle day 36 against a 28-day reference to read as long")
+	}
+	if !context.NextPeriodEstimatePaused {
+		t.Fatalf("expected an overdue cycle to pause the next-period estimate")
+	}
+	if !context.LateCycle.Visible {
+		t.Fatalf("expected the late-cycle notice to keep carrying the state")
+	}
+	if !context.DisplayNextPeriodStart.IsZero() || !context.DisplayNextPeriodEnd.IsZero() {
+		t.Fatalf(
+			"expected no projected next-period window, got %s — %s",
+			context.DisplayNextPeriodStart.Format("2006-01-02"),
+			context.DisplayNextPeriodEnd.Format("2006-01-02"),
+		)
+	}
+	if context.DisplayNextPeriodUseRange ||
+		!context.DisplayNextPeriodRangeStart.IsZero() ||
+		!context.DisplayNextPeriodRangeEnd.IsZero() {
+		t.Fatalf("expected no projected next-period range either")
+	}
+	if !context.DisplayOvulationDate.IsZero() || context.DisplayOvulationUseRange || context.DisplayOvulationExact {
+		t.Fatalf("expected the ovulation estimate derived from the same projection to go with it")
+	}
+	if context.DisplayNextPeriodPrompt || context.DisplayNextPeriodNeedsData {
+		t.Fatalf("expected an overdue cycle to stay out of the prompt and needs-data branches")
+	}
+	if context.NextPeriodInPast || context.OvulationInPast {
+		t.Fatalf("expected no in-the-past warning about a window that is not shown")
+	}
+
+	banner := BuildDashboardReminderBanner(context, today, 0)
+	if banner.Show {
+		t.Fatalf("expected no reminder banner for a withheld estimate, got %q", banner.TitleKey)
+	}
+}
+
+// TestBuildDashboardCycleContextKeepsTheWindowAtExactlyTheLateThreshold is the
+// other side of the boundary: DashboardCycleDayLooksLong fires strictly past
+// reference + 7, so day 35 against a 28-day reference still shows its window.
+// Same account as the test above, one day earlier.
+func TestBuildDashboardCycleContextKeepsTheWindowAtExactlyTheLateThreshold(t *testing.T) {
+	userStart := mustParseDashboardDay(t, "2026-02-10")
+	user := &models.User{
+		CycleLength:     28,
+		PeriodLength:    5,
+		LastPeriodStart: &userStart,
+	}
+	stats := CycleStats{
+		CurrentCycleDay:     35,
+		LastPeriodStart:     mustParseDashboardDay(t, "2026-02-10"),
+		MedianCycleLength:   28,
+		AverageCycleLength:  28.4,
+		AveragePeriodLength: 5,
+		CompletedCycleCount: 5,
+		CycleLengthStdDev:   2.4,
+		NextPeriodStart:     mustParseDashboardDay(t, "2026-03-10"),
+		OvulationDate:       mustParseDashboardDay(t, "2026-02-24"),
+		OvulationExact:      true,
+	}
+	today := mustParseDashboardDay(t, "2026-03-16")
+
+	context := BuildDashboardCycleContext(user, stats, today, time.UTC)
+	if context.CycleDayWarning {
+		t.Fatalf("expected cycle day 35 against a 28-day reference to stay inside the threshold")
+	}
+	if context.NextPeriodEstimatePaused {
+		t.Fatalf("did not expect the estimate to pause at exactly reference + 7")
+	}
+	if !context.DisplayNextPeriodUseRange {
+		t.Fatalf("expected the uncertainty range to survive at exactly reference + 7")
+	}
+	if got := context.DisplayNextPeriodRangeStart.Format("2006-01-02"); got != "2026-04-05" {
+		t.Fatalf("expected range start 2026-04-05, got %s", got)
+	}
+	if got := context.DisplayNextPeriodRangeEnd.Format("2006-01-02"); got != "2026-04-09" {
+		t.Fatalf("expected range end 2026-04-09, got %s", got)
+	}
+	if got := context.DisplayNextPeriodStart.Format("2006-01-02"); got != "2026-04-07" {
+		t.Fatalf("expected next period start 2026-04-07, got %s", got)
+	}
+	if context.DisplayOvulationDate.IsZero() {
+		t.Fatalf("expected the ovulation estimate to survive at exactly reference + 7")
 	}
 }
 

--- a/internal/services/dashboard_reminder_banner.go
+++ b/internal/services/dashboard_reminder_banner.go
@@ -107,6 +107,11 @@ type DashboardReminderBanner struct {
 //
 // The banner is suppressed (Show=false) whenever:
 //   - predictions are disabled or paused (PredictionDisabled),
+//   - the next-period estimate is withheld because the cycle is overdue
+//     (NextPeriodEstimatePaused). The cleared Display* fields already suppress
+//     the banner through the zero-date branch below; the explicit check keeps the
+//     rule readable at the surface that would otherwise announce "period in ~N
+//     days" for a window the dashboard itself refuses to show,
 //   - the cycle context has no single-date estimate to summarize (needs more
 //     data, ovulation is impossible, or the corresponding date is zero),
 //   - the context is showing an uncertainty *range* instead of a single date
@@ -121,7 +126,7 @@ type DashboardReminderBanner struct {
 // When both the next period and ovulation fall inside the window on the same
 // request, the period reminder is returned (see DashboardReminderBannerKindPeriod).
 func BuildDashboardReminderBanner(cycleContext DashboardCycleContext, today time.Time, leadDays int) DashboardReminderBanner {
-	if cycleContext.PredictionDisabled {
+	if cycleContext.PredictionDisabled || cycleContext.NextPeriodEstimatePaused {
 		return DashboardReminderBanner{}
 	}
 	windowDays := dashboardReminderBannerWindowDays(leadDays)

--- a/internal/services/dashboard_view_service.go
+++ b/internal/services/dashboard_view_service.go
@@ -236,13 +236,19 @@ type dashboardTimingFrame struct {
 // resolveDashboardTimingFrame decides that frame from the resolved usage goal.
 // The ovulation estimate follows the next-period item's gating exactly: a
 // suppressed prediction (unpredictable cycle, pregnancy pause) stays suppressed
-// here too, and BBT keeps existing only where the tracking settings grant it.
+// here too, and so does a cycle overdue enough that the next-period window is
+// withheld (NextPeriodEstimatePaused) — the ovulation estimate is derived from
+// the same projection, so an account trying to conceive would otherwise be the
+// one cohort still reading a placeholder where the window used to be. BBT keeps
+// existing only where the tracking settings grant it, and its placement is a
+// property of the goal alone: a late cycle is when a morning reading matters
+// most, so nothing about the cycle demotes the field.
 func resolveDashboardTimingFrame(user *models.User, cycleContext DashboardCycleContext, visibility dashboardOwnerVisibility) dashboardTimingFrame {
 	if !IsOwnerUser(user) || NormalizeUsageGoal(user.UsageGoal) != models.UsageGoalTrying {
 		return dashboardTimingFrame{}
 	}
 	return dashboardTimingFrame{
-		ShowOvulationEstimate: !cycleContext.PredictionDisabled,
+		ShowOvulationEstimate: !cycleContext.PredictionDisabled && !cycleContext.NextPeriodEstimatePaused,
 		BBTInVisibleTier:      visibility.ShowBBTField,
 	}
 }

--- a/internal/services/dashboard_view_service_test.go
+++ b/internal/services/dashboard_view_service_test.go
@@ -374,6 +374,46 @@ func TestFirstMissingTrackedDayFindsTrackedGap(t *testing.T) {
 	}
 }
 
+// TestResolveDashboardTimingFrameGatesTheOvulationEstimateOnEverySuppression
+// pins which cycle states the goal-aware ovulation item survives. The frame
+// answers a question about the goal, but the estimate it adds is a prediction:
+// it must disappear wherever the next-period window does — an unpredictable
+// cycle, a pregnancy pause, and a cycle overdue past reference + 7, where the
+// projection has nothing left to say. The temperature's placement answers the
+// goal question alone and is unmoved by any of them.
+func TestResolveDashboardTimingFrameGatesTheOvulationEstimateOnEverySuppression(t *testing.T) {
+	user := &models.User{Role: models.RoleOwner, UsageGoal: models.UsageGoalTrying}
+	visibility := dashboardOwnerVisibility{ShowBBTField: true}
+
+	for name, testCase := range map[string]struct {
+		cycleContext DashboardCycleContext
+		wantEstimate bool
+	}{
+		"stable cycle": {
+			cycleContext: DashboardCycleContext{},
+			wantEstimate: true,
+		},
+		"predictions suppressed": {
+			cycleContext: DashboardCycleContext{PredictionDisabled: true},
+			wantEstimate: false,
+		},
+		"cycle overdue": {
+			cycleContext: DashboardCycleContext{NextPeriodEstimatePaused: true},
+			wantEstimate: false,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			frame := resolveDashboardTimingFrame(user, testCase.cycleContext, visibility)
+			if frame.ShowOvulationEstimate != testCase.wantEstimate {
+				t.Fatalf("expected ovulation estimate=%v, got %v", testCase.wantEstimate, frame.ShowOvulationEstimate)
+			}
+			if !frame.BBTInVisibleTier {
+				t.Fatalf("expected the temperature field to stay in the visible tier for this goal")
+			}
+		})
+	}
+}
+
 func mustParseDashboardServiceDay(t *testing.T, raw string) time.Time {
 	t.Helper()
 	parsed, err := time.ParseInLocation("2006-01-02", raw, time.UTC)

--- a/internal/services/webhook_notify_service_test.go
+++ b/internal/services/webhook_notify_service_test.go
@@ -402,6 +402,138 @@ func TestNotifyRetriesAfterFailure(t *testing.T) {
 	}
 }
 
+// notifyDay builds a UTC calendar day for the resume timeline below.
+func notifyDay(year int, month time.Month, day int) time.Time {
+	return time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+}
+
+// overdueResumeRecord is the owner of the resume timeline: a regular 28-day
+// account with period reminders on and a 3-day lead, anchored at the given last
+// period start and carrying the watermark a previous pass would have written.
+func overdueResumeRecord(lastPeriodStart time.Time, periodWatermark *time.Time) models.WebhookNotifyRecord {
+	anchor := lastPeriodStart
+	return models.WebhookNotifyRecord{
+		ID:                              1,
+		CycleLength:                     28,
+		PeriodLength:                    5,
+		LutealPhase:                     14,
+		LastPeriodStart:                 &anchor,
+		WebhookEnabled:                  true,
+		WebhookURL:                      "https://a.example/hook",
+		WebhookNotifyPeriod:             true,
+		WebhookNotifyOvulation:          false,
+		ReminderLeadDays:                3,
+		WebhookPeriodLastSentCycleStart: periodWatermark,
+	}
+}
+
+// runOverdueResumePass runs one notify pass over a single owner and returns the
+// report together with the stubs, so the caller can assert on deliveries and
+// watermark writes.
+func runOverdueResumePass(t *testing.T, record models.WebhookNotifyRecord, dayLogs []models.DailyLog, now time.Time) (NotifyReport, *stubNotifyRepo, *stubDeliverer) {
+	t.Helper()
+	repo := &stubNotifyRepo{records: []models.WebhookNotifyRecord{record}}
+	deliverer := &stubDeliverer{}
+	service := newTestNotifyService(repo, stubLogReader{byUser: map[uint][]models.DailyLog{1: dayLogs}}, stubDecryptor{}, deliverer)
+	report, err := service.RunOnce(context.Background(), now, time.UTC, false)
+	if err != nil {
+		t.Fatalf("RunOnce at %s: %v", now.Format("2006-01-02"), err)
+	}
+	return report, repo, deliverer
+}
+
+// TestNotifyOverdueCycleLeavesNoWatermarkAndResumesOnce walks the whole idempotency
+// story an overdue cycle used to break, as four passes over one owner.
+//
+// The watermark is keyed on the PREDICTED next-period date, which is also the
+// reminder's cycle anchor. While a cycle runs past its reference length the
+// projection rolls forward one whole cycle at a time, so before the overdue gate
+// every roll produced an anchor no watermark covered and re-armed a fresh "period
+// soon" send — once per invented cycle, for as long as the cycle stayed open.
+//
+//   - 2026-03-23, cycle day 26: the honest reminder for 2026-03-26 is sent and its
+//     watermark written.
+//   - 2026-04-20, cycle day 54: the projection has rolled to 2026-04-23, three days
+//     out and inside the lead window, but the account is overdue — nothing is sent,
+//     AND nothing is written, so the watermark still points at 2026-03-26. That is
+//     the resume path: suppression that wrote a watermark for the phantom would
+//     have consumed the next real cycle's key.
+//   - 2026-05-27, after the owner logs the real cycle start on 2026-05-02: the
+//     reminder for 2026-05-30 fires exactly once past the stale 2026-03-26
+//     watermark, and advances it.
+//   - Same day, with the advanced watermark: nothing again.
+func TestNotifyOverdueCycleLeavesNoWatermarkAndResumesOnce(t *testing.T) {
+	anchor := notifyDay(2026, time.February, 26)
+	history := []models.DailyLog{
+		periodStartLog(1, notifyDay(2025, time.December, 4)),
+		periodStartLog(1, notifyDay(2026, time.January, 1)),
+		periodStartLog(1, notifyDay(2026, time.January, 29)),
+		periodStartLog(1, anchor),
+	}
+
+	// Pass 1 — inside the reference length: the estimate is honest and is sent.
+	report1, repo1, deliverer1 := runOverdueResumePass(t, overdueResumeRecord(anchor, nil), history, notifyDay(2026, time.March, 23))
+	if report1.Sent != 1 {
+		t.Fatalf("pass 1 expected one honest reminder sent, got sent=%d due=%d", report1.Sent, report1.Due)
+	}
+	writes1 := repo1.writes()
+	if len(writes1) != 1 {
+		t.Fatalf("pass 1 expected one watermark write, got %d", len(writes1))
+	}
+	firstWatermark := writes1[0].anchor
+	if got := firstWatermark.Format("2006-01-02"); got != "2026-03-26" {
+		t.Fatalf("pass 1 watermark = %s, want the predicted 2026-03-26", got)
+	}
+	if got := deliverer1.deliveries()[0].payload.EventDate; got != "2026-03-26" {
+		t.Fatalf("pass 1 delivered event date = %s, want 2026-03-26", got)
+	}
+
+	// Pass 2 — the period never came and the cycle is overdue. The phantom
+	// 2026-04-23 is in-window, so only the overdue gate keeps it out.
+	report2, repo2, deliverer2 := runOverdueResumePass(t, overdueResumeRecord(anchor, &firstWatermark), history, notifyDay(2026, time.April, 20))
+	if report2.Due != 0 || report2.Sent != 0 {
+		t.Fatalf("pass 2 must compute nothing for an overdue cycle, got due=%d sent=%d", report2.Due, report2.Sent)
+	}
+	if len(deliverer2.deliveries()) != 0 {
+		t.Fatalf("pass 2 delivered a phantom reminder: %#v", deliverer2.deliveries())
+	}
+	if len(repo2.writes()) != 0 {
+		t.Fatalf("pass 2 wrote a watermark for a reminder it never sent: %#v", repo2.writes())
+	}
+	if report2.SkippedIdempotent != 0 {
+		t.Fatalf("pass 2 should have no candidate at all, not one hidden by a watermark (skipped=%d)", report2.SkippedIdempotent)
+	}
+
+	// Pass 3 — the owner logs the real cycle start. The stale watermark still
+	// names 2026-03-26, so the new cycle's reminder is free to fire once.
+	resumed := notifyDay(2026, time.May, 2)
+	resumedLogs := append(append([]models.DailyLog{}, history...), periodStartLog(1, resumed))
+	report3, repo3, deliverer3 := runOverdueResumePass(t, overdueResumeRecord(resumed, &firstWatermark), resumedLogs, notifyDay(2026, time.May, 27))
+	if report3.Sent != 1 {
+		t.Fatalf("pass 3 expected exactly one reminder after the real cycle start, got sent=%d due=%d", report3.Sent, report3.Due)
+	}
+	writes3 := repo3.writes()
+	if len(writes3) != 1 {
+		t.Fatalf("pass 3 expected one watermark write, got %d", len(writes3))
+	}
+	resumedWatermark := writes3[0].anchor
+	if got := resumedWatermark.Format("2006-01-02"); got != "2026-05-30" {
+		t.Fatalf("pass 3 watermark = %s, want the new cycle's 2026-05-30", got)
+	}
+	if got := deliverer3.deliveries()[0].payload.EventDate; got != "2026-05-30" {
+		t.Fatalf("pass 3 delivered event date = %s, want 2026-05-30", got)
+	}
+
+	// Pass 4 — the same day again: exactly once means once.
+	report4, repo4, deliverer4 := runOverdueResumePass(t, overdueResumeRecord(resumed, &resumedWatermark), resumedLogs, notifyDay(2026, time.May, 27))
+	if report4.Sent != 0 || len(deliverer4.deliveries()) != 0 {
+		t.Fatalf("pass 4 must send nothing, got sent=%d deliveries=%d", report4.Sent, len(deliverer4.deliveries()))
+	}
+	if len(repo4.writes()) != 0 {
+		t.Fatalf("pass 4 wrote a watermark despite sending nothing: %#v", repo4.writes())
+	}
+}
+
 // TestNotifyDryRunMakesNoRequestOrWatermark proves --dry-run computes due
 // reminders but performs no delivery and writes no watermark.
 func TestNotifyDryRunMakesNoRequestOrWatermark(t *testing.T) {

--- a/internal/services/webhook_reminder.go
+++ b/internal/services/webhook_reminder.go
@@ -18,9 +18,9 @@ import (
 //
 // Medical-safety invariant: this function reuses the EXACT prediction path the
 // dashboard uses (BuildCycleStatsFromLogs → DashboardUpcomingPredictions, gated
-// by DashboardPredictionDisabled / PregnancyPaused). It never fabricates a date
-// the app itself refuses to show — when in-app predictions are suppressed, it
-// emits nothing.
+// by DashboardPredictionDisabled / PregnancyPaused / DashboardCycleOverdue). It
+// never fabricates a date the app itself refuses to show — when in-app
+// predictions are suppressed, it emits nothing.
 
 const (
 	// DueReminderTypePeriod and DueReminderTypeOvulation identify which upcoming
@@ -113,8 +113,24 @@ func WebhookReminderSettingsFromNotifyRecord(record models.WebhookNotifyRecord) 
 //   - Build cycle stats from the owner's logs via the SAME path the dashboard
 //     uses (StatsService.BuildCycleStatsFromLogs, which needs no repositories).
 //   - In-app predictions suppressed (DashboardPredictionDisabled — the owner's
-//     unpredictable-cycle mode — or stats.PregnancyPaused) ⇒ nothing. This is
-//     the medical-safety gate: never emit a date the app itself refuses to show.
+//     unpredictable-cycle mode — stats.PregnancyPaused, or DashboardCycleOverdue
+//     — the running cycle is past the account's reference length by more than a
+//     week) ⇒ nothing. This is the medical-safety gate: never emit a date the app
+//     itself refuses to show.
+//
+//     The overdue disjunct also ends a repeat that had no end: past that point
+//     DashboardUpcomingPredictions rolls the projection a whole cycle forward, so
+//     the next-period date it yields is manufactured, and — because that same
+//     date is the period reminder's watermark KEY — every roll produced an anchor
+//     no watermark covered and re-armed a fresh "period soon" send, once per
+//     projected cycle, for as long as the cycle stayed unclosed. Suppressing the
+//     reminder suppresses the write too: this decision emits nothing, the notify
+//     pass writes a watermark only after a 2xx delivery, so an overdue cycle
+//     leaves the watermarks exactly where the last real send left them. When the
+//     owner finally logs the real cycle start, the anchor is that new cycle's
+//     projected next-period date — different from the stale watermark — so the
+//     next legitimate reminder fires exactly once and its own watermark then
+//     covers it.
 //   - Resolve "today" as the owner-local calendar day (DateAtLocation) and the
 //     median-first projection cycle length the dashboard feeds to its predictions
 //     (DashboardProjectionCycleLength — the same statistic as stats.NextPeriodStart,
@@ -147,7 +163,7 @@ func DecideDueReminders(user *models.User, settings WebhookReminderSettings, log
 	stats := NewStatsService(nil, nil).BuildCycleStatsFromLogs(user, logs, now, location)
 
 	// Medical-safety gate: if the app suppresses predictions, emit nothing.
-	if DashboardPredictionDisabled(user) || stats.PregnancyPaused {
+	if DashboardPredictionDisabled(user) || stats.PregnancyPaused || DashboardCycleOverdue(user, stats) {
 		return nil
 	}
 

--- a/internal/services/webhook_reminder_test.go
+++ b/internal/services/webhook_reminder_test.go
@@ -324,6 +324,79 @@ func TestDecideDueRemindersSuppression(t *testing.T) {
 	})
 }
 
+// regularWebhookCycleStartLogs is a stable 28-day history: four cycle starts a
+// cycle apart, so the observed average and median are both 28 and the account is
+// neither sparse nor irregular. The last start is 2026-02-26, which is the anchor
+// every overdue case below runs from.
+func regularWebhookCycleStartLogs(t *testing.T) []models.DailyLog {
+	t.Helper()
+	logs := make([]models.DailyLog, 0, 4)
+	for _, day := range []string{"2025-12-04", "2026-01-01", "2026-01-29", "2026-02-26"} {
+		logs = append(logs, models.DailyLog{
+			Date:       mustParseWebhookReminderDay(t, day, time.UTC),
+			IsPeriod:   true,
+			CycleStart: true,
+		})
+	}
+	return logs
+}
+
+// TestDecideDueRemindersSuppressesOverdueCycle covers the third medical-safety
+// gate: an account whose cycle has run past its own reference length by more than
+// a week (DashboardCycleOverdue) gets no reminder at all.
+//
+// The projection is what makes this necessary. From the 2026-02-26 anchor with a
+// 28-day cycle, DashboardUpcomingPredictions rolls forward a whole cycle at a
+// time, so on 2026-04-20 — cycle day 54 against a 28-day reference — it yields
+// 2026-04-23, three days out and squarely inside the lead window. Nothing in the
+// account's data supports that date: no period was logged, and the reminder would
+// have announced one. The in-window assertion below is the point of the test — it
+// proves the reminder is withheld by the overdue gate and not merely by the
+// window, so the case cannot go quietly green if the gate is removed.
+func TestDecideDueRemindersSuppressesOverdueCycle(t *testing.T) {
+	const leadDays = 3
+	user := regularWebhookUser()
+	logs := regularWebhookCycleStartLogs(t)
+
+	t.Run("a cycle inside its reference length still reminds", func(t *testing.T) {
+		// Cycle day 26 of a 28-day reference: the estimate is honest, and the
+		// reminder for 2026-03-26 fires. Positive anchor for the case below.
+		now := mustParseWebhookReminderDay(t, "2026-03-23", time.UTC)
+		reminders := DecideDueReminders(user, enabledWebhookSettings(leadDays), logs, now, time.UTC)
+		period, ok := findDueReminder(reminders, DueReminderTypePeriod)
+		if !ok {
+			t.Fatalf("expected a period reminder inside the reference length, got %#v", reminders)
+		}
+		if got := period.EventDate.Format("2006-01-02"); got != "2026-03-26" {
+			t.Fatalf("period event date = %s, want 2026-03-26", got)
+		}
+	})
+
+	t.Run("an overdue cycle emits nothing", func(t *testing.T) {
+		now := mustParseWebhookReminderDay(t, "2026-04-20", time.UTC)
+		stats := NewStatsService(nil, nil).BuildCycleStatsFromLogs(user, logs, now, time.UTC)
+
+		if !DashboardCycleOverdue(user, stats) {
+			t.Fatalf("test setup expects an overdue cycle: cycle day %d against reference %d",
+				stats.CurrentCycleDay, DashboardCycleReferenceLength(user, stats))
+		}
+
+		// The rolled-forward projection IS inside the lead window here: without the
+		// overdue gate this decision emits a "period soon" reminder for a date the
+		// account's own data does not support.
+		prediction := DashboardUpcomingPredictions(stats, user, now, DashboardProjectionCycleLength(user, stats))
+		if !reminderWithinWindow(now, prediction.NextPeriodStart, leadDays) {
+			t.Fatalf("test setup expects the phantom projection %s inside the %d-day window from %s",
+				prediction.NextPeriodStart.Format("2006-01-02"), leadDays, now.Format("2006-01-02"))
+		}
+
+		reminders := DecideDueReminders(user, enabledWebhookSettings(leadDays), logs, now, time.UTC)
+		if len(reminders) != 0 {
+			t.Fatalf("expected no reminders for an overdue cycle, got %#v", reminders)
+		}
+	})
+}
+
 // TestDecideDueRemindersToggles covers the enable switches: the master
 // webhook-enabled flag off suppresses everything, and each per-kind flag off
 // omits exactly that kind while leaving the other in place. today=2026-03-28

--- a/internal/templates/dashboard.html
+++ b/internal/templates/dashboard.html
@@ -58,6 +58,9 @@
             </span>
             {{end}}
             <span class="dashboard-status-separator" aria-hidden="true">·</span>
+            {{if .NextPeriodEstimatePaused}}
+            <span class="dashboard-status-item journal-muted" data-dashboard-next-period-paused data-next-period-paused-key="dashboard.next_period_estimate_paused">{{t .Messages "dashboard.next_period_estimate_paused"}}</span>
+            {{else}}
             <span class="dashboard-status-item">{{t .Messages "dashboard.next_period"}}:
               <span data-dashboard-next-period>
                 {{if .DisplayNextPeriodUseRange}}
@@ -73,10 +76,12 @@
                 {{end}}
               </span>
             </span>
+            {{end}}
             {{/* The goal decides how timing is framed: an account tracking to
                  conceive is here for the fertile window, so the same status line
                  also names the ovulation estimate. It rides the next-period
-                 item's gating — a suppressed prediction never reaches this
+                 item's gating — a suppressed prediction, and a cycle overdue
+                 enough that the window above is withheld, never reach this
                  branch — and stays an estimate in its own wording. */}}
             {{if .ShowOvulationEstimate}}
             <span class="dashboard-status-separator" aria-hidden="true">·</span>


### PR DESCRIPTION
## Stacking

Builds on #445 (`fix-overdue-prediction-window`), which exports
`services.DashboardCycleOverdue(user, stats)` — the reference+7 predicate — and gates the dashboard
display and the reminder banner on it. **Merge after #445.** The diff against `main` currently
contains that branch's commit too; it disappears once #445 lands.

## What was wrong

A cycle running past the account's own reference length by more than a week still received
manufactured dates on three surfaces, because `DashboardUpcomingPredictions` / `ProjectCycleStart`
roll the projection forward one whole cycle at a time and therefore always yield a strictly future
date. Each of the three gated only on `DashboardPredictionDisabled || PregnancyPaused`:

- **Webhook reminders** (`internal/services/webhook_reminder.go:150`) — a "period soon" POST for a
  date nothing in the account supports. Worse, it repeated: the idempotency watermark is keyed on
  the predicted next-period date, which is also the reminder's cycle anchor, so every roll produced
  an anchor no watermark covered and re-armed a fresh send, roughly once per invented cycle, for as
  long as the cycle stayed open.
- **`.ics` feed** (`internal/services/calendar_feed_ics.go:122`) — the builder projects three cycles
  ahead, so an overdue account pushed up to six invented all-day events into third-party calendar
  clients, where they outlive any correction made in the app.
- **Calendar grid** (`internal/services/calendar_days.go:84`) — `appendPredictedCycles` chains from
  the **un-rolled** `stats.NextPeriodStart`, so the grid painted a predicted period **in the past**
  — days that came and went with no period logged — and then a phantom window every cycle length
  after it.

## What changed

`DashboardCycleOverdue(user, stats)` is now the third disjunct at all three gates; the projection
math itself is untouched (the gate sits above it), so no golden vectors, docs or reference tests
move. Suppression per surface: no reminder is computed at all; the feed takes its existing
well-formed events-less `VCALENDAR` path (it carries prediction events only, so there are no
recorded facts in it to preserve); the grid returns empty prediction maps, leaving logged period
days, has-data and sex markers, and the day encodings, untouched.

## The watermark, and the resume path

The concern is that suppression must not consume the next real cycle's key.

The write is bound to a delivery: `WebhookNotifyService.processOwner` advances a watermark **only
after a 2xx** (`internal/services/webhook_notify_service.go:252`). A suppressed reminder is never
due, never delivered, and therefore never written — an overdue cycle leaves both watermarks exactly
where the last honest send left them. There is no separate "mark as skipped" path to get this wrong.

Resume: when the owner logs the real cycle start, the anchor becomes that new cycle's projected
next-period date — `newStart + projectionLength` against a stale watermark of `oldStart +
projectionLength`, and `newStart` is strictly later — so the reminder fires, exactly once, and its
own watermark then covers it. The two coincide only if the projection length shrank by exactly the
gap between the starts, and a skip is then the correct answer anyway: a reminder for that very date
was already delivered. `TestNotifyOverdueCycleLeavesNoWatermarkAndResumesOnce`
walks the whole timeline as four passes over one owner: honest send on cycle day 26 (watermark
2026-03-26) → overdue pass on cycle day 54 where the phantom 2026-04-23 **is** inside the lead
window yet nothing is sent, delivered or written → real cycle start logged, one reminder for
2026-05-30 → same day again, nothing.

Note the grace week the reference+7 threshold leaves is harmless here rather than merely tolerated:
between cycle day `reference` and `reference+7` the roll-forward has already pushed the next-period
date a full cycle out, so it is far outside any lead window (max 14 days); by the time it re-enters
the window the account is long past the threshold and suppressed.

## Secondary findings — checked, not fixed

- `dashboard_cycle.go` `DashboardPredictionRange`, irregular branch: the range is still measured from
  the un-rolled `stats.LastPeriodStart`. Its only caller is `applyDashboardPredictionRanges` on the
  dashboard display path, which #445 already short-circuits for an overdue account, so nothing falls
  out of this gate and nothing is reachable that was not before.
- `calendar_days.go` `appendCurrentCycleBBTSignal`: the BBT tentative-ovulation window is still
  bounded by `stats.NextPeriodStart`. For an overdue account it is now unreachable — the gate returns
  before it — so the phantom-bounded case is gone; inside the threshold the bound is the honest one.

## Tests

Each fails with its gate removed and names the culprit (verified by reintroducing all three and
re-running):

- `TestDecideDueRemindersSuppressesOverdueCycle` — overdue emits nothing, with an in-window
  assertion on the phantom projection so it cannot pass because the window is empty, plus a
  same-account control inside the reference length.
- `TestNotifyOverdueCycleLeavesNoWatermarkAndResumesOnce` — the four-pass resume timeline above
  (pre-fix: pass 2 reports `due=1 sent=1`).
- `TestBuildCalendarFeedICSSuppressesForOverdueCycle` — no `VEVENT`, well-formed `VCALENDAR` shell
  kept, positive control (pre-fix: five invented events).
- `TestBuildCalendarDayStatesSuppressesPredictionsForOverdueCycle` — the past-painted period case
  specifically (2026-03-26, behind "today", never logged), the phantom future window, recorded facts
  intact, positive control.

Two API fixtures were green **about** the defect — they seeded a cycle at fixed 2026 dates against a
live clock, so the accounts were thousands of days into a cycle and only the roll-forward kept them
producing predictions: `TestCalendarFeedServesOwnersICSWithHardenedHeaders` (via
`armCalendarFeedForUser`) and `TestCalendarRendersOvulationTagWithoutFertileOverride`. Both now seed
relative to the current day, which is what the header/marker contracts they pin were always about.
No e2e spec needed a change: the calendar specs already onboard relative to today.

Run locally: `go test ./...`, `golangci-lint run ./...` (0 issues), `scripts/patchcov` (OK),
`npm run lint`, `npm run test:unit` (62), `npm run e2e -- e2e/calendar.spec.ts` (16) plus the feed,
webhook and reminder-banner specs (7).

Rollback: revert the commit. No data, schema or contract change is involved.
