### PR TITLE
chore: drop the auth-session builders nothing but their wrappers used

### DIFF
--- a/changelog.d/chore-drop-dead-auth-session-builders.md
+++ b/changelog.d/chore-drop-dead-auth-session-builders.md
@@ -1,0 +1,9 @@
+none
+
+Dead-code removal in the auth-session area with no user-visible effect: the two
+free-function auth-session token builders that only discarded what the real one
+returns, the `AuthService` method wrapping one of them, and the handler helper
+that sealed an auth token beside the shared sealing path. Every caller now uses
+the live builder, and the security regressions on that path keep asserting the
+same refusals — expired token, invalid signature, legacy unsealed JWT cookie,
+and the unsupported-role matrix over every authenticated route.

--- a/internal/api/auth_cookie_compat_regression_test.go
+++ b/internal/api/auth_cookie_compat_regression_test.go
@@ -142,7 +142,11 @@ func TestAuthMiddlewareRejectsRevokedAuthSessionCookieForAPI(t *testing.T) {
 func buildLegacyJWTForUser(t *testing.T, user models.User) string {
 	t.Helper()
 
-	signed, err := services.BuildAuthSessionToken([]byte("test-secret-key"), user.ID, user.Role, time.Hour, time.Now())
+	// Session version 1 is pinned deliberately rather than read from the
+	// fixture: ResolveAuthSession checks the version before the role, so a
+	// mismatched one would make this token die in the revoked arm instead of
+	// the legacy-shape arm the test names.
+	signed, _, err := services.BuildAuthSessionTokenWithVersionAndSessionID([]byte("test-secret-key"), user.ID, user.Role, 1, time.Hour, time.Now())
 	if err != nil {
 		t.Fatalf("sign legacy jwt token: %v", err)
 	}
@@ -184,7 +188,7 @@ func TestAuthMiddlewareMapsSessionResolveErrorsToClearedAuthCookie(t *testing.T)
 
 	// A well-formed session token whose TTL already elapsed: parsing reports
 	// expiry before any user lookup, exercising the token-expired arm.
-	expiredToken, err := services.BuildAuthSessionToken([]byte("test-secret-key"), user.ID, user.Role, time.Hour, time.Now().Add(-2*time.Hour))
+	expiredToken, _, err := services.BuildAuthSessionTokenWithVersionAndSessionID([]byte("test-secret-key"), user.ID, user.Role, 1, time.Hour, time.Now().Add(-2*time.Hour))
 	if err != nil {
 		t.Fatalf("build expired session token: %v", err)
 	}

--- a/internal/api/handlers_auth_token_helpers.go
+++ b/internal/api/handlers_auth_token_helpers.go
@@ -194,19 +194,6 @@ func (handler *Handler) refreshCurrentSession(c fiber.Ctx, user *models.User, sc
 	return nil
 }
 
-func (handler *Handler) encodeAuthCookieToken(rawToken string) (string, error) {
-	rawToken = strings.TrimSpace(rawToken)
-	if rawToken == "" {
-		return "", errors.New("auth token is required")
-	}
-
-	codec, err := handler.cookieCodec()
-	if err != nil {
-		return "", err
-	}
-	return codec.seal(authCookieName, []byte(rawToken))
-}
-
 func (handler *Handler) decodeSealedAuthCookieToken(rawValue string) (string, error) {
 	codec, err := handler.cookieCodec()
 	if err != nil {

--- a/internal/api/page_request_regressions_test.go
+++ b/internal/api/page_request_regressions_test.go
@@ -50,9 +50,9 @@ func TestRedirectAuthenticatedUserIfPresentRedirectsAuthenticatedRequest(t *test
 	if err != nil {
 		t.Fatalf("buildToken returned error: %v", err)
 	}
-	sealedToken, err := handler.encodeAuthCookieToken(token)
+	sealedToken, err := handler.sealCookieValue(authCookieName, []byte(token))
 	if err != nil {
-		t.Fatalf("encodeAuthCookieToken returned error: %v", err)
+		t.Fatalf("sealCookieValue returned error: %v", err)
 	}
 
 	app := fiber.New()

--- a/internal/api/test_onboarding_auth_helpers_test.go
+++ b/internal/api/test_onboarding_auth_helpers_test.go
@@ -102,7 +102,12 @@ func issueAuthCookieForUser(t *testing.T, user models.User) string {
 	t.Helper()
 
 	service := services.NewAuthService(nil)
-	token, err := service.BuildAuthSessionToken([]byte("test-secret-key"), user.ID, user.Role, user.AuthSessionVersion, time.Hour, time.Now())
+	// The services builder mints for any role on purpose: this helper exists to
+	// hand an unsupported-role account a well-formed cookie, so the owner-only
+	// route matrix can prove the request is refused at the gate rather than at
+	// the mint. Going through the handler's own buildTokenWithSessionID would
+	// refuse to issue one and leave those routes untested.
+	token, _, err := service.BuildAuthSessionTokenWithSessionID([]byte("test-secret-key"), user.ID, user.Role, user.AuthSessionVersion, time.Hour, time.Now())
 	if err != nil {
 		t.Fatalf("build auth session token: %v", err)
 	}

--- a/internal/services/auth_service.go
+++ b/internal/services/auth_service.go
@@ -359,10 +359,6 @@ func (service *AuthService) BuildPasswordResetToken(secretKey []byte, userID uin
 	return BuildPasswordResetToken(secretKey, userID, passwordHash, ttl, now)
 }
 
-func (service *AuthService) BuildAuthSessionToken(secretKey []byte, userID uint, role string, sessionVersion int, ttl time.Duration, now time.Time) (string, error) {
-	return BuildAuthSessionTokenWithVersion(secretKey, userID, role, sessionVersion, ttl, now)
-}
-
 func (service *AuthService) BuildAuthSessionTokenWithSessionID(secretKey []byte, userID uint, role string, sessionVersion int, ttl time.Duration, now time.Time) (string, string, error) {
 	return BuildAuthSessionTokenWithVersionAndSessionID(secretKey, userID, role, sessionVersion, ttl, now)
 }

--- a/internal/services/auth_service_recovery_test.go
+++ b/internal/services/auth_service_recovery_test.go
@@ -600,9 +600,9 @@ func TestAuthServiceResolveUserByAuthSessionToken(t *testing.T) {
 	}
 	service := NewAuthService(repo)
 
-	token, err := service.BuildAuthSessionToken(secret, 42, models.RoleOwner, 1, 30*time.Minute, now)
+	token, _, err := service.BuildAuthSessionTokenWithSessionID(secret, 42, models.RoleOwner, 1, 30*time.Minute, now)
 	if err != nil {
-		t.Fatalf("BuildAuthSessionToken() unexpected error: %v", err)
+		t.Fatalf("BuildAuthSessionTokenWithSessionID() unexpected error: %v", err)
 	}
 
 	user, err := service.ResolveUserByAuthSessionToken(context.Background(), secret, token, now.Add(1*time.Minute))
@@ -628,9 +628,9 @@ func TestAuthServiceResolveUserByAuthSessionTokenRejectsRevokedSession(t *testin
 	}
 	service := NewAuthService(repo)
 
-	token, err := service.BuildAuthSessionToken(secret, 42, models.RoleOwner, 1, 30*time.Minute, now)
+	token, _, err := service.BuildAuthSessionTokenWithSessionID(secret, 42, models.RoleOwner, 1, 30*time.Minute, now)
 	if err != nil {
-		t.Fatalf("BuildAuthSessionToken() unexpected error: %v", err)
+		t.Fatalf("BuildAuthSessionTokenWithSessionID() unexpected error: %v", err)
 	}
 
 	if _, err := service.ResolveUserByAuthSessionToken(context.Background(), secret, token, now.Add(1*time.Minute)); !errors.Is(err, ErrAuthSessionTokenRevoked) {

--- a/internal/services/auth_session_policy.go
+++ b/internal/services/auth_session_policy.go
@@ -28,16 +28,15 @@ type AuthSessionClaims struct {
 	jwt.RegisteredClaims
 }
 
-func BuildAuthSessionToken(secretKey []byte, userID uint, role string, ttl time.Duration, now time.Time) (string, error) {
-	token, _, err := BuildAuthSessionTokenWithVersionAndSessionID(secretKey, userID, role, 1, ttl, now)
-	return token, err
-}
-
-func BuildAuthSessionTokenWithVersion(secretKey []byte, userID uint, role string, sessionVersion int, ttl time.Duration, now time.Time) (string, error) {
-	token, _, err := BuildAuthSessionTokenWithVersionAndSessionID(secretKey, userID, role, sessionVersion, ttl, now)
-	return token, err
-}
-
+// BuildAuthSessionTokenWithVersionAndSessionID mints an auth session token and
+// returns the session id it embedded. It is the only builder: a caller that has
+// no use for the session id discards it, rather than reaching for a wrapper that
+// hides which session was created.
+//
+// The role travels into the claims unchecked on purpose. Whether a role may hold
+// a web session is decided by ValidateSupportedWebUser at the two places that
+// matter — where the api layer issues a cookie, and where ResolveAuthSession
+// admits one — so this stays a pure minting primitive.
 func BuildAuthSessionTokenWithVersionAndSessionID(secretKey []byte, userID uint, role string, sessionVersion int, ttl time.Duration, now time.Time) (string, string, error) {
 	if userID == 0 {
 		return "", "", ErrAuthSessionTokenInvalidUserID

--- a/internal/services/auth_session_policy_test.go
+++ b/internal/services/auth_session_policy_test.go
@@ -12,9 +12,9 @@ func TestBuildAndParseAuthSessionToken(t *testing.T) {
 	secret := []byte("test-auth-secret")
 	now := time.Date(2026, time.March, 1, 10, 0, 0, 0, time.UTC)
 
-	token, err := BuildAuthSessionTokenWithVersion(secret, 42, "owner", 3, 30*time.Minute, now)
+	token, _, err := BuildAuthSessionTokenWithVersionAndSessionID(secret, 42, "owner", 3, 30*time.Minute, now)
 	if err != nil {
-		t.Fatalf("BuildAuthSessionToken() unexpected error: %v", err)
+		t.Fatalf("BuildAuthSessionTokenWithVersionAndSessionID() unexpected error: %v", err)
 	}
 
 	claims, err := ParseAuthSessionToken(secret, token, now.Add(1*time.Minute))
@@ -39,9 +39,9 @@ func TestParseAuthSessionTokenRejectsExpired(t *testing.T) {
 	secret := []byte("test-auth-secret")
 	now := time.Date(2026, time.March, 1, 10, 0, 0, 0, time.UTC)
 
-	token, err := BuildAuthSessionToken(secret, 42, "owner", 1*time.Minute, now)
+	token, _, err := BuildAuthSessionTokenWithVersionAndSessionID(secret, 42, "owner", 1, 1*time.Minute, now)
 	if err != nil {
-		t.Fatalf("BuildAuthSessionToken() unexpected error: %v", err)
+		t.Fatalf("BuildAuthSessionTokenWithVersionAndSessionID() unexpected error: %v", err)
 	}
 
 	_, err = ParseAuthSessionToken(secret, token, now.Add(2*time.Minute))
@@ -54,9 +54,9 @@ func TestParseAuthSessionTokenRejectsInvalidSignature(t *testing.T) {
 	secret := []byte("test-auth-secret")
 	now := time.Date(2026, time.March, 1, 10, 0, 0, 0, time.UTC)
 
-	token, err := BuildAuthSessionToken(secret, 42, "owner", 30*time.Minute, now)
+	token, _, err := BuildAuthSessionTokenWithVersionAndSessionID(secret, 42, "owner", 1, 30*time.Minute, now)
 	if err != nil {
-		t.Fatalf("BuildAuthSessionToken() unexpected error: %v", err)
+		t.Fatalf("BuildAuthSessionTokenWithVersionAndSessionID() unexpected error: %v", err)
 	}
 
 	_, err = ParseAuthSessionToken([]byte("other-secret"), token, now.Add(1*time.Minute))


### PR DESCRIPTION
## What

Four declarations in the auth-session path existed only to hide part of what the
real builder returns, or to duplicate a sealing path that already exists:

- `services.BuildAuthSessionToken` — the builder with the session version pinned
  to `1` and the minted session id discarded.
- `services.BuildAuthSessionTokenWithVersion` — the builder with the session id
  discarded.
- `(*AuthService).BuildAuthSessionToken` — a method wrapping the second one, with
  no production caller.
- `(*Handler).encodeAuthCookieToken` — a second sealing path for `ovumcy_auth`,
  differing from the shared `sealCookieValue` only by trimming and rejecting an
  empty token, reached from one test.

`services.BuildAuthSessionTokenWithVersionAndSessionID` is the only builder, and
the api layer already reaches it through `(*AuthService).BuildAuthSessionTokenWithSessionID`
wherever a cookie is issued. Only tests kept the wrappers reachable; each now
calls the live builder and discards the session id itself, which makes the
session version every call site mints under explicit.

## Meaning preserved at each re-pointed call site

| Call site | Before | After |
| --- | --- | --- |
| `internal/services/auth_session_policy_test.go:15` | `BuildAuthSessionTokenWithVersion(secret, 42, "owner", 3, …)` | `BuildAuthSessionTokenWithVersionAndSessionID(secret, 42, "owner", 3, …)`, id discarded |
| `internal/services/auth_session_policy_test.go:42` | `BuildAuthSessionToken(secret, 42, "owner", 1*time.Minute, now)` | same builder, version `1` explicit |
| `internal/services/auth_session_policy_test.go:57` | `BuildAuthSessionToken(secret, 42, "owner", 30*time.Minute, now)` | same builder, version `1` explicit |
| `internal/services/auth_service_recovery_test.go:603`, `:631` | `service.BuildAuthSessionToken(…, 1, …)` | `service.BuildAuthSessionTokenWithSessionID(…, 1, …)`, id discarded |
| `internal/api/auth_cookie_compat_regression_test.go:149` (`buildLegacyJWTForUser`, was `:145`) | `services.BuildAuthSessionToken(…)` (version pinned to 1 inside the wrapper) | version **1 still pinned explicitly** |
| `internal/api/auth_cookie_compat_regression_test.go:191` (was `:187`) | `services.BuildAuthSessionToken(…)` | version `1` explicit |
| `internal/api/test_onboarding_auth_helpers_test.go:110` (`issueAuthCookieForUser`, was `:105`; ~20 call sites) | `service.BuildAuthSessionToken(…, user.AuthSessionVersion, …)` | `service.BuildAuthSessionTokenWithSessionID(…, user.AuthSessionVersion, …)` |
| `internal/api/page_request_regressions_test.go:53` | `handler.encodeAuthCookieToken(token)` | `handler.sealCookieValue(authCookieName, []byte(token))` |

Two of those carry their reason in a comment beside them:

- `buildLegacyJWTForUser` keeps pinning version `1` rather than reading
  `user.AuthSessionVersion`. `ResolveAuthSession` checks the session version
  before the role, so a version drawn from the fixture would make the token die
  in the revoked arm instead of the legacy-shape arm the test names.
- `issueAuthCookieForUser` stays on the services builder, which mints for any
  role. It exists to hand an unsupported-role account a well-formed cookie so
  the owner-only route matrix can prove the refusal happens at the gate; routing
  it through the handler's `buildTokenWithSessionID` would apply
  `ValidateSupportedWebUser` and refuse to mint one, leaving those routes
  untested.

No assertion rested on `encodeAuthCookieToken`'s empty-token rejection: its one
caller seals a token freshly minted by `buildTokenWithSessionID`, and the
subject of that test is `redirectAuthenticatedUserIfPresent` answering 303 to
`/dashboard`. `decodeSealedAuthCookieToken` is live and untouched.

Decision (2026-08-15): the role a token carries stays unchecked inside the
minting primitive. Whether a role may hold a web session is decided by
`ValidateSupportedWebUser` where the api layer issues a cookie
(`internal/api/handlers_auth_token_helpers.go`) and again where
`ResolveAuthSession` admits one — which is exactly what lets the test helper
keep minting partner-role cookies for the owner-only matrix.

## Verification

Test Enforcement Matrix rows that run through the removed doors, all green and
still asserting the same refusal (`go test ./internal/services/ -run …`,
`go test ./internal/api/ -run …`):

| Row | Test | Result |
| --- | --- | --- |
| `SECURITY.md:280` | `TestParseAuthSessionTokenRejectsExpired`, `TestParseAuthSessionTokenRejectsInvalidSignature` | PASS |
| `SECURITY.md:243` | `TestAuthMiddlewareRejectsLegacyJWTAuthCookieFallback` | PASS (303 → `/login`, cleared cookie) |
| `SECURITY.md:86` / `:88`, `docs/SECURITY_INVARIANTS.md:15`, `docs/gdpr.md:60` | `TestUnsupportedRoleRejectedAcrossEveryAuthedV1Route` (`internal/api/owner_only_coverage_regression_test.go`) | PASS, every subtest 403 + cleared cookie |

Each refusal was proved to still bite by reintroducing the condition it denies
and watching it fail, then restoring:

- parse the expired token before its TTL elapses → `expected ErrAuthSessionTokenExpired, got <nil>`;
- parse the token with the signing secret → `expected ErrAuthSessionTokenInvalid, got <nil>`;
- **seal** the legacy token so it is a well-formed sealed cookie → `expected status 303 with rejected legacy jwt cookie, got 200`. That 200 is the load-bearing one: it shows the token minted at version `1` is admitted for this fixture, so the real test's 303 comes from the unsealed legacy shape and not from the revoked arm.

The unsupported-role matrix needs no separate probe — it asserts **403**
specifically, which an unusable cookie could not produce.

Dead-code report, `deadcode v0.49.0`, production scope (no `-test`):

```
$ deadcode ./cmd/... ./internal/... ./migrations/... ./scripts/... ./web/...
```

17 lines, none naming these four (grepping the report for all four names:
0 matches). The remaining names belong to areas
other branches own (`internal/db`, `internal/i18n`, `internal/security`,
`internal/services/day_service.go`, `internal/services/calendar_view_policy.go`,
`internal/testdb`). The CI-shape run — `deadcode -test ./cmd/... ./internal/...
./migrations/... ./scripts/... ./web/...` — is empty, exit 0.

Full suite: `go build ./...` clean; `go test ./...` green except `internal/api`,
which trips **Go's 600 s per-package default on this dev host** (609 s, a host
running several suites at once). Re-run alone with
`go test ./internal/api/ -timeout 30m` → `ok … 603.032s`, no failing test.
`golangci-lint run ./internal/api/... ./internal/services/...` → `0 issues.`
Patch coverage, run after the commit with the profile regenerated in the same
invocation (`go test … -coverprofile=coverage.out -covermode=atomic -coverpkg=…`
then `COVERAGE_FILE=coverage.out BASE_REF=origin/main go run ./scripts/patchcov`):
`patch coverage gate OK: every modified coverable line is covered by tests.`

## Changelog

`changelog.d/chore-drop-dead-auth-session-builders.md`, first line `none` — no
user-visible effect.
