### PR TITLE
test: stop the More-disclosure spec navigating onto an in-flight request

### DIFF
--- a/changelog.d/fix-dashboard-more-disclosure-navigation-race.md
+++ b/changelog.d/fix-dashboard-more-disclosure-navigation-race.md
@@ -1,0 +1,5 @@
+none
+
+Test-only fix: a dashboard spec navigated on top of the page's in-flight htmx
+lazy-loads, which aborted the navigation and surfaced as a flaky e2e shard. No
+product code involved.

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -471,6 +471,12 @@ test.describe('Dashboard: today editor', () => {
     // the one opening it.
     await page.goto('/dashboard#dashboard-pregnancy-test');
     await expect(dashboardMoreDisclosure(page)).toHaveAttribute('open', '');
+    // The disclosure's `open` attribute settles before the dashboard's htmx
+    // lazy-loads do, so the assertion above is not evidence the page is idle.
+    // Navigating on top of an in-flight request aborts it and `goto` reports
+    // net::ERR_ABORTED — a failure of the navigation, not of the product, which
+    // passes on retry and reads as a flake.
+    await page.waitForLoadState('networkidle');
     await page.goto('/dashboard');
     await expect(dashboardMoreDisclosure(page)).not.toHaveAttribute('open', '');
 


### PR DESCRIPTION
The merge-queue run for #491 went red on `e2e-shard (2)` with **59 passed, 1 flaky** — and `failOnFlakyTests` is what turned a retry-pass into a failure, which is exactly what it is for.

## What actually failed

```
e2e/dashboard.spec.ts:445 › rare journal fields wait behind More …
Error: page.goto: net::ERR_ABORTED at http://127.0.0.1:18080/dashboard
> 474 |     await page.goto('/dashboard');
```

The spec navigates to `/dashboard#dashboard-pregnancy-test`, asserts the disclosure opened, then immediately navigates back to `/dashboard`. The `open` attribute settles before the dashboard's htmx lazy-loads do, so that assertion is **not** evidence the page is idle. The second navigation lands on top of an in-flight request and aborts it.

Nothing about the product is wrong here, and nothing in the five dead-code changes that merged just before it is implicated: the failure is in the navigation the spec performs, and it reproduces as a race rather than as a verdict.

## The fix

Wait for the network to settle between the two navigations. This is the remedy already recorded in the browser-e2e rules for htmx cascades — a click or navigation followed by another navigation has to let the first one's fan-out finish, or the second aborts it.

No product code changes.

## Verification

- `npm run e2e -- e2e/dashboard.spec.ts` — 22 passed, none flaky
- `npm run lint` — clean (`eslint` over `e2e`, then `tsc --noEmit`)

A single green run does not prove an intermittent race closed. The change is reasoned from the failure mode and from the rule that already names this class; the run is evidence of no regression, not of the race being gone.

## Ordering

This should land before #491 and #492, so their merge-queue runs stop drawing the same flake.