### PR TITLE
ci: type-check and lint the browser e2e suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,19 +50,77 @@ jobs:
     permissions:
       contents: read
 
+    # Each pinned analysis-tool version lives here, in exactly ONE place,
+    # because the binary cache key below is built from these same values. A key
+    # repeating the version as its own literal would be keyed on a SPELLING
+    # rather than on the thing: bumping a `go install` line and forgetting the
+    # key hands every later run the OLD binary out of cache, silently, while the
+    # workflow reads as though it had been bumped.
+    env:
+      # git SHA for v0.6.1 (tag 2025.1.1): b8ec13ce4d00445d75da053c47498e6f9ec5d7d6 (verified via go list -m -json)
+      STATICCHECK_VERSION: v0.6.1
+      # git SHA for golang.org/x/tools v0.49.0: 18332fec72972efbb8ab9881984fec2d8cfc2b58 (verified via go list -m -json)
+      DEADCODE_VERSION: v0.49.0
+      # git SHA for v2.12.2: c0d3ddc9cf3faa61a4e378e879ece580256d76e5 (verified via go list -m -json)
+      GOLANGCI_LINT_VERSION: v2.12.2
+
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Go
+        id: setup-go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache: true
 
+      # Caches the tool BINARIES. This is NOT the forbidden analysis cache, and
+      # the difference is the whole reason it is allowed: golangci-lint's
+      # analysis cache stores facts derived from a source tree that an
+      # actions/cache key cannot name, so a hit can carry a verdict computed
+      # against different code — that is what produced six deterministic phantom
+      # SA5011 findings (2026-08-03; see the note above the golangci-lint step).
+      # A compiled binary carries no facts about this repository at all: it is a
+      # pure function of its pinned version and the toolchain that built it, and
+      # the key names both in full.
+      #
+      # No `restore-keys`: a prefix match would serve a binary of a DIFFERENT
+      # pinned version, the exact failure the full key exists to prevent. A miss
+      # costs the 54 s below and nothing else.
+      #
+      # Measured 2026-08-15 on run 31849738519: `Install golangci-lint` 41 s,
+      # `Install staticcheck` 9 s, `Install deadcode` 4 s, on a 7 min 23 s job.
+      - name: Cache Go tool binaries
+        id: go-tools
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/go/bin
+          key: ${{ runner.os }}-gotools-go${{ steps.setup-go.outputs.go-version }}-staticcheck${{ env.STATICCHECK_VERSION }}-deadcode${{ env.DEADCODE_VERSION }}-golangcilint${{ env.GOLANGCI_LINT_VERSION }}
+
+      - name: Verify the restored binaries are the pinned versions
+        # A cache hit is only as good as its key, and a key that quietly stopped
+        # tracking a bump would lint this repository with the wrong tool while
+        # every step stayed green. This turns that into a red step.
+        #
+        # Both tools print the version WITHOUT the leading `v` (measured
+        # 2026-08-15: `staticcheck.exe 2025.1.1 (0.6.1)` and `golangci-lint has
+        # version 2.12.2 built with ...`), so the pin is matched with `${VAR#v}`
+        # — grepping the tag as written would fail every cache hit. `deadcode`
+        # has no version flag; the key covers it and its own step fails loudly
+        # if the binary is missing.
+        if: steps.go-tools.outputs.cache-hit == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          bin="$(go env GOPATH)/bin"
+          "$bin/staticcheck" -version | grep -F "(${STATICCHECK_VERSION#v})"
+          "$bin/golangci-lint" --version | grep -F "version ${GOLANGCI_LINT_VERSION#v} "
+          test -x "$bin/deadcode"
+
       - name: Install staticcheck
-        # git SHA for v0.6.1 (tag 2025.1.1): b8ec13ce4d00445d75da053c47498e6f9ec5d7d6 (verified via go list -m -json)
-        run: go install honnef.co/go/tools/cmd/staticcheck@v0.6.1
+        if: steps.go-tools.outputs.cache-hit != 'true'
+        run: go install "honnef.co/go/tools/cmd/staticcheck@$STATICCHECK_VERSION"
 
       # The Go wildcards in this job are scoped to our module's package trees
       # (cmd, internal, migrations, scripts, web) instead of ./... — this job
@@ -74,8 +132,8 @@ jobs:
         run: '"$(go env GOPATH)/bin/staticcheck" ./cmd/... ./internal/... ./migrations/... ./scripts/... ./web/...'
 
       - name: Install deadcode
-        # git SHA for golang.org/x/tools v0.49.0: 18332fec72972efbb8ab9881984fec2d8cfc2b58 (verified via go list -m -json)
-        run: go install golang.org/x/tools/cmd/deadcode@v0.49.0
+        if: steps.go-tools.outputs.cache-hit != 'true'
+        run: go install "golang.org/x/tools/cmd/deadcode@$DEADCODE_VERSION"
 
       # A barrier, not a detector: this reports nothing on the tree it was added
       # to, and its job is to keep it that way. Measured 2026-08-15 — it found
