### PR TITLE
chore: drop Go declarations no caller reaches

### DIFF
--- a/changelog.d/chore-drop-dead-go-declarations.md
+++ b/changelog.d/chore-drop-dead-go-declarations.md
@@ -1,0 +1,8 @@
+none
+
+Dead-code removal with no user-visible effect: an unused settings-update struct,
+an unused TOTP sentinel error, the single-branch `httpx.JSONMode` enum (JSON
+negotiation already ran in accept-or-content-type mode everywhere, and now says
+so without a parameter), and an exported phase-symptom-insight wrapper no
+production caller reached — its test now drives the same path the stats page
+does.

--- a/internal/api/http_helpers.go
+++ b/internal/api/http_helpers.go
@@ -33,7 +33,7 @@ func hasJSONBody(c fiber.Ctx) bool {
 }
 
 func responseFormat(c fiber.Ctx) httpx.ResponseFormat {
-	return httpx.NegotiateResponseFormat(c, httpx.JSONModeAcceptOrContentType)
+	return httpx.NegotiateResponseFormat(c)
 }
 
 // csrfToken returns the per-request CSRF token the middleware stored in the

--- a/internal/httpx/negotiation.go
+++ b/internal/httpx/negotiation.go
@@ -6,13 +6,6 @@ import (
 	"github.com/gofiber/fiber/v3"
 )
 
