### PR TITLE
chore: drop the two internal/security declarations only tests reach

### DIFF
--- a/changelog.d/chore-security-test-only-decls.md
+++ b/changelog.d/chore-security-test-only-decls.md
@@ -1,0 +1,7 @@
+none
+
+Dead-code removal with no user-visible effect: the two `internal/security`
+declarations only tests could reach — `EncryptFieldNoAADForTest` and the
+`SealedCipher.NonceSize` accessor. The AEAD construction, the sealed-cookie
+envelope and the legacy-ciphertext fallback are untouched, and every assertion
+that stood on those declarations now runs against the shipping path instead.

--- a/internal/api/secure_cookie_codec_security_test.go
+++ b/internal/api/secure_cookie_codec_security_test.go
@@ -118,29 +118,18 @@ func TestSecureCookieCodecRejectsTamperedCiphertext(t *testing.T) {
 		t.Fatalf("unexpectedly short sealed payload: %d bytes", len(payload))
 	}
 
-	// Flip the last byte (inside the GCM auth tag).
-	tamperedTail := append([]byte{}, payload...)
-	tamperedTail[len(tamperedTail)-1] ^= 0xFF
-	tamperedTailEncoded := version + "." + base64.RawURLEncoding.EncodeToString(tamperedTail)
-	if _, err := codec.open(authCookieName, tamperedTailEncoded); !errors.Is(err, errInvalidSecureCookieValue) {
-		t.Fatalf("expected tampered auth tag to be rejected, got %v", err)
-	}
-
-	// Flip a byte in the middle (inside ciphertext body, past the nonce).
-	nonceSize := codec.aead.NonceSize()
-	tamperedBody := append([]byte{}, payload...)
-	tamperedBody[nonceSize+1] ^= 0x01
-	tamperedBodyEncoded := version + "." + base64.RawURLEncoding.EncodeToString(tamperedBody)
-	if _, err := codec.open(authCookieName, tamperedBodyEncoded); !errors.Is(err, errInvalidSecureCookieValue) {
-		t.Fatalf("expected tampered ciphertext byte to be rejected, got %v", err)
-	}
-
-	// Flip a byte in the nonce.
-	tamperedNonce := append([]byte{}, payload...)
-	tamperedNonce[0] ^= 0x01
-	tamperedNonceEncoded := version + "." + base64.RawURLEncoding.EncodeToString(tamperedNonce)
-	if _, err := codec.open(authCookieName, tamperedNonceEncoded); !errors.Is(err, errInvalidSecureCookieValue) {
-		t.Fatalf("expected tampered nonce to be rejected, got %v", err)
+	// Flip one byte at every offset of the sealed payload. The three regions
+	// the earlier version of this test picked by offset — nonce, ciphertext
+	// body, GCM auth tag — are all covered, and so is any region a future
+	// envelope adds, without this package having to know where the nonce
+	// prefix ends. The layout is internal/security's, not the codec's.
+	for offset := range payload {
+		tampered := append([]byte{}, payload...)
+		tampered[offset] ^= 0x01
+		tamperedEncoded := version + "." + base64.RawURLEncoding.EncodeToString(tampered)
+		if _, err := codec.open(authCookieName, tamperedEncoded); !errors.Is(err, errInvalidSecureCookieValue) {
+			t.Fatalf("expected a flipped byte at offset %d of %d to be rejected, got %v", offset, len(payload), err)
+		}
 	}
 }
 
@@ -216,8 +205,6 @@ func TestSecureCookieCodecRejectsTruncatedPayload(t *testing.T) {
 		{name: "version_only", value: secureCookieVersion},
 		{name: "wrong_version_prefix", value: "v9." + base64.RawURLEncoding.EncodeToString(randomBytes(t, 32))},
 		{name: "non_base64_payload", value: secureCookieVersion + ".!!not-base64!!"},
-		{name: "shorter_than_nonce", value: secureCookieVersion + "." + base64.RawURLEncoding.EncodeToString(randomBytes(t, 8))},
-		{name: "exactly_nonce_no_ciphertext", value: secureCookieVersion + "." + base64.RawURLEncoding.EncodeToString(randomBytes(t, codec.aead.NonceSize()))},
 	}
 	for _, tc := range cases {
 
@@ -228,6 +215,30 @@ func TestSecureCookieCodecRejectsTruncatedPayload(t *testing.T) {
 				t.Fatalf("expected truncated/malformed payload %q to be rejected, got %v", tc.name, err)
 			}
 		})