@@ -100,8 +158,8 @@ jobs:
           fi
 
       - name: Install golangci-lint
-        # git SHA for v2.12.2: c0d3ddc9cf3faa61a4e378e879ece580256d76e5 (verified via go list -m -json)
-        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
+        if: steps.go-tools.outputs.cache-hit != 'true'
+        run: go install "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$GOLANGCI_LINT_VERSION"
 
       # No cache for golangci-lint's own analysis cache: its key can only name
       # go.sum and .golangci.yml, never the source tree, so a branch whose
@@ -472,7 +530,6 @@ jobs:
     permissions:
       contents: read
     needs:
-      - test
       - changes
     # `e2e` is a required status check (branch protection). Historical note:
     # this job gates each work STEP instead of using a job-level `if` because
@@ -488,6 +545,22 @@ jobs:
     # ordinary path, not only if the two allowlists in `changes` ever diverge.
     # Those guards carry the battery's fail-safe form
     # (`!= 'false'`): an absent output must not silently green a job that ran.
+    #
+    # NOT `needs: test`. That edge was the whole critical path: measured
+    # 2026-08-15 on run 31849738519, `test-go` ran 7 min 23 s and this job did
+    # not start until it finished, so a 13 min 48 s browser suite reported at
+    # 21 min 27 s. Nothing here consumes an artifact or an output of the unit
+    # battery — the edge only expressed "don't burn browser minutes until the
+    # cheap suites pass", which on a public repository buys nothing and costs
+    # every green run those 7 minutes twice over (pull_request, then again in
+    # merge_group).
+    #
+    # Dropping it also closes a hole rather than opening one. A failed
+    # dependency SKIPS a job, and a skipped required check counts as SATISFIED
+    # (measured 2026-08-08) — so while this edge existed, a failing `test-go`
+    # left `e2e` skipped, i.e. green, and the browser suite never judged that
+    # commit at all. Now it runs on its own evidence and reports its own
+    # verdict.
     env:
       RUN_E2E: ${{ needs.changes.outputs.run_e2e }}
 
@@ -562,7 +635,6 @@ jobs:
     permissions:
       contents: read
     needs:
-      - test
       - changes
     # Required status check with admin enforcement: always run the job and gate
     # the work per step (see the `e2e` job above) so docs-only PRs stay green
@@ -635,7 +707,6 @@ jobs:
     permissions:
       contents: read
     needs:
-      - test
       - changes
     # Not a required status check, so cross-browser coverage beyond the plain
     # `e2e` job's Chromium run is deferred to push/release/dispatch. The

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,7 +213,24 @@ jobs:
         run: npm ci
 
       - name: Frontend lint
+        # Now scoped over e2e/ and playwright.config.ts as well. Until it was,
+        # the 47 .ts files of the browser suite were checked by nothing at all:
+        # this script never named them and TypeScript was not a dependency.
+        # Type-AWARE for those files, which is what buys `no-floating-promises`
+        # — a Playwright call whose `await` went missing still passes today,
+        # because the assertion it should have made never runs before the test
+        # ends. Measured 2026-08-15: 6.1 s locally for the whole scope.
         run: npm run lint:js
+
+      - name: Type-check the browser e2e suite
+        # The other half of the same hole. A broken signature or a dangling
+        # import in e2e/ used to reach CI only as a failing spec, minutes into
+        # a browser run; `tsc --noEmit` reports it in seconds. The first run of
+        # this check found six defects — three declarations nothing read and
+        # three reads of a possibly-null response — which are fixed in the same
+        # change, because a barrier that ships with a baseline is a list, not a
+        # barrier. Measured 2026-08-15: 2.4 s locally.
+        run: npm run lint:types
 
       - name: Frontend unit tests
         run: npm run test:unit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -524,14 +524,42 @@ jobs:
           # (not in consumers) if that ever changes.
           echo "run_battery=$run_e2e" >> "$GITHUB_OUTPUT"
 
