### PR TITLE
chore: open test databases through the production opener

### DIFF
--- a/changelog.d/chore-deadcode-test-only-declarations.md
+++ b/changelog.d/chore-deadcode-test-only-declarations.md
@@ -1,0 +1,13 @@
+none
+
+Dead-code removal with no user-visible effect: `db.OpenSQLite` is gone and its
+47 test call sites across `cmd/ovumcy`, `internal/api`, `internal/cli` and
+`internal/db` now open through `db.OpenDatabase(db.Config{...})`, the same
+configured entry point the server and the CLI subcommands use. The wrapper only
+filled in a `Config` literal, so migrations and the SQLite PRAGMA/DSN form were
+already identical on both paths and no test changes what it exercises.
+
+`i18n.PluralCategories` stays where it is: it is the single source of truth for
+which CLDR categories a language's locale files must carry, and it is read from
+two packages' tests, so it cannot become a `_test.go` declaration. Its comment
+now records that.

--- a/cmd/ovumcy/auth_email_renormalize_boot_test.go
+++ b/cmd/ovumcy/auth_email_renormalize_boot_test.go
@@ -17,9 +17,9 @@ import (
 // the marker byte-identical. (Full row-level repair semantics are proven in
 // internal/db; the pass logic in internal/services.)
 func TestMustRenormalizeAuthEmailsAcrossBoots(t *testing.T) {
-	database, err := db.OpenSQLite(filepath.Join(t.TempDir(), "email-renormalize-boot.db"))
+	database, err := db.OpenDatabase(db.Config{Driver: db.DriverSQLite, SQLitePath: filepath.Join(t.TempDir(), "email-renormalize-boot.db")})
 	if err != nil {
-		t.Fatalf("OpenSQLite: %v", err)
+		t.Fatalf("OpenDatabase: %v", err)
 	}
 	t.Cleanup(func() { closeDatabase(database) })
 	repositories := db.NewRepositories(database)

--- a/cmd/ovumcy/calendar_feed_rotation_boot_test.go
+++ b/cmd/ovumcy/calendar_feed_rotation_boot_test.go
@@ -16,9 +16,9 @@ import (
 // and a rotated-key boot moves it. (The row-level disarm semantics are proven
 // in internal/db; the sentinel's ordering contract in internal/services.)
 func TestMustEnforceCalendarFeedKeyRotationAcrossBoots(t *testing.T) {
-	database, err := db.OpenSQLite(filepath.Join(t.TempDir(), "rotation-boot.db"))
+	database, err := db.OpenDatabase(db.Config{Driver: db.DriverSQLite, SQLitePath: filepath.Join(t.TempDir(), "rotation-boot.db")})
 	if err != nil {
-		t.Fatalf("OpenSQLite: %v", err)
+		t.Fatalf("OpenDatabase: %v", err)
 	}
 	t.Cleanup(func() { closeDatabase(database) })
 	repositories := db.NewRepositories(database)

--- a/cmd/ovumcy/main_test.go
+++ b/cmd/ovumcy/main_test.go
@@ -2422,9 +2422,9 @@ func mustRateLimitedResponse(t *testing.T, app *fiber.App, request *http.Request
 // *sql.DB must reject further use, so SQLite has checkpointed its WAL and
 // freed the file before process exit.
 func TestCloseDatabaseClosesUnderlyingConnection(t *testing.T) {
-	database, err := db.OpenSQLite(filepath.Join(t.TempDir(), "close-test.db"))
+	database, err := db.OpenDatabase(db.Config{Driver: db.DriverSQLite, SQLitePath: filepath.Join(t.TempDir(), "close-test.db")})
 	if err != nil {
-		t.Fatalf("OpenSQLite() unexpected error: %v", err)
+		t.Fatalf("OpenDatabase() unexpected error: %v", err)
 	}
 
 	closeDatabase(database)
@@ -2448,9 +2448,9 @@ func TestCloseDatabaseClosesUnderlyingConnection(t *testing.T) {
 // subsequent closeDatabase still checkpoints and closes it, so SQLite releases
 // the file even on a failed start.
 func TestRunServerReturnsListenError(t *testing.T) {
-	database, err := db.OpenSQLite(filepath.Join(t.TempDir(), "runserver-err.db"))
+	database, err := db.OpenDatabase(db.Config{Driver: db.DriverSQLite, SQLitePath: filepath.Join(t.TempDir(), "runserver-err.db")})
 	if err != nil {
-		t.Fatalf("OpenSQLite() unexpected error: %v", err)
+		t.Fatalf("OpenDatabase() unexpected error: %v", err)
 	}
 	app := fiber.New()
 
@@ -2482,9 +2482,9 @@ func TestRunServerReturnsListenError(t *testing.T) {
 // Shutdown to take effect. The DB close now happens in main after runServer
 // returns; this test mirrors that final close and asserts the file is released.
 func TestRunServerReturnsAfterGracefulStop(t *testing.T) {
-	database, err := db.OpenSQLite(filepath.Join(t.TempDir(), "runserver-stop.db"))
+	database, err := db.OpenDatabase(db.Config{Driver: db.DriverSQLite, SQLitePath: filepath.Join(t.TempDir(), "runserver-stop.db")})
 	if err != nil {
-		t.Fatalf("OpenSQLite() unexpected error: %v", err)
+		t.Fatalf("OpenDatabase() unexpected error: %v", err)
 	}
 	app := fiber.New()
 
@@ -2551,9 +2551,9 @@ func TestRunServerReturnsAfterGracefulStop(t *testing.T) {
 // loop must still notice and bridge the gap once Serve registers the
 // listener.
 func TestRetryShutdownBridgesBootWindow(t *testing.T) {
-	database, err := db.OpenSQLite(filepath.Join(t.TempDir(), "boot-window-stop.db"))
+	database, err := db.OpenDatabase(db.Config{Driver: db.DriverSQLite, SQLitePath: filepath.Join(t.TempDir(), "boot-window-stop.db")})
 	if err != nil {
-		t.Fatalf("OpenSQLite() unexpected error: %v", err)
+		t.Fatalf("OpenDatabase() unexpected error: %v", err)
 	}
 	app := fiber.New()
 
@@ -2715,9 +2715,9 @@ func TestInstallGracefulShutdownBridgesSIGTERM(t *testing.T) {
 		t.Skip("SIGTERM self-delivery is not supported by the Go runtime on windows; validated in Linux CI")
 	}
 
-	database, err := db.OpenSQLite(filepath.Join(t.TempDir(), "sigterm-stop.db"))
+	database, err := db.OpenDatabase(db.Config{Driver: db.DriverSQLite, SQLitePath: filepath.Join(t.TempDir(), "sigterm-stop.db")})
 	if err != nil {
-		t.Fatalf("OpenSQLite() unexpected error: %v", err)
+		t.Fatalf("OpenDatabase() unexpected error: %v", err)
 	}
 	app := fiber.New()
 

--- a/internal/api/dashboard_regressions_test.go
+++ b/internal/api/dashboard_regressions_test.go
@@ -785,7 +785,7 @@ func newOnboardingTestAppWithLocation(t *testing.T, location *time.Location) (*f
 
 	databasePath := filepath.Join(t.TempDir(), "ovumcy-onboarding-test-tz.db")
 
-	database, err := db.OpenSQLite(databasePath)
+	database, err := db.OpenDatabase(db.Config{Driver: db.DriverSQLite, SQLitePath: databasePath})
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}

--- a/internal/api/fullpage_fallback_regressions_test.go
+++ b/internal/api/fullpage_fallback_regressions_test.go
@@ -42,7 +42,7 @@ func newFullPageFallbackApp(t *testing.T, options onboardingTestAppOptions) (*fi
 	t.Helper()
 
 	databasePath := filepath.Join(t.TempDir(), "ovumcy-fullpage-fallback-test.db")
-	database, err := db.OpenSQLite(databasePath)
+	database, err := db.OpenDatabase(db.Config{Driver: db.DriverSQLite, SQLitePath: databasePath})
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}

--- a/internal/api/handler_init_security_test.go
+++ b/internal/api/handler_init_security_test.go
@@ -12,7 +12,7 @@ import (
 func TestNewHandlerRejectsEmptySecret(t *testing.T) {
 	databasePath := filepath.Join(t.TempDir(), "ovumcy-handler-init-test.db")
 
-	database, err := db.OpenSQLite(databasePath)
+	database, err := db.OpenDatabase(db.Config{Driver: db.DriverSQLite, SQLitePath: databasePath})
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}

--- a/internal/api/privacy_route_app_setup_test.go
+++ b/internal/api/privacy_route_app_setup_test.go
@@ -15,7 +15,7 @@ func newTestAppWithPrivacyRoute(t *testing.T) *fiber.App {
 
 	databasePath := filepath.Join(t.TempDir(), "ovumcy-test.db")
 
-	database, err := db.OpenSQLite(databasePath)
+	database, err := db.OpenDatabase(db.Config{Driver: db.DriverSQLite, SQLitePath: databasePath})
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}

--- a/internal/api/settings_mutation_handlers_test.go
+++ b/internal/api/settings_mutation_handlers_test.go
@@ -414,7 +414,7 @@ func newSettingsMutationStepupApp(t *testing.T, stub *stubOIDCWorkflowService) (
 	t.Helper()
 
 	databasePath := filepath.Join(t.TempDir(), "ovumcy-settings-stepup-test.db")
-	database, err := db.OpenSQLite(databasePath)
+	database, err := db.OpenDatabase(db.Config{Driver: db.DriverSQLite, SQLitePath: databasePath})
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}

--- a/internal/api/test_data_access_helpers_test.go
+++ b/internal/api/test_data_access_helpers_test.go
@@ -14,7 +14,7 @@ func newDataAccessTestHandler(t *testing.T) (*Handler, *gorm.DB) {
 	t.Helper()
 
 	databasePath := filepath.Join(t.TempDir(), "ovumcy-data-access-test.db")
-	database, err := db.OpenSQLite(databasePath)
+	database, err := db.OpenDatabase(db.Config{Driver: db.DriverSQLite, SQLitePath: databasePath})
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}

--- a/internal/api/test_onboarding_app_setup_helpers_test.go
+++ b/internal/api/test_onboarding_app_setup_helpers_test.go
@@ -54,7 +54,7 @@ func newOnboardingTestAppWithOptions(t *testing.T, options onboardingTestAppOpti
 
 	databasePath := filepath.Join(t.TempDir(), "ovumcy-onboarding-test.db")
 
-	database, err := db.OpenSQLite(databasePath)
+	database, err := db.OpenDatabase(db.Config{Driver: db.DriverSQLite, SQLitePath: databasePath})
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}

--- a/internal/cli/reset_test.go
+++ b/internal/cli/reset_test.go
@@ -128,7 +128,7 @@ func createCLIResetDatabase(t *testing.T) string {
 	t.Helper()
 
 	databasePath := filepath.Join(t.TempDir(), "cli-reset-test.db")
-	database, err := db.OpenSQLite(databasePath)
+	database, err := db.OpenDatabase(db.Config{Driver: db.DriverSQLite, SQLitePath: databasePath})
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}
@@ -145,7 +145,7 @@ func createCLIResetDatabase(t *testing.T) string {
 func createCLIResetUser(t *testing.T, databasePath string, email string, password string) {
 	t.Helper()
 
-	database, err := db.OpenSQLite(databasePath)
+	database, err := db.OpenDatabase(db.Config{Driver: db.DriverSQLite, SQLitePath: databasePath})
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}
@@ -178,7 +178,7 @@ func createCLIResetUser(t *testing.T, databasePath string, email string, passwor
 func loadCLIResetUser(t *testing.T, databasePath string, email string) models.User {
 	t.Helper()
 
-	database, err := db.OpenSQLite(databasePath)
+	database, err := db.OpenDatabase(db.Config{Driver: db.DriverSQLite, SQLitePath: databasePath})
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}

--- a/internal/cli/users_additional_test.go
+++ b/internal/cli/users_additional_test.go
@@ -161,7 +161,7 @@ func TestRunUsersDeleteRequiresConfirmationInputWhenYesFlagIsAbsent(t *testing.T
 func mustCLIUsersService(t *testing.T, databasePath string) *services.OperatorUserService {
 	t.Helper()
 
-	database, err := db.OpenSQLite(databasePath)
+	database, err := db.OpenDatabase(db.Config{Driver: db.DriverSQLite, SQLitePath: databasePath})
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}

--- a/internal/cli/users_test.go
+++ b/internal/cli/users_test.go
@@ -125,7 +125,7 @@ func createCLIUsersDatabase(t *testing.T) string {
 	t.Helper()
 
 	databasePath := filepath.Join(t.TempDir(), "cli-users-test.db")
-	database, err := db.OpenSQLite(databasePath)
+	database, err := db.OpenDatabase(db.Config{Driver: db.DriverSQLite, SQLitePath: databasePath})
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}
@@ -142,7 +142,7 @@ func createCLIUsersDatabase(t *testing.T) string {
 func createCLIUsersUser(t *testing.T, databasePath string, email string, displayName string, role string, onboardingCompleted bool, createdAt time.Time) models.User {
 	t.Helper()
 
-	database, err := db.OpenSQLite(databasePath)
+	database, err := db.OpenDatabase(db.Config{Driver: db.DriverSQLite, SQLitePath: databasePath})
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}
@@ -177,7 +177,7 @@ func createCLIUsersUser(t *testing.T, databasePath string, email string, display
 func listCLIUserEmails(t *testing.T, databasePath string) []string {
 	t.Helper()
 
-	database, err := db.OpenSQLite(databasePath)
+	database, err := db.OpenDatabase(db.Config{Driver: db.DriverSQLite, SQLitePath: databasePath})
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}
@@ -202,7 +202,7 @@ func listCLIUserEmails(t *testing.T, databasePath string) []string {
 func seedCLIUsersHealthData(t *testing.T, databasePath string, userID uint) {
 	t.Helper()
 
-	database, err := db.OpenSQLite(databasePath)
+	database, err := db.OpenDatabase(db.Config{Driver: db.DriverSQLite, SQLitePath: databasePath})
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}
@@ -239,7 +239,7 @@ func seedCLIUsersHealthData(t *testing.T, databasePath string, userID uint) {
 func assertCLIUsersDataCounts(t *testing.T, databasePath string, userID uint, wantUsers int64, wantSymptoms int64, wantLogs int64) {
 	t.Helper()
 
-	database, err := db.OpenSQLite(databasePath)
+	database, err := db.OpenDatabase(db.Config{Driver: db.DriverSQLite, SQLitePath: databasePath})
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}
@@ -426,7 +426,7 @@ func TestRunUsersCommandCreateRejectsWeakPassword(t *testing.T) {
 func countCLISymptomTypes(t *testing.T, databasePath string) int64 {
 	t.Helper()
 
-	database, err := db.OpenSQLite(databasePath)
+	database, err := db.OpenDatabase(db.Config{Driver: db.DriverSQLite, SQLitePath: databasePath})
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}

--- a/internal/cli/webhook_test.go
+++ b/internal/cli/webhook_test.go
@@ -31,7 +31,7 @@ func createCLIWebhookDatabase(t *testing.T) string {
 	t.Helper()
 
 	databasePath := filepath.Join(t.TempDir(), "cli-webhook-test.db")
-	database, err := db.OpenSQLite(databasePath)
+	database, err := db.OpenDatabase(db.Config{Driver: db.DriverSQLite, SQLitePath: databasePath})
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}
@@ -46,7 +46,7 @@ func createCLIWebhookDatabase(t *testing.T) string {
 func createCLIWebhookOwner(t *testing.T, databasePath string, email string) models.User {
 	t.Helper()
 
-	database, err := db.OpenSQLite(databasePath)
+	database, err := db.OpenDatabase(db.Config{Driver: db.DriverSQLite, SQLitePath: databasePath})
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}
@@ -84,7 +84,7 @@ func createCLIWebhookOwner(t *testing.T, databasePath string, email string) mode
 func loadWebhookRow(t *testing.T, databasePath string, userID uint) models.User {
 	t.Helper()
 
-	database, err := db.OpenSQLite(databasePath)
+	database, err := db.OpenDatabase(db.Config{Driver: db.DriverSQLite, SQLitePath: databasePath})
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}

--- a/internal/db/app_state_repository_test.go
+++ b/internal/db/app_state_repository_test.go
@@ -14,9 +14,9 @@ import (
 // ON CONFLICT (key) update) rather than erroring on the primary-key collision or
 // appending a second row.
 func TestAppStateRepositoryRoundTripAndUpsert(t *testing.T) {
-	database, err := OpenSQLite(filepath.Join(t.TempDir(), "app-state.db"))
+	database, err := OpenDatabase(Config{Driver: DriverSQLite, SQLitePath: filepath.Join(t.TempDir(), "app-state.db")})
 	if err != nil {
-		t.Fatalf("OpenSQLite() unexpected error: %v", err)
+		t.Fatalf("OpenDatabase() unexpected error: %v", err)
 	}
 	t.Cleanup(func() {
 		if sqlDB, dbErr := database.DB(); dbErr == nil {
@@ -60,9 +60,9 @@ func TestAppStateRepositoryRoundTripAndUpsert(t *testing.T) {
 // TestAppStateRepositoryRejectsBlankKey covers the guard: an empty/whitespace key
 // is not a valid marker. Get treats it as missing; Set refuses it.
 func TestAppStateRepositoryRejectsBlankKey(t *testing.T) {
-	database, err := OpenSQLite(filepath.Join(t.TempDir(), "app-state-blank.db"))
+	database, err := OpenDatabase(Config{Driver: DriverSQLite, SQLitePath: filepath.Join(t.TempDir(), "app-state-blank.db")})
 	if err != nil {
-		t.Fatalf("OpenSQLite() unexpected error: %v", err)
+		t.Fatalf("OpenDatabase() unexpected error: %v", err)
 	}
 	t.Cleanup(func() {
 		if sqlDB, dbErr := database.DB(); dbErr == nil {
@@ -86,9 +86,9 @@ func TestAppStateRepositoryRejectsBlankKey(t *testing.T) {
 // relies on this so a real DB failure fails its catch-up safe rather than
 // silently reading "never ran".
 func TestAppStateRepositoryGetSurfacesNonNotFoundError(t *testing.T) {
-	database, err := OpenSQLite(filepath.Join(t.TempDir(), "app-state-closed.db"))
+	database, err := OpenDatabase(Config{Driver: DriverSQLite, SQLitePath: filepath.Join(t.TempDir(), "app-state-closed.db")})
 	if err != nil {
-		t.Fatalf("OpenSQLite() unexpected error: %v", err)
+		t.Fatalf("OpenDatabase() unexpected error: %v", err)
 	}
 	repo := NewAppStateRepository(database)
 

--- a/internal/db/database.go
+++ b/internal/db/database.go
@@ -108,10 +108,3 @@ func closeOpenedPool(database *gorm.DB) {
 	}
 	_ = sqlDB.Close()
 }
-
-func OpenSQLite(dbPath string) (*gorm.DB, error) {
-	return OpenDatabase(Config{
-		Driver:     DriverSQLite,
-		SQLitePath: dbPath,
-	})
-}

--- a/internal/db/delete_account_completeness_test.go
+++ b/internal/db/delete_account_completeness_test.go
@@ -27,7 +27,7 @@ func countWhere(t *testing.T, database *gorm.DB, model any, query string, args .
 // independently of whether ON DELETE CASCADE is enforced.
 func TestDeleteAccountAndRelatedDataRemovesAllUserRows(t *testing.T) {
 	dir := t.TempDir()
-	database, err := OpenSQLite(filepath.Join(dir, "erasure.db"))
+	database, err := OpenDatabase(Config{Driver: DriverSQLite, SQLitePath: filepath.Join(dir, "erasure.db")})
 	requireNoErr(t, err, "open sqlite")
 	t.Cleanup(func() {
 		if sqlDB, err := database.DB(); err == nil {
@@ -116,7 +116,7 @@ func TestDeleteAccountAndRelatedDataRollsBackOnChildDeleteError(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := t.TempDir()
-			database, err := OpenSQLite(filepath.Join(dir, "delerr.db"))
+			database, err := OpenDatabase(Config{Driver: DriverSQLite, SQLitePath: filepath.Join(dir, "delerr.db")})
 			if err != nil {
 				t.Fatalf("open sqlite: %v", err)
 			}

--- a/internal/db/health_repository_test.go
+++ b/internal/db/health_repository_test.go
@@ -12,7 +12,7 @@ import (
 func openHealthProbeDB(t *testing.T) *gorm.DB {
 	t.Helper()
 
-	database, err := OpenSQLite(filepath.Join(t.TempDir(), "health-probe.db"))
+	database, err := OpenDatabase(Config{Driver: DriverSQLite, SQLitePath: filepath.Join(t.TempDir(), "health-probe.db")})
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}

--- a/internal/db/method_coverage_test.go
+++ b/internal/db/method_coverage_test.go
@@ -16,7 +16,7 @@ import (
 
 func openMethodCoverageDB(t *testing.T) *gorm.DB {
 	t.Helper()
-	database, err := OpenSQLite(filepath.Join(t.TempDir(), "method-coverage.db"))
+	database, err := OpenDatabase(Config{Driver: DriverSQLite, SQLitePath: filepath.Join(t.TempDir(), "method-coverage.db")})
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}

--- a/internal/db/migrations_bootstrap_test.go
+++ b/internal/db/migrations_bootstrap_test.go
@@ -360,7 +360,7 @@ func TestMigrationReappliesWhenItsSchemaMigrationsRecordIsMissing(t *testing.T) 
 				t.Fatalf("close sql db: %v", err)
 			}
 
-			reopened, err := OpenSQLite(databasePath)
+			reopened, err := OpenDatabase(Config{Driver: DriverSQLite, SQLitePath: databasePath})
 			if err != nil {
 				t.Fatalf(
 					"expected migration %s to re-apply cleanly with %s.%s already present, but boot failed — the runner did not recognize its ADD COLUMN as skippable: %v",
@@ -724,7 +724,7 @@ func assertAppStateSchema(t *testing.T, database *gorm.DB) {
 func TestOpenSQLiteMigrationBootstrapIsIdempotent(t *testing.T) {
 	databasePath := filepath.Join(t.TempDir(), "ovumcy-idempotent.db")
 
-	firstOpen, err := OpenSQLite(databasePath)
+	firstOpen, err := OpenDatabase(Config{Driver: DriverSQLite, SQLitePath: databasePath})
 	if err != nil {
 		t.Fatalf("first open sqlite: %v", err)
 	}
@@ -775,7 +775,7 @@ func TestOpenSQLiteReleasesTheConnectionWhenMigrationsFail(t *testing.T) {
 	failedPath := filepath.Join(t.TempDir(), "ovumcy-migration-failure.db")
 	seedShadowedSchemaMigrationsTable(t, failedPath)
 
-	database, err := OpenSQLite(failedPath)
+	database, err := OpenDatabase(Config{Driver: DriverSQLite, SQLitePath: failedPath})
 	if err == nil {
 		if sqlDB, handleErr := database.DB(); handleErr == nil {
 			_ = sqlDB.Close()
@@ -794,7 +794,7 @@ func TestOpenSQLiteReleasesTheConnectionWhenMigrationsFail(t *testing.T) {
 	// Positive anchor: the same two assertions against a successful open, closed
 	// by the test itself.
 	succeededPath := filepath.Join(t.TempDir(), "ovumcy-migration-success.db")
-	succeeded, err := OpenSQLite(succeededPath)
+	succeeded, err := OpenDatabase(Config{Driver: DriverSQLite, SQLitePath: succeededPath})
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}
@@ -861,7 +861,7 @@ func assertSQLiteConnectionReleased(t *testing.T, databasePath string) {
 func openSQLiteForMigrationBootstrapTest(t *testing.T, databasePath string) *gorm.DB {
 	t.Helper()
 
-	database, err := OpenSQLite(databasePath)
+	database, err := OpenDatabase(Config{Driver: DriverSQLite, SQLitePath: databasePath})
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}

--- a/internal/db/sqlite_concurrency_test.go
+++ b/internal/db/sqlite_concurrency_test.go
@@ -18,7 +18,7 @@ import (
 func openConcurrencyRepo(t *testing.T) *Repositories {
 	t.Helper()
 	dir := t.TempDir()
-	database, err := OpenSQLite(filepath.Join(dir, "retry.db"))
+	database, err := OpenDatabase(Config{Driver: DriverSQLite, SQLitePath: filepath.Join(dir, "retry.db")})
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}
@@ -86,7 +86,7 @@ func TestWithinTransactionRespectsContextCancellation(t *testing.T) {
 // asserts not a single SQLITE_BUSY surfaces.
 func TestSQLiteConcurrentDayWritesNoBusyError(t *testing.T) {
 	dir := t.TempDir()
-	database, err := OpenSQLite(filepath.Join(dir, "concurrency.db"))
+	database, err := OpenDatabase(Config{Driver: DriverSQLite, SQLitePath: filepath.Join(dir, "concurrency.db")})
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}

--- a/internal/db/sqlite_pragma_test.go
+++ b/internal/db/sqlite_pragma_test.go
@@ -20,7 +20,7 @@ import (
 // daily_logs row is gone.
 func TestSQLitePragmasEnforced(t *testing.T) {
 	dir := t.TempDir()
-	database, err := OpenSQLite(filepath.Join(dir, "pragma.db"))
+	database, err := OpenDatabase(Config{Driver: DriverSQLite, SQLitePath: filepath.Join(dir, "pragma.db")})
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}

--- a/internal/db/sqlite_user_email_index_test.go
+++ b/internal/db/sqlite_user_email_index_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestOpenSQLiteCreatesCaseInsensitiveUserEmailUniqueIndex(t *testing.T) {
 	databasePath := filepath.Join(t.TempDir(), "ovumcy-email-index.db")
-	database, err := OpenSQLite(databasePath)
+	database, err := OpenDatabase(Config{Driver: DriverSQLite, SQLitePath: databasePath})
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}

--- a/internal/db/user_repository_calendar_feed_force_clear_test.go
+++ b/internal/db/user_repository_calendar_feed_force_clear_test.go
@@ -27,7 +27,7 @@ import (
 // and bump the version together.
 func createArmedFeedUserForForceClear(t *testing.T, email string) (*UserRepository, uint) {
 	t.Helper()
-	database, err := OpenSQLite(filepath.Join(t.TempDir(), "feed-force-clear.db"))
+	database, err := OpenDatabase(Config{Driver: DriverSQLite, SQLitePath: filepath.Join(t.TempDir(), "feed-force-clear.db")})
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}

--- a/internal/db/user_repository_cas_test.go
+++ b/internal/db/user_repository_cas_test.go
@@ -18,7 +18,7 @@ import (
 //     ErrResetTokenAlreadyConsumed because the stored hash already changed.
 func TestUpdatePasswordRecoveryCodeAndRevokeSessionsCASRejectsReplay(t *testing.T) {
 	dir := t.TempDir()
-	database, err := OpenSQLite(filepath.Join(dir, "cas_test.db"))
+	database, err := OpenDatabase(Config{Driver: DriverSQLite, SQLitePath: filepath.Join(dir, "cas_test.db")})
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}
@@ -124,7 +124,7 @@ func TestOpenSQLiteConnectionPoolLimits(t *testing.T) {
 // revoked by an internal storage upgrade.
 func TestUpdatePasswordHashOnlyPreservesSessionVersion(t *testing.T) {
 	dir := t.TempDir()
-	database, err := OpenSQLite(filepath.Join(dir, "rehash_test.db"))
+	database, err := OpenDatabase(Config{Driver: DriverSQLite, SQLitePath: filepath.Join(dir, "rehash_test.db")})
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}

--- a/internal/db/user_repository_registration_test.go
+++ b/internal/db/user_repository_registration_test.go
@@ -14,7 +14,7 @@ func openRegistrationRepositoryForTest(t *testing.T) *UserRepository {
 	t.Helper()
 
 	databasePath := filepath.Join(t.TempDir(), "registration-repository.db")
-	database, err := OpenSQLite(databasePath)
+	database, err := OpenDatabase(Config{Driver: DriverSQLite, SQLitePath: databasePath})
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}

--- a/internal/i18n/plural.go
+++ b/internal/i18n/plural.go
@@ -48,9 +48,20 @@ func PluralCategory(language string, n int) string {
 }
 
 // PluralCategories lists every category PluralCategory can return for the
-// given language, in CLDR order. Used by the locale parity test to demand
-// exactly the variants a language needs — no missing Russian "few", no dead
-// English "many".
+// given language, in CLDR order. It is the single source of truth for the set
+// of suffixed keys a plural family owes per language — the locale parity test
+// demands exactly those variants (no missing Russian "few", no dead English
+// "many"), the printf-verb test compares them against each other, and the
+// late-cycle locale test in internal/services enumerates them for its own key
+// families. Callers in two packages are why this stays an exported
+// declaration in production code rather than moving into a _test.go: a
+// _test.go declaration is invisible outside its own package, and duplicating
+// the table would let the copies disagree about which variants a locale file
+// must carry. It is unreachable from the running binary on purpose; any check
+// that has to enumerate a plural key family should compute it from here.
+//
+// Decision (2026-08-15): keep as production code, documented, rather than
+// resolve the production-scope dead-code finding by duplicating the table.
 func PluralCategories(language string) []string {
 	if strings.ToLower(strings.TrimSpace(language)) == LangRU {
 		return []string{"one", "few", "many"}


### PR DESCRIPTION
Two declarations were reachable only from tests, which is what keeps the
production-scoped `deadcode` run red (CI runs the `-test` scope; the scope
without `-test` is the one this works toward). They are resolved differently,
because their caller sets differ.

## `db.OpenSQLite` — removed, tests re-pointed at the production opener

`OpenSQLite` was a three-line wrapper: it filled in a `Config` literal and
delegated to `OpenDatabase`. So it was **not** a second, weaker door — the
embedded migrations and the SQLite DSN (`foreign_keys`, `busy_timeout`, WAL,
`_txlock=immediate`) were applied identically on both paths, and no test was
green about a database the application would never produce. What it was is an
entry point nothing in the running binary uses: the server (`cmd/ovumcy/main.go:148`)
and every CLI subcommand (`internal/cli/{users,reset,notify,webhook}.go`) open
through `db.OpenDatabase(db.Config{...})`.

All 47 call sites now name that same entry point and the wrapper is gone:

| package | call sites |
| --- | --- |
| `cmd/ovumcy` | 7 |
| `internal/api` | 7 |
| `internal/cli` | 13 |
| `internal/db` | 20 |

Moving the declaration into a `_test.go` was not available: its callers span
four packages, and a `_test.go` declaration is invisible outside its own
package. Coverage does not move — `OpenDatabase` was already the covered path
and the rewrite is a spelling change at every site. Test function names are
left alone; `TestOpenSQLiteReleasesTheConnectionWhenMigrationsFail` and its
siblings still name the SQLite open path they exercise, and renaming them would
only break the references that point at them by name.

Write-path concurrency is unchanged: `internal/db/sqlite_concurrency_test.go`
still drives the real read-then-write upsert inside one `WithinTransaction`
across 50 goroutines and still fails on a single `SQLITE_BUSY`.

## `i18n.PluralCategories` — stays, and now says why

It is the single source of truth for the CLDR category set a language's locale
files must carry. Three tests read it, across two packages:

- `internal/i18n/locales_parity_test.go:78` — demands exactly the variants a
  language needs (no missing Russian `few`, no dead English `many`)
- `internal/i18n/plural_test.go:173` — compares `%d` verb counts between the
  variants of one plural family
- `internal/services/late_cycle_policy_test.go:230` — expands the late-cycle
  key families over each locale

The third caller is in a different package, so the "move it into a `_test.go`"
disposition does not compile: a declaration in `internal/i18n`'s test files is
visible to that package's own external test package, but never to
`package services`. Duplicating the table instead would let the copies disagree
about which variants a locale file owes — precisely the thing the parity test
exists to prevent. So it stays exported production code, and its doc comment
now records the decision and the callers, so a later reachability sweep does not
re-open it. A plural-key reachability check should compute its expected key set
from this function rather than restating the categories.

## Verification

- `go build ./...` — clean
- `go test ./...` — all packages pass
- `go test ./cmd/... ./internal/... ./migrations/... ./scripts/... ./web/...
  -timeout 30m -coverprofile=coverage.out -covermode=atomic -coverpkg=...`
  followed by `go run ./scripts/patchcov` in the same invocation —
  *patch coverage gate OK*. The explicit `-timeout 30m` is a local-machine
  concession: under coverage instrumentation `internal/api` runs past the
  default 10 minute alarm here (615 s wall). It is unrelated to this change.
- `golangci-lint run ./...` — 0 issues
- `deadcode -test ./cmd/... ./internal/... ./migrations/... ./scripts/... ./web/...`
  (the CI gate) — no findings
- `deadcode ./cmd/... ./internal/... ./migrations/... ./scripts/... ./web/...`
  (production scope) — `OpenSQLite` is gone from the list; `PluralCategories`
  remains by the decision above, alongside the findings other changes own
  (`internal/api`, `internal/security`, `internal/services`) and the whole of
  `internal/testdb`, which is a test-support package and unreachable from the
  binary by construction.

Remaining: the production scope cannot go green while `PluralCategories` and
`internal/testdb` are counted, so wiring it into CI needs a decision about how a
deliberate cross-package test seam is expressed to the analyser.
