### PR TITLE
test(e2e): the cycle-start suggestion seeds its competing start on the cluster's first day

### DIFF
--- a/changelog.d/test-cycle-start-first-cluster-fixture.md
+++ b/changelog.d/test-cycle-start-first-cluster-fixture.md
@@ -1,0 +1,8 @@
+none
+
+Test-only: the dashboard cycle-start-suggestion browser spec now seeds its
+competing cycle start on the first day of the period cluster — the position the
+conflict search and the clearing pass used to lose ahead of UTC — instead of the
+interior day it was placed on while that defect was open, and takes its
+onboarding seed from the shared e2e helper. No product code, template or copy
+changes.

--- a/e2e/dashboard-cycle-start-suggestion.spec.ts
+++ b/e2e/dashboard-cycle-start-suggestion.spec.ts
@@ -1,17 +1,12 @@
 import { test, expect, type Page } from '@playwright/test';
-import {
-  apiOriginHeader,
-  continueFromRecoveryCode,
-  createCredentials,
-  expectInlineRegisterRecoveryStep,
-  readRecoveryCode,
-  registerOwnerViaUI,
-} from './support/auth-helpers';
+import { apiOriginHeader } from './support/auth-helpers';
 import { cancelConfirmDialog, mutatingRequestsDuring } from './support/confirm-dialog-helpers';
 import { localeText } from './support/locale-helpers';
-import { selectOnboardingStartDate } from './support/onboarding-helpers';
-import { shiftISODate, todayISOFromDashboard } from './support/stats-helpers';
-import { setRequestTimezoneFromBrowser } from './support/timezone-helpers';
+import {
+  registerAndOnboardWithStartDaysAgo,
+  shiftISODate,
+  todayISOFromDashboard,
+} from './support/stats-helpers';
 
 /**
  * The dashboard's calm cycle-start SUGGESTION — the `[data-cycle-start-suggestion]`
@@ -44,72 +39,42 @@ import { setRequestTimezoneFromBrowser } from './support/timezone-helpers';
  *   -40  onboarding start, so the account's last-period-start cannot become the
  *        anchor (the default onboarding of today-3 would make the gap 3 and no
  *        hint would render at all)
- *   -20  a period day, which only exists so the recorded start below sits INSIDE
- *        the cluster rather than on its first day (see below); it carries no
- *        cycle start, so it does not move the anchor
- *   -16  explicit cycle start -> the anchor, gap 16 >= 15, and the competing
- *        start inside the cluster
+ *   -16  explicit cycle start -> the anchor, gap 16 >= 15, the FIRST day of the
+ *        period cluster below, and the competing start inside it
  *   -12, -8, -4, today  period days at <= 5-day steps, which is what keeps them
  *        in ONE period cluster: `buildPeriodClusters` splits only on a gap of
- *        5+ empty days, so -20..today stays a single cluster and -16's start
+ *        5+ empty days, so -16..today stays a single cluster and -16's start
  *        competes with today
  *
  * Auto-period-fill (on by default from onboarding) widens each written day
  * forward by up to the period length and never writes a cycle start, so it can
  * only reinforce that single cluster, never split it or move the anchor.
  *
- * Why the competing start may not be the cluster's first day: inside
- * `findCompetingCycleStart` each candidate is rebuilt at location midnight while
- * the cluster bounds come from `dateOnly` (UTC midnight), so under a positive
- * UTC offset a start on the first day of the cluster reads as sitting *before*
- * the cluster and is skipped. Measured in `internal/services`: with
- * `Europe/Belgrade` the same logs yield no conflict for a start on the cluster's
- * first day and the expected conflict for an interior one. An interior day is
- * strictly inside the bounds at every offset, which is what makes this spec
- * timezone-independent.
+ * Why the competing start sits on the cluster's FIRST day: that position is the
+ * one the flow used to lose, so it is where the browser lane is worth spending.
+ * `findCompetingCycleStart` rebuilds each candidate at location midnight while
+ * the cluster bounds come from `dateOnly` (UTC midnight); those are different
+ * instants under a non-zero UTC offset, so a start on the cluster's first day
+ * read as sitting *before* the cluster ahead of UTC — no conflict reported, and
+ * the confirmed replacement left it in place. `withinPeriodCluster`
+ * (`internal/services/cycle_start_policy.go`) now re-anchors the compared day to
+ * the bounds' own UTC midnight, and the offset-parameterized guarantee lives in
+ * the service regression (`cycle_start_policy_boundary_test.go`), which pins
+ * both cluster edges against a UTC+1 and a UTC-5 location.
+ *
+ * This spec runs in whatever timezone the runner's browser reports (pinned by
+ * `registerAndOnboardWithStartDaysAgo`), so what it adds over that regression is the
+ * end-to-end path across the first-day position — the hint, the replace
+ * confirmation, and the clearing pass that must remove that start once the owner
+ * accepts. On a UTC runner (CI) the two midnights coincide and the position is
+ * no harder than any other; on a machine ahead of UTC — Europe/Belgrade, where
+ * this seed was run — it is precisely the day the old comparison dropped.
  *
  * Seeding goes through the API with an explicit `Origin` (the CSRF middleware
  * validates it and `page.request.*` sends none of its own) rather than through
  * the dashboard's save button: the button is being removed with the autosave
  * work, and this spec's subject is the hint, not the save control.
  */
