### PR TITLE
fix: flush a dashboard edit made during an in-flight autosave on unload

### DIFF
--- a/changelog.d/fix-autosave-unload-drops-newer-edit.md
+++ b/changelog.d/fix-autosave-unload-drops-newer-edit.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- **Leaving the dashboard no longer drops a journal edit made while a save was still running.** The
+  autosave coalesces on the request already in flight, so an edit typed during a slow save bumped the
+  pending version but queued nothing; the only thing that would have carried it was the re-arm timer
+  that runs after the response, which a page unload never reaches. Closing the tab or navigating away
+  in that window therefore left the newer value on screen and the older one on the server, with no
+  error shown. The unload flush now sends the current form state on its own keepalive request
+  whenever it is newer than the save on the wire — once per version, so a cancelled navigation does
+  not resend it. The ordinary debounce path is unchanged.

--- a/web/src/js/__tests__/dashboard-autosave.test.mjs
+++ b/web/src/js/__tests__/dashboard-autosave.test.mjs
@@ -54,6 +54,35 @@ function dashboardPage({ entryExists = false, notes = "" } = {}) {
 </body></html>`;
 }
 
+/**
+ * Records every fetch and leaves each one unresolved until `settleAll` is
+ * called, so a test can hold a save open on the wire without a timer.
+ */
+function installDeferredFetchRecorder(window) {
+  const calls = [];
+  const pending = [];
+  window.fetch = (url, init) => {
+    calls.push({ url: String(url), init: init || {} });
+    return new Promise((resolve) => {
+      pending.push(() =>
+        resolve({
+          ok: true,
+          status: 200,
+          headers: { get: () => null },
+          text: () => Promise.resolve(""),
+        })
+      );
+    });
+  };
+  return {
+    calls,
+    settleAll() {
+      const waiting = pending.splice(0, pending.length);
+      waiting.forEach((resolve) => resolve());
+    },
+  };
+}
+
 /** Records every fetch the bundle makes and answers each one with `ok`. */
 function installFetchRecorder(window, { ok = true } = {}) {
   const calls = [];
@@ -96,10 +125,12 @@ function fireChange(node) {
   node.dispatchEvent(new node.ownerDocument.defaultView.Event("change", { bubbles: true }));
 }
 
-// The keepalive flush the bundle installs for page unload runs the same runner
-// the 2 s debounce does, so a test can reach the request without sitting out
-// the debounce. What it cannot do is invent a request the runner would not
-// make: an untouched form is still skipped, which is exactly the rail below.
+// The keepalive flush the bundle installs for page unload reaches the same
+// runner the 2 s debounce does, so a test can get at the request without
+// sitting out the debounce. What it cannot do is invent a request the runner
+// would not make: an untouched form is still skipped, which is exactly the rail
+// below. With a save already open it takes the other branch and sends the
+// newest body itself — the subject of the in-flight test further down.
 function flushAutosave(window) {
   window.dispatchEvent(new window.Event("beforeunload"));
 }
@@ -232,6 +263,59 @@ test("undoing the first save of an empty day clears it instead of writing an emp
     assert.equal(calls()[1].init.method, "DELETE", "an empty day is an absent entry, not an empty one");
     assert.equal(calls()[1].url, `/api/v1/days/${TODAY}?source=dashboard`);
     assert.equal(toggle.checked, false, "the screen goes back with it");
+  } finally {
+    dom.window.close();
+  }
+});
+
+// The journal has no save button, so the page leaving is the last chance the
+// newest value gets. An edit made while an earlier save is still open bumps the
+// version but queues nothing — the only thing that would ever carry it is the
+// re-arm that runs after the response, a timer no unload survives. So the
+// unload flush has to put that body on the wire itself.
+test("an edit made while a save is in flight still reaches the server on unload", async () => {
+  const recorder = { value: null };
+  const dom = await loadDOMWithScript(APP_BUNDLE, {
+    html: dashboardPage({ entryExists: true, notes: "" }),
+    beforeRun: (window) => {
+      recorder.value = installDeferredFetchRecorder(window);
+    },
+  });
+  const { calls, settleAll } = recorder.value;
+  try {
+    const notes = dom.window.document.querySelector("#today-notes");
+    notes.value = "first edit";
+    notes.dispatchEvent(new dom.window.Event("input", { bubbles: true }));
+    flushAutosave(dom.window);
+    await settle();
+
+    assert.equal(calls.length, 1, "the first edit goes out");
+    assert.ok(bodyOf(calls[0]).includes(formValue("notes", "first edit")));
+
+    // The response never arrives: this save is still open on the wire.
+    notes.value = "newer edit before navigation";
+    notes.dispatchEvent(new dom.window.Event("input", { bubbles: true }));
+    flushAutosave(dom.window);
+    await settle();
+
+    assert.equal(calls.length, 2, "the edit made during the open save is sent on its own request");
+    const flushed = calls[1];
+    assert.equal(flushed.url, `/api/v1/days/${TODAY}`);
+    assert.equal(flushed.init.method, "PUT");
+    assert.equal(flushed.init.keepalive, true, "an unload request must outlive the page");
+    assert.ok(
+      bodyOf(flushed).includes(formValue("notes", "newer edit before navigation")),
+      "the newest journal value is what the server must end up holding"
+    );
+
+    // A cancelled navigation fires beforeunload again; the same body must not
+    // be sent a second time.
+    flushAutosave(dom.window);
+    await settle();
+    assert.equal(calls.length, 2, "the unload flush sends a given version at most once");
+
+    settleAll();
+    await settle();
   } finally {
     dom.window.close();
   }

--- a/web/src/js/app/53-dashboard-autosave.js
+++ b/web/src/js/app/53-dashboard-autosave.js
@@ -232,8 +232,32 @@
     renderDaySaveUnreachable(form);
   }
 
+  // Pick the HTTP verb from whichever hx-* attribute the form uses so the
+  // autosave fetch tracks the canonical REST verb declared in the template
+  // (PUT for /api/v1/days/{date} upsert, falling back to POST / action for
+  // legacy or non-HTMX forms).
+  function dashboardAutosaveEndpoint(form) {
+    var hxVerbs = ["hx-put", "hx-patch", "hx-delete", "hx-post"];
+    var endpoint = {
+      method: "POST",
+      url: String(form.getAttribute("action") || "").trim()
+    };
+    var hxValue;
+
+    for (var verbIndex = 0; verbIndex < hxVerbs.length; verbIndex += 1) {
+      hxValue = form.getAttribute(hxVerbs[verbIndex]);
+      if (hxValue) {
+        endpoint.method = hxVerbs[verbIndex].substring(3).toUpperCase();
+        endpoint.url = String(hxValue).trim();
+        break;
+      }
+    }
+    return endpoint;
+  }
+
   function runDashboardAutosave(form, keepalive, mode) {
     var requestVersion;
+    var endpoint;
     var url;
     var method;
     var headers;
@@ -260,27 +284,19 @@
     requestVersion = form.__ovumcyAutosaveVersion || 0;
     captureDashboardPersistedState(form);
     previousState = form.__ovumcyPersistedState;
-    // Pick the HTTP verb from whichever hx-* attribute the form uses so the
-    // autosave fetch tracks the canonical REST verb declared in the template
-    // (PUT for /api/v1/days/{date} upsert, falling back to POST / action for
-    // legacy or non-HTMX forms).
-    var hxVerbs = ["hx-put", "hx-patch", "hx-delete", "hx-post"];
-    method = "POST";
-    url = String(form.getAttribute("action") || "").trim();
-    for (var verbIndex = 0; verbIndex < hxVerbs.length; verbIndex += 1) {
-      var hxValue = form.getAttribute(hxVerbs[verbIndex]);
-      if (hxValue) {
-        method = hxVerbs[verbIndex].substring(3).toUpperCase();
-        url = String(hxValue).trim();
-        break;
-      }
-    }
+    endpoint = dashboardAutosaveEndpoint(form);
+    method = endpoint.method;
+    url = endpoint.url;
     headers = dashboardRequestHeaders();
     body = buildDashboardAutosaveBody(form);
     // What is on the wire is what the server will hold: snapshot it here, and
     // promote it to "persisted" only once the server has said yes.
     sentState = dashboardFormState(form, false);
 
+    // Which edit is on the wire, readable from outside this call: the unload
+    // flush has to know whether the open request already carries the newest
+    // body or an older one.
+    form.__ovumcyAutosaveInFlightVersion = requestVersion;
     form.__ovumcyAutosaveInFlight = window.fetch(url, {
       method: method,
       credentials: "same-origin",
@@ -318,6 +334,7 @@
       return false;
     }).finally(function () {
       form.__ovumcyAutosaveInFlight = null;
+      form.__ovumcyAutosaveInFlightVersion = 0;
       if (form.dataset.autosaveDirty === "true" && !form.__ovumcyAutosaveFailed) {
         form.__ovumcyAutosaveTimer = window.setTimeout(function () {
           runDashboardAutosave(form, false);
@@ -487,6 +504,58 @@
     return runDashboardAutosave(form, false, "undo");
   }
 
+  // The page going away is the last chance the newest journal value gets, and
+  // the ordinary runner cannot take it: while a save is open it hands back that
+  // pending promise, which carries the older body. An edit made in that window
+  // bumps the version and queues nothing — the only thing that would ever send
+  // it is the re-arm in the runner's `finally`, a 2 s timer no unload survives
+  // (and one that would go out without `keepalive` besides). So a newer version
+  // leaves on its own keepalive request, beside the one already on the wire.
+  //
+  // The day upsert is idempotent, so a version this flush already sent is not
+  // taken off the dirty ledger: should the navigation be cancelled, the normal
+  // path re-sending the same body costs nothing, while clearing dirty here
+  // against a request whose outcome nobody will see could lose the edit twice.
+  function flushDashboardAutosaveBeforeUnload(form) {
+    var version;
+    var endpoint;
+
+    if (!form || form.dataset.autosaveDirty !== "true") {
+      return;
+    }
+    if (!form.__ovumcyAutosaveInFlight) {
+      runDashboardAutosave(form, true);
+      return;
+    }
+
+    version = form.__ovumcyAutosaveVersion || 0;
+    // The open request already carries this edit.
+    if (version === (form.__ovumcyAutosaveInFlightVersion || 0)) {
+      return;
+    }
+    // beforeunload fires again on every cancelled navigation: send once.
+    if (version === (form.__ovumcyAutosaveUnloadFlushedVersion || 0)) {
+      return;
+    }
+    // The same refusal the ordinary runner makes: a body it would not send is
+    // not one to smuggle out on the unload path.
+    if (!validateTemperatureInputs(form, false)) {
+      return;
+    }
+
+    endpoint = dashboardAutosaveEndpoint(form);
+    form.__ovumcyAutosaveUnloadFlushedVersion = version;
+    window.fetch(endpoint.url, {
+      method: endpoint.method,
+      credentials: "same-origin",
+      keepalive: true,
+      headers: dashboardRequestHeaders(),
+      body: buildDashboardAutosaveBody(form).toString()
+    }).catch(function () {
+      // The page is leaving; there is no surface left to report to.
+    });
+  }
+
   function bindDashboardAutosaveBeforeUnload() {
     if (document.body && document.body.dataset.dashboardAutosaveBeforeUnloadBound === "1") {
       return;
@@ -498,9 +567,7 @@
     window.addEventListener("beforeunload", function () {
       var forms = document.querySelectorAll("[data-dashboard-save-form]");
       for (var index = 0; index < forms.length; index++) {
-        if (forms[index].dataset.autosaveDirty === "true") {
-          runDashboardAutosave(forms[index], true);
-        }
+        flushDashboardAutosaveBeforeUnload(forms[index]);
       }
     });
   }

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -3730,8 +3730,32 @@
     renderDaySaveUnreachable(form);
   }
 
+  // Pick the HTTP verb from whichever hx-* attribute the form uses so the
+  // autosave fetch tracks the canonical REST verb declared in the template
+  // (PUT for /api/v1/days/{date} upsert, falling back to POST / action for
+  // legacy or non-HTMX forms).
+  function dashboardAutosaveEndpoint(form) {
+    var hxVerbs = ["hx-put", "hx-patch", "hx-delete", "hx-post"];
+    var endpoint = {
+      method: "POST",
+      url: String(form.getAttribute("action") || "").trim()
+    };
+    var hxValue;
+
+    for (var verbIndex = 0; verbIndex < hxVerbs.length; verbIndex += 1) {
+      hxValue = form.getAttribute(hxVerbs[verbIndex]);
+      if (hxValue) {
+        endpoint.method = hxVerbs[verbIndex].substring(3).toUpperCase();
+        endpoint.url = String(hxValue).trim();
+        break;
+      }
+    }
+    return endpoint;
+  }
+
   function runDashboardAutosave(form, keepalive, mode) {
     var requestVersion;
+    var endpoint;
     var url;
     var method;
     var headers;
@@ -3758,27 +3782,19 @@
     requestVersion = form.__ovumcyAutosaveVersion || 0;
     captureDashboardPersistedState(form);
     previousState = form.__ovumcyPersistedState;
-    // Pick the HTTP verb from whichever hx-* attribute the form uses so the
-    // autosave fetch tracks the canonical REST verb declared in the template
-    // (PUT for /api/v1/days/{date} upsert, falling back to POST / action for
-    // legacy or non-HTMX forms).
-    var hxVerbs = ["hx-put", "hx-patch", "hx-delete", "hx-post"];
-    method = "POST";
-    url = String(form.getAttribute("action") || "").trim();
-    for (var verbIndex = 0; verbIndex < hxVerbs.length; verbIndex += 1) {
-      var hxValue = form.getAttribute(hxVerbs[verbIndex]);
-      if (hxValue) {
-        method = hxVerbs[verbIndex].substring(3).toUpperCase();
-        url = String(hxValue).trim();
-        break;
-      }
-    }
+    endpoint = dashboardAutosaveEndpoint(form);
+    method = endpoint.method;
+    url = endpoint.url;
     headers = dashboardRequestHeaders();
     body = buildDashboardAutosaveBody(form);
     // What is on the wire is what the server will hold: snapshot it here, and
     // promote it to "persisted" only once the server has said yes.
     sentState = dashboardFormState(form, false);
 
+    // Which edit is on the wire, readable from outside this call: the unload
+    // flush has to know whether the open request already carries the newest
+    // body or an older one.
+    form.__ovumcyAutosaveInFlightVersion = requestVersion;
     form.__ovumcyAutosaveInFlight = window.fetch(url, {
       method: method,
       credentials: "same-origin",
@@ -3816,6 +3832,7 @@
       return false;
     }).finally(function () {
       form.__ovumcyAutosaveInFlight = null;
+      form.__ovumcyAutosaveInFlightVersion = 0;
       if (form.dataset.autosaveDirty === "true" && !form.__ovumcyAutosaveFailed) {
         form.__ovumcyAutosaveTimer = window.setTimeout(function () {
           runDashboardAutosave(form, false);
@@ -3985,6 +4002,58 @@
     return runDashboardAutosave(form, false, "undo");
   }
 
+  // The page going away is the last chance the newest journal value gets, and
+  // the ordinary runner cannot take it: while a save is open it hands back that
+  // pending promise, which carries the older body. An edit made in that window
+  // bumps the version and queues nothing — the only thing that would ever send
+  // it is the re-arm in the runner's `finally`, a 2 s timer no unload survives
+  // (and one that would go out without `keepalive` besides). So a newer version
+  // leaves on its own keepalive request, beside the one already on the wire.
+  //
+  // The day upsert is idempotent, so a version this flush already sent is not
+  // taken off the dirty ledger: should the navigation be cancelled, the normal
+  // path re-sending the same body costs nothing, while clearing dirty here
+  // against a request whose outcome nobody will see could lose the edit twice.
+  function flushDashboardAutosaveBeforeUnload(form) {
+    var version;
+    var endpoint;
+
+    if (!form || form.dataset.autosaveDirty !== "true") {
+      return;
+    }
+    if (!form.__ovumcyAutosaveInFlight) {
+      runDashboardAutosave(form, true);
+      return;
+    }
+
+    version = form.__ovumcyAutosaveVersion || 0;
+    // The open request already carries this edit.
+    if (version === (form.__ovumcyAutosaveInFlightVersion || 0)) {
+      return;
+    }
+    // beforeunload fires again on every cancelled navigation: send once.
+    if (version === (form.__ovumcyAutosaveUnloadFlushedVersion || 0)) {
+      return;
+    }
+    // The same refusal the ordinary runner makes: a body it would not send is
+    // not one to smuggle out on the unload path.
+    if (!validateTemperatureInputs(form, false)) {
+      return;
+    }
+
+    endpoint = dashboardAutosaveEndpoint(form);
+    form.__ovumcyAutosaveUnloadFlushedVersion = version;
+    window.fetch(endpoint.url, {
+      method: endpoint.method,
+      credentials: "same-origin",
+      keepalive: true,
+      headers: dashboardRequestHeaders(),
+      body: buildDashboardAutosaveBody(form).toString()
+    }).catch(function () {
+      // The page is leaving; there is no surface left to report to.
+    });
+  }
+
   function bindDashboardAutosaveBeforeUnload() {
     if (document.body && document.body.dataset.dashboardAutosaveBeforeUnloadBound === "1") {
       return;
@@ -3996,9 +4065,7 @@
     window.addEventListener("beforeunload", function () {
       var forms = document.querySelectorAll("[data-dashboard-save-form]");
       for (var index = 0; index < forms.length; index++) {
-        if (forms[index].dataset.autosaveDirty === "true") {
-          runDashboardAutosave(forms[index], true);
-        }
+        flushDashboardAutosaveBeforeUnload(forms[index]);
       }
     });
   }


### PR DESCRIPTION
## The defect

The dashboard journal has no save button, so an edit that never reaches the wire is simply lost —
and it was, silently: closing the tab or navigating away while a save was still running dropped any
edit made after that save started.

## The interleaving

1. Edit A marks the form dirty and arms the 2 s debounce.
2. The timer fires; `fetch(A)` is open and `__ovumcyAutosaveInFlight` is set.
3. Edit B arrives. `markDashboardAutosaveDirty` bumps `__ovumcyAutosaveVersion` and returns early
   because a save is in flight — nothing is queued.
4. `beforeunload` walks the dirty forms and calls the runner, which short-circuits on
   `__ovumcyAutosaveInFlight` and hands back the promise for A. No byte of B goes out.

The only path that would ever have carried B is the 2 s re-arm in the runner's `.finally` — a timer
that needs the response first and a page that is still alive, and that would go out without
`keepalive` besides. Result: the newer journal value on screen, the older one on the server, and no
error anywhere.

## The fix

`web/src/js/app/53-dashboard-autosave.js`

- `beforeunload` now calls `flushDashboardAutosaveBeforeUnload` instead of re-entering the runner.
  With nothing in flight it behaves exactly as before (`runDashboardAutosave(form, true)`). With a
  save open it issues its **own** keepalive request carrying the current form state, rather than
  returning the pending promise.
- The version a request carries is recorded on the form (`__ovumcyAutosaveInFlightVersion`), so the
  flush sends only when the form is genuinely newer than what is on the wire.
- A given version is flushed **at most once** (`__ovumcyAutosaveUnloadFlushedVersion`), so a
  cancelled navigation does not resend it.
- The flush honours the same temperature validation the ordinary runner does — a body the runner
  would refuse is not smuggled out on the unload path.
- Verb/URL resolution, needed by both paths, moves into `dashboardAutosaveEndpoint`.
- Dirty is deliberately **not** cleared by the flush. The day upsert is idempotent, so a redundant
  re-send after a cancelled navigation costs nothing, while clearing dirty against a request whose
  outcome nobody will observe could lose the edit outright.

Ordinary in-flight coalescing and the debounce path are unchanged and gain no extra request.

## The guard

`web/src/js/__tests__/dashboard-autosave.test.mjs` — "an edit made while a save is in flight still
reaches the server on unload". A deferred fetch recorder holds the first request unresolved (no
timers, resolved by hand at the end), a second edit is made, `beforeunload` is fired, and the test
asserts the newest body goes out on its own `keepalive: true` PUT — and that firing `beforeunload`
again adds no third request.

Written first and run against the unfixed bundle:

```
✖ an edit made while a save is in flight still reaches the server on unload (138.4752ms)
  AssertionError [ERR_ASSERTION]: the edit made during the open save is sent on its own request

  1 !== 2
```

## Validation

- `node --test web/src/js/__tests__/dashboard-autosave.test.mjs` — 6/6 pass after the fix (the new
  guard fails on the unfixed bundle, output above).
- `npm run test:unit` — 67 tests, 0 failures.
- `npm run lint` (eslint `--max-warnings=0` over sources and the built bundles, plus `tsc --noEmit`)
  — clean.
- `npm run build` — the committed `web/static/js/app.js` matches a fresh build; no CSS drift.

## Rollback

Single commit; `git revert` of it restores the previous behaviour, source and built bundle together.