-type JSONMode uint8
-
-const (
-	JSONModeAcceptOnly JSONMode = iota
-	JSONModeAcceptOrContentType
-)
-
 type ResponseFormat uint8
 
 const (
@@ -30,24 +23,22 @@ func HasJSONContentType(c fiber.Ctx) bool {
 	return strings.Contains(contentType, fiber.MIMEApplicationJSON)
 }
 
-func AcceptsJSON(c fiber.Ctx, mode JSONMode) bool {
+// AcceptsJSON reports whether the caller asked for JSON, either through the
+// Accept header or by sending a JSON body.
+func AcceptsJSON(c fiber.Ctx) bool {
 	accept := strings.ToLower(c.Get("Accept"))
 	if strings.Contains(accept, fiber.MIMEApplicationJSON) {
 		return true
 	}
 
-	if mode == JSONModeAcceptOrContentType && HasJSONContentType(c) {
-		return true
-	}
-
-	return false
+	return HasJSONContentType(c)
 }
 
-func NegotiateResponseFormat(c fiber.Ctx, mode JSONMode) ResponseFormat {
+func NegotiateResponseFormat(c fiber.Ctx) ResponseFormat {
 	switch {
 	case IsHTMX(c):
 		return ResponseFormatHTMX
-	case AcceptsJSON(c, mode):
+	case AcceptsJSON(c):
 		return ResponseFormatJSON
 	default:
 		return ResponseFormatHTML

--- a/internal/httpx/negotiation_test.go
+++ b/internal/httpx/negotiation_test.go
@@ -10,11 +10,10 @@ import (
 )
 
 type negotiationSnapshot struct {
-	HTMX                 bool   `json:"htmx"`
-	JSONAcceptOnly       bool   `json:"json_accept_only"`
-	JSONAcceptOrBodyType bool   `json:"json_accept_or_body_type"`
-	HasJSONContentType   bool   `json:"has_json_content_type"`
-	ResponseFormat       string `json:"response_format"`
+	HTMX               bool   `json:"htmx"`
+	AcceptsJSON        bool   `json:"accepts_json"`
+	HasJSONContentType bool   `json:"has_json_content_type"`
+	ResponseFormat     string `json:"response_format"`
 }
 
 func readNegotiationSnapshot(t *testing.T, headers map[string]string) negotiationSnapshot {
@@ -23,7 +22,7 @@ func readNegotiationSnapshot(t *testing.T, headers map[string]string) negotiatio
 	app := fiber.New()
 	app.Post("/", func(c fiber.Ctx) error {
 		format := "html"
-		switch NegotiateResponseFormat(c, JSONModeAcceptOrContentType) {
+		switch NegotiateResponseFormat(c) {
 		case ResponseFormatHTMX:
 			format = "htmx"
 		case ResponseFormatJSON:
@@ -31,11 +30,10 @@ func readNegotiationSnapshot(t *testing.T, headers map[string]string) negotiatio
 		}
 
 		return c.JSON(negotiationSnapshot{
-			HTMX:                 IsHTMX(c),
-			JSONAcceptOnly:       AcceptsJSON(c, JSONModeAcceptOnly),
-			JSONAcceptOrBodyType: AcceptsJSON(c, JSONModeAcceptOrContentType),
-			HasJSONContentType:   HasJSONContentType(c),
-			ResponseFormat:       format,
+			HTMX:               IsHTMX(c),
+			AcceptsJSON:        AcceptsJSON(c),
+			HasJSONContentType: HasJSONContentType(c),
+			ResponseFormat:     format,
 		})
 	})
 
@@ -70,27 +68,21 @@ func TestIsHTMXAndAcceptsJSONViaAcceptHeader(t *testing.T) {
 	if !snapshot.HTMX {
 		t.Fatal("expected HTMX=true")
 	}
-	if !snapshot.JSONAcceptOnly {
-		t.Fatal("expected JSONAcceptOnly=true")
-	}
-	if !snapshot.JSONAcceptOrBodyType {
-		t.Fatal("expected JSONAcceptOrBodyType=true")
+	if !snapshot.AcceptsJSON {
+		t.Fatal("expected AcceptsJSON=true")
 	}
 	if snapshot.ResponseFormat != "htmx" {
 		t.Fatalf("expected HTMX response format, got %q", snapshot.ResponseFormat)
 	}
 }
 
-func TestAcceptsJSONViaContentTypeOnlyWhenModeAllows(t *testing.T) {
+func TestAcceptsJSONViaContentTypeAlone(t *testing.T) {
 	snapshot := readNegotiationSnapshot(t, map[string]string{
 		"Content-Type": "application/json; charset=utf-8",
 	})
 
-	if snapshot.JSONAcceptOnly {
-		t.Fatal("expected JSONAcceptOnly=false when Accept header has no json")
-	}
-	if !snapshot.JSONAcceptOrBodyType {
-		t.Fatal("expected JSONAcceptOrBodyType=true for JSON Content-Type")
+	if !snapshot.AcceptsJSON {
+		t.Fatal("expected AcceptsJSON=true for a JSON Content-Type without a JSON Accept header")
 	}
 	if !snapshot.HasJSONContentType {
 		t.Fatal("expected HasJSONContentType=true for JSON Content-Type")
@@ -109,11 +101,8 @@ func TestAcceptsJSONFalseWhenHeadersDoNotContainJSON(t *testing.T) {
 	if snapshot.HTMX {
 		t.Fatal("expected HTMX=false")
 	}
-	if snapshot.JSONAcceptOnly {
-		t.Fatal("expected JSONAcceptOnly=false")
-	}
-	if snapshot.JSONAcceptOrBodyType {
-		t.Fatal("expected JSONAcceptOrBodyType=false")
+	if snapshot.AcceptsJSON {
+		t.Fatal("expected AcceptsJSON=false")
 	}
 	if snapshot.HasJSONContentType {
 		t.Fatal("expected HasJSONContentType=false")

--- a/internal/services/settings_interface_policy.go
+++ b/internal/services/settings_interface_policy.go
@@ -2,11 +2,6 @@ package services
 
 import "strings"
 
-type InterfaceSettingsUpdate struct {
-	Language string
-	Theme    string
-}
-
 // NormalizeInterfaceTheme accepts the three theme preferences the interface
 // form can submit. The theme itself stays client-side (localStorage), so the
 // server only validates the value; "system" is a standing instruction to follow

--- a/internal/services/stats_phase_insights.go
+++ b/internal/services/stats_phase_insights.go
@@ -173,24 +173,6 @@ func (service *StatsService) BuildPhaseMoodInsights(user *models.User, logs []mo
 	return insights, hasData
 }
 
-func (service *StatsService) BuildPhaseSymptomInsights(ctx context.Context, user *models.User, logs []models.DailyLog, location *time.Location) ([]StatsPhaseSymptomInsight, bool, error) {
-	if !canBuildPhaseSymptomInsights(service, user) {
-		return nil, false, nil
-	}
-
-	symptomByID, err := service.phaseInsightSymptomMap(ctx, user.ID)
-	if err != nil {
-		return nil, false, err
-	}
-
-	insights, hasData := buildPhaseSymptomInsightsWithMap(logs, location, symptomByID)
-	return insights, hasData, nil
-}
-
-func canBuildPhaseSymptomInsights(service *StatsService, user *models.User) bool {
-	return IsOwnerUser(user) && service != nil && service.symptoms != nil
-}
-
 func buildPhaseSymptomInsightsWithMap(logs []models.DailyLog, location *time.Location, symptomByID map[uint]models.SymptomType) ([]StatsPhaseSymptomInsight, bool) {
 	cycles := buildCompletedCyclePhaseContexts(logs, location)
 	if len(cycles) < minimumPhaseInsightCycles || len(symptomByID) == 0 {

--- a/internal/services/stats_phase_insights_test.go
+++ b/internal/services/stats_phase_insights_test.go
@@ -53,12 +53,17 @@ func TestBuildPhaseSymptomInsightsSortsAndTruncatesTopThree(t *testing.T) {
 			{ID: 4, Name: "Headache", Icon: "H"},
 		},
 	})
-	owner := &models.User{ID: 7, Role: models.RoleOwner}
-
-	insights, ok, err := service.BuildPhaseSymptomInsights(context.Background(), owner, buildPhaseInsightLogs(t), time.UTC)
+	// The live path (buildOwnerStatsInsights) checks the owner role and the
+	// symptom reader itself, then resolves the catalogue and folds the logs
+	// against it — so the test drives those two steps rather than a wrapper of
+	// its own.
+	const ownerID uint = 7
+	symptomByID, err := service.phaseInsightSymptomMap(context.Background(), ownerID)
 	if err != nil {
 		t.Fatalf("expected nil error, got %v", err)
 	}
+
+	insights, ok := buildPhaseSymptomInsightsWithMap(buildPhaseInsightLogs(t), time.UTC, symptomByID)
 	if !ok {
 		t.Fatal("expected phase symptom insights to be available")
 	}

--- a/internal/services/totp_service.go
+++ b/internal/services/totp_service.go
@@ -23,7 +23,6 @@ const (
 )
 
 var (
-	ErrTOTPInvalidCode        = errors.New("totp invalid code")
 	ErrTOTPRateLimited        = errors.New("totp rate limited")
 	ErrTOTPDisableRateLimited = errors.New("totp disable rate limited")
 	ErrTOTPSecretEncrypt      = errors.New("totp secret encrypt failed")


### PR DESCRIPTION
First of five removals from a repository-wide dead-code audit. This one is Go
declarations only; the template-helper cascade, the locale keys, the CSS and the
unreachable JS branches follow in their own pull requests.

## What goes

| Declaration | Why it is dead |
| --- | --- |
| `services.InterfaceSettingsUpdate` | The only occurrence in the repository is the declaration. |
| `services.ErrTOTPInvalidCode` | Nothing returns it and nothing matches on it. |
| `httpx.JSONMode` (both constants, and the `mode` parameter) | Every production call site passed `JSONModeAcceptOrContentType`; the accept-only branch was reachable from its own unit test alone. |
| `StatsService.BuildPhaseSymptomInsights` + `canBuildPhaseSymptomInsights` | An exported wrapper only its own test called. |

## Notes

`AcceptsJSON` and `NegotiateResponseFormat` keep the behaviour they always had —
JSON is negotiated from the `Accept` header **or** a JSON `Content-Type`. Dropping
the parameter removes a knob that advertised a mode the product never selected.

The phase-insight gate went with the wrapper rather than surviving it: the live
path in `buildOwnerStatsInsights` already checks `IsOwnerUser` and a nil symptom
reader itself before resolving the catalogue, so `canBuildPhaseSymptomInsights`
duplicated checks that stay in force. The test now drives
`phaseInsightSymptomMap` + `buildPhaseSymptomInsightsWithMap`, which is what the
stats page runs.

## Verification

- `go build ./...`, `go vet`, `go test ./...`, `golangci-lint run ./...` — green.
- `deadcode ./cmd/...` no longer reports the phase-insight wrapper; the nine
  remaining entries are test-only helpers, handled in a later wave.

No user-visible change; changelog fragment is `none`.
