### PR TITLE
fix(ui): the goal chooser leads with the neutral default

### DIFF
--- a/changelog.d/fix-goal-chooser-health-first.md
+++ b/changelog.d/fix-goal-chooser-health-first.md
@@ -1,0 +1,7 @@
+### Changed
+
+- **The usage-goal chooser now leads with "track my health".** Onboarding, the
+  settings cycle section and the dashboard goal switch list the neutral default
+  first, followed by the two alternative modes (avoid pregnancy, trying to
+  conceive). Display order only: the default mode, what a submitted answer
+  means, and skipping the onboarding question are all unchanged.

--- a/internal/api/onboarding_step2_values_regressions_test.go
+++ b/internal/api/onboarding_step2_values_regressions_test.go
@@ -58,6 +58,41 @@ func TestOnboardingPageRendersPersistedStep2Values(t *testing.T) {
 	}
 }
 
+// TestOnboardingStep2ModeChooserLeadsWithTheNeutralDefault pins the display
+// order of the mode question: the neutral default ("track my health") is the
+// first option and the two alternative modes follow it. Only the order is
+// pinned — the submitted value is read by name, never by position, so the
+// default stays the default whether it is answered, changed, or skipped.
+func TestOnboardingStep2ModeChooserLeadsWithTheNeutralDefault(t *testing.T) {
+	app, database := newOnboardingTestApp(t)
+	user := createOnboardingTestUser(t, database, "onboarding-step2-goal-order@example.com", "StrongPass1", false)
+	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
+
+	request := httptest.NewRequest(http.MethodGet, "/onboarding?step=2", nil)
+	request.Header.Set("Cookie", authCookie)
+
+	response := mustAppResponse(t, app, request)
+	assertStatusCode(t, response, http.StatusOK)
+	document := mustParseHTMLDocument(t, mustReadBodyString(t, response.Body))
+
+	assertUsageGoalOrder(t, htmlRadioValues(document, "usage_goal"))
+}
+
+// assertUsageGoalOrder holds the one order every usage-goal chooser renders.
+func assertUsageGoalOrder(t *testing.T, values []string) {
+	t.Helper()
+
+	want := []string{models.UsageGoalHealth, models.UsageGoalAvoid, models.UsageGoalTrying}
+	if len(values) != len(want) {
+		t.Fatalf("expected usage-goal options %v, got %v", want, values)
+	}
+	for index, value := range want {
+		if values[index] != value {
+			t.Fatalf("expected usage-goal options %v, got %v", want, values)
+		}
+	}
+}
+
 // TestOnboardingStep2DropsAgeAndKeepsASkippableModeChoice pins the shape of the
 // second onboarding step: the age bracket is no longer asked for here (it stays
 // reachable in settings), while the usage-goal question stays visible and gains

--- a/internal/api/settings_cycle_regressions_test.go
+++ b/internal/api/settings_cycle_regressions_test.go
@@ -162,6 +162,19 @@ func TestSettingsPageRendersPersistedCycleValues(t *testing.T) {
 	}
 }
 
+// TestSettingsUsageGoalChooserLeadsWithTheNeutralDefault pins the display order
+// of the settings mode chooser against the same contract onboarding renders:
+// the neutral default first, the two alternative modes after it.
+func TestSettingsUsageGoalChooserLeadsWithTheNeutralDefault(t *testing.T) {
+	app, database := newOnboardingTestApp(t)
+	user := createOnboardingTestUser(t, database, "settings-goal-order@example.com", "StrongPass1", true)
+	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
+
+	document := mustParseHTMLDocument(t, renderSettingsPageForTest(t, app, authCookie))
+
+	assertUsageGoalOrder(t, htmlRadioValues(document, "usage_goal"))
+}
+
 // TestSettingsCycleGoalOnlyPatchWritesNothingButTheGoal covers the shape the
 // dashboard quick switch sends: a body carrying usage_goal and nothing else.
 // It rides the endpoint the settings form already uses, writes only that one