-  e2e:
+  # The browser suite runs here, split across shards, and the required status
+  # check named `e2e` is the thin gate job below — the same shape branch
+  # protection already forces on `test`, and for the same reason: a matrix job
+  # reports one context per cell (`e2e-shard (1)`, ...), none of which is the
+  # literal name the required check is pinned to.
+  #
+  # Sharding is NOT raising parallelism inside one database, which
+  # `.claude/rules/e2e.md` rules out for the SQLite-backed stateful flows.
+  # Every shard is its own runner: its own `go run` app, its own SQLite file
+  # under .tmp/e2e, and still `--workers=1` from the runner (`--mode=ci`). What
+  # changes is how many app instances exist, not how many tests share one.
+  # This is only safe because every spec provisions its own owner —
+  # `createCredentials` mints a unique address per call — so no spec depends on
+  # state another spec file left behind.
+  #
+  # Measured 2026-08-15: 200 tests over 33 spec files, 793 s in one lane; three
+  # shards split them 76/60/64. The shard count is NOT repeated in the
+  # `--shard=` argument — `strategy.job-total` reads it off the matrix itself,
+  # so adding a shard is a one-line edit that cannot leave the divisor behind.
+  e2e-shard:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:
       contents: read
     needs:
       - changes
-    # `e2e` is a required status check (branch protection). Historical note:
+    strategy:
+      # One shard's failure must not cancel its siblings: the point of the
+      # split is to learn everything the browser lane knows in one run.
+      fail-fast: false
+      matrix:
+        shard:
+          - 1
+          - 2
+          - 3
+    # Historical note:
     # this job gates each work STEP instead of using a job-level `if` because
     # job-level skips were believed to leave the required check unsatisfied —
     # that is not how GitHub behaves today (a skipped job reports as a
@@ -563,32 +591,39 @@ jobs:
     # verdict.
     env:
       RUN_E2E: ${{ needs.changes.outputs.run_e2e }}
+      # On `push` the browser lane is a three-spec smoke, which is smaller than
+      # a single shard's share — so it runs whole on shard 1 and the other
+      # shards stand down rather than paying setup to run a fraction of it.
+      # Written in the fail-safe direction (`!= 'false'` at every use) like
+      # RUN_E2E: an expression that ever evaluates empty must leave the work
+      # running, never silently drop it.
+      SHARD_ACTIVE: ${{ github.event_name != 'push' || matrix.shard == 1 }}
 
     steps:
       - name: Checkout
-        if: env.RUN_E2E != 'false'
+        if: env.RUN_E2E != 'false' && env.SHARD_ACTIVE != 'false'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Go
-        if: env.RUN_E2E != 'false'
+        if: env.RUN_E2E != 'false' && env.SHARD_ACTIVE != 'false'
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache: false
 
       - name: Setup Node.js
-        if: env.RUN_E2E != 'false'
+        if: env.RUN_E2E != 'false' && env.SHARD_ACTIVE != 'false'
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: npm
 
       - name: Install frontend and e2e dependencies
-        if: env.RUN_E2E != 'false'
+        if: env.RUN_E2E != 'false' && env.SHARD_ACTIVE != 'false'
         run: npm ci
 
       - name: Cache Playwright browsers
-        if: env.RUN_E2E != 'false'
+        if: env.RUN_E2E != 'false' && env.SHARD_ACTIVE != 'false'
         id: playwright-cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -596,7 +631,7 @@ jobs:
           key: ${{ runner.os }}-playwright-chromium-${{ hashFiles('package-lock.json') }}
 
       - name: Install Playwright browser
-        if: env.RUN_E2E != 'false' && steps.playwright-cache.outputs.cache-hit != 'true'
+        if: env.RUN_E2E != 'false' && env.SHARD_ACTIVE != 'false' && steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
 
       - name: Install Playwright OS dependencies (cache hit)
@@ -604,16 +639,21 @@ jobs:
         # ~/.cache/ms-playwright; system packages (apt) never persist across
         # a fresh runner, so they still need installing even on a browser
         # cache hit — this is the fast path (no browser download).
-        if: env.RUN_E2E != 'false' && steps.playwright-cache.outputs.cache-hit == 'true'
+        if: env.RUN_E2E != 'false' && env.SHARD_ACTIVE != 'false' && steps.playwright-cache.outputs.cache-hit == 'true'
         run: npx playwright install-deps chromium
 
       - name: Run Playwright e2e (smoke on push, full otherwise)
-        if: env.RUN_E2E != 'false'
+        # The divisor comes from `strategy.job-total`, which GitHub computes
+        # from the matrix above — never a second literal to keep in step with
+        # it. `--shard` splits by spec file, and each shard gets its own app
+        # and database, so the runner's own `--workers=1` still holds inside
+        # one shard.
+        if: env.RUN_E2E != 'false' && env.SHARD_ACTIVE != 'false'
         run: |
           if [ "${{ github.event_name }}" = "push" ]; then
             npm run e2e:ci -- e2e/auth-login-register.spec.ts e2e/dashboard.spec.ts e2e/theme-dark-mode.spec.ts
           else
-            npm run e2e:ci
+            npm run e2e:ci -- --shard=${{ matrix.shard }}/${{ strategy.job-total }}
           fi
         env:
           E2E_APP_PORT: 18080
