### PR TITLE
chore: resolve three test-only declarations in services

### DIFF
--- a/changelog.d/chore-services-test-only-declarations.md
+++ b/changelog.d/chore-services-test-only-declarations.md
@@ -1,0 +1,8 @@
+none
+
+Internal only: three `internal/services` declarations the application could not
+reach are resolved so the production-scoped `deadcode` run stops reporting them.
+The two calendar-navigation wrappers are gone and their tests now drive the
+bounded forms the calendar page and the calendar view service actually call; the
+runner-less `DayService` constructor moved into a test file, since production
+always builds the service with a transaction runner. No behaviour change.

--- a/internal/services/calendar_view_policy.go
+++ b/internal/services/calendar_view_policy.go
@@ -10,10 +10,10 @@ import (
 
 var ErrCalendarMonthInvalid = errors.New("calendar invalid month")
 
-func ResolveCalendarMonthAndSelectedDate(monthQueryRaw string, selectedDayRaw string, now time.Time, location *time.Location) (time.Time, string, error) {
-	return ResolveCalendarMonthAndSelectedDateWithinBounds(monthQueryRaw, selectedDayRaw, now, location, time.Time{})
-}
-
+// ResolveCalendarMonthAndSelectedDateWithinBounds resolves the active month and
+// the selected day. A zero minMonth means no lower bound: calendarMonthBefore
+// reports false for every month, so neither the clamp nor the selected-date
+// reset fires.
 func ResolveCalendarMonthAndSelectedDateWithinBounds(monthQueryRaw string, selectedDayRaw string, now time.Time, location *time.Location, minMonth time.Time) (time.Time, string, error) {
 	if location == nil {
 		location = time.UTC
@@ -50,10 +50,9 @@ func ResolveCalendarMonthAndSelectedDateWithinBounds(monthQueryRaw string, selec
 	return activeMonth, selectedDate, nil
 }
 
-func CalendarAdjacentMonthValues(monthStart time.Time) (string, string) {
-	return CalendarAdjacentMonthValuesWithinBounds(monthStart, time.Time{})
-}
-
+// CalendarAdjacentMonthValuesWithinBounds returns the previous and next month
+// values for the navigation controls; the previous one is empty when it would
+// fall before minMonth. A zero minMonth means no lower bound.
 func CalendarAdjacentMonthValuesWithinBounds(monthStart time.Time, minMonth time.Time) (string, string) {
 	prevMonth := monthStart.AddDate(0, -1, 0)
 	prevValue := prevMonth.Format("2006-01")

--- a/internal/services/calendar_view_policy_coverage_test.go
+++ b/internal/services/calendar_view_policy_coverage_test.go
@@ -35,12 +35,12 @@ func TestCalendarViewPolicyNilLocationUsesUTC(t *testing.T) {
 	}
 }
 
-// calendarviewpolicyCovNilLocationViaWrapper verifies the same nil-guard through
-// the public ResolveCalendarMonthAndSelectedDate wrapper (which chains through).
-func TestCalendarViewPolicyNilLocationViaWrapper(t *testing.T) {
+// calendarviewpolicyCovNilLocationWithSelectedDay verifies the same nil-guard on
+// the path that derives the active month from the selected day.
+func TestCalendarViewPolicyNilLocationWithSelectedDay(t *testing.T) {
 	now := time.Date(2026, time.April, 5, 12, 0, 0, 0, time.UTC)
 
-	withNil, selNil, err := ResolveCalendarMonthAndSelectedDate("", "2026-04-05", now, nil)
+	withNil, selNil, err := ResolveCalendarMonthAndSelectedDateWithinBounds("", "2026-04-05", now, nil, time.Time{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/services/calendar_view_policy_test.go
+++ b/internal/services/calendar_view_policy_test.go
@@ -8,18 +8,20 @@ import (
 	"github.com/ovumcy/ovumcy-web/internal/models"
 )
 
-func TestResolveCalendarMonthAndSelectedDate(t *testing.T) {
+// A zero minMonth is the "no lower bound" input: the clamp and the
+// selected-date reset both stay inert, which is the behaviour these cases pin.
+func TestResolveCalendarMonthAndSelectedDateWithoutMinimumMonth(t *testing.T) {
 	now := time.Date(2026, time.February, 21, 10, 30, 0, 0, time.UTC)
 
 	t.Run("invalid month", func(t *testing.T) {
-		_, _, err := ResolveCalendarMonthAndSelectedDate("2026-99", "", now, time.UTC)
+		_, _, err := ResolveCalendarMonthAndSelectedDateWithinBounds("2026-99", "", now, time.UTC, time.Time{})
 		if !errors.Is(err, ErrCalendarMonthInvalid) {
 			t.Fatalf("expected ErrCalendarMonthInvalid, got %v", err)
 		}
 	})
 
 	t.Run("uses selected day month when month missing", func(t *testing.T) {
-		month, selectedDate, err := ResolveCalendarMonthAndSelectedDate("", "2026-02-17", now, time.UTC)
+		month, selectedDate, err := ResolveCalendarMonthAndSelectedDateWithinBounds("", "2026-02-17", now, time.UTC, time.Time{})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -32,7 +34,7 @@ func TestResolveCalendarMonthAndSelectedDate(t *testing.T) {
 	})
 
 	t.Run("keeps explicit month query", func(t *testing.T) {
-		month, selectedDate, err := ResolveCalendarMonthAndSelectedDate("2026-03", "2026-02-17", now, time.UTC)
+		month, selectedDate, err := ResolveCalendarMonthAndSelectedDateWithinBounds("2026-03", "2026-02-17", now, time.UTC, time.Time{})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -45,7 +47,7 @@ func TestResolveCalendarMonthAndSelectedDate(t *testing.T) {
 	})
 
 	t.Run("ignores invalid selected day", func(t *testing.T) {
-		month, selectedDate, err := ResolveCalendarMonthAndSelectedDate("2026-03", "invalid-day", now, time.UTC)
+		month, selectedDate, err := ResolveCalendarMonthAndSelectedDateWithinBounds("2026-03", "invalid-day", now, time.UTC, time.Time{})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -58,7 +60,7 @@ func TestResolveCalendarMonthAndSelectedDate(t *testing.T) {
 	})
 
 	t.Run("defaults selected day to today when both params missing", func(t *testing.T) {
-		month, selectedDate, err := ResolveCalendarMonthAndSelectedDate("", "", now, time.UTC)
+		month, selectedDate, err := ResolveCalendarMonthAndSelectedDateWithinBounds("", "", now, time.UTC, time.Time{})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -102,9 +104,11 @@ func TestResolveCalendarMonthAndSelectedDateWithinBounds(t *testing.T) {
 	})
 }
 
-func TestCalendarAdjacentMonthValues(t *testing.T) {
+// With a zero minMonth there is no lower bound, so the previous month is always
+// offered — the complement of the bounded case below.
+func TestCalendarAdjacentMonthValuesWithoutMinimumMonth(t *testing.T) {
 	monthStart := time.Date(2026, time.February, 1, 0, 0, 0, 0, time.UTC)
-	prev, next := CalendarAdjacentMonthValues(monthStart)
+	prev, next := CalendarAdjacentMonthValuesWithinBounds(monthStart, time.Time{})
 	if prev != "2026-01" {
 		t.Fatalf("expected prev month 2026-01, got %q", prev)
 	}

--- a/internal/services/day_service.go
+++ b/internal/services/day_service.go
@@ -80,13 +80,6 @@ type DayService struct {
 	runInTx DayLogTxRunner
 }
 
-func NewDayService(logs DayLogRepository, users DayUserRepository) *DayService {
-	return &DayService{
-		logs:  logs,
-		users: users,
-	}
-}
-
 // NewDayServiceWithTx wires a transaction runner so multi-step writes commit
 // atomically. The composition root supplies runInTx; tests may omit it.
 func NewDayServiceWithTx(logs DayLogRepository, users DayUserRepository, runInTx DayLogTxRunner) *DayService {

--- a/internal/services/day_service_test_constructors_test.go
+++ b/internal/services/day_service_test_constructors_test.go
@@ -1,0 +1,19 @@
+package services
+
+// Test-only constructors for DayService.
+//
+// The composition root always wires a transaction runner
+// (NewDayServiceWithTx, internal/bootstrap), so a DayService with a nil runner
+// is a shape production never builds — it exists so unit fixtures can drive the
+// service against in-memory stubs, where withinTransaction falls back to the
+// pass-through path. Keeping it here rather than in day_service.go states that
+// status in the file layout and keeps the production build free of a
+// constructor nothing in the application reaches.
+
+// NewDayService builds a DayService without a transaction runner.
+func NewDayService(logs DayLogRepository, users DayUserRepository) *DayService {
+	return &DayService{
+		logs:  logs,
+		users: users,
+	}
+}


### PR DESCRIPTION
The production-scoped `deadcode` run — the CI gate's command without `-test` —
reported three declarations in `internal/services` that nothing in the
application can reach. They are resolved here, each on its own terms rather than
by one mechanical rule.

## `ResolveCalendarMonthAndSelectedDate` — wrapper removed, tests re-pointed

A pure pass-through: it called `ResolveCalendarMonthAndSelectedDateWithinBounds`
with `minMonth = time.Time{}`. Production calls the bounded form directly
(`internal/api/handlers_calendar_page.go:26`); the wrapper's only callers were
five sub-cases in `internal/services/calendar_view_policy_test.go` and one in
`calendar_view_policy_coverage_test.go`.

Those six sites now call the bounded form with `time.Time{}` passed explicitly.
The wrapper's own defaulting behaviour was exactly "supply a zero `minMonth`", so
the assertions survive on identical inputs while running the code the calendar
page runs. `TestResolveCalendarMonthAndSelectedDate` is renamed
`TestResolveCalendarMonthAndSelectedDateWithoutMinimumMonth` after that input,
and the coverage case that existed to drive the wrapper keeps its distinct
assertion — nil location plus a selected day, which derives the active month from
the day — under the name `TestCalendarViewPolicyNilLocationWithSelectedDay`.

## `CalendarAdjacentMonthValues` — wrapper removed, test re-pointed

Same shape, one caller (`calendar_view_policy_test.go`). Production uses the
bounded form at `internal/services/calendar_view_service.go:67`. The test now
passes `time.Time{}`, which keeps the branch it was the only cover for: with a
zero `minMonth`, `calendarMonthBefore` returns false immediately and the previous
month is always offered. The bounded test beside it passes a real `minMonth` and
covers the opposite verdict, so both sides of that guard stay pinned.

The zero-`minMonth` contract the two wrapper names used to carry is now stated in
a doc comment on each bounded function, so removing the names does not remove the
explanation.

## `NewDayService` — moved into a test file

It builds a `DayService` with a nil transaction runner. The composition root
always calls `NewDayServiceWithTx` (`internal/bootstrap/bootstrap.go:106`), so
the runner-less shape is one production never builds; the comment on
`NewDayServiceWithTx` already described omitting the runner as a test affordance.

All twenty-eight call sites are tests in `internal/services` itself, and a
repository-wide search finds no caller in another package, so the declaration
moves unchanged into `internal/services/day_service_test_constructors_test.go`
and every call site keeps compiling untouched.

Re-pointing was considered and rejected here: `NewDayServiceWithTx(logs, users,
nil)` constructs the identical value, so it would not move any fixture onto the
shipping path, and threading a runner stub through all twenty-eight would change
what each fixture exercises. That is the opposite verdict from the calendar
wrappers, where the bounded form is a strict superset and re-pointing does put the
test on the production path.

## Verification

- `go build ./...` — clean.
- `go test ./...` — all packages pass.
- `golangci-lint run ./...` — `0 issues`.
- `deadcode ./cmd/... ./internal/... ./migrations/... ./scripts/... ./web/...` —
  before: nineteen findings, including the three above; after: sixteen, none of
  them in `internal/services` except `BuildAuthSessionToken`
  (`internal/services/auth_session_policy.go:31`), which is outside this change's
  scope.
- `deadcode -test ...` — the wired CI gate stays clean.
- `go test ... -coverprofile=coverage.out -covermode=atomic -coverpkg=...` followed
  by `go run ./scripts/patchcov` in the same invocation, after committing:
  "patch coverage gate OK: every modified coverable line is covered by tests."

No behaviour change; no production call path is added or removed.