--- a/internal/api/test_html_helpers_test.go
+++ b/internal/api/test_html_helpers_test.go
@@ -74,6 +74,21 @@ func htmlSectionIDs(root *html.Node) []string {
 	return ids
 }
 
+// htmlRadioValues lists the value attributes of one radio group in document
+// order, so a test can pin the order options are offered in.
+func htmlRadioValues(root *html.Node, name string) []string {
+	radios := htmlFindElements(root, func(node *html.Node) bool {
+		return node.Type == html.ElementNode && node.Data == "input" &&
+			htmlAttr(node, "type") == "radio" && htmlAttr(node, "name") == name
+	})
+
+	values := make([]string, 0, len(radios))
+	for _, radio := range radios {
+		values = append(values, htmlAttr(radio, "value"))
+	}
+	return values
+}
+
 func htmlFindElement(root *html.Node, predicate func(*html.Node) bool) *html.Node {
 	var found *html.Node
 	var walk func(*html.Node)

--- a/internal/services/settings_cycle_policy.go
+++ b/internal/services/settings_cycle_policy.go
@@ -117,11 +117,12 @@ func (service *SettingsService) ApplyUsageGoal(user *models.User, usageGoal stri
 
 // AlternativeUsageGoals lists the modes the owner is not currently in, in a
 // stable order, so a quick-switch surface can offer every other mode without
-// re-offering the one already in force.
+// re-offering the one already in force. The order matches the chooser on every
+// other surface: the neutral default first, the two alternative modes after it.
 func AlternativeUsageGoals(current string) []string {
 	normalized := NormalizeUsageGoal(current)
 	alternatives := make([]string, 0, 2)
-	for _, goal := range []string{models.UsageGoalAvoid, models.UsageGoalTrying, models.UsageGoalHealth} {
+	for _, goal := range []string{models.UsageGoalHealth, models.UsageGoalAvoid, models.UsageGoalTrying} {
 		if goal != normalized {
 			alternatives = append(alternatives, goal)
 		}

--- a/internal/services/usage_goal_autonomy_test.go
+++ b/internal/services/usage_goal_autonomy_test.go
@@ -138,8 +138,8 @@ func TestApplyUsageGoalNormalizesAndToleratesAMissingUser(t *testing.T) {
 func TestAlternativeUsageGoalsOffersEveryOtherMode(t *testing.T) {
 	cases := map[string][]string{
 		models.UsageGoalHealth: {models.UsageGoalAvoid, models.UsageGoalTrying},
-		models.UsageGoalAvoid:  {models.UsageGoalTrying, models.UsageGoalHealth},
-		models.UsageGoalTrying: {models.UsageGoalAvoid, models.UsageGoalHealth},
+		models.UsageGoalAvoid:  {models.UsageGoalHealth, models.UsageGoalTrying},
+		models.UsageGoalTrying: {models.UsageGoalHealth, models.UsageGoalAvoid},
 		// An unset column reads as the neutral default, so it offers the same
 		// pair as an explicit "track my health".
 		"": {models.UsageGoalAvoid, models.UsageGoalTrying},

--- a/internal/templates/components/settings_cycle.html
+++ b/internal/templates/components/settings_cycle.html
@@ -136,16 +136,16 @@
         </div>
         <div class="grid gap-2">
           <label class="choice-option">
+            <input type="radio" name="usage_goal" value="health" class="choice-input" {{if or (eq .UsageGoal "health") (eq .UsageGoal "")}}checked{{end}}>
+            <span class="chip chip-stack"><span>{{t .Messages "settings.goal.health"}}</span></span>
+          </label>
+          <label class="choice-option">
             <input type="radio" name="usage_goal" value="avoid_pregnancy" class="choice-input" {{if eq .UsageGoal "avoid_pregnancy"}}checked{{end}}>
             <span class="chip chip-stack"><span>{{t .Messages "settings.goal.avoid"}}</span></span>
           </label>
           <label class="choice-option">
             <input type="radio" name="usage_goal" value="trying_to_conceive" class="choice-input" {{if eq .UsageGoal "trying_to_conceive"}}checked{{end}}>
             <span class="chip chip-stack"><span>{{t .Messages "settings.goal.trying"}}</span></span>
-          </label>
-          <label class="choice-option">
-            <input type="radio" name="usage_goal" value="health" class="choice-input" {{if or (eq .UsageGoal "health") (eq .UsageGoal "")}}checked{{end}}>
-            <span class="chip chip-stack"><span>{{t .Messages "settings.goal.health"}}</span></span>
           </label>
         </div>
         {{/* The mode summary sits inside the group it belongs to. Its

--- a/internal/templates/onboarding.html
+++ b/internal/templates/onboarding.html
@@ -160,16 +160,16 @@
           <p class="field-label">{{t .Messages "onboarding.step2.usage_goal"}}</p>
           <div class="grid gap-2">
             <label class="choice-option">
+              <input type="radio" name="usage_goal" value="health" class="choice-input" {{if or (eq .UsageGoal "health") (eq .UsageGoal "")}}checked{{end}}>
+              <span class="chip chip-stack"><span>{{t .Messages "settings.goal.health"}}</span></span>
+            </label>
+            <label class="choice-option">
               <input type="radio" name="usage_goal" value="avoid_pregnancy" class="choice-input" {{if eq .UsageGoal "avoid_pregnancy"}}checked{{end}}>
               <span class="chip chip-stack"><span>{{t .Messages "settings.goal.avoid"}}</span></span>
             </label>
             <label class="choice-option">
               <input type="radio" name="usage_goal" value="trying_to_conceive" class="choice-input" {{if eq .UsageGoal "trying_to_conceive"}}checked{{end}}>
               <span class="chip chip-stack"><span>{{t .Messages "settings.goal.trying"}}</span></span>
-            </label>
-            <label class="choice-option">
-              <input type="radio" name="usage_goal" value="health" class="choice-input" {{if or (eq .UsageGoal "health") (eq .UsageGoal "")}}checked{{end}}>
-              <span class="chip chip-stack"><span>{{t .Messages "settings.goal.health"}}</span></span>
             </label>
           </div>
           <button type="submit" class="btn-secondary" data-onboarding-usage-goal-skip>{{t .Messages "onboarding.step2.usage_goal_skip"}}</button>


### PR DESCRIPTION
## Why

Every surface that lets an account choose its usage goal listed the neutral default — "track my
health" — last, behind avoid pregnancy and trying to conceive. The mode an account is in until it
says otherwise read as an afterthought, and the two intent-carrying modes led the list.

## What changed

The three choosers now offer the neutral default first, with the two alternative modes after it:

- onboarding step 2 (`internal/templates/onboarding.html`),
- the settings cycle section (`internal/templates/components/settings_cycle.html`),
- the dashboard goal switch, which takes its order from `services.AlternativeUsageGoals` — that
  list leads with health too, so the neutral mode is the first offer whenever it is not the mode
  already in force.

Display order only. The submitted value is read by name and normalized (`NormalizeUsageGoal`), an
unknown or absent answer still resolves to health, skipping the onboarding question still completes
with the neutral default, and the radio group, keyboard behaviour and chip states are untouched. No
service behaviour, no schema, no persistence change.

## Tests

New regressions pin the rendered order on both radio choosers
(`TestOnboardingStep2ModeChooserLeadsWithTheNeutralDefault`,
`TestSettingsUsageGoalChooserLeadsWithTheNeutralDefault`, sharing a new `htmlRadioValues` helper);
both were confirmed red against the previous order before the fix was restored.
`TestAlternativeUsageGoalsOffersEveryOtherMode` pins the same order for the dashboard switch.

Run locally: `go test ./...` (all packages green), `golangci-lint run ./internal/...` (0 issues),
`npm run build` (no bundle diff) and `npm run lint`, plus Playwright headless over
`onboarding.spec.ts`, `settings-profile-cycle.spec.ts` and `dashboard.spec.ts` — 49 passed, no spec
asserted the old order, so no spec needed updating.