-
-function isoDateDaysAgo(days: number): string {
-  const date = new Date();
-  date.setHours(0, 0, 0, 0);
-  date.setDate(date.getDate() - days);
-  const yyyy = date.getFullYear();
-  const mm = String(date.getMonth() + 1).padStart(2, '0');
-  const dd = String(date.getDate()).padStart(2, '0');
-  return `${yyyy}-${mm}-${dd}`;
-}
-
-async function registerAndOnboardWithStartDaysAgo(
-  page: Page,
-  prefix: string,
-  startDaysAgo: number
-): Promise<void> {
-  // completeOnboardingIfPresent hardcodes today-3 as the period start, which
-  // would leave the account's last-period-start as a three-day-old anchor and
-  // silence the policy. Run onboarding with an explicit older date instead.
-  const credentials = createCredentials(prefix);
-  await registerOwnerViaUI(page, credentials);
-  await expectInlineRegisterRecoveryStep(page);
-  await readRecoveryCode(page);
-  await continueFromRecoveryCode(page);
-
-  await selectOnboardingStartDate(page, isoDateDaysAgo(startDaysAgo));
-  await page.locator('form[hx-post="/api/v1/onboarding/steps/1"] button[type="submit"]').click();
-
-  const stepTwoForm = page.locator('form[hx-post="/api/v1/onboarding/steps/2"]');
-  await expect(stepTwoForm).toBeVisible();
-  await Promise.all([
-    page.waitForURL(/\/dashboard(?:\?.*)?$/, { timeout: 15000 }),
-    stepTwoForm.locator('[data-onboarding-step2-submit]').click(),
-  ]);
-
-  await setRequestTimezoneFromBrowser(page);
-}
 
 async function csrfToken(page: Page): Promise<string> {
   return (await page.locator('meta[name="csrf-token"]').getAttribute('content')) ?? '';
@@ -128,10 +93,11 @@ async function savePeriodDay(page: Page, isoDate: string): Promise<void> {
 }
 
 async function markCycleStartViaAPI(page: Page, isoDate: string): Promise<void> {
-  // `replace_existing=false` on purpose: this seed day must be conflict-free, so
-  // a rejected replace is a broken precondition rather than something to paper
-  // over. The endpoint sets is_period AND cycle_start on the day, which is what
-  // makes it the explicit anchor.
+  // Local on purpose, unlike the other seeding helpers: `replace_existing=false`
+  // is what makes this seed day conflict-free, so a rejected replace surfaces as
+  // a broken precondition instead of being papered over — `stats-helpers`'
+  // exported helper of the same name sends `true`. The endpoint sets is_period
+  // AND cycle_start on the day, which is what makes it the explicit anchor.
   const response = await page.request.post(`/api/v1/days/${isoDate}/cycle-start`, {
     headers: {
       ...apiOriginHeader(page),
@@ -151,7 +117,6 @@ async function fetchDay(page: Page, isoDate: string): Promise<Record<string, unk
   return (await response.json()) as Record<string, unknown>;
 }
 
-const CLUSTER_OPENING_DAYS_BACK = 20;
 const ANCHOR_DAYS_BACK = 16;
 const BRIDGE_DAYS_BACK = [12, 8, 4, 0];
 
@@ -165,7 +130,9 @@ test.describe('Dashboard: cycle-start suggestion', () => {
     const today = await todayISOFromDashboard(page);
     const anchorISO = shiftISODate(today, -ANCHOR_DAYS_BACK);
 
-    await savePeriodDay(page, shiftISODate(today, -CLUSTER_OPENING_DAYS_BACK));
+    // The anchor is written first and opens the cluster: nothing bleeding
+    // precedes it, so it is the cluster's first day, which is the position the
+    // conflict search and the clearing pass must both see.
     await markCycleStartViaAPI(page, anchorISO);
     for (const daysBack of BRIDGE_DAYS_BACK) {
       await savePeriodDay(page, shiftISODate(today, -daysBack));


### PR DESCRIPTION
## Problem

`e2e/dashboard-cycle-start-suggestion.spec.ts` seeded a period day at today-20
whose only job was to keep the recorded cycle start at today-16 *inside* the
period cluster rather than on its first day. The reason was a defect, not a
property of the scenario: `findCompetingCycleStart` rebuilt each candidate at
location midnight while the cluster bounds come from `dateOnly` (UTC midnight),
so ahead of UTC a start on the cluster's first day read as sitting before the
cluster and was skipped — no conflict reported, and the confirmed replacement
left it in place.

That comparison is fixed: `withinPeriodCluster`
(`internal/services/cycle_start_policy.go:206`) re-anchors the compared day to
the bounds' own UTC midnight, and
`TestResolveManualCycleStartPolicy_CompetingStartCrossTimezone`
(`internal/services/cycle_start_policy_boundary_test.go:157`) pins both cluster
edges against a UTC+1 and a UTC-5 location. The spec was left stepping around
semantics that now hold.

## Change

Test-only; no production code, template or copy is touched.

- The today-20 cluster opener is gone, so the today-16 recorded start is itself
  the first day of the period cluster (today-16, -12, -8, -4, today: 3 empty
  days between each, under `buildPeriodClusters`' 5-empty-day split). The spec
  now drives the hint, the replace confirmation and the clearing pass across the
  position that used to be lost, end to end.
- The header comment is rewritten around that: what the seed is, why the first
  day is the interesting position, and where the offset-parameterized guarantee
  lives (the service regression above) versus what the browser lane adds.
- Two spec-local duplicates of shared e2e helpers are dropped in favour of
  `support/stats-helpers`: `isoDateDaysAgo` and
  `registerAndOnboardWithStartDaysAgo`. The local `markCycleStartViaAPI` stays
  and now says why — it sends `replace_existing=false` so a conflicting seed day
  fails as a broken precondition, where the exported helper of the same name
  sends `true`.

Independent of #454: only names that already exist on `main` are imported, and
#454 re-exports them through the same module, so neither PR blocks the other.
#454's diff does not include this spec, and this one does not include
`e2e/support/`, so the two cannot conflict either.

## Tests

- `npm run e2e -- e2e/dashboard-cycle-start-suggestion.spec.ts` — 1 passed, run
  three times (after the fixture move, after the comment correction, after the
  helper dedup). The runner's browser reports `Europe/Belgrade` (UTC+2), i.e.
  the offset under which the old comparison dropped a first-day start, so the
  green run is over the fixed path rather than the zero-offset case.
- Seed geometry measured directly in `internal/services` before editing the
  spec — with logs at today-16 (period + cycle start), -12, -8, -4 and today,
  `ResolveManualCycleStartPolicy` reports today-16 as the conflict,
  `ShouldSuggestManualCycleStart` is true and `ShouldAskCycleStartQuestion` is
  false, under both UTC and UTC+1. That probe was scratch and is not part of the
  diff; the shipped assertions are the spec's own
  (`data-cycle-start-conflict=true`, the replace dialog's two dates, and the
  cleared anchor after accepting).
- `go test ./internal/services/ -count=1` and `golangci-lint run
  ./internal/services/...` (0 issues) — unchanged package, run as a control that
  nothing in the policy moved. `npm run lint` clean (it does not cover `e2e/`;
  no `tsc` step exists, and the Playwright run resolves the imports).

No behaviour defect surfaced while moving the fixture.
