### PR TITLE
ci: shard the race lane's dominant package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,14 +320,68 @@ jobs:
           done
           echo "test-go and test-frontend passed."
 
-  race:
+  # internal/services alone was 461 s of the race lane's 589 s (measured
+  # 2026-08-15), and 75% of THAT sits in the 99 tests whose files hash
+  # passwords: bcrypt is deliberately expensive and the race detector
+  # multiplies that kind of code hardest — about four times harder than the
+  # rest of the package. No race can live in those tests (they spawn no
+  # goroutines), so they were paying the lane's largest bill for a check that
+  # finds nothing in them.
+  #
+  # Go has no test sharding below package granularity, so the split is a `-run`
+  # regexp — and the names come from `go test -list`, never from a hand-written
+  # pattern. A pattern keyed on a SPELLING would leave a new test matching no
+  # shard at all, running NOWHERE while every shard reported success. See
+  # scripts/racepartition, whose tests pin exhaustiveness and disjointness
+  # against a synthesised listing.
+  race-services:
     runs-on: ubuntu-latest
     needs:
       - changes
-    # Same fail-safe gate as test-go above. This is the slowest lane, and the
-    # one the merge queue's 60-minute status-check timeout is measured against,
-    # so a queue entry that touches nothing the Go toolchain can observe must
-    # not spend it.
+    # Same fail-safe gate as test-go above.
+    if: ${{ !cancelled() && needs.changes.outputs.run_battery != 'false' }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        shard:
+          - 1
+          - 2
+          - 3
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Go test with race detector — internal/services shard
+        # The listing is taken WITHOUT -race: the names are the same and the
+        # instrumented build is the expensive half. The divisor comes from
+        # `strategy.job-total`, computed from the matrix above, so adding a
+        # shard cannot leave a second literal behind.
+        #
+        # `set -o pipefail` matters here: without it the exit status would come
+        # from `racepartition` and a failing listing would read as a pass.
+        env:
+          CGO_ENABLED: "1"
+        shell: bash
+        run: |
+          set -euo pipefail
+          go test -list '.*' ./internal/services/ > "$RUNNER_TEMP/tests.txt"
+          run_pattern="$(go run ./scripts/racepartition -shard=${{ matrix.shard }} -of=${{ strategy.job-total }} < "$RUNNER_TEMP/tests.txt")"
+          echo "shard ${{ matrix.shard }}/${{ strategy.job-total }} selects $(grep -cE '^(Test|Example|Fuzz)' "$RUNNER_TEMP/tests.txt") listed tests split by racepartition"
+          go test -race -run "$run_pattern" ./internal/services/
+
+  race-rest:
+    runs-on: ubuntu-latest
+    needs:
+      - changes
     if: ${{ !cancelled() && needs.changes.outputs.run_battery != 'false' }}
     permissions:
       contents: read
@@ -351,9 +405,13 @@ jobs:
         # the memory-store GC goroutine) that never occurs with the single app
         # instance in production — racing it only produces library noise, not ovumcy
         # bugs. The concurrency that is ours lives in the packages below.
+        #
+        # internal/services is NOT here: it is sharded in race-services above.
+        # These four trees ran 100 s of the lane's 589 s together, so they stay
+        # whole — splitting them would buy nothing and cost a job.
         env:
           CGO_ENABLED: "1"
-        run: go test -race ./internal/services/... ./internal/db/... ./internal/security/... ./internal/i18n/... ./internal/httpx/...
+        run: go test -race ./internal/db/... ./internal/security/... ./internal/i18n/... ./internal/httpx/...
 
       - name: Go test with race detector — cross-owner isolation
         # The exclusion above is by package, not by property, and the property
@@ -365,6 +423,39 @@ jobs:
         env:
           CGO_ENABLED: "1"
         run: go test -race -count=1 -run TestOwnerIsolationHoldsUnderConcurrentCrossOwnerRequests ./internal/api/
+
+  # Thin gate job named exactly `race` — branch protection's required status
+  # check is pinned to that literal name, which a matrix job cannot provide
+  # (its contexts are `race-services (1)`, ...). Same shape and same reasoning
+  # as the `test` and `e2e` gates: WITHOUT AN `if`, A FAILED DEPENDENCY SKIPS
+  # THIS JOB, and a skipped required check counts as satisfied — which would
+  # report a green `race` on a run where every shard failed.
+  race:
+    runs-on: ubuntu-latest
+    needs:
+      - race-services
+      - race-rest
+    if: ${{ !cancelled() }}
+    permissions:
+      contents: read
+    steps:
+      - name: Judge the race lanes
+        env:
+          SERVICES_RESULT: ${{ needs.race-services.result }}
+          REST_RESULT: ${{ needs.race-rest.result }}
+        run: |
+          set -euo pipefail
+          echo "race-services=$SERVICES_RESULT race-rest=$REST_RESULT"
+          # `skipped` is a PASS here and only here, for the same reason as in
+          # the other two gates: the `changes` job judged the diff irrelevant,
+          # which is a decision not to run rather than a failure to run.
+          for result in "$SERVICES_RESULT" "$REST_RESULT"; do
+            case "$result" in
+              success|skipped) ;;
+              *) echo "::error::a race lane reported \"$result\""; exit 1 ;;
+            esac
+          done
+          echo "every race lane passed."
 
   coverage-upload:
     runs-on: ubuntu-latest

