### PR TITLE
test(e2e): one home for the shared ISO-date arithmetic

### DIFF
--- a/changelog.d/test-hoist-iso-date-days-ago.md
+++ b/changelog.d/test-hoist-iso-date-days-ago.md
@@ -1,0 +1,6 @@
+none
+
+Tests only: the last hand-rolled `isoDateDaysAgo` in the e2e auth helper is gone.
+The ISO-date arithmetic the helpers share now lives in one dependency-free e2e
+module, which is what lets the auth helper reach it without importing the stats
+helper back and closing an import cycle between the two. No product code.

--- a/e2e/support/auth-helpers.ts
+++ b/e2e/support/auth-helpers.ts
@@ -1,4 +1,5 @@
 import { expect, type BrowserContext, type Locator, type Page } from '@playwright/test';
+import { isoToday, shiftISODate } from './iso-date-helpers';
 import { selectOnboardingStartDate } from './onboarding-helpers';
 
 export type Credentials = {
@@ -43,17 +44,6 @@ export function expectNoSensitiveAuthParams(urlString: string): void {
   expect(combined).not.toContain('iss=');
   expect(combined).not.toContain('token=');
   expect(combined).not.toContain('recovery=');
-}
-
-function isoDateDaysAgo(days: number): string {
-  const date = new Date();
-  date.setHours(0, 0, 0, 0);
-  date.setDate(date.getDate() - days);
-
-  const yyyy = date.getFullYear();
-  const mm = String(date.getMonth() + 1).padStart(2, '0');
-  const dd = String(date.getDate()).padStart(2, '0');
-  return `${yyyy}-${mm}-${dd}`;
 }
 
 export async function registerOwnerViaUI(
@@ -160,7 +150,7 @@ export async function completeOnboardingIfPresent(page: Page): Promise<void> {
   const isStepTwoVisible = await stepTwoForm.isVisible().catch(() => false);
 
   if (isStepOneVisible) {
-    await selectOnboardingStartDate(page, isoDateDaysAgo(3));
+    await selectOnboardingStartDate(page, shiftISODate(isoToday(), -3));
     await stepOneForm.locator('button[type="submit"]').click();
   }
 

--- a/e2e/support/iso-date-helpers.ts
+++ b/e2e/support/iso-date-helpers.ts
@@ -1,0 +1,36 @@
+/**
+ * ISO-date arithmetic on the runner's own clock, shared by the e2e helpers and
+ * the specs.
+ *
+ * This module imports nothing — not Playwright, not another helper — and that is
+ * the point: `stats-helpers` already imports `auth-helpers`, so hosting these two
+ * functions there would force `auth-helpers` to import back and close a cycle
+ * between the two biggest helper modules. A leaf both sides can depend on has no
+ * such edge. Keep it dependency-free.
+ */
+
+/** Shifts an ISO date by whole days in local time (a negative count goes back). */
+export function shiftISODate(iso: string, days: number): string {
+  const [year, month, day] = iso.split('-').map((part) => Number(part));
+  const shifted = new Date(year, month - 1, day);
+  shifted.setDate(shifted.getDate() + days);
+  const yyyy = shifted.getFullYear();
+  const mm = String(shifted.getMonth() + 1).padStart(2, '0');
+  const dd = String(shifted.getDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+/**
+ * Today by the runner's own clock, as an ISO date. Distinct from
+ * `todayISOFromDashboard`, which reads the date the *server* rendered: use this
+ * one to compute the dates a scenario seeds, and that one when the assertion is
+ * about the day the app itself thinks it is.
+ */
+export function isoToday(): string {
+  const date = new Date();
+  date.setHours(0, 0, 0, 0);
+  const yyyy = date.getFullYear();
+  const mm = String(date.getMonth() + 1).padStart(2, '0');
+  const dd = String(date.getDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}

--- a/e2e/support/stats-helpers.ts
+++ b/e2e/support/stats-helpers.ts
@@ -8,33 +8,15 @@ import {
   readRecoveryCode,
   registerOwnerViaUI,
 } from './auth-helpers';
+import { isoToday, shiftISODate } from './iso-date-helpers';
 import { selectOnboardingStartDate } from './onboarding-helpers';
 import { setRequestTimezoneFromBrowser } from './timezone-helpers';
 
-export function shiftISODate(iso: string, days: number): string {
-  const [year, month, day] = iso.split('-').map((part) => Number(part));
-  const shifted = new Date(year, month - 1, day);
-  shifted.setDate(shifted.getDate() + days);
-  const yyyy = shifted.getFullYear();
-  const mm = String(shifted.getMonth() + 1).padStart(2, '0');
-  const dd = String(shifted.getDate()).padStart(2, '0');
-  return `${yyyy}-${mm}-${dd}`;
-}
-
-/**
- * Today by the runner's own clock, as an ISO date. Distinct from
- * `todayISOFromDashboard`, which reads the date the *server* rendered: use this
- * one to compute the dates a scenario seeds, and that one when the assertion is
- * about the day the app itself thinks it is.
- */
-export function isoToday(): string {
-  const date = new Date();
-  date.setHours(0, 0, 0, 0);
-  const yyyy = date.getFullYear();
-  const mm = String(date.getMonth() + 1).padStart(2, '0');
-  const dd = String(date.getDate()).padStart(2, '0');
-  return `${yyyy}-${mm}-${dd}`;
-}
+// The date arithmetic itself lives in the dependency-free `iso-date-helpers`, so
+// that `auth-helpers` can use it without importing this module back. Re-exported
+// here because the specs that seed cycle data already reach for it under this
+// module's name.
+export { isoToday, shiftISODate };
 
 export async function registerOwnerAndEnableIrregularMode(
   page: Page,


### PR DESCRIPTION
Tests only; no product code.

`e2e/support/auth-helpers.ts` carried the last hand-rolled `isoDateDaysAgo` — the copy the earlier
hoists left behind. The obvious home for it, `e2e/support/stats-helpers.ts`, already imports
`auth-helpers` (`registerOwnerViaUI`, `completeOnboardingIfPresent`, `apiOriginHeader`, …), so
importing `isoToday`/`shiftISODate` back from there would have closed an import cycle between the
two largest helper modules.

**Decision (2026-08-13): break the cycle rather than pin the duplicate.** The cycle is closed by
*where* the arithmetic lives, not by what it does, and the arithmetic depends on nothing — not
Playwright, not another helper. Moving it into a leaf module both sides may import removes the edge
outright; the cost is one small new file and a re-export line, against keeping a second
implementation alive plus a test that only asserts the two agree. The alternative (keep the
duplicate, comment the cycle, assert equality) buys nothing the leaf does not, and leaves the
second copy free to drift between the runs that would catch it.

## What changed

- New `e2e/support/iso-date-helpers.ts`: `shiftISODate` and `isoToday`, moved verbatim from
  `stats-helpers`. The module imports nothing, and its header says why that is a property to keep.
- `e2e/support/stats-helpers.ts`: the two function bodies are replaced by an import plus
  `export { isoToday, shiftISODate }`. Re-exported so the specs that already reach for them under
  this module's name keep working — no spec import lines are touched, which also keeps this off the
  path of the open UI branch that edits the same file.
- `e2e/support/auth-helpers.ts`: `isoDateDaysAgo` is deleted; `completeOnboardingIfPresent` seeds
  today−3 as `shiftISODate(isoToday(), -3)`, the same expression `registerAndOnboardWithStartDaysAgo`
  already uses. Both spellings do their arithmetic in local time, so the value is identical, DST
  included.

`dashboard-cycle-start-suggestion.spec.ts` still holds a spec-local `isoDateDaysAgo` next to its own
seeding helper; it is out of this change's scope and left as is.

## Validation

Run in this branch's worktree through the repo runner, headless chromium, SQLite lane:

- `npm run e2e -- e2e/auth-login-register.spec.ts e2e/auth-recovery.spec.ts e2e/auth-session-rotation.spec.ts e2e/security-role.spec.ts` — 29 passed, 1 skipped (the closed-registration test, which is env-gated and skips without its own env; nothing in this change reaches it).
- `npm run e2e -- e2e/onboarding.spec.ts e2e/dashboard-cycle-start-suggestion.spec.ts e2e/dashboard-reminder-banner.spec.ts` — 17 passed. These cover the re-export path: `dashboard-cycle-start-suggestion` imports `shiftISODate` from `stats-helpers`, and `dashboard-reminder-banner` seeds through `registerAndOnboardWithStartDaysAgo`, which uses both functions internally.

The edited call site was proved reachable rather than assumed: with the shift temporarily set to
−300 (outside the onboarding picker's MinDate window) all 5 `security-role` tests failed, each stack
naming `completeOnboardingIfPresent (e2e/support/auth-helpers.ts:153)`; restored, the same 5 pass.

No standalone TypeScript compiler is installed for this repository, so the change is proved by the
runs above rather than by a type-check.

## Risk

Confined to the e2e helper layer. The failure mode of a wrong move here is loud — every seeding path
asserts the date it selected — and the runs above exercise both the moved functions and the rewritten
call site.
