### PR TITLE
ci: record why the production dead-code scope stays unwired

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,9 +146,23 @@ jobs:
       # functions were reached from a templateFuncMap entry no template used.
       # What it does catch is a NEW function that nothing can reach.
       #
-      # -test keeps deliberate test seams out of the verdict. Nine functions are
-      # reachable only from tests today; until they move into _test.go files the
-      # production-scoped run stays red, so it is not wired here yet.
+      # -test keeps deliberate test seams out of the verdict, and the scope
+      # without it is deliberately NOT wired.
+      #
+      # Decision (2026-08-15): the nine declarations that were reachable only
+      # from tests are resolved — moved into test files, or re-pointed at the
+      # production path they were shadowing — and the production scope is still
+      # red, on two seams no code change removes. internal/testdb is test support
+      # shared by several packages' tests, so it can never live in a _test.go;
+      # i18n.PluralCategories is the single source of truth for a language's CLDR
+      # category set and is read from two packages' tests for the same reason.
+      # Wiring the scope would therefore mean carrying an exception list, and a
+      # list that grows by one line per audit is what it was meant to replace.
+      #
+      # The reachability it would have guaranteed is covered by purpose-built
+      # barriers instead, each failing on the layer deadcode cannot see:
+      # TestEveryTemplateFuncIsCalledByATemplate (internal/api) and
+      # TestEveryLocaleKeyIsReachableFromTheApplication (internal/i18n).
       #
       # deadcode exits 0 with findings on stdout, so the output is what decides.
       - name: Go dead code

--- a/changelog.d/ci-record-the-deadcode-scope-decision.md
+++ b/changelog.d/ci-record-the-deadcode-scope-decision.md
@@ -1,0 +1,6 @@
+none
+
+Comment-only change to the CI dead-code step: it described a plan to wire the
+production-scoped `deadcode` run once nine test-only declarations were resolved.
+They are resolved, and the scope stays unwired for a different reason, now
+recorded beside the step.


### PR DESCRIPTION
The comment beside the `Go dead code` step described a plan rather than a
state: nine declarations were reachable only from tests, and the
production-scoped run (`deadcode` without `-test`) would be wired once they
moved into test files.

Those nine are resolved across #486, #488, #489 and #490 — moved into a test
file where every caller was a test in the same package, re-pointed at the
production path they were shadowing where that path was a strict superset — and
the production scope is **still red**.

## Why it stays unwired

Two seams keep it red, and neither is debt that a later change removes:

- **`internal/testdb`** (ten declarations) is test support shared by several
  packages' tests. A `_test.go` declaration is invisible outside its own
  package, so this one cannot move there by construction.
- **`i18n.PluralCategories`** is the single source of truth for the CLDR
  category set a language's locale files must carry, read by
  `internal/i18n/locales_parity_test.go`, `internal/i18n/plural_test.go` and
  `internal/services/late_cycle_policy_test.go` — three callers across two
  packages, for the same reason. Duplicating the table instead would let the
  copies disagree about which variants a locale owes, which is what the parity
  test exists to prevent.

Wiring the scope therefore means carrying an exception list, and a list that
grows by one line per audit is the thing a barrier is supposed to replace.

## What covers it instead

`deadcode` was never the instrument that found this campaign's dead code: it
analyses functions only, and counts a caller as a caller even when the caller is
itself dead, so it reported **none** of the ~40 declarations removed. Both
findings came from purpose-built barriers, each failing on a layer `deadcode`
cannot see:

- `TestEveryTemplateFuncIsCalledByATemplate` (`internal/api`) — a func-map entry
  no shipped template calls
- `TestEveryLocaleKeyIsReachableFromTheApplication` (`internal/i18n`, #487) — a
  catalogue key no shipped Go file or template can name

`deadcode -test` stays wired and stays clean; what it still catches is a new
function nothing can reach at all.

## Verification

- `actionlint -shellcheck= .github/workflows/ci.yml` — exit 0 (shellcheck
  disabled explicitly, as the CI step does)
- YAML parses
- The step's command is unchanged; this is a comment plus a changelog fragment.