--- a/changelog.d/ci-shard-race-services.md
+++ b/changelog.d/ci-shard-race-services.md
@@ -1,0 +1,5 @@
+none
+
+CI only: the race lane splits `internal/services` across three shards, with the
+test list taken from the Go toolchain rather than a hand-written pattern, and a
+thin gate job keeping the required `race` status check. No product code.

--- a/scripts/racepartition/main.go
+++ b/scripts/racepartition/main.go
@@ -1,0 +1,143 @@
+// Command racepartition splits a `go test -list` listing into N disjoint,
+// exhaustive shards and prints one of them as an anchored `-run` regexp.
+//
+// It exists because the race lane is dominated by a single package.
+// internal/services took 461 s of the lane's 589 s (measured 2026-08-15), and
+// 75% of that sits in the 99 tests whose files hash passwords: bcrypt is
+// deliberately expensive and the race detector multiplies exactly that kind of
+// code hardest. Go has no native test sharding below package granularity, so
+// the split has to be expressed as a `-run` regexp.
+//
+// The names come from `go test -list`, never from a hand-written pattern. That
+// is the whole design: a rule keyed on a SPELLING silently stops covering
+// whatever the spelling missed, and here the failure would be a test that
+// matches no shard's regexp and therefore runs NOWHERE while every shard stays
+// green. Reading the list from the toolchain makes a new test land in a shard
+// by construction, and `TestPartitionsAreExhaustiveAndDisjoint` pins that
+// property against a synthesised listing.
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// testNamePattern is what a Go test identifier can be. Anything else in the
+// listing is refused rather than escaped: a name carrying a regexp
+// metacharacter would change the meaning of the alternation this builds, and
+// silently selecting the wrong tests is the failure this command exists to
+// prevent.
+var testNamePattern = regexp.MustCompile(`^(?:Test|Example|Fuzz)[\p{L}\p{N}_]*$`)
+
+// benchmarkPattern names the one kind of entry the listing carries that `-run`
+// does not govern: benchmarks execute only under `-bench`. They are recognised
+// and deliberately left out of the alternation rather than skipped as noise —
+// an entry this command cannot name is an error, and one it can name but must
+// not select is a decision worth having in the code.
+//
+// `go test -list` printing benchmarks at all was measured, not assumed:
+// internal/services carries BenchmarkBuildCycleStats, and the first run against
+// the real listing refused it, which is what this pattern answers.
+var benchmarkPattern = regexp.MustCompile(`^Benchmark[\p{L}\p{N}_]*$`)
+
+// matchesNothing is an empty character class: a negated class covering every
+// code point can match no character, so the pattern matches no string at all —
+// the empty string included.
+const matchesNothing = `[^\x00-\x{10FFFF}]`
+
+func main() {
+	shard := flag.Int("shard", 0, "1-based index of the shard to print")
+	of := flag.Int("of", 0, "total number of shards")
+	flag.Parse()
+
+	if *of < 1 {
+		fail("-of must be at least 1, got %d", *of)
+	}
+	if *shard < 1 || *shard > *of {
+		fail("-shard must be in [1,%d], got %d", *of, *shard)
+	}
+
+	names, err := readNames(os.Stdin)
+	if err != nil {
+		fail("%v", err)
+	}
+
+	fmt.Println(BuildRunRegexp(names, *shard, *of))
+}
+
+func fail(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "racepartition: "+format+"\n", args...)
+	os.Exit(2)
+}
+
+// readNames keeps the test identifiers out of a `go test -list` listing. The
+// listing ends with the package's own `ok  <pkg> <time>` line, and a build or
+// vet failure can add anything at all; a line that is neither a test name nor
+// one of those trailers is an error rather than something to skip past,
+// because a listing this command cannot fully account for is a listing whose
+// shards cannot be proven exhaustive.
+func readNames(r io.Reader) ([]string, error) {
+	var names []string
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		switch {
+		case line == "":
+			continue
+		case testNamePattern.MatchString(line):
+			names = append(names, line)
+		case benchmarkPattern.MatchString(line):
+			continue
+		case strings.HasPrefix(line, "ok "), strings.HasPrefix(line, "?   "),
+			strings.HasPrefix(line, "no test files"):
+			continue
+		default:
+			return nil, fmt.Errorf("unrecognised line in the listing: %q", line)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return names, nil
+}
+
+// BuildRunRegexp returns the anchored `-run` value selecting the given shard.
+//
+// Sorting first makes the assignment independent of the order the toolchain
+// happened to print, so the same tree always produces the same split; the
+// round-robin then spreads a run of related (and usually similarly priced)
+// tests across shards instead of dropping a whole expensive file into one.
+//
+// An empty shard yields an empty character class, which matches no string at
+// all. `^$` reads like the obvious spelling and is not the same thing: it
+// matches the empty string, so the pattern's meaning would rest on "no test is
+// named the empty string" rather than on the pattern itself. Returning
+// something that matches EVERYTHING would be the dangerous version of the same
+// edge — every shard would run the whole package and it would read only as the
+// lane getting slower.
+func BuildRunRegexp(names []string, shard, of int) string {
+	sorted := append([]string(nil), names...)
+	sort.Strings(sorted)
+
+	var selected []string
+	for index, name := range sorted {
+		if index%of == shard-1 {
+			selected = append(selected, name)
+		}
+	}
+
+	if len(selected) == 0 {
+		return matchesNothing
+	}
+
+	return "^(?:" + strings.Join(selected, "|") + ")$"
+}

--- a/scripts/racepartition/main_test.go
+++ b/scripts/racepartition/main_test.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// synthesisedListing builds a listing of its own rather than measuring this
+// repository. A partitioner is judged on a property — every test lands in
+// exactly one shard — and a fixture that reads the real tree would pass for as
+// long as that tree happened to be convenient, which is the shape of a green
+// fixture that asserts nothing.
+func synthesisedListing(count int) []string {
+	names := make([]string, 0, count)
+	for index := range count {
+		names = append(names, fmt.Sprintf("TestSynthesised%03d", index))
+	}
+	return names
+}
+
+// This is the property the whole design rests on. A test matching no shard's
+// regexp would run NOWHERE while every shard reported success — a false green
+// that no other check in the repository could see.
+func TestPartitionsAreExhaustiveAndDisjoint(t *testing.T) {
+	for _, of := range []int{1, 2, 3, 5, 8} {
+		for _, count := range []int{0, 1, 2, 7, 99, 100} {
+			names := synthesisedListing(count)
+
+			seen := map[string]int{}
+			for shard := 1; shard <= of; shard++ {
+				matcher := regexp.MustCompile(BuildRunRegexp(names, shard, of))
+				for _, name := range names {
+					if matcher.MatchString(name) {
+						seen[name]++
+					}
+				}
+			}
+
+			for _, name := range names {
+				if seen[name] != 1 {
+					t.Fatalf("of=%d count=%d: %q matched %d shards, want exactly 1",
+						of, count, name, seen[name])
+				}
+			}
+		}
+	}
+}
+
+// A shard's regexp must not select a test whose name merely CONTAINS a
+// selected one. `go test -run` is an unanchored match by default, so an
+// alternation written without anchors would pull TestFoo's neighbours in with
+// it and run them twice across the fleet.
+func TestShardRegexpIsAnchored(t *testing.T) {
+	names := []string{"TestFoo", "TestFooBar"}
+	matcher := regexp.MustCompile(BuildRunRegexp(names, 1, 2))
+
+	selected := []string{}
+	for _, name := range names {
+		if matcher.MatchString(name) {
+			selected = append(selected, name)
+		}
+	}
+	if len(selected) != 1 {
+		t.Fatalf("shard 1 of 2 selected %v, want exactly one of %v", selected, names)
+	}
+}
+
+// An empty shard must match NOTHING. The dangerous spelling of this edge is a
+// regexp that matches everything, which would run the whole package on every
+// shard and read only as "the lane got slower".
+func TestEmptyShardMatchesNothing(t *testing.T) {
+	matcher := regexp.MustCompile(BuildRunRegexp(synthesisedListing(2), 3, 3))
+
+	for _, name := range []string{"TestSynthesised000", "TestSynthesised001", "", "Test"} {
+		if matcher.MatchString(name) {
+			t.Fatalf("empty shard matched %q", name)
+		}
+	}
+}
+
+// The split may not depend on the order the toolchain printed the listing, or
+// two shards computed from differently-ordered runs would disagree about who
+// owns a test — and a test owned by nobody runs nowhere.
+func TestPartitionIgnoresListingOrder(t *testing.T) {
+	names := synthesisedListing(20)
+	reversed := make([]string, len(names))
+	for index, name := range names {
+		reversed[len(names)-1-index] = name
+	}
+
+	for shard := 1; shard <= 3; shard++ {
+		if got, want := BuildRunRegexp(reversed, shard, 3), BuildRunRegexp(names, shard, 3); got != want {
+			t.Fatalf("shard %d: reversed listing gave %q, want %q", shard, got, want)
+		}
+	}
+}
+
+// Benchmarks appear in the listing and must be recognised without being
+// selected: `go test -run` never executes them. Measured against the real
+// listing, which carries BenchmarkBuildCycleStats.
+func TestReadNamesRecognisesBenchmarksWithoutSelectingThem(t *testing.T) {
+	names, err := readNames(strings.NewReader("TestAlpha\nBenchmarkBuildCycleStats\n"))
+	if err != nil {
+		t.Fatalf("readNames refused a benchmark line: %v", err)
+	}
+	if len(names) != 1 || names[0] != "TestAlpha" {
+		t.Fatalf("readNames = %v, want just [TestAlpha]", names)
+	}
+}
+
+func TestReadNamesKeepsTestsAndToleratesTrailers(t *testing.T) {
+	listing := strings.Join([]string{
+		"TestAlpha",
+		"ExampleBeta",
+		"FuzzGamma",
+		"",
+		"ok  \tgithub.com/ovumcy/ovumcy-web/internal/services\t0.412s",
+	}, "\n")
+
+	names, err := readNames(strings.NewReader(listing))
+	if err != nil {
+		t.Fatalf("readNames: %v", err)
+	}
+	if want := []string{"TestAlpha", "ExampleBeta", "FuzzGamma"}; strings.Join(names, ",") != strings.Join(want, ",") {
+		t.Fatalf("readNames = %v, want %v", names, want)
+	}
+}
+
+// A listing carrying something this command cannot account for must fail
+// loudly. Skipping the unknown line would drop whatever it named out of every
+// shard, which is the exact false green the exhaustiveness property forbids.
+func TestReadNamesRefusesAnUnaccountableLine(t *testing.T) {
+	if _, err := readNames(strings.NewReader("TestAlpha\nFAIL\tsome/pkg [build failed]\n")); err == nil {
+		t.Fatal("readNames accepted a listing it could not account for")
+	}
+}
+
+// A name carrying a regexp metacharacter would change the alternation's
+// meaning, so it is refused rather than escaped.
+func TestReadNamesRefusesAMetacharacterName(t *testing.T) {
+	if _, err := readNames(strings.NewReader("TestAlpha|TestBeta\n")); err == nil {
+		t.Fatal("readNames accepted a name carrying a regexp metacharacter")
+	}
+}


### PR DESCRIPTION
Stacked on #482 → #481 → #480. Base is `ci/honest-verdicts`; GitHub retargets as the parents merge, and CI does **not** re-run on a base change — `gh pr update-branch <n> --rebase` before queueing.

## Why

`race` is the ceiling now that the browser suite is split. Measured on run 31881678369 (PR #480):

| job | duration |
| --- | --- |
| **race** | **589 s** |
| test-go | 412 s |
| e2e-shard 1 / 2 / 3 | 310 / 326 / 364 s |
| run total | 9 min 59 s |

## Where the 589 s actually was

Profiled on a throwaway branch — `-race` needs cgo and the development machine has no C toolchain, so this could only be measured on a runner:

| | tests | under `-race` |
| --- | --- | --- |
| `internal/services`, files that hash passwords (15 of 209) | 99 | **346.7 s — 75.3%** |
| `internal/services`, everything else | 1208 | 113.5 s |
| `internal/db` | | 88.3 s |
| `internal/security` / `i18n` / `httpx` | | 12.4 s |

`passwordHashCost = 12`, four times bcrypt's default, and the race detector multiplies that kind of code hardest — about four times harder than the rest of the package (without `-race` the same 99 tests are 44.7% of the package, not 75.3%). Those tests spawn no goroutines, so they were paying the lane's largest bill for a check that can find nothing in them.

**`passwordHashCost` is not touched.** A test seam lowering it would buy a comparable saving by changing what the tests prove, in auth code, where the constant is pinned by `TestNewPasswordHashesUseConfiguredCost`. Sharding buys the same time and touches no product code.

## The design decision that matters

Go has no test sharding below package granularity, so the split has to be a `-run` regexp. **Every name in it comes from `go test -list`.**

A hand-written pattern would be a rule keyed on a spelling, and the failure mode here is specific and silent: a test matching no shard's regexp runs **nowhere**, while all three shards report success. Nothing else in the repository could see that.

`scripts/racepartition` therefore reads the toolchain's own listing, and its tests pin the properties against a **synthesised** listing rather than against this repository:

- every test matches exactly one shard, over 5 shard counts × 6 listing sizes
- the alternation is anchored, so `TestFoo` cannot drag `TestFooBar` in
- an empty shard matches nothing
- the split does not depend on the order the listing was printed
- a line the tool cannot account for is an error, not something to skip past

Two findings came out of building it, both because the tool refused rather than guessed:

- **`go test -list` also prints benchmarks** — this package carries `BenchmarkBuildCycleStats`, and the first run against the real listing refused it. Benchmarks are now recognised and deliberately excluded, since `-run` never executes them.
- **`^$` is not "matches nothing"** — it matches the empty string, so the pattern's safety would have rested on "no test is named the empty string" rather than on the pattern. An empty shard now emits an empty character class. The unit test caught this, not review.

## Shape

- `race-services` — matrix of 3, each running its partition of `internal/services`
- `race-rest` — the other four trees plus the cross-owner isolation test, together ~100 s, left whole because splitting them would cost a job and buy nothing
- `race` — thin gate judging both, the same shape as the `test` and `e2e` gates, `!cancelled()` included: without it a failed lane would *skip* the gate, and a skipped required check counts as satisfied

The divisor is `strategy.job-total`, read off the matrix rather than repeated as a literal.

## Verification

- against the real listing: **438 + 438 + 437 = 1313**, exactly the number of tests listed
- `go test ./scripts/racepartition/` green; `go vet`, `golangci-lint` clean; `deadcode -test` reports nothing
- `actionlint` exit 0

Predicted after this lands: `race` 589 → ~170 s, making `test-go` (412 s, of which `internal/api` is 271 s) the next ceiling, and the run about 7 minutes — against 21 min 27 s when this track started.
