### PR TITLE
ci: fail the Go job on a function nothing can reach

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,32 @@ jobs:
       - name: Staticcheck
         run: '"$(go env GOPATH)/bin/staticcheck" ./cmd/... ./internal/... ./migrations/... ./scripts/... ./web/...'
 
+      - name: Install deadcode
+        # git SHA for golang.org/x/tools v0.49.0: 18332fec72972efbb8ab9881984fec2d8cfc2b58 (verified via go list -m -json)
+        run: go install golang.org/x/tools/cmd/deadcode@v0.49.0
+
+      # A barrier, not a detector: this reports nothing on the tree it was added
+      # to, and its job is to keep it that way. Measured 2026-08-15 — it found
+      # none of the ~40 declarations the dead-code campaign removed, because it
+      # analyses functions only (types and vars are out of scope) and counts a
+      # caller as a caller even when the caller is itself dead: three services
+      # functions were reached from a templateFuncMap entry no template used.
+      # What it does catch is a NEW function that nothing can reach.
+      #
+      # -test keeps deliberate test seams out of the verdict. Nine functions are
+      # reachable only from tests today; until they move into _test.go files the
+      # production-scoped run stays red, so it is not wired here yet.
+      #
+      # deadcode exits 0 with findings on stdout, so the output is what decides.
+      - name: Go dead code
+        shell: bash
+        run: |
+          findings="$("$(go env GOPATH)/bin/deadcode" -test ./cmd/... ./internal/... ./migrations/... ./scripts/... ./web/...)"
+          if [[ -n "${findings}" ]]; then
+            printf '%s\n' "${findings}"
+            exit 1
+          fi
+
       - name: Install golangci-lint
         # git SHA for v2.12.2: c0d3ddc9cf3faa61a4e378e879ece580256d76e5 (verified via go list -m -json)
         run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2

--- a/changelog.d/ci-deadcode-gate.md
+++ b/changelog.d/ci-deadcode-gate.md
@@ -1,0 +1,5 @@
+none
+
+CI only: the Go job now fails on a function nothing can reach, via a pinned
+`deadcode -test` run over the same five package trees the other Go steps use.
+No product code.


### PR DESCRIPTION
A preventive barrier, added while the tree is clean. Independent of the five
removal PRs (#469–#473) — this one is green on `main` as it stands today.

## Shape

A **step** in the existing `test-go` job, after Staticcheck, over the same five
package trees the other Go steps use. A step and not a job, so no new required
status check appears and the merge queue's contexts are untouched.

`deadcode` exits 0 with its findings on stdout, so the step inspects the output
rather than trusting the exit code. The version is pinned with its verified git
SHA in a comment, the convention the `staticcheck` and `golangci-lint` installs
already follow.

## Barrier, not detector — measured

On the tree it is added to, this run reports **nothing**. That includes every one
of the ~40 declarations #469–#473 remove. The reasons are structural:

- `deadcode` analyses **functions**; `InterfaceSettingsUpdate` and `JSONMode` are
  types, `ErrTOTPInvalidCode` is a var.
- it counts a caller as a caller **even when the caller is itself dead** —
  `SymptomGroup`, `RoleTranslationKey` and `StatusOKMarkup` were all reached from
  `templateFuncMap` entries no template ever used.
- `-test` treats a test as a consumer, which is what hides
  `BuildPhaseSymptomInsights`.

So this does not find existing dead code. It stops a **new** unreachable function
from landing, which is worth having precisely because the tree is about to be
clean.

## Both directions observed

A green run proves only that the tool agrees with the tree, so the gate was
checked from both sides:

| | result |
| --- | --- |
| current tree, pinned `v0.49.0` | green, no findings |
| plus one exported probe function nothing calls | **red, exit 1**, naming the probe |

The probe was deleted after the observation; `git status` clean.

## Why `-test` and not the production scope

Nine functions are reachable only from tests today (`OpenSQLite`, `NewDayService`,
`BuildAuthSessionToken`, `PluralCategories`, `EncryptFieldNoAADForTest`,
`SealedCipher.NonceSize`, `Handler.encodeAuthCookieToken`, and two calendar
compatibility wrappers). The production-scoped run stays red until those move
into `_test.go` files or their tests are re-pointed at the live path, so it is
deliberately not wired here. Wiring it is the follow-up to that cleanup, not a
reason to carry an allowlist — an allowlist is where later findings go unnoticed.

Changelog fragment is `none`.