@@ -622,12 +662,48 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: playwright-artifacts
+          name: playwright-artifacts-shard-${{ matrix.shard }}
           path: |
             playwright-report
             test-results
             .tmp/e2e
           if-no-files-found: ignore
+
+  # Thin gate job named exactly `e2e` — branch protection's required status
+  # check is pinned to that literal context name, and a matrix job cannot
+  # provide it (its contexts are `e2e-shard (1)`, `e2e-shard (2)`, ...).
+  # Identical in shape and in reasoning to the `test` gate above: WITHOUT AN
+  # `if`, A FAILED DEPENDENCY SKIPS THIS JOB, and a skipped required check
+  # counts as satisfied — which would hand the merge a green `e2e` on a run
+  # where every shard failed.
+  #
+  # `needs.e2e-shard.result` is the aggregate over the whole matrix: `success`
+  # only when every shard succeeded, `failure` when any of them failed. With
+  # `fail-fast: false` above, all shards have reported by the time this runs.
+  e2e:
+    runs-on: ubuntu-latest
+    needs:
+      - e2e-shard
+    if: ${{ !cancelled() }}
+    permissions:
+      contents: read
+    steps:
+      - name: Judge the browser shards
+        env:
+          SHARDS_RESULT: ${{ needs.e2e-shard.result }}
+        run: |
+          set -euo pipefail
+          echo "e2e-shard=$SHARDS_RESULT"
+          # `skipped` is a PASS here and only here, for the same reason it is in
+          # the `test` gate: the `changes` job judged the diff irrelevant, which
+          # is a decision not to run rather than a failure to run. Anything else
+          # — failure, cancelled, or a state this gate has never seen — is this
+          # context's failure.
+          case "$SHARDS_RESULT" in
+            success|skipped) ;;
+            *) echo "::error::the browser shards reported \"$SHARDS_RESULT\""; exit 1 ;;
+          esac
+          echo "every browser shard passed."
 
   e2e-postgres-smoke:
     runs-on: ubuntu-latest

--- a/changelog.d/ci-e2e-off-critical-path.md
+++ b/changelog.d/ci-e2e-off-critical-path.md
@@ -1,0 +1,5 @@
+none
+
+CI only: the browser e2e jobs no longer wait for the unit battery, and the Go
+job's pinned analysis binaries are restored from cache instead of rebuilt. No
+product code.

--- a/changelog.d/ci-shard-browser-e2e.md
+++ b/changelog.d/ci-shard-browser-e2e.md
@@ -1,0 +1,5 @@
+none
+
+CI only: the browser e2e suite runs as three shards on separate runners, with a
+thin gate job keeping the required `e2e` status check. No product code, and no
+change to how many tests share one database.

--- a/changelog.d/ci-typecheck-e2e.md
+++ b/changelog.d/ci-typecheck-e2e.md
@@ -1,0 +1,5 @@
+none
+
+CI only: the browser e2e suite is now type-checked (`tsc --noEmit`) and linted
+(type-aware ESLint), and the six defects that first run found are fixed. No
+product code.

--- a/e2e/auth-recovery.spec.ts
+++ b/e2e/auth-recovery.spec.ts
@@ -61,7 +61,7 @@ test.describe('Auth: recovery and reset password', () => {
     expect(download.suggestedFilename()).toBe('ovumcy-recovery-code.txt');
     const downloadPath = await download.path();
     expect(downloadPath).toBeTruthy();
-    const downloadedContent = await fs.readFile(downloadPath!, 'utf8');
+    const downloadedContent = await fs.readFile(downloadPath, 'utf8');
     expect(downloadedContent).toContain(recoveryCode);
 
     await checkbox.check();

--- a/e2e/bugs.spec.ts
+++ b/e2e/bugs.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test, type Page } from '@playwright/test';
-import { clearDateField, fillDateField, formatDisplayDate } from './support/date-field-helpers';
+import { fillDateField, formatDisplayDate } from './support/date-field-helpers';
 import { selectOnboardingStartDate } from './support/onboarding-helpers';
 import { openCalendarDayEditor } from './support/stats-helpers';
 import { checkStyledControl } from './support/form-helpers';

--- a/e2e/calendar.spec.ts
+++ b/e2e/calendar.spec.ts
@@ -453,7 +453,11 @@ test.describe('Calendar page', () => {
       page.locator('#confirm-modal-accept').click(),
     ]);
     const cycleStartResponse = await cycleStartRequest.response();
-    expect(cycleStartResponse.status()).toBeLessThan(400);
+    expect(
+      cycleStartResponse,
+      `expected a response for POST /api/v1/days/${tomorrowISO}/cycle-start?source=calendar`
+    ).not.toBeNull();
+    expect(cycleStartResponse!.status()).toBeLessThan(400);
     await page.waitForLoadState('networkidle');
 
     await page.locator(`[data-day-editor-open="${tomorrowISO}"]`).first().click();
@@ -506,7 +510,11 @@ test.describe('Calendar page', () => {
       page.locator('#confirm-modal-accept').click(),
     ]);
     const cycleStartResponse = await cycleStartRequest.response();
-    expect(cycleStartResponse.status()).toBeLessThan(400);
+    expect(
+      cycleStartResponse,
+      `expected a response for POST /api/v1/days/${tomorrowISO}/cycle-start?source=calendar`
+    ).not.toBeNull();
+    expect(cycleStartResponse!.status()).toBeLessThan(400);
   });
 
   test('BBT tracking without a confirmed signal demotes the predicted ovulation day to a tentative dash', async ({
@@ -787,6 +795,10 @@ test.describe('Calendar page', () => {
       page.locator('#confirm-modal-accept').click(),
     ]);
     const cycleStartResponse = await cycleStartRequest.response();
-    expect(cycleStartResponse.status()).toBeLessThan(400);
+    expect(
+      cycleStartResponse,
+      `expected a response for POST /api/v1/days/${tomorrowISO}/cycle-start?source=calendar`
+    ).not.toBeNull();
+    expect(cycleStartResponse!.status()).toBeLessThan(400);
   });
 });

