### PR TITLE
feat(dashboard): fertility waits for the first completed cycle

### DIFF
--- a/changelog.d/design-w2-early-tier.md
+++ b/changelog.d/design-w2-early-tier.md
@@ -1,0 +1,10 @@
+### Changed
+
+- **A new account no longer sees a fertile window invented from its setup
+  defaults.** Until one cycle has been completed, the dashboard status header
+  shows no fertility status and no ovulation estimate: with nothing recorded to
+  measure, both were the onboarding cycle-length slider projected forward. The
+  cycle day, the phase and the next-period estimate are unchanged, and an
+  account tracking to conceive reads one line naming when its fertile window
+  arrives instead of a date. Once a first cycle is completed, the header renders
+  as before.

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -796,7 +796,7 @@ test.describe('Dashboard: today editor', () => {
     ).toBeChecked();
   });
 
-  test('the goal about timing gets the ovulation estimate and the temperature in the open', async ({
+  test('the goal about timing gets the first-cycle promise and the temperature in the open', async ({
     page,
   }) => {
     await registerOwnerOnDashboard(page, 'dashboard-timing-frame');
@@ -804,11 +804,13 @@ test.describe('Dashboard: today editor', () => {
 
     const statusLine = dashboardStatusLine(page);
     const ovulation = statusLine.locator('[data-dashboard-ovulation]');
+    const bridge = statusLine.locator('[data-dashboard-first-cycle-bridge]');
     const bbtInput = page.locator('#dashboard-bbt');
 
-    // The default goal is the neutral one: no timing line, temperature folded
-    // away with the other rare fields.
+    // The default goal is the neutral one: no timing line at all, temperature
+    // folded away with the other rare fields.
     await expect(ovulation).toHaveCount(0);
+    await expect(bridge).toHaveCount(0);
     await expect(bbtInput).toBeHidden();
 
     await page.locator('[data-usage-goal-chip]').click();
@@ -818,10 +820,22 @@ test.describe('Dashboard: today editor', () => {
       'settings.goal.trying'
     );
 
-    // What the goal promised at onboarding, on the next load of the page.
+    // What the goal promised at onboarding, on the next load of the page. This
+    // account has completed no cycle yet, so the timing item is the one line
+    // naming when its fertile window arrives — an ovulation date here could only
+    // be the onboarding cycle length projected forward. The date itself, once a
+    // cycle has been observed, is pinned in the Go render regression
+    // (TestDashboardFramesTimingForTheGoalThatIsAboutIt).
     await page.reload();
-    await expect(statusLine).toContainText(localeText('en', 'dashboard.ovulation'));
-    await expect(ovulation).toHaveCount(1);
+    await expect(ovulation).toHaveCount(0);
+    await expect(bridge).toHaveCount(1);
+    await expect(bridge).toHaveAttribute(
+      'data-first-cycle-bridge-key',
+      'dashboard.fertile_window_after_first_cycle'
+    );
+    await expect(bridge).toHaveText(
+      localeText('en', 'dashboard.fertile_window_after_first_cycle')
+    );
     await expect(bbtInput).toBeVisible();
     await expect(dashboardMoreDisclosure(page).locator('#dashboard-bbt')).toHaveCount(0);
 

--- a/internal/api/dashboard_journal_regressions_test.go
+++ b/internal/api/dashboard_journal_regressions_test.go
@@ -554,6 +554,10 @@ func TestDashboardJournalMoreDisclosureOpensForDataItHolds(t *testing.T) {
 // morning temperature sits in the journal's visible tier; the disclosure then
 // stops counting a recorded temperature, which is no longer behind it. Every
 // other goal keeps the line and the two tiers it had.
+//
+// Both accounts own one completed cycle: the estimate exists only once there is
+// an observed cycle to project from, and what the same goal reads before that
+// is TestDashboardHeaderWithholdsFertilityUntilTheFirstCompletedCycle's subject.
 func TestDashboardFramesTimingForTheGoalThatIsAboutIt(t *testing.T) {
 	for name, testCase := range map[string]struct {
 		goal   string
@@ -567,6 +571,7 @@ func TestDashboardFramesTimingForTheGoalThatIsAboutIt(t *testing.T) {
 			user := createOnboardingTestUser(t, database, "dashboard-timing-"+testCase.goal+"@example.com", "StrongPass1", true)
 			enableDashboardMeasurementTracking(t, database, user.ID)
 			seedDashboardStableCycleForGoal(t, database, user.ID, testCase.goal)
+			seedDashboardCompletedCycle(t, database, user.ID)
 			seedDashboardTodayLog(t, database, user.ID, func(entry *models.DailyLog) {
 				entry.BBT = new(36.6)
 			})
@@ -696,6 +701,26 @@ func seedDashboardStableCycleForGoal(t *testing.T, database *gorm.DB, userID uin
 		"last_period_start": today.AddDate(0, 0, -2),
 	}).Error; err != nil {
 		t.Fatalf("seed cycle context for %s: %v", goal, err)
+	}
+}
+
+// seedDashboardCompletedCycle records the two cycle starts that make one
+// completed cycle — the threshold the status header's fertility half waits for —
+// keeping the running cycle on the same recent anchor
+// seedDashboardStableCycleForGoal set.
+func seedDashboardCompletedCycle(t *testing.T, database *gorm.DB, userID uint) {
+	t.Helper()
+
+	today := services.DateAtLocation(time.Now().UTC(), time.UTC)
+	for _, offsetDays := range []int{-30, -2} {
+		if err := database.Create(&models.DailyLog{
+			UserID:     userID,
+			Date:       today.AddDate(0, 0, offsetDays),
+			IsPeriod:   true,
+			CycleStart: true,
+		}).Error; err != nil {
+			t.Fatalf("seed cycle start %d: %v", offsetDays, err)
+		}
 	}
 }
 

--- a/internal/api/dashboard_regressions_test.go
+++ b/internal/api/dashboard_regressions_test.go
@@ -380,6 +380,124 @@ func TestDashboardAndStatsAgreeOnPhaseAndFertilityOnAFertileWindowDay(t *testing
 	}
 }
 
+// TestDashboardHeaderWithholdsFertilityUntilTheFirstCompletedCycle is the
+// render regression for the first reliability tier. Both accounts below sit on
+// cycle day 12 of a 28-day baseline — a fertile-window day by the same math the
+// test above uses — and differ only in whether one cycle has been observed.
+//
+// With none, the fertile window and the ovulation date exist only because the
+// onboarding cycle-length slider was projected forward, so the header shows
+// neither and declares no fertility status; an account tracking to conceive
+// reads one bridge line naming when the window arrives instead. With one
+// completed cycle the header renders exactly as it always did. What the tier
+// never touches is asserted in both states: the phase and the next-period item,
+// which carries its own estimate qualifier.
+func TestDashboardHeaderWithholdsFertilityUntilTheFirstCompletedCycle(t *testing.T) {
+	for name, testCase := range map[string]struct {
+		account        string
+		goal           string
+		completedCycle bool
+		wantFertility  bool
+		wantOvulation  bool
+		wantBridge     bool
+	}{
+		"trying to conceive, fresh baseline": {
+			account:    "trying-fresh",
+			goal:       models.UsageGoalTrying,
+			wantBridge: true,
+		},
+		"trying to conceive, one completed cycle": {
+			account:        "trying-one-cycle",
+			goal:           models.UsageGoalTrying,
+			completedCycle: true,
+			wantFertility:  true,
+			wantOvulation:  true,
+		},
+		"general health, fresh baseline": {
+			account: "health-fresh",
+			goal:    models.UsageGoalHealth,
+		},
+		"general health, one completed cycle": {
+			account:        "health-one-cycle",
+			goal:           models.UsageGoalHealth,
+			completedCycle: true,
+			wantFertility:  true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			app, database := newOnboardingTestApp(t)
+			user := createOnboardingTestUser(t, database, "dashboard-first-tier-"+testCase.account+"@example.com", "StrongPass1", true)
+			today := services.DateAtLocation(time.Now().UTC(), time.UTC)
+			if err := database.Model(&models.User{}).Where("id = ?", user.ID).Updates(map[string]any{
+				"usage_goal":        testCase.goal,
+				"cycle_length":      28,
+				"period_length":     5,
+				"last_period_start": today.AddDate(0, 0, -11),
+			}).Error; err != nil {
+				t.Fatalf("seed cycle baseline: %v", err)
+			}
+			if testCase.completedCycle {
+				// Two recorded starts 28 days apart: one completed cycle, and the
+				// running one still on day 12.
+				for _, offsetDays := range []int{-39, -11} {
+					if err := database.Create(&models.DailyLog{
+						UserID:     user.ID,
+						Date:       today.AddDate(0, 0, offsetDays),
+						IsPeriod:   true,
+						CycleStart: true,
+					}).Error; err != nil {
+						t.Fatalf("seed cycle start %d: %v", offsetDays, err)
+					}
+				}
+			}
+
+			authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
+			document := mustParseHTMLDocument(t, mustRenderDashboard(t, app, authCookie, "en"))
+
+			header := dashboardElementByDataAttr(document, "data-dashboard-status-header")
+			if header == nil {
+				t.Fatal("expected the dashboard status header")
+			}
+			wantStatus := "unknown"
+			if testCase.wantFertility {
+				wantStatus = "fertile"
+			}
+			if got := htmlAttr(header, "data-fertility-status"); got != wantStatus {
+				t.Fatalf("expected the header to declare fertility %q, got %q", wantStatus, got)
+			}
+
+			statusLine := dashboardElementByDataAttr(document, "data-dashboard-status-line")
+			if statusLine == nil {
+				t.Fatal("expected the dashboard status line")
+			}
+			if got := htmlFindElement(statusLine, htmlNodeHasAttr("data-fertile-window")) != nil; got != testCase.wantFertility {
+				t.Fatalf("expected the fertile-window item=%v, got %v", testCase.wantFertility, got)
+			}
+			if got := htmlFindElement(statusLine, htmlNodeHasAttr("data-dashboard-ovulation")) != nil; got != testCase.wantOvulation {
+				t.Fatalf("expected the ovulation estimate=%v, got %v", testCase.wantOvulation, got)
+			}
+
+			bridge := htmlFindElement(statusLine, htmlNodeHasAttr("data-dashboard-first-cycle-bridge"))
+			if got := bridge != nil; got != testCase.wantBridge {
+				t.Fatalf("expected the first-cycle bridge line=%v, got %v", testCase.wantBridge, got)
+			}
+			if bridge != nil {
+				if got := htmlAttr(bridge, "data-first-cycle-bridge-key"); got != "dashboard.fertile_window_after_first_cycle" {
+					t.Fatalf("expected the bridge line to name its copy key, got %q", got)
+				}
+			}
+
+			// The tier withholds the two slider-derived items and nothing else.
+			if got := htmlAttr(header, "data-dashboard-phase"); got == "" || got == "unknown" {
+				t.Fatalf("expected the phase to survive the tier, got %q", got)
+			}
+			if htmlFindElement(statusLine, htmlNodeHasAttr("data-dashboard-next-period")) == nil {
+				t.Fatal("expected the next-period estimate to survive the tier")
+			}
+		})
+	}
+}
+
 func TestDashboardTodaySavePersistsPeriodToggleAndNotes(t *testing.T) {
 	app, database := newOnboardingTestApp(t)
 	user := createOnboardingTestUser(t, database, "dashboard-today-save@example.com", "StrongPass1", true)

--- a/internal/api/page_view_data_helpers.go
+++ b/internal/api/page_view_data_helpers.go
@@ -73,6 +73,8 @@ func (handler *Handler) buildDashboardViewData(ctx context.Context, user *models
 		"ShowNotesField":                        viewData.ShowNotesField,
 		"MoreFieldsOpen":                        viewData.MoreFieldsOpen,
 		"ShowOvulationEstimate":                 viewData.ShowOvulationEstimate,
+		"ShowFirstCycleBridge":                  viewData.ShowFirstCycleBridge,
+		"ShowFertilityStatus":                   viewData.ShowFertilityStatus,
 		"ShowBBTInVisibleTier":                  viewData.ShowBBTInVisibleTier,
 		"TemperatureUnit":                       bbtView.Unit,
 		"TemperatureUnitSymbol":                 bbtView.Symbol,

--- a/internal/i18n/locales/de.json
+++ b/internal/i18n/locales/de.json
@@ -401,6 +401,7 @@
   "dashboard.high_fertility_badge": "Hohe Fruchtbarkeit",
   "dashboard.fertility_badge_warning": "Fruchtbare Phase",
   "dashboard.fertile_window": "Fruchtbares Fenster",
+  "dashboard.fertile_window_after_first_cycle": "Ihr fruchtbares Fenster erscheint nach Ihrem ersten abgeschlossenen Zyklus",
   "dashboard.fertility_badge_positive": "Fruchtbare Phase, beste Zeit",
   "dashboard.ovulation": "Eisprung",
   "dashboard.ovulation_range": "%s — %s",

--- a/internal/i18n/locales/en.json
+++ b/internal/i18n/locales/en.json
@@ -401,6 +401,7 @@
   "dashboard.high_fertility_badge": "High fertility",
   "dashboard.fertility_badge_warning": "Fertile period",
   "dashboard.fertile_window": "Fertile window",
+  "dashboard.fertile_window_after_first_cycle": "Your fertile window appears after your first completed cycle",
   "dashboard.fertility_badge_positive": "Fertile period, best timing",
   "dashboard.ovulation": "Ovulation",
   "dashboard.ovulation_range": "%s — %s",

--- a/internal/i18n/locales/es.json
+++ b/internal/i18n/locales/es.json
@@ -401,6 +401,7 @@
   "dashboard.high_fertility_badge": "Alta fertilidad",
   "dashboard.fertility_badge_warning": "Fase fértil",
   "dashboard.fertile_window": "Ventana fértil",
+  "dashboard.fertile_window_after_first_cycle": "Tu ventana fértil aparecerá después de tu primer ciclo completo",
   "dashboard.fertility_badge_positive": "Fase fértil, mejor momento",
   "dashboard.ovulation": "Ovulación",
   "dashboard.ovulation_range": "%s — %s",

--- a/internal/i18n/locales/fr.json
+++ b/internal/i18n/locales/fr.json
@@ -517,6 +517,7 @@
   "dashboard.high_fertility_badge": "Fertilité élevée",
   "dashboard.fertility_badge_warning": "Période fertile",
   "dashboard.fertile_window": "Fenêtre fertile",
+  "dashboard.fertile_window_after_first_cycle": "Votre fenêtre fertile apparaîtra après votre premier cycle terminé",
   "dashboard.fertility_badge_positive": "Période fertile, meilleur moment",
   "dashboard.ovulation": "Ovulation",
   "dashboard.ovulation_range": "%s — %s",

--- a/internal/i18n/locales/it.json
+++ b/internal/i18n/locales/it.json
@@ -401,6 +401,7 @@
   "dashboard.high_fertility_badge": "Alta fertilità",
   "dashboard.fertility_badge_warning": "Periodo fertile",
   "dashboard.fertile_window": "Finestra fertile",
+  "dashboard.fertile_window_after_first_cycle": "La tua finestra fertile comparirà dopo il tuo primo ciclo completato",
   "dashboard.fertility_badge_positive": "Periodo fertile, momento migliore",
   "dashboard.ovulation": "Ovulazione",
   "dashboard.ovulation_range": "%s — %s",

--- a/internal/i18n/locales/ru.json
+++ b/internal/i18n/locales/ru.json
@@ -403,6 +403,7 @@
   "dashboard.high_fertility_badge": "Высокая фертильность",
   "dashboard.fertility_badge_warning": "Фертильный период",
   "dashboard.fertile_window": "Фертильное окно",
+  "dashboard.fertile_window_after_first_cycle": "Фертильное окно появится после Вашего первого завершённого цикла",
   "dashboard.fertility_badge_positive": "Фертильный период — лучшее время",
   "dashboard.ovulation": "Овуляция",
   "dashboard.ovulation_range": "%s — %s",

--- a/internal/services/dashboard_cycle.go
+++ b/internal/services/dashboard_cycle.go
@@ -15,6 +15,9 @@ import (
 // filled is cleared, and the surfaces derived from them — the status header slot,
 // the reminder banner — say so instead of naming a date. The cycle day and the
 // late-cycle notice carry the state on their own.
+//
+// AwaitingFirstCycle reports the earliest data tier — no completed cycle yet —
+// which decides how much detail the header may show (DashboardAwaitingFirstCycle).
 type DashboardCycleContext struct {
 	CycleDayReference           int
 	CycleDayWarning             bool
@@ -37,6 +40,7 @@ type DashboardCycleContext struct {
 	DisplayOvulationExact       bool
 	DisplayOvulationImpossible  bool
 	NextPeriodEstimatePaused    bool
+	AwaitingFirstCycle          bool
 	NextPeriodInPast            bool
 	OvulationInPast             bool
 }
@@ -121,6 +125,25 @@ func DashboardProjectionCycleLength(user *models.User, stats CycleStats) int {
 // reminder and the .ics feed are the remaining callers of that pair.
 func DashboardCycleOverdue(user *models.User, stats CycleStats) bool {
 	return DashboardCycleDayLooksLong(stats.CurrentCycleDay, DashboardCycleReferenceLength(user, stats))
+}
+
+// DashboardAwaitingFirstCycle reports that the account has not completed a
+// single cycle yet, which is the earliest tier of the same reliability signal
+// the stats page already counts on: CompletedCycleCount, the "based on N
+// completed cycles" number behind buildStatsPredictionReliability and
+// HasPersonalCycleRange. It is read here rather than recounted — a second count
+// of the same thing is a second answer waiting to disagree.
+//
+// Until that first cycle closes, every fertility surface on the dashboard is
+// derived from the onboarding cycle-length slider rather than from anything the
+// account recorded: the fertile window and the ovulation date are the settings
+// default projected forward. Showing them at the same confidence as a measured
+// window is the estimate-presented-as-fact the medical-safety invariant forbids,
+// so the header withholds them until one cycle has been observed. The phase and
+// the next-period estimate stay: the phase follows the recorded anchor, and the
+// next-period item already carries its own estimate qualifier.
+func DashboardAwaitingFirstCycle(stats CycleStats) bool {
+	return stats.CompletedCycleCount < 1
 }
 
 func DashboardCycleDayLooksLong(currentDay int, referenceLength int) bool {
@@ -259,11 +282,17 @@ func DashboardUpcomingPredictions(stats CycleStats, user *models.User, today tim
 }
 
 func BuildDashboardCycleContext(user *models.User, stats CycleStats, today time.Time, location *time.Location) DashboardCycleContext {
+	// The tier is a property of the account's history, so it is resolved before
+	// the suppression branches and carried by every one of them: a context that
+	// reported "not awaiting" merely because predictions are off would disable
+	// the gate for exactly the accounts with the least data.
+	awaitingFirstCycle := DashboardAwaitingFirstCycle(stats)
 	if stats.PregnancyPaused {
 		return DashboardCycleContext{
 			CycleDayReference:  DashboardCycleReferenceLength(user, stats),
 			PredictionDisabled: true,
 			PregnancyPaused:    true,
+			AwaitingFirstCycle: awaitingFirstCycle,
 		}
 	}
 	if DashboardPredictionDisabled(user) {
@@ -272,6 +301,7 @@ func BuildDashboardCycleContext(user *models.User, stats CycleStats, today time.
 			CycleDayWarning:    false,
 			CycleDataStale:     false,
 			PredictionDisabled: true,
+			AwaitingFirstCycle: awaitingFirstCycle,
 		}
 	}
 
@@ -302,6 +332,7 @@ func BuildDashboardCycleContext(user *models.User, stats CycleStats, today time.
 		DisplayOvulationExact:       display.ovulationExact,
 		DisplayOvulationImpossible:  display.ovulationImpossible,
 		NextPeriodEstimatePaused:    display.estimatePaused,
+		AwaitingFirstCycle:          awaitingFirstCycle,
 		NextPeriodInPast:            dashboardNextPeriodInPast(display, today),
 		OvulationInPast:             dashboardOvulationInPast(display, today),
 	}

--- a/internal/services/dashboard_view_service.go
+++ b/internal/services/dashboard_view_service.go
@@ -38,6 +38,13 @@ type DashboardViewService struct {
 	days   DashboardDayStateProvider
 }
 
+// DashboardViewData is everything the dashboard page renders.
+//
+// ShowFertilityStatus gates the slider-derived fertility half of the status
+// header — the fertile-window item and the status the header declares — on the
+// first completed cycle (DashboardAwaitingFirstCycle), for every goal: until one
+// cycle has been observed that window is the onboarding cycle length projected
+// forward, whatever the account is tracking for.
 type DashboardViewData struct {
 	Stats                             CycleStats
 	CycleContext                      DashboardCycleContext
@@ -63,6 +70,8 @@ type DashboardViewData struct {
 	ShowNotesField                    bool
 	MoreFieldsOpen                    bool
 	ShowOvulationEstimate             bool
+	ShowFirstCycleBridge              bool
+	ShowFertilityStatus               bool
 	ShowBBTInVisibleTier              bool
 	AllowManualCycleStart             bool
 	ManualCycleStartPolicy            ManualCycleStartPolicy
@@ -188,6 +197,8 @@ func (service *DashboardViewService) BuildDashboardViewData(ctx context.Context,
 		ShowNotesField:                    visibility.ShowNotesField,
 		MoreFieldsOpen:                    dashboardMoreFieldsHoldData(todayLog, visibility, timingFrame.BBTInVisibleTier),
 		ShowOvulationEstimate:             timingFrame.ShowOvulationEstimate,
+		ShowFirstCycleBridge:              timingFrame.ShowFirstCycleBridge,
+		ShowFertilityStatus:               !cycleContext.AwaitingFirstCycle,
 		ShowBBTInVisibleTier:              timingFrame.BBTInVisibleTier,
 		AllowManualCycleStart:             visibility.AllowManualCycleStart,
 		ManualCycleStartPolicy:            cycleStart.Policy,
@@ -228,8 +239,13 @@ type dashboardOwnerVisibility struct {
 // the ovulation estimate beside the next-period one and the morning temperature
 // such an account records daily sits in the journal's visible tier instead of
 // behind the "More" disclosure. Every other goal reads the page unchanged.
+//
+// ShowFirstCycleBridge is the one state where the timing item is replaced
+// rather than dropped: an account with no completed cycle yet gets a single line
+// naming when its fertile window arrives, so the goal it chose still answers it.
 type dashboardTimingFrame struct {
 	ShowOvulationEstimate bool
+	ShowFirstCycleBridge  bool
 	BBTInVisibleTier      bool
 }
 
@@ -239,16 +255,23 @@ type dashboardTimingFrame struct {
 // here too, and so does a cycle overdue enough that the next-period window is
 // withheld (NextPeriodEstimatePaused) — the ovulation estimate is derived from
 // the same projection, so an account trying to conceive would otherwise be the
-// one cohort still reading a placeholder where the window used to be. BBT keeps
-// existing only where the tracking settings grant it, and its placement is a
-// property of the goal alone: a late cycle is when a morning reading matters
-// most, so nothing about the cycle demotes the field.
+// one cohort still reading a placeholder where the window used to be. The third
+// condition is of the same kind and answers the same question from the other
+// end: before the first completed cycle (AwaitingFirstCycle) the projection has
+// nothing but the onboarding slider to project from, so the estimate is
+// manufactured rather than measured. That state alone gets the bridge line in
+// place of the estimate — a promise about data, not a date. BBT keeps existing
+// only where the tracking settings grant it, and its placement is a property of
+// the goal alone: a late cycle is when a morning reading matters most, so
+// nothing about the cycle demotes the field.
 func resolveDashboardTimingFrame(user *models.User, cycleContext DashboardCycleContext, visibility dashboardOwnerVisibility) dashboardTimingFrame {
 	if !IsOwnerUser(user) || NormalizeUsageGoal(user.UsageGoal) != models.UsageGoalTrying {
 		return dashboardTimingFrame{}
 	}
+	predictionSuppressed := cycleContext.PredictionDisabled || cycleContext.NextPeriodEstimatePaused
 	return dashboardTimingFrame{
-		ShowOvulationEstimate: !cycleContext.PredictionDisabled && !cycleContext.NextPeriodEstimatePaused,
+		ShowOvulationEstimate: !predictionSuppressed && !cycleContext.AwaitingFirstCycle,
+		ShowFirstCycleBridge:  !predictionSuppressed && cycleContext.AwaitingFirstCycle,
 		BBTInVisibleTier:      visibility.ShowBBTField,
 	}
 }

--- a/internal/services/dashboard_view_service_test.go
+++ b/internal/services/dashboard_view_service_test.go
@@ -388,6 +388,7 @@ func TestResolveDashboardTimingFrameGatesTheOvulationEstimateOnEverySuppression(
 	for name, testCase := range map[string]struct {
 		cycleContext DashboardCycleContext
 		wantEstimate bool
+		wantBridge   bool
 	}{
 		"stable cycle": {
 			cycleContext: DashboardCycleContext{},
@@ -401,14 +402,108 @@ func TestResolveDashboardTimingFrameGatesTheOvulationEstimateOnEverySuppression(
 			cycleContext: DashboardCycleContext{NextPeriodEstimatePaused: true},
 			wantEstimate: false,
 		},
+		"awaiting the first completed cycle": {
+			cycleContext: DashboardCycleContext{AwaitingFirstCycle: true},
+			wantEstimate: false,
+			wantBridge:   true,
+		},
+		"awaiting the first cycle with predictions off": {
+			cycleContext: DashboardCycleContext{AwaitingFirstCycle: true, PredictionDisabled: true},
+			wantEstimate: false,
+			wantBridge:   false,
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			frame := resolveDashboardTimingFrame(user, testCase.cycleContext, visibility)
 			if frame.ShowOvulationEstimate != testCase.wantEstimate {
 				t.Fatalf("expected ovulation estimate=%v, got %v", testCase.wantEstimate, frame.ShowOvulationEstimate)
 			}
+			if frame.ShowFirstCycleBridge != testCase.wantBridge {
+				t.Fatalf("expected the first-cycle bridge line=%v, got %v", testCase.wantBridge, frame.ShowFirstCycleBridge)
+			}
 			if !frame.BBTInVisibleTier {
 				t.Fatalf("expected the temperature field to stay in the visible tier for this goal")
+			}
+		})
+	}
+}
+
+// TestBuildDashboardViewDataHoldsFertilityBackUntilTheFirstCompletedCycle pins
+// the early data tier at its boundary — zero completed cycles against one — for
+// both the goal that asks about timing and the neutral one.
+//
+// With no completed cycle the fertile window and the ovulation date are the
+// onboarding cycle-length slider projected forward, so the header withholds both
+// and an account tracking to conceive reads one bridge line in the ovulation
+// item's place instead. The moment a single cycle closes, the account has an
+// observation to reason from and the header renders exactly as it did before.
+// The count itself is the stats reliability signal (CompletedCycleCount), read
+// rather than recomputed here.
+func TestBuildDashboardViewDataHoldsFertilityBackUntilTheFirstCompletedCycle(t *testing.T) {
+	today := mustParseDashboardServiceDay(t, "2026-02-21")
+
+	for name, testCase := range map[string]struct {
+		completedCycles int
+		goal            string
+		wantFertility   bool
+		wantOvulation   bool
+		wantBridge      bool
+	}{
+		"trying, no completed cycle": {
+			completedCycles: 0,
+			goal:            models.UsageGoalTrying,
+			wantBridge:      true,
+		},
+		"trying, one completed cycle": {
+			completedCycles: 1,
+			goal:            models.UsageGoalTrying,
+			wantFertility:   true,
+			wantOvulation:   true,
+		},
+		"health, no completed cycle": {
+			completedCycles: 0,
+			goal:            models.UsageGoalHealth,
+		},
+		"health, one completed cycle": {
+			completedCycles: 1,
+			goal:            models.UsageGoalHealth,
+			wantFertility:   true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			user := &models.User{ID: 9, Role: models.RoleOwner, CycleLength: 28, UsageGoal: testCase.goal, TrackBBT: true}
+			service := NewDashboardViewService(
+				&stubDashboardStatsProvider{stats: CycleStats{
+					CompletedCycleCount: testCase.completedCycles,
+					CurrentCycleDay:     5,
+					MedianCycleLength:   28,
+					LastPeriodStart:     mustParseDashboardServiceDay(t, "2026-02-17"),
+					NextPeriodStart:     mustParseDashboardServiceDay(t, "2026-03-17"),
+				}},
+				&stubDashboardViewerProvider{logEntry: models.DailyLog{Date: today}},
+				&stubDashboardDayStateProvider{},
+			)
+
+			viewData, err := service.BuildDashboardViewData(context.Background(), user, "en", today, time.UTC)
+			if err != nil {
+				t.Fatalf("BuildDashboardViewData() unexpected error: %v", err)
+			}
+			if viewData.ShowFertilityStatus != testCase.wantFertility {
+				t.Fatalf("expected fertility status shown=%v, got %v", testCase.wantFertility, viewData.ShowFertilityStatus)
+			}
+			if viewData.ShowOvulationEstimate != testCase.wantOvulation {
+				t.Fatalf("expected ovulation estimate=%v, got %v", testCase.wantOvulation, viewData.ShowOvulationEstimate)
+			}
+			if viewData.ShowFirstCycleBridge != testCase.wantBridge {
+				t.Fatalf("expected the first-cycle bridge line=%v, got %v", testCase.wantBridge, viewData.ShowFirstCycleBridge)
+			}
+			// The tier moves nothing else: the cycle day and the next-period
+			// estimate the header shows beside them are untouched by it.
+			if viewData.Stats.CurrentCycleDay != 5 {
+				t.Fatalf("expected the cycle day to survive the tier, got %d", viewData.Stats.CurrentCycleDay)
+			}
+			if viewData.CycleContext.DisplayNextPeriodStart.IsZero() {
+				t.Fatal("expected the next-period estimate to survive the tier")
 			}
 		})
 	}

--- a/internal/templates/dashboard.html
+++ b/internal/templates/dashboard.html
@@ -7,7 +7,7 @@
       class="journal-card dashboard-status-header reveal"
       data-dashboard-status-header
       data-dashboard-phase="{{$phase}}"
-      data-fertility-status="{{if .CycleDataStale}}unknown{{else}}{{.Stats.CurrentFertility}}{{end}}"
+      data-fertility-status="{{if or .CycleDataStale (not .ShowFertilityStatus)}}unknown{{else}}{{.Stats.CurrentFertility}}{{end}}"
       {{if .CycleHero.Approximate}}data-cycle-hero-approximate="true"{{end}}>
       <div class="dashboard-status-top">
         <div class="dashboard-cycle-ring-wrap" data-dashboard-cycle-ring data-cycle-ring-segmented="{{if .CycleHero.Visible}}true{{else}}false{{end}}">
@@ -38,7 +38,10 @@
             <span aria-hidden="true">{{phaseIcon $phase}}</span>
             <span>{{phaseLabel .Messages $phase}}</span>
           </span>
-          {{if and (not .CycleDataStale) (eq .Stats.CurrentFertility "fertile")}}
+          {{/* The fertile window is read off the projected cycle, so before the
+               first completed cycle it says the onboarding slider back to the
+               owner. It waits for the data that makes it a measurement. */}}
+          {{if and .ShowFertilityStatus (not .CycleDataStale) (eq .Stats.CurrentFertility "fertile")}}
           <span class="dashboard-status-separator" aria-hidden="true">·</span>
           <span class="dashboard-status-item" data-fertile-window>{{t .Messages "dashboard.fertile_window"}}</span>
           {{end}}
@@ -100,6 +103,15 @@
                 {{end}}
               </span>
             </span>
+            {{else if .ShowFirstCycleBridge}}
+            {{/* The same slot before the first completed cycle: one line saying
+                 when the window arrives, instead of a date projected from the
+                 onboarding cycle length. */}}
+            <span class="dashboard-status-separator" aria-hidden="true">·</span>
+            <span
+              class="dashboard-status-item journal-muted"
+              data-dashboard-first-cycle-bridge
+              data-first-cycle-bridge-key="dashboard.fertile_window_after_first_cycle">{{t .Messages "dashboard.fertile_window_after_first_cycle"}}</span>
             {{end}}
             {{if .CycleHero.Approximate}}
             <span class="dashboard-status-separator" aria-hidden="true">·</span>


### PR DESCRIPTION
Wave 2 design pass, review finding: **display confidence follows data confidence** — first tier.

## Finding

A brand-new account with zero completed cycles read a fertile window in its dashboard status
header, and — with the trying-to-conceive goal — an ovulation date beside it. Both were the
onboarding cycle-length slider projected forward: nothing the account had recorded supported
either. That is the estimate-presented-as-fact the medical-safety invariant forbids, and on the
first screen it reads as presumptuous.

## What changes

- `DashboardAwaitingFirstCycle` (internal/services/dashboard_cycle.go) states the threshold once,
  against `CycleStats.CompletedCycleCount` — the same count the stats reliability card and
  `HasPersonalCycleRange` already read. No second count is derived.
- `DashboardCycleContext.AwaitingFirstCycle` carries it, and is resolved **before** the pregnancy
  and unpredictable-cycle branches so every one of them reports it: a context that answered "not
  awaiting" merely because predictions are off would disable the gate for exactly the accounts
  with the least data.
- Until that first cycle closes the status header withholds the fertility status it declares
  (`data-fertility-status` reads `unknown`) and the fertile-window item, for every goal.
- `resolveDashboardTimingFrame` gains the condition as a third of the same kind beside
  `PredictionDisabled` and `NextPeriodEstimatePaused`, so the ovulation estimate goes with it. For
  a `trying` account one bridge line takes that slot instead —
  `dashboard.fertile_window_after_first_cycle`, "Your fertile window appears after your first
  completed cycle" — a promise about data, not a date. New key in all six catalogues, no plural
  forms, ru formal «Вы».
- Once one cycle is completed, the header renders exactly as before.

## Deliberately untouched

The cycle day and the ring, the phase, the next-period estimate (it already carries its own
estimate qualifier — no new qualifier copy), the hero segments, `BBTInVisibleTier`, and the
calendar / stats / egress surfaces, which have their own gates.

One judgement call worth naming: the **egg-white fertility badge stays** on a fresh account. It is
a recorded cervical-mucus observation, the highest data confidence there is, not a projection —
suppressing it would hide recorded data, which the "recorded facts only" rule protects. The scope
here is the slider-derived half of the header.

## Tests (fail before the change, on the reintroduced defect)

- Service table over {0 cycles, 1 cycle} × {health, trying} for the fertility flag, the ovulation
  estimate and the bridge line; the timing-frame table gains the awaiting-first-cycle rows.
- Render regression on the status header at the same boundary: no fertility status, no
  fertile-window item, no `data-dashboard-ovulation`, the bridge line with its `data-*` hook and
  copy key; one completed cycle unchanged — and in both states the phase and the next-period item
  are asserted to survive.
- The #444 goal-frame render regression now seeds one completed cycle, which is what a "stable
  cycle" fixture always meant; the browser spec covers the fresh-account state it used to pin.

Run: `go test ./...`, `golangci-lint run ./internal/...`, `npm run lint`, `npm run test:unit`,
`npm run e2e -- e2e/dashboard.spec.ts e2e/onboarding.spec.ts e2e/dashboard-fertility.spec.ts`
(38 passed), patch-coverage gate after the commit. `web/src` untouched, so no bundle rebuild.
