### PR TITLE
ci: stop counting a retried flake and an unchecked workflow as green

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,8 @@ jobs:
       DEADCODE_VERSION: v0.49.0
       # git SHA for v2.12.2: c0d3ddc9cf3faa61a4e378e879ece580256d76e5 (verified via go list -m -json)
       GOLANGCI_LINT_VERSION: v2.12.2
+      # git SHA for v1.7.12: 914e7df21a07ef503a81201c76d2b11c789d3fca (verified via go list -m -json)
+      ACTIONLINT_VERSION: v1.7.12
 
     steps:
       - name: Checkout
@@ -96,7 +98,7 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/go/bin
-          key: ${{ runner.os }}-gotools-go${{ steps.setup-go.outputs.go-version }}-staticcheck${{ env.STATICCHECK_VERSION }}-deadcode${{ env.DEADCODE_VERSION }}-golangcilint${{ env.GOLANGCI_LINT_VERSION }}
+          key: ${{ runner.os }}-gotools-go${{ steps.setup-go.outputs.go-version }}-staticcheck${{ env.STATICCHECK_VERSION }}-deadcode${{ env.DEADCODE_VERSION }}-golangcilint${{ env.GOLANGCI_LINT_VERSION }}-actionlint${{ env.ACTIONLINT_VERSION }}
 
       - name: Verify the restored binaries are the pinned versions
         # A cache hit is only as good as its key, and a key that quietly stopped
@@ -116,6 +118,7 @@ jobs:
           bin="$(go env GOPATH)/bin"
           "$bin/staticcheck" -version | grep -F "(${STATICCHECK_VERSION#v})"
           "$bin/golangci-lint" --version | grep -F "version ${GOLANGCI_LINT_VERSION#v} "
+          "$bin/actionlint" -version | grep -Fx "$ACTIONLINT_VERSION"
           test -x "$bin/deadcode"
 
       - name: Install staticcheck
@@ -160,6 +163,28 @@ jobs:
       - name: Install golangci-lint
         if: steps.go-tools.outputs.cache-hit != 'true'
         run: go install "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$GOLANGCI_LINT_VERSION"
+
+      - name: Install actionlint
+        if: steps.go-tools.outputs.cache-hit != 'true'
+        run: go install "github.com/rhysd/actionlint/cmd/actionlint@$ACTIONLINT_VERSION"
+
+      # The workflows are 1757 lines across ten files, a good deal of it bash
+      # inside `run:`, and nothing checked any of it. actionlint reads what YAML
+      # alone cannot: undefined `steps.*`/`needs.*` references, contexts used
+      # where they are not available, and `${{ }}` interpolated straight into a
+      # shell script (the script-injection class). Proved in both directions on
+      # 2026-08-15 — the ten workflows report nothing, and a copy carrying a
+      # bogus `steps.*` reference plus an interpolated PR title reports both and
+      # exits 1.
+      #
+      # shellcheck is DISABLED explicitly rather than left to the runner. The
+      # ubuntu image ships shellcheck, so actionlint would silently add a whole
+      # second analyser whose findings this repository has never measured, at a
+      # version the image chooses and can change under us — a barrier that means
+      # something different on each runner is not a barrier. Enabling it is a
+      # separate change that starts by measuring the findings.
+      - name: Lint the workflows
+        run: '"$(go env GOPATH)/bin/actionlint" -shellcheck='
 
       # No cache for golangci-lint's own analysis cache: its key can only name
       # go.sum and .golangci.yml, never the source tree, so a branch whose

--- a/changelog.d/ci-honest-verdicts.md
+++ b/changelog.d/ci-honest-verdicts.md
@@ -1,0 +1,4 @@
+none
+
+CI only: a browser test that passes only on retry now fails the run, and the
+workflow files are linted by `actionlint`. No product code.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,6 +12,13 @@ export default defineConfig({
   // local runs surface flakiness instead of hiding it behind retries.
   forbidOnly: isCI,
   retries: isCI ? 2 : 0,
+  // A test that failed and then passed on retry is NOT a pass. With `retries`
+  // above and this left at its default, CI reported such a run green and the
+  // flake was visible only to whoever opened the report — which is the same
+  // false green the suite guards against everywhere else. Scoped to CI because
+  // `retries` is: with 0 retries locally, nothing can be flaky by this
+  // definition, so the flag would never fire there anyway.
+  failOnFlakyTests: isCI,
   use: {
     baseURL: process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:8080',
     headless: true,


### PR DESCRIPTION
Stacked on #481 → #480 → #479. Base is `ci/typecheck-e2e`; GitHub retargets as the parents merge, and CI does **not** re-run on a base change — `gh pr update-branch <n> --rebase` before queueing.

## What

Two verdicts CI was giving without evidence.

### A retried flake was reported green

`retries: 2` on CI is deliberate. Playwright's default, though, leaves the run green when a retry rescues a test, so a flake was visible only to whoever opened the report — the same false green the suite guards against everywhere else. `failOnFlakyTests: isCI` closes it.

Scoped to CI for the same reason `retries` is: with zero retries locally, nothing can be flaky by this definition, so the flag would never fire there.

The option name is now checked, not trusted: `playwright.config.ts` is inside the tsconfig added in #481, and renaming it to `failOnFlakyTestsTypo` fails the type-check with *"Did you mean to write 'failOnFlakyTests'?"*. That was run before committing.

### The workflows were checked by nothing

1757 lines across ten files, a good deal of it bash inside `run:`. `actionlint` reads what YAML validation cannot: undefined `steps.*` / `needs.*` references, contexts used where they are not available, and `${{ }}` interpolated straight into a shell script.

Proved in both directions before wiring: the ten workflows report nothing and exit 0; a copy carrying a bogus `steps.nosuchstep` reference plus an interpolated `github.event.pull_request.title` reports both and exits 1. The undefined-step half matters beyond the demo — it is what proves the `steps.setup-go.outputs.go-version` reference in #479's cache key is actually validated rather than passed through.

## shellcheck is disabled explicitly

The ubuntu runner image ships shellcheck, and actionlint picks it up when present. Left implicit, this step would silently carry a second analyser whose findings this repository has never measured, at a version the image chooses and can change underneath us — and the local run that pronounced the tree clean has no shellcheck at all, so it would have been measuring a different thing from CI.

A barrier that means something different on each runner is not a barrier. Enabling shellcheck is a separate change whose first step is measuring what it says.

## Shape and cost

It lands as a **step** in `test-go`, not a job, so no new required context is needed and the merge queue is untouched. Its binary joins the tool cache added in #479, keyed on `ACTIONLINT_VERSION` like the others, and the cache-hit path asserts it reports the pinned version before use.

Measured 2026-08-15: `actionlint` runs in **0.33 s**. The install is 1 `go install` on a cache miss only.