--- a/e2e/settings-password-export-danger.spec.ts
+++ b/e2e/settings-password-export-danger.spec.ts
@@ -65,12 +65,6 @@ async function registerOwnerAndOpenSettings(page: Page, prefix: string) {
   return { ...creds, recoveryCode };
 }
 
-async function readCSRFToken(page: Page): Promise<string> {
-  const csrfToken = await page.locator('meta[name="csrf-token"]').getAttribute('content');
-  expect(csrfToken).toBeTruthy();
-  return csrfToken ?? '';
-}
-
 async function todayISOFromCalendar(page: Page): Promise<string> {
   const todayButton = page.locator('button[data-day]:has(.calendar-today-pill)').first();
   await expect(todayButton).toBeVisible();

--- a/e2e/stats-insights.spec.ts
+++ b/e2e/stats-insights.spec.ts
@@ -8,6 +8,22 @@ import {
 } from './support/stats-helpers';
 import { localeText } from './support/locale-helpers';
 
+// The shape `mapStatsBBTChartData` serialises into the chart's `data-chart`
+// attribute (lowercase keys; `baseline`/`marker*` are present only when a
+// coverline was detected, with no separate boolean). Naming it once is what
+// lets the assertions below read fields instead of indexing an `any`: an
+// untyped `JSON.parse` makes every `parsed.<field>` unverifiable, so a typo in
+// a field name reads as `undefined` and quietly satisfies a `toBeUndefined()`.
+type BBTChartPayload = {
+  labels: string[];
+  values: (number | null)[];
+  valueTexts?: string[];
+  baseline?: number;
+  markerIndex?: number;
+  markerLabel?: string;
+  markerLabelKey?: string;
+};
+
 async function csrfToken(page: Page): Promise<string> {
   return (await page.locator('meta[name="csrf-token"]').getAttribute('content')) ?? '';
 }
@@ -75,7 +91,7 @@ test.describe('Stats: BBT chart', () => {
         headers: { Accept: 'application/json', ...apiOriginHeader(page) },
       });
       expect(response.status(), `GET ${isoDate}`).toBe(200);
-      const body = await response.json();
+      const body = (await response.json()) as { BBT?: number; bbt?: number };
       expect(body.BBT ?? body.bbt, `BBT on ${isoDate}`).toBeGreaterThan(35);
     }
 