+	}
+
+	// Every proper prefix of a genuine sealed payload must be refused:
+	// shorter than the nonce, exactly the nonce with no ciphertext, and a
+	// nonce plus a partial ciphertext are all in the sweep, so the boundary
+	// cases hold without the codec asking internal/security for the nonce
+	// length.
+	sealed, err := codec.seal(authCookieName, []byte("genuine-payload"))
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	version, encoded, _ := strings.Cut(sealed, ".")
+	payload, err := base64.RawURLEncoding.DecodeString(encoded)
+	if err != nil {
+		t.Fatalf("decode sealed payload: %v", err)
+	}
+	if len(payload) < 16 {
+		t.Fatalf("unexpectedly short sealed payload: %d bytes — the length sweep below would assert nothing", len(payload))
+	}
+	for length := range payload {
+		truncated := version + "." + base64.RawURLEncoding.EncodeToString(payload[:length])
+		if _, err := codec.open(authCookieName, truncated); !errors.Is(err, errInvalidSecureCookieValue) {
+			t.Fatalf("expected a %d-byte prefix of a %d-byte sealed payload to be rejected, got %v", length, len(payload), err)
+		}
 	}
 }
 

--- a/internal/security/field_crypto.go
+++ b/internal/security/field_crypto.go
@@ -96,15 +96,3 @@ func openFieldCiphertext(encoded string, secretKey []byte, aad []byte) (string, 
 
 	return string(plaintext), nil
 }
-
-// EncryptFieldNoAADForTest produces a ciphertext using the legacy no-aad
-// format that earlier Ovumcy versions wrote to disk. It exists ONLY so
-// regression tests in other packages can construct legacy fixtures without
-// re-implementing the AEAD machinery (the HKDF labels are unexported).
-// Production code MUST NOT call this function — use EncryptField instead.
-func EncryptFieldNoAADForTest(plaintext string, secretKey []byte) (string, error) {
-	if len(secretKey) == 0 {
-		return "", errors.New("field crypto: secret key is required")
-	}
-	return sealFieldCiphertext(plaintext, secretKey, nil)
-}

--- a/internal/security/field_crypto_legacy_helper_test.go
+++ b/internal/security/field_crypto_legacy_helper_test.go
@@ -4,15 +4,17 @@ import (
 	"testing"
 )
 
-// encryptFieldLegacyForTest is a thin same-package wrapper around the
-// cross-package test helper EncryptFieldNoAADForTest. It exists so the
-// other test functions in this file can stay readable without the longer
-// public-API name.
+// encryptFieldLegacyForTest seals a value in the legacy no-aad format that
+// earlier Ovumcy versions wrote to disk, so the fallback path in DecryptField
+// has a fixture to open. It goes through the same sealFieldCiphertext the
+// shipping EncryptField calls, with the aad EncryptField itself refuses —
+// this package's tests can reach it directly, and no production door for the
+// unbound format exists or should exist.
 func encryptFieldLegacyForTest(t *testing.T, secretKey []byte, plaintext string) string {
 	t.Helper()
-	encoded, err := EncryptFieldNoAADForTest(plaintext, secretKey)
+	encoded, err := sealFieldCiphertext(plaintext, secretKey, nil)
 	if err != nil {
-		t.Fatalf("EncryptFieldNoAADForTest: %v", err)
+		t.Fatalf("sealFieldCiphertext with nil aad: %v", err)
 	}
 	return encoded
 }

--- a/internal/security/sealed_cipher.go
+++ b/internal/security/sealed_cipher.go
@@ -77,12 +77,6 @@ func newSealedCipher(secretKey []byte, saltLabel, infoLabel string) (*SealedCiph
 	return &SealedCipher{aead: aead}, nil
 }
 
