### PR TITLE
ci: declare a test timeout budget instead of inheriting the default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,7 +205,22 @@ jobs:
         # cross-package integration tests), not only its own package's unit
         # tests. The patch-coverage gate consumes this profile. Scoped to the
         # module trees (see the note above the Staticcheck step).
-        run: go test ./cmd/... ./internal/... ./migrations/... ./scripts/... ./web/... -coverprofile=coverage.out -covermode=atomic -coverpkg=./cmd/...,./internal/...,./migrations/...,./scripts/...,./web/...
+        #
+        # `-timeout 20m` declares a budget that was previously left implicit.
+        # Go's default is 10 minutes PER PACKAGE, and internal/api sits right at
+        # that edge: measured 2026-08-15 on a dev host, 603 s run alone and 610 s
+        # inside `go test ./...`, with coverage instrumentation slower still
+        # (-covermode=atomic adds an atomic counter per block). The lane passed
+        # only because the runner happens to be faster than a dev host, which is
+        # not a margin anyone chose.
+        #
+        # What the budget prevents does not read as "this needed more time": the
+        # runtime panics with `test timed out after 10m0s` and dumps every
+        # goroutine, so a required check fails with a stack trace that reads like
+        # a product bug. Every `go test` in this file that runs a suite declares
+        # the same budget — fixing only the lane where the pressure was measured
+        # would leave the identical default armed in three other spellings.
+        run: go test ./cmd/... ./internal/... ./migrations/... ./scripts/... ./web/... -timeout 20m -coverprofile=coverage.out -covermode=atomic -coverpkg=./cmd/...,./internal/...,./migrations/...,./scripts/...,./web/...
 
       - name: Upload coverage artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -376,7 +391,7 @@ jobs:
           go test -list '.*' ./internal/services/ > "$RUNNER_TEMP/tests.txt"
           run_pattern="$(go run ./scripts/racepartition -shard=${{ matrix.shard }} -of=${{ strategy.job-total }} < "$RUNNER_TEMP/tests.txt")"
           echo "shard ${{ matrix.shard }}/${{ strategy.job-total }} selects $(grep -cE '^(Test|Example|Fuzz)' "$RUNNER_TEMP/tests.txt") listed tests split by racepartition"
-          go test -race -run "$run_pattern" ./internal/services/
+          go test -race -timeout 20m -run "$run_pattern" ./internal/services/
 
   race-rest:
     runs-on: ubuntu-latest
@@ -411,7 +426,10 @@ jobs:
         # whole — splitting them would buy nothing and cost a job.
         env:
           CGO_ENABLED: "1"
-        run: go test -race ./internal/db/... ./internal/security/... ./internal/i18n/... ./internal/httpx/...
+        # `-timeout 20m`: the declared budget from the coverage step in test-go.
+        # The race detector is strictly slower per test, so an undeclared
+        # 10-minute default is armed harder here than where it was measured.
+        run: go test -race -timeout 20m ./internal/db/... ./internal/security/... ./internal/i18n/... ./internal/httpx/...
 
       - name: Go test with race detector — cross-owner isolation
         # The exclusion above is by package, not by property, and the property
@@ -422,7 +440,7 @@ jobs:
         # back to the package.
         env:
           CGO_ENABLED: "1"
-        run: go test -race -count=1 -run TestOwnerIsolationHoldsUnderConcurrentCrossOwnerRequests ./internal/api/
+        run: go test -race -timeout 20m -count=1 -run TestOwnerIsolationHoldsUnderConcurrentCrossOwnerRequests ./internal/api/
 
   # Thin gate job named exactly `race` — branch protection's required status
   # check is pinned to that literal name, which a matrix job cannot provide

--- a/changelog.d/ci-declare-a-test-timeout-budget.md
+++ b/changelog.d/ci-declare-a-test-timeout-budget.md
@@ -1,0 +1,5 @@
+none
+
+CI change with no user-visible effect: every `go test` run in the workflow now
+declares `-timeout 20m` instead of inheriting Go's implicit 10-minute
+per-package default, which `internal/api` was running within seconds of.


### PR DESCRIPTION
Go's test timeout is **10 minutes per package** by default, and no `go test` in
this workflow said otherwise.

`internal/api` runs right at that edge. Measured 2026-08-15 on a dev host:
**603 s** run alone, **610 s** inside `go test ./...`, and slower still under
coverage instrumentation, since `-covermode=atomic` adds an atomic counter per
block. Four independent runs on that host crossed the limit; the CI lane passed
only because the runner happens to be faster. That is not a margin anyone chose,
and nothing declares it.

## Why it is worth a change while it is still green

The failure it leaves armed does not read as "this needed more time". The
runtime panics:

```
panic: test timed out after 10m0s
	running tests:
		TestSettingsRemindersUpdateScopedToSessionOwner (0s)
```

…and dumps every goroutine. A required check goes red with a stack trace that
reads like a product bug, so the symptom carries none of its own cause — which
is the expensive half. It cost time in this session twice before being
recognised.

## All four runs, not just the measured one

| line | run | why it is included |
| --- | --- | --- |
| `test-go` | coverage over the module trees | where the pressure was measured |
| `race-services` | sharded `internal/services` under `-race` | detector is strictly slower per test |
| `race-rest` | `db`, `security`, `i18n`, `httpx` under `-race` | same |
| `race-rest` | the named cross-owner isolation test in `internal/api` | `-race` **and** the slow package |

Fixing only the lane where the pressure was measured would leave the identical
default armed in three other spellings — the failure mode of a rule keyed on a
spelling rather than on the thing.

`go test -list` in the race-shard step is left alone; it runs no test.

## The trade

`-timeout 20m` is a declared ceiling, not a target. A genuinely hung test now
burns twenty minutes instead of ten before failing. That is the cost; the risk
it removes is a false timeout on a slow runner, which is the one currently live.

## Verification

- `actionlint -shellcheck= .github/workflows/ci.yml` — exit 0 (shellcheck
  disabled explicitly, as the CI step does)
- flag order proved as written, with the flag after the package patterns:
  `go test ./internal/i18n/ -timeout 20m -coverprofile=... -covermode=atomic -coverpkg=./internal/...`
  — exit 0
- `go test ./scripts/... -timeout 20m` — all eight packages pass, including
  `changelogd` and `readmeversion`, which read tracked files

No product code changes.