@@ -97,11 +113,11 @@ test.describe('Stats: BBT chart', () => {
     // WITHOUT a coverline: the section itself is gated only on >= 5 values.
     const chartData = await bbtChart.getAttribute('data-chart');
     expect(chartData).toBeTruthy();
-    const parsed = JSON.parse(chartData ?? '');
+    const parsed = JSON.parse(chartData ?? '') as BBTChartPayload;
     expect(Array.isArray(parsed.labels)).toBe(true);
     expect(parsed.labels.length).toBeGreaterThanOrEqual(5);
     expect(Array.isArray(parsed.values)).toBe(true);
-    const numericValues = parsed.values.filter((v: number | null) => v !== null);
+    const numericValues = parsed.values.filter((v) => v !== null);
     expect(numericValues.length).toBeGreaterThanOrEqual(5);
     expect(parsed.baseline).toBeUndefined();
     expect(parsed.markerIndex).toBeUndefined();
@@ -128,7 +144,7 @@ test.describe('Stats: BBT chart', () => {
     // The same ±1 day boundary the rest of this spec tolerates can drop the
     // sample logged on "today", so the rendered readings are the leading run of
     // the seeded ones rather than all of them.
-    const valueTexts = parsed.valueTexts as string[];
+    const valueTexts = parsed.valueTexts ?? [];
     const expectedCells = valueTexts.map((text) => (text === '' ? noReading : `${text}${unit}`));
     const renderedReadings = expectedCells.filter((cell) => cell !== noReading);
     expect(renderedReadings.length).toBeGreaterThanOrEqual(5);
@@ -136,7 +152,7 @@ test.describe('Stats: BBT chart', () => {
       bbtSeries.slice(0, renderedReadings.length).map((value) => `${value.toFixed(1)}${unit}`)
     );
 
-    const values = parsed.values as Array<number | null>;
+    const values = parsed.values;
     await expect(disclosure.locator('[data-bbt-table-row]')).toHaveCount(values.length);
     expect(await disclosure.locator('[data-bbt-table-value]').allTextContents()).toEqual(
       expectedCells
@@ -223,7 +239,7 @@ test.describe('Stats: BBT chart', () => {
 
     const chartData = await page.locator('#bbt-chart').getAttribute('data-chart');
     expect(chartData).toBeTruthy();
-    const parsed = JSON.parse(chartData ?? '');
+    const parsed = JSON.parse(chartData ?? '') as BBTChartPayload;
     // The exact maxDay (and therefore markerIndex) shifts by ±1 with TZ
     // boundary effects between the JS local date and the server's calendar
     // day for stats.LastPeriodStart. Instead of pinning the index, assert
@@ -240,9 +256,12 @@ test.describe('Stats: BBT chart', () => {
     expect(parsed.markerIndex).toBeGreaterThanOrEqual(0);
     expect(typeof parsed.baseline).toBe('number');
 
-    const coverline = parsed.baseline as number;
-    const values = parsed.values as Array<number | null>;
-    const riseValues = values.slice(parsed.markerIndex + 1, parsed.markerIndex + 4);
+    // Both were just asserted to be numbers; `!` keeps the reads typed
+    // without restating the check as a type guard.
+    const coverline = parsed.baseline!;
+    const markerIndex = parsed.markerIndex!;
+    const values = parsed.values;
+    const riseValues = values.slice(markerIndex + 1, markerIndex + 4);
     expect(riseValues).toHaveLength(3);
     for (const v of riseValues) {
       expect(v).not.toBeNull();

--- a/e2e/visual-a11y.spec.ts
+++ b/e2e/visual-a11y.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Locator, type Page } from '@playwright/test';
+import { expect, test, type Page } from '@playwright/test';
 import { mutatingRequestsDuring } from './support/confirm-dialog-helpers';
 import { fillDateField } from './support/date-field-helpers';
 import {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,6 @@
 import js from "@eslint/js";
 import globals from "globals";
+import tseslint from "typescript-eslint";
 
 export default [
   {
@@ -52,6 +53,38 @@ export default [
         ...globals.node,
         setImmediate: "readonly"
       }
+    }
+  },
+  // The browser e2e suite. Until this block existed nothing checked e2e/ at
+  // all — `lint:js` never scoped there and TypeScript was not a dependency —
+  // so a broken signature or a dangling import surfaced only as a failing spec
+  // minutes into a browser run. `npm run lint:types` (tsc --noEmit) covers the
+  // types; this covers what a type-checker does not judge.
+  //
+  // Type-AWARE, on purpose. The rule that pays for the whole block is
+  // `no-floating-promises`: a Playwright call whose `await` went missing still
+  // passes, silently, because the assertion it should have made never runs
+  // before the test ends. That is a false GREEN, the failure mode this
+  // repository cares about most, and no untyped linter can see it.
+  ...tseslint.configs.recommendedTypeChecked.map((config) => ({
+    ...config,
+    files: ["e2e/**/*.ts", "playwright.config.ts"]
+  })),
+  {
+    files: ["e2e/**/*.ts", "playwright.config.ts"],
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname
+      }
+    },
+    rules: {
+      // The suite's own house style, already followed ~20 times: assert a
+      // response is not null, then read it through `!`. Forbidding the
+      // assertion would mean rewriting every one of those into a type guard
+      // for no gain — the `expect(...).not.toBeNull()` on the line above is
+      // what makes the failure legible.
+      "@typescript-eslint/no-non-null-assertion": "off"
     }
   }
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,12 +11,15 @@
         "@eslint/js": "10.0.1",
         "@playwright/test": "1.62.1",
         "@tailwindcss/cli": "^4.3.3",
+        "@types/node": "^22.20.1",
         "eslint": "10.8.1",
         "globals": "17.10.0",
         "htmx.org": "2.0.10",
         "jsdom": "30.0.1",
         "otplib": "13.4.1",
-        "tailwindcss": "^4.3.0"
+        "tailwindcss": "^4.3.0",
+        "typescript": "^5.9.3",
+        "typescript-eslint": "^8.67.0"
       },
       "engines": {
         "node": ">=22"
@@ -1240,6 +1243,246 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.67.0.tgz",
+      "integrity": "sha512-Un7Heoyj65NREbKAyIrFxeM143NZpExWmy1Nep4DLeQOeLlTeumPjoNKnBrU5D5moWXbPJgRa5Uwcdu0faVNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.67.0",
+        "@typescript-eslint/type-utils": "8.67.0",
+        "@typescript-eslint/utils": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.67.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.67.0.tgz",
+      "integrity": "sha512-fUBfTuuEulWqX6V8+O3PtScV01tzYYRUDTAirHFKoRAt7nOzoGiPt0M/bB47wWNy0coOOcgEwAMUtBpykMxl6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.67.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.67.0.tgz",
+      "integrity": "sha512-cvE8c7ulYeXN9fYuszhCeCsbzyVEXuhrRCybnBre7TUmqb5nRmBfQAwCj0O3WJFDeyAZt4VYv51vMCC9LHSdYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.67.0",
+        "@typescript-eslint/types": "^8.67.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.67.0.tgz",
+      "integrity": "sha512-EgvsleTwS4E+WzzSvem8fAUubLwatMNF1B5hHSLQxcvs7q2dtRhGyujHwLJSYlG41niJ7GP24Aha2+0mb1b2kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.67.0.tgz",
+      "integrity": "sha512-vV+LUSv5njUWsknE71fqKTlXUva+R76SaeORd6Zojcunk/6DvKFXONU3BrAs2H49mbygUXt6gbYunzwqNwlhdg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.67.0.tgz",
+      "integrity": "sha512-aVWDXbRmdXO9siTfX4ditQI1T9+zVcNazT48EJCD0v40/9RIFoUgZ05CmGEq9H2gixRpjUn/iplwvlcvutJW/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0",
+        "@typescript-eslint/utils": "8.67.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.67.0.tgz",
+      "integrity": "sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.67.0.tgz",
+      "integrity": "sha512-EKQBCE9yNlRJYm7jdTW5AhDacDUmSwQb0FAJAmK2EKYrNXIsa2vxcSZx6PvJ/dEdI6lS+Y9W+EXckLj0iPFGcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.67.0",
+        "@typescript-eslint/tsconfig-utils": "8.67.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.67.0.tgz",
+      "integrity": "sha512-U9D1FdwEWBwok3hxxSdhclMb0twvt9QnjIQ0VfQ1AiX2epnpSgv2ubVDsayOFyY8K6FX+AQ7E0FKWVG3iKsj1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.67.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.67.0.tgz",
+      "integrity": "sha512-fkv8dHRDqfGtTHuJeebdrQ7cX6Ad4WAS00rgHh9UGvMycF1mjBfsxry1XsLIFhWZ6Judlh6UdzK+TYlbpCXgnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.67.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
     },
     "node_modules/acorn": {
       "version": "8.16.0",
@@ -2521,6 +2764,19 @@
         "node": ">=v12.22.7"
       }
     },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -2582,6 +2838,54 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/tldts": {
       "version": "7.4.10",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.10.tgz",
@@ -2641,6 +2945,19 @@
         "node": ">=20"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -2654,6 +2971,44 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.67.0.tgz",
+      "integrity": "sha512-S2udFs8tCKEKffuJ4TB1idGUZiXdCPGi3IPBGWXarbLQ5UPXORV8QEVzJ4gCRduURMb5EkpNCdjbk0eDIuI8Yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.67.0",
+        "@typescript-eslint/parser": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0",
+        "@typescript-eslint/utils": "8.67.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
     "node_modules/undici": {
       "version": "8.10.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
@@ -2663,6 +3018,13 @@
       "engines": {
         "node": ">=22.19.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
     "build:css": "node ./scripts/build-css.mjs",
     "build:js": "node ./scripts/build-js.mjs",
     "build": "npm run build:css && npm run build:js",
-    "lint": "npm run lint:js",
-    "lint:js": "eslint --max-warnings=0 web/src/js web/static/js/chart-lite.js web/static/js/app.js web/static/js/settings-export.js scripts",
+    "lint": "npm run lint:js && npm run lint:types",
+    "lint:js": "eslint --max-warnings=0 web/src/js web/static/js/chart-lite.js web/static/js/app.js web/static/js/settings-export.js scripts e2e playwright.config.ts",
+    "lint:types": "tsc --noEmit -p tsconfig.json",
     "test:unit": "node --test web/src/js/__tests__/*.test.mjs",
     "e2e": "node ./scripts/run-e2e.mjs --mode=stable --project=chromium",
     "e2e:ci": "node ./scripts/run-e2e.mjs --mode=ci --project=chromium",
@@ -24,12 +25,15 @@
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.62.1",
     "@tailwindcss/cli": "^4.3.3",
+    "@types/node": "^22.20.1",
     "eslint": "10.8.1",
     "globals": "17.10.0",
     "htmx.org": "2.0.10",
     "jsdom": "30.0.1",
     "otplib": "13.4.1",
-    "tailwindcss": "^4.3.0"
+    "tailwindcss": "^4.3.0",
+    "typescript": "^5.9.3",
+    "typescript-eslint": "^8.67.0"
   },
   "overrides": {
     "brace-expansion": "^5.0.8"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,31 @@
+{
+  // Type-checking only — the repository ships no TypeScript build output.
+  // Playwright transpiles e2e/**/*.ts with esbuild and never type-checks it, so
+  // until this file existed a broken signature or a dangling import reached CI
+  // only as a failing spec, minutes into a browser run. `npm run lint:types`
+  // turns that into a fast, local, whole-directory error.
+  //
+  // "moduleResolution": "Bundler" matches how Playwright actually resolves the
+  // specs' extensionless relative imports ("./support/auth-helpers"); Node16
+  // would demand an explicit ".js" the runtime does not want.
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "types": ["node"],
+
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["e2e/**/*.ts", "playwright.config.ts"]
+}


### PR DESCRIPTION
Stacked on #480 (which is stacked on #479). Base is `ci/shard-browser-e2e` so the diff shows only this change; GitHub retargets to `main` as the parents merge, and CI does **not** re-run on a base change — `gh pr update-branch <n> --rebase` before queueing.

## What

`e2e/` gets a type-checker and a linter. It had neither.

- new `tsconfig.json` (type-check only, no build output) + `npm run lint:types`
- `lint:js` widens to `e2e` and `playwright.config.ts`, with a **type-aware** ESLint block for them
- the six defects the first type-check found, fixed

## The hole

`lint:js` scoped to `web/src/js`, three files under `web/static/js`, and `scripts` — not `e2e/`. TypeScript was not a dependency and the repository carried no tsconfig at all. Playwright transpiles the 47 `.ts` files with esbuild and never type-checks them, so a broken signature or a dangling import reached CI only as a failing spec, minutes into a browser run, and an unused export reached nothing at all. This is the largest hole per unit of effort on the CI track, and it is recorded as such in `.claude/rules/e2e.md`.

## What the first run found — fixed, not baselined

`tsc --noEmit`, six findings:

| where | what |
| --- | --- |
| `bugs.spec.ts` | `clearDateField` imported, never used |
| `visual-a11y.spec.ts` | `Locator` type imported, never used |
| `settings-password-export-danger.spec.ts` | the whole `readCSRFToken` helper, never called |
| `calendar.spec.ts` ×3 | `request.response()` dereferenced without the null check |

The three `calendar.spec.ts` sites are the interesting ones. The suite's convention — used about twenty times, including three other times *in that same file* — is `expect(response, '…').not.toBeNull()` before reading it. These three had skipped it, so a missing response failed as `Cannot read properties of null` instead of as the assertion that says what went wrong. They now follow the file's own convention.

`clearDateField` itself stays: `settings-password-export-danger.spec.ts` still calls it, so the export below it is still reached. (Walking the chain down after removing a consumer is the rule that produced this campaign's cascade findings.)

ESLint's first run reported 29 findings in two files, every one a descendant of an untyped `JSON.parse` / `response.json()`. Naming the BBT chart payload's shape once removes the findings *and* the scattered `as string[]` / `as Array<number|null>` / `as number` casts that were standing in for a type.

## Why type-aware linting

The rule that pays for the extra dependency is `no-floating-promises`. A Playwright call whose `await` went missing still passes, because the assertion it should have made never runs before the test ends. That is a false green — the failure mode this suite guards against everywhere else — and no untyped linter can see it.

`no-non-null-assertion` is turned off: the suite's house style asserts `not.toBeNull()` and then reads through `!`, and the assertion on the line above is what makes the failure legible.

## Both barriers proved in both directions

- a probe with a type error → `tsc` exits 2; tree clean → exits 0
- a probe with a floating `page.goto` → `no-floating-promises`; tree clean → `npm run lint` exits 0

Worth stating, because the first probe was written as a **dotfile** and passed: `e2e/**/*.ts` does not match one, so the barrier had measured nothing. It was re-run with an ordinary filename before being believed.

## Cost and verification

Measured 2026-08-15: `lint:js` 6.1 s over the widened scope, `lint:types` 2.4 s — both steps in `test-frontend`, which ran 17 s.

The six edited specs were run locally in full and passed (exit 0). `npm run build` leaves `web/static/` clean, so the committed-bundle guard is unaffected.