-// NonceSize returns the AEAD nonce length in bytes — the length of the nonce
-// prefix in payloads produced by Seal.
-func (c *SealedCipher) NonceSize() int {
-	return c.aead.NonceSize()
-}
-
 // Seal encrypts plaintext bound to aad and returns nonce||ciphertext with a
 // fresh random nonce. The aad is passed through to the AEAD as-is; callers
 // enforce their own non-empty-AAD policies.

--- a/internal/security/sealed_cipher_test.go
+++ b/internal/security/sealed_cipher_test.go
@@ -17,8 +17,8 @@ func TestSealedCipherRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Seal: %v", err)
 	}
-	if len(payload) <= c.NonceSize() {
-		t.Fatalf("Seal produced %d bytes, want more than the %d-byte nonce", len(payload), c.NonceSize())
+	if len(payload) <= c.aead.NonceSize() {
+		t.Fatalf("Seal produced %d bytes, want more than the %d-byte nonce", len(payload), c.aead.NonceSize())
 	}
 
 	opened, err := c.Open(payload, aad)
@@ -83,9 +83,9 @@ func TestSealedCipherRejectsTooShortPayload(t *testing.T) {
 		t.Fatalf("NewSecureCookieCipher: %v", err)
 	}
 
-	for size := 0; size <= c.NonceSize(); size++ {
+	for size := 0; size <= c.aead.NonceSize(); size++ {
 		if _, err := c.Open(make([]byte, size), []byte("aad")); err == nil {
-			t.Fatalf("Open must reject a %d-byte payload (nonce size %d)", size, c.NonceSize())
+			t.Fatalf("Open must reject a %d-byte payload (nonce size %d)", size, c.aead.NonceSize())
 		}
 	}
 }

--- a/internal/services/totp_service_aad_test.go
+++ b/internal/services/totp_service_aad_test.go
@@ -11,14 +11,21 @@ import (
 
 func nowForTOTPTest() time.Time { return time.Now() }
 
-func encryptFieldLegacyForTOTPTest(t *testing.T, secretKey []byte, plaintext string) string {
-	t.Helper()
-	encoded, err := security.EncryptFieldNoAADForTest(plaintext, secretKey)
-	if err != nil {
-		t.Fatalf("EncryptFieldNoAADForTest: %v", err)
-	}
-	return encoded
-}
+// A users.totp_secret ciphertext as a pre-aad Ovumcy revision actually wrote
+// it: sealed with nil aad, base64url-framed, recorded rather than re-derived.
+// The same bytes are the legacy half of the back-compat fixture in
+// internal/security/field_crypto_golden_test.go, which pins the HKDF labels
+// and the nonce||ciphertext layout; they are repeated here because a test
+// fixture in one package's _test.go is invisible to another package. If this
+// value stops opening, key derivation or framing has changed and every
+// 2FA-enabled account upgraded from that revision would lose their second
+// factor — fix the regression, do not regenerate the constant.
+const (
+	legacyTOTPSecretKey  = "golden-backcompat-secret-key-0123456789"
+	legacyTOTPRawSecret  = "JBSWY3DPEHPK3PXP"
+	legacyTOTPCiphertext = "qqd8hcE4OAzAXieRHELQMKshSBcewFcPLCu4Lb0CCOv_BV1UQuUNHSJyTLE"
+	legacyTOTPOwnerID    = 42
+)
 
 // TestTOTPService_ValidateCode_RejectsCiphertextFromAnotherUser is the
 // runtime contract test for Finding #2 (encrypted TOTP secret was not
@@ -80,17 +87,14 @@ func TestTOTPService_ValidateCode_RejectsCiphertextFromAnotherUser(t *testing.T)
 // their security posture — they just logged in).
 func TestTOTPService_ValidateCode_LegacyCiphertextReencrypts(t *testing.T) {
 	repo := &stubTOTPUserRepo{}
-	secretKey := []byte("test-secret-key-32-bytes-padding!")
+	secretKey := []byte(legacyTOTPSecretKey)
 	svc := NewTOTPService(repo, secretKey, nil)
 
-	rawSecret := "JBSWY3DPEHPK3PXP"
-	legacy := encryptFieldLegacyForTOTPTest(t, secretKey, rawSecret)
-
-	code, err := totp.GenerateCode(rawSecret, nowForTOTPTest())
+	code, err := totp.GenerateCode(legacyTOTPRawSecret, nowForTOTPTest())
 	if err != nil {
 		t.Fatalf("GenerateCode: %v", err)
 	}
-	valid, err := svc.ValidateCode(context.Background(), 42, legacy, code)
+	valid, err := svc.ValidateCode(context.Background(), legacyTOTPOwnerID, legacyTOTPCiphertext, code)
 	if err != nil {
 		t.Fatalf("ValidateCode on legacy ciphertext: %v", err)
 	}
@@ -101,21 +105,21 @@ func TestTOTPService_ValidateCode_LegacyCiphertextReencrypts(t *testing.T) {
 	if !repo.reencryptCalled {
 		t.Fatal("ValidateCode succeeded on legacy ciphertext but did not invoke UpdateTOTPSecretCiphertext for re-encryption")
 	}
-	if repo.reencryptedUserID != 42 {
-		t.Errorf("re-encrypt called for userID=%d, want 42", repo.reencryptedUserID)
+	if repo.reencryptedUserID != legacyTOTPOwnerID {
+		t.Errorf("re-encrypt called for userID=%d, want %d", repo.reencryptedUserID, legacyTOTPOwnerID)
 	}
 	// The re-encrypted value MUST be aad-bound. The simplest way to assert
 	// this is to verify it opens cleanly under the expected aad and reports
 	// isLegacy=false.
-	got, isLegacy, err := security.DecryptField(repo.reencryptedCiphertext, secretKey, aadForTOTPSecret(42))
+	got, isLegacy, err := security.DecryptField(repo.reencryptedCiphertext, secretKey, aadForTOTPSecret(legacyTOTPOwnerID))
 	if err != nil {
 		t.Fatalf("re-encrypted ciphertext failed to decrypt under new aad: %v", err)
 	}
 	if isLegacy {
 		t.Fatal("re-encrypted ciphertext is still in legacy (no-aad) form")
 	}
-	if got != rawSecret {
-		t.Fatalf("re-encrypted plaintext mismatch: got %q, want %q", got, rawSecret)
+	if got != legacyTOTPRawSecret {
+		t.Fatalf("re-encrypted plaintext mismatch: got %q, want %q", got, legacyTOTPRawSecret)
 	}
 
 	if repo.updateTOTPCalled {


### PR DESCRIPTION
Resolves the last two `internal/security` declarations the production-scoped
`deadcode` run reports as unreachable, so that scope can be wired without an
allowlist. Each is decided on its own callers rather than by one mechanical
rule, and no assertion that stood on either is lost.

Baseline, measured on `origin/main` before the change:

```
$ deadcode -filter 'ovumcy-web/internal/security' ./cmd/... ./internal/... ./migrations/... ./scripts/... ./web/...
internal\security\field_crypto.go:105:6: unreachable func: EncryptFieldNoAADForTest
internal\security\sealed_cipher.go:82:24: unreachable func: SealedCipher.NonceSize
```

After: that command prints nothing, and the wired CI scope
(`deadcode -test` over the same five trees) also prints nothing.

## `EncryptFieldNoAADForTest` — removed, both fixtures re-pointed

Callers were two test fixtures and nothing else:

- `internal/security/field_crypto_legacy_helper_test.go:13`, wrapped as
  `encryptFieldLegacyForTest` and consumed by `field_crypto_test.go:151`
  (`TestDecryptField_LegacyFallback`)
- `internal/services/totp_service_aad_test.go:16`, wrapped as
  `encryptFieldLegacyForTOTPTest` and consumed by
  `TestTOTPService_ValidateCode_LegacyCiphertextReencrypts`

Moving it into a `_test.go` was therefore not available: a declaration in one
is invisible to other packages, and the `internal/services` caller sits in a
different package.

The same-package fixture now calls `sealFieldCiphertext` directly — the
shipping seal `EncryptField` itself calls, one layer below the empty-aad
refusal. The cross-package fixture is gone entirely: the services test now
uses the recorded pre-consolidation legacy ciphertext, the same bytes
`internal/security/field_crypto_golden_test.go` pins as the legacy half of its
back-compat fixture. That test consequently proves lazy re-encryption against
what an upgraded instance actually has on disk instead of against a parallel
sealer written for it. The constant is repeated rather than shared because a
fixture in one package's `_test.go` cannot be imported; its comment names the
canonical copy and says not to regenerate it.

**The AAD assertions survive.** `TestEncryptField_EmptyAAD`
still pins that `EncryptField` refuses nil and empty aad — it never used the
helper. `TestDecryptField_LegacyFallback` still pins that the unbound form
opens through the fallback and is flagged `isLegacy`, now built through
`sealFieldCiphertext`. `TestDecryptField_RejectsWrongAAD` and
`TestDecryptFieldOpensPreConsolidationGoldenCiphertexts` are untouched. What
disappears is only the exported door for producing the unbound format, which
production must never open.

## `SealedCipher.NonceSize` — removed, the codec tests stop indexing

Callers were `internal/security/sealed_cipher_test.go:20,21,86,88` **and**
`internal/api/secure_cookie_codec_security_test.go:130,220` — the second set
reaching it across the package boundary through `codec.aead`, which is a
`*security.SealedCipher`. So moving the method into a `_test.go` would have
broken `internal/api`; that disposition was checked explicitly and rejected.

The two `internal/api` call sites used the accessor to place a byte flip past
the nonce and to build a payload of exactly nonce length. Both now sweep
instead of indexing, which needs no boundary at all:

- every byte offset of a genuine sealed payload must fail to open after a
  single-bit flip — covering the nonce, the ciphertext body and the GCM auth
  tag that the three hand-placed offsets used to cover one at a time, plus any
  region a later envelope adds
- every proper prefix of a genuine sealed payload must be refused — covering
  `shorter_than_nonce` and `exactly_nonce_no_ciphertext`, plus the partial
  ciphertexts between them that the old table did not reach

Both sweeps carry a length floor that fails the run if the sealed payload is
too short to assert anything, so neither can go quietly vacuous. The
`internal/security` test reads `c.aead.NonceSize()`, as it is in that package.

Decision (2026-08-15): the nonce prefix stays unpublished. Routing `Seal` and
`Open` through the accessor would have made it reachable in two lines, but the
production scope exists to keep test-only doors out of shipped code, and
satisfying it by manufacturing a caller defeats the barrier.

## Files outside `internal/security`

Two, both edited only because they called one of the two declarations:
`internal/api/secure_cookie_codec_security_test.go` (called
`SealedCipher.NonceSize`) and `internal/services/totp_service_aad_test.go`
(called `EncryptFieldNoAADForTest`). No production file outside
`internal/security` changes.

## Proof on defect

Deleting the legacy fallback from `DecryptField` fails
`TestTOTPService_ValidateCode_LegacyCiphertextReencrypts`,
`TestDecryptField_LegacyFallback` and
`TestDecryptFieldOpensPreConsolidationGoldenCiphertexts`, each naming the
failed open. Swallowing the AEAD error in `secureCookieCodec.open` fails both
new sweeps, naming the offset (`offset 0 of 43`) and the prefix length
(`1-byte prefix of a 43-byte sealed payload`). Both defects were restored and
the suites re-run green.

## Verification

- `go build ./...` — clean
- `go test ./...` — green; `internal/api` needs `-timeout 30m` on a dev host
  running suites concurrently (576–580 s against Go's 600 s per-package
  default), which is the known local-host artifact, not a CI figure
- `deadcode` production scope over the five trees, filtered to
  `internal/security` — no findings; `deadcode -test` over the same trees — no
  findings
- `golangci-lint run --max-issues-per-linter=0 --max-same-issues=0` over the
  five trees — `0 issues`
- patch coverage, profile regenerated in the same invocation:
  `go test ... -coverprofile=coverage.out -covermode=atomic -coverpkg=...`
  then `BASE_REF=origin/main COVERAGE_FILE=coverage.out go run ./scripts/patchcov`
  — "every modified coverable line is covered by tests"
