### PR TITLE
fix(ui): the phase cards on Insights draw an icon, not its name

### DIFF
--- a/changelog.d/fix-stats-bare-phase-icon.md
+++ b/changelog.d/fix-stats-bare-phase-icon.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- **The mood- and symptom-by-phase cards on Insights draw their phase icon
+  again.** Both cards passed the phase icon's *name* to the page instead of the
+  icon, so each phase heading read "drop Menstrual" or "sprout Follicular", with
+  the English name showing through in every language. They now render the same
+  sprite icon as the rest of the page, and a template guard fails the build if
+  any surface reaches for a phase icon without drawing it.

--- a/internal/api/a11y_live_region_regression_test.go
+++ b/internal/api/a11y_live_region_regression_test.go
@@ -382,6 +382,61 @@ func TestInterfaceGlyphsComeFromTheFirstPartyIconSet(t *testing.T) {
 	}
 }
 
+// phaseIconWrapperPattern matches the only sanctioned use of the phase-icon
+// helper: the name it returns handed straight to the icon template.
+var phaseIconWrapperPattern = regexp.MustCompile(`{{template "icon" \(phaseIcon [^()]*\)}}`)
+
+// TestTemplatesDrawThePhaseIconThroughTheIconTemplate closes the gap the guard
+// above cannot see. phaseIcon returns an icon *name*, not markup, so a bare
+// {{phaseIcon .Phase}} renders that name as visible text — Insights read
+// "drop Menstrual" and "sprout Follicular" next to the phase labels, in every
+// locale, and the sprite-and-emoji scan passed it because a name is neither an
+// emoji nor an {{template "icon" "..."}} reference. Every call site therefore
+// goes through the icon template.
+func TestTemplatesDrawThePhaseIconThroughTheIconTemplate(t *testing.T) {
+	var scanned, wrapped int
+	err := fs.WalkDir(templates.Files, ".", func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() || !strings.HasSuffix(path, ".html") {
+			return nil
+		}
+		source, readErr := templates.Files.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		scanned++
+
+		for number, line := range strings.Split(string(source), "\n") {
+			wrapped += len(phaseIconWrapperPattern.FindAllString(line, -1))
+			// What is left once the sanctioned form is removed is a call site
+			// whose result reaches the page as text.
+			if !strings.Contains(phaseIconWrapperPattern.ReplaceAllString(line, ""), "phaseIcon") {
+				continue
+			}
+			t.Errorf(
+				"%s:%d: the phase icon is invoked outside the icon template, so its name renders as visible text.\n"+
+					"Write {{template \"icon\" (phaseIcon <phase>)}} inside an element carrying aria-hidden=\"true\".\n"+
+					"line: %s",
+				path, number+1, strings.TrimSpace(line),
+			)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk embedded templates: %v", err)
+	}
+	if scanned == 0 {
+		t.Fatal("no templates were scanned: the embedded template FS layout changed and this guard silently stopped checking anything")
+	}
+	// Without this anchor the guard would also pass a UI that stopped drawing
+	// the phase icon anywhere at all.
+	if wrapped == 0 {
+		t.Fatal("no template draws the phase icon through the icon template any more: the phase chips lost their glyph, or the helper was renamed")
+	}
+}
+
 // TestBaseLayoutInlinesTheIconSprite keeps the sprite in the document every
 // icon references: <use> resolves same-document only here, by design — an
 // external sprite file would need a request the strict CSP is meant to make

--- a/internal/templates/stats.html
+++ b/internal/templates/stats.html
@@ -363,7 +363,7 @@
           {{range .PhaseMoodInsights}}
           <article class="card-quiet card-fit">
             <div class="flex items-center gap-2">
-              <span aria-hidden="true">{{phaseIcon .Phase}}</span>
+              <span aria-hidden="true">{{template "icon" (phaseIcon .Phase)}}</span>
               <p class="text-sm font-semibold text-(--text-primary)">{{phaseLabel $.Messages .Phase}}</p>
             </div>
             {{if .HasData}}
@@ -389,7 +389,7 @@
           {{range .PhaseSymptomInsights}}
           <article class="card-quiet card-fit">
             <div class="flex items-center gap-2">
-              <span aria-hidden="true">{{phaseIcon .Phase}}</span>
+              <span aria-hidden="true">{{template "icon" (phaseIcon .Phase)}}</span>
               <p class="text-sm font-semibold text-(--text-primary)">{{phaseLabel $.Messages .Phase}}</p>
             </div>
             {{if .HasData}}


### PR DESCRIPTION
## Problem

The mood-by-phase and symptoms-by-phase cards on Insights rendered
`{{phaseIcon .Phase}}` bare. That helper returns an icon *name*, so the name
itself reached the page as text: every card heading read "drop Menstrual",
"sprout Follicular", "sun Ovulation", "leaf Luteal". The names are English, so
the leak showed on every locale's Insights page, not only `en`.

The conversion of `PhaseIcon` to icon names fixed the phase chip at the top of
the same page (`internal/templates/stats.html:106`, `:109`) and the dashboard
chip; these two call sites in the lower card grid were missed.

## Change

- `internal/templates/stats.html:366`, `:392` — both call sites now draw the
  icon through the icon template, `{{template "icon" (phaseIcon .Phase)}}`,
  inside the same `aria-hidden="true"` span the fixed sites use. Markup,
  classes and copy are otherwise untouched; no new utility class, so the CSS
  bundle is unchanged (`npm run build` produces no diff).
- `internal/api/a11y_live_region_regression_test.go` —
  `TestTemplatesDrawThePhaseIconThroughTheIconTemplate` closes the gap that let
  this ship. `TestInterfaceGlyphsComeFromTheFirstPartyIconSet` verifies that
  referenced icons exist in the sprite and that no emoji remain, but a bare
  name is neither an emoji nor an `{{template "icon" "..."}}` reference, so it
  had nothing to match. The new guard scans the embedded templates and fails
  any line that invokes the phase icon outside that wrapper, naming file and
  line. It also anchors on at least one wrapped call site, so a UI that stopped
  drawing the phase icon anywhere would fail rather than pass vacuously.

## Verification

- Proof on the defect: with both template sites reverted to the bare form, the
  new guard fails and names `stats.html:366` and `stats.html:392`; the existing
  icon-set guard stays green throughout, which is the gap this closes. Fix
  restored, both green.
- `go test ./internal/api/... ./internal/services/...` — green.
- `golangci-lint run ./internal/api/...` — 0 issues.
- `npm run build` — `web/static` unchanged.
- `npm run e2e:fast -- e2e/stats-insights.spec.ts` (chromium, headless) —
  4 passed, including the symptom-pattern scenario that renders a by-phase card.

## Risk

Presentational and confined to two template expressions plus one new test. No
service, persistence, transport or i18n change; no new data reaches the page —
the icon name stops reaching it.
