### PR TITLE
fix: count the day-notes limit in characters, not bytes

### DIFF
--- a/changelog.d/fix-day-notes-character-limit.md
+++ b/changelog.d/fix-day-notes-character-limit.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- **A day note in a non-Latin script is no longer cut in half on save.** The notes field advertises a
+  2000-character limit, but the server measured that number in bytes: 2000 typed Cyrillic characters
+  are 4000 bytes, so roughly half the note was dropped on save, and 2000 emoji were dropped to 500 —
+  with no warning and no error, the shortened text simply came back on reload. The limit is now
+  counted in characters on both sides, so everything the field accepts is stored whole. The limit
+  itself is unchanged at 2000 characters.

--- a/internal/services/day_input.go
+++ b/internal/services/day_input.go
@@ -92,13 +92,25 @@ func IsValidDayMood(value int) bool {
 	return value == 0 || (value >= MinDayMood && value <= MaxDayMood)
 }
 
+// TrimDayNotes caps a note at MaxDayNotesLength CHARACTERS, the unit the notes
+// textareas declare through maxlength. Measured in bytes the same number cut
+// what the browser had already accepted, silently: 2000 typed Cyrillic
+// characters are 4000 bytes and came back as roughly 1000 characters.
+//
+// HTML maxlength counts UTF-16 code units, so a character (rune) count is at
+// worst MORE permissive than the browser — an astral character is one rune and
+// two code units — and the server therefore never truncates a value the browser
+// was willing to submit. The cut stays on a character boundary.
 func TrimDayNotes(value string) string {
-	if len(value) <= MaxDayNotesLength {
+	if utf8.RuneCountInString(value) <= MaxDayNotesLength {
 		return value
 	}
-	end := MaxDayNotesLength
-	for end > 0 && !utf8.RuneStart(value[end]) {
-		end--
+	characters := 0
+	for index := range value {
+		if characters == MaxDayNotesLength {
+			return value[:index]
+		}
+		characters++
 	}
-	return value[:end]
+	return value
 }

--- a/internal/services/day_input.go
+++ b/internal/services/day_input.go
@@ -3,7 +3,6 @@ package services
 import (
 	"errors"
 	"strings"
-	"unicode/utf8"
 
 	"github.com/ovumcy/ovumcy-web/internal/models"
 )
@@ -100,11 +99,14 @@ func IsValidDayMood(value int) bool {
 // HTML maxlength counts UTF-16 code units, so a character (rune) count is at
 // worst MORE permissive than the browser — an astral character is one rune and
 // two code units — and the server therefore never truncates a value the browser
-// was willing to submit. The cut stays on a character boundary.
+// was willing to submit.
+//
+// Ranging over the string yields the byte offset of each character's first
+// byte, so a single pass both counts and locates the cut: an over-limit value
+// is sliced at the offset of the character after the cap — always a character
+// boundary — and a value at or under the cap falls out of the loop and is
+// returned whole.
 func TrimDayNotes(value string) string {
-	if utf8.RuneCountInString(value) <= MaxDayNotesLength {
-		return value
-	}
 	characters := 0
 	for index := range value {
 		if characters == MaxDayNotesLength {

--- a/internal/services/day_input_mutation_test.go
+++ b/internal/services/day_input_mutation_test.go
@@ -54,28 +54,26 @@ func TestNormalizeDayEntryInputRejectsNegativeMood(t *testing.T) {
 	}
 }
 
-// TestTrimDayNotesDoesNotUnderflowOnAllContinuationBytes pins the rune-rewind
-// loop's lower-bound guard `end > 0` in TrimDayNotes (day_input.go). When an
-// over-limit notes value is made entirely of UTF-8 continuation bytes — crafted
-// invalid input that is reachable from the untrusted day-notes field, and which
-// the existing valid-UTF-8 cases never produce — the rewind walks `end` down to
-// index 0. The guard must stop there and yield an empty string. The
-// CONDITIONALS_BOUNDARY mutant `end > 0` -> `end >= 0` instead decrements to -1
-// and panics on value[:-1]; a panic fails this test.
-func TestTrimDayNotesDoesNotUnderflowOnAllContinuationBytes(t *testing.T) {
-	// 0x80 is a UTF-8 continuation byte and never a rune start, so a run of them
-	// longer than the cap drives the rewind loop all the way to index 0.
+// TestTrimDayNotesCapsCraftedInvalidUTF8 pins the character-counting loop in
+// TrimDayNotes (day_input.go) on crafted invalid input, which is reachable from
+// the untrusted day-notes field and which the valid-UTF-8 cases never produce.
+// A run of bare UTF-8 continuation bytes decodes as one replacement character
+// per byte, so the count and the cut must agree on that reading: the
+// CONDITIONALS_BOUNDARY mutant `characters == MaxDayNotesLength` ->
+// `characters >= MaxDayNotesLength` never fires and the whole over-limit value
+// comes back, while an off-by-one in the guard drops the cut below the cap.
+// Neither may panic on the slice bound.
+func TestTrimDayNotesCapsCraftedInvalidUTF8(t *testing.T) {
+	// 0x80 is a UTF-8 continuation byte and never a rune start; each one counts
+	// as a single character, so this value is exactly one character over the cap.
 	value := strings.Repeat("\x80", MaxDayNotesLength+1)
 
 	got := TrimDayNotes(value)
 
-	if got != "" {
-		t.Fatalf("expected empty result when every in-range byte is a continuation byte, got %d bytes", len(got))
+	if characters := utf8.RuneCountInString(got); characters != MaxDayNotesLength {
+		t.Fatalf("expected an over-limit value to be cut to exactly %d characters, got %d", MaxDayNotesLength, characters)
 	}
-	if len(got) > MaxDayNotesLength {
-		t.Fatalf("expected trimmed length <= %d, got %d", MaxDayNotesLength, len(got))
-	}
-	if !utf8.ValidString(got) {
-		t.Fatalf("expected valid UTF-8 result, got invalid string of length %d", len(got))
+	if !strings.HasPrefix(value, got) {
+		t.Fatalf("expected the result to be a prefix of the input, got %d bytes", len(got))
 	}
 }

--- a/internal/services/day_input_test.go
+++ b/internal/services/day_input_test.go
@@ -2,11 +2,15 @@ package services
 
 import (
 	"errors"
+	"io/fs"
+	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 	"unicode/utf8"
 
 	"github.com/ovumcy/ovumcy-web/internal/models"
+	"github.com/ovumcy/ovumcy-web/internal/templates"
 )
 
 func TestNormalizeDayEntryInputRejectsInvalidFlow(t *testing.T) {
@@ -38,47 +42,159 @@ func TestNormalizeDayEntryInputNormalizesNonPeriodDay(t *testing.T) {
 }
 
 func TestNormalizeDayEntryInputTrimsNotes(t *testing.T) {
+	// Non-Latin text on the normalization path too: the cap is a character cap,
+	// so an over-limit note is cut to MaxDayNotesLength characters whatever the
+	// script costs in bytes.
 	normalized, err := NormalizeDayEntryInput(DayEntryInput{
 		IsPeriod: true,
 		Flow:     models.FlowNone,
-		Notes:    strings.Repeat("x", MaxDayNotesLength+13),
+		Notes:    strings.Repeat("б", MaxDayNotesLength+13),
 	})
 	if err != nil {
 		t.Fatalf("NormalizeDayEntryInput() unexpected error: %v", err)
 	}
-	if len(normalized.Notes) != MaxDayNotesLength {
-		t.Fatalf("expected notes length %d, got %d", MaxDayNotesLength, len(normalized.Notes))
+	if characters := utf8.RuneCountInString(normalized.Notes); characters != MaxDayNotesLength {
+		t.Fatalf("expected notes length %d characters, got %d", MaxDayNotesLength, characters)
 	}
 }
 
+// TestTrimDayNotes pins the unit of the notes cap: MaxDayNotesLength counts
+// CHARACTERS, the same unit the textarea's maxlength speaks in. Measured in
+// bytes the cap silently cut a note the browser had accepted — 2000 typed
+// Cyrillic characters are 4000 bytes and survived as ~1000 characters, 2000
+// typed emoji as 500 — and nothing on the write path reported the loss. The
+// non-Latin cases below are the regression; on ASCII the two units coincide,
+// which is why the defect stayed invisible.
 func TestTrimDayNotes(t *testing.T) {
 	asciiAtLimit := strings.Repeat("a", MaxDayNotesLength)
+	cyrillicAtLimit := strings.Repeat("б", MaxDayNotesLength) // 2 bytes per character: 4000 bytes at the limit
+	emojiAtLimit := strings.Repeat("😀", MaxDayNotesLength)    // 4 bytes per character: 8000 bytes at the limit
 
-	cyrillicTail := strings.Repeat("a", MaxDayNotesLength-1) + "б" // "б" is 2 bytes; 2nd byte lands at index 2000
-	emojiTail := strings.Repeat("a", MaxDayNotesLength-3) + "😀"    // emoji is 4 bytes; last 3 bytes land inside the limit
+	// Mixed values whose last character straddles the old byte index: under a
+	// character cap they are at the limit and must survive whole.
+	cyrillicTail := strings.Repeat("a", MaxDayNotesLength-1) + "б"
+	emojiTail := strings.Repeat("a", MaxDayNotesLength-1) + "😀"
 
 	tests := []struct {
-		name  string
-		value string
+		name      string
+		value     string
+		wantWhole bool
 	}{
-		{"ascii at limit unchanged", asciiAtLimit},
-		{"cyrillic rune split at byte boundary", cyrillicTail},
-		{"emoji rune split at byte boundary", emojiTail},
+		{"ascii at limit unchanged", asciiAtLimit, true},
+		{"cyrillic at limit unchanged", cyrillicAtLimit, true},
+		{"emoji at limit unchanged", emojiAtLimit, true},
+		{"cyrillic tail at the character limit unchanged", cyrillicTail, true},
+		{"emoji tail at the character limit unchanged", emojiTail, true},
+		{"ascii over the limit cut to the limit", asciiAtLimit + "overflow", false},
+		{"cyrillic over the limit cut to the limit", cyrillicAtLimit + "хвост", false},
+		{"emoji over the limit cut to the limit", emojiAtLimit + "😀😀", false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := TrimDayNotes(tt.value)
-			if len(got) > MaxDayNotesLength {
-				t.Fatalf("expected trimmed length <= %d, got %d", MaxDayNotesLength, len(got))
+			if characters := utf8.RuneCountInString(got); characters > MaxDayNotesLength {
+				t.Fatalf("expected trimmed length <= %d characters, got %d", MaxDayNotesLength, characters)
 			}
 			if !utf8.ValidString(got) {
-				t.Fatalf("expected valid UTF-8, got invalid string of length %d", len(got))
+				t.Fatalf("expected valid UTF-8, got invalid string of length %d bytes", len(got))
 			}
-			if tt.value == asciiAtLimit && len(got) != MaxDayNotesLength {
-				t.Fatalf("expected ascii-at-limit to remain unchanged at %d bytes, got %d", MaxDayNotesLength, len(got))
+			if !strings.HasPrefix(tt.value, got) {
+				t.Fatalf("expected the result to be a prefix of the input, got %d bytes", len(got))
+			}
+			if tt.wantWhole {
+				if got != tt.value {
+					t.Fatalf(
+						"expected a value of %d characters to survive whole, got %d characters (%d of %d bytes)",
+						utf8.RuneCountInString(tt.value), utf8.RuneCountInString(got), len(got), len(tt.value),
+					)
+				}
+				return
+			}
+			if characters := utf8.RuneCountInString(got); characters != MaxDayNotesLength {
+				t.Fatalf("expected an over-limit value to be cut to exactly %d characters, got %d", MaxDayNotesLength, characters)
 			}
 		})
+	}
+}
+
+// dayNotesMaxlengthPattern reads the maxlength attribute off a template element.
+var dayNotesMaxlengthPattern = regexp.MustCompile(`maxlength="(\d+)"`)
+
+// dayNotesTextareaSurfaces are the templates that must carry a notes textarea.
+// Naming them keeps the scan from passing vacuously if the markup hook is
+// renamed and nothing at all is matched.
+var dayNotesTextareaSurfaces = []string{"dashboard.html", "day_editor_partial.html"}
+
+// TestDayNotesTextareaMaxlengthMatchesTheServerCapInCharacters ties the two
+// halves of the notes limit together so they cannot drift apart again: the
+// number the browser enforces on the textarea and the number the server trims
+// at must be the same, AND they must mean the same thing. The number alone is
+// not the contract — both sides read 2000 while the server counted bytes and
+// the browser characters — so the check is behavioral: the largest value the
+// textarea will hand over, spelled in a non-Latin script, has to reach the
+// server untouched.
+//
+// It scans the embedded templates the runtime itself parses, so a notes field
+// added on a new surface is covered without anyone remembering this test.
+func TestDayNotesTextareaMaxlengthMatchesTheServerCapInCharacters(t *testing.T) {
+	found := map[string]int{}
+	err := fs.WalkDir(templates.Files, ".", func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() || !strings.HasSuffix(path, ".html") {
+			return nil
+		}
+		source, readErr := templates.Files.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		// Element boundaries are enough here: a textarea's attributes all sit in
+		// its opening tag, so splitting on '<' keeps one element's maxlength from
+		// being read off its neighbor.
+		for _, element := range strings.Split(string(source), "<") {
+			if !strings.HasPrefix(element, "textarea") || !strings.Contains(element, "data-dashboard-notes") {
+				continue
+			}
+			found[path]++
+
+			match := dayNotesMaxlengthPattern.FindStringSubmatch(element)
+			if match == nil {
+				t.Errorf("%s: the notes textarea declares no maxlength, so the browser accepts input the server will cut.\nelement: <%s", path, strings.TrimSpace(element))
+				continue
+			}
+			declared, convErr := strconv.Atoi(match[1])
+			if convErr != nil {
+				t.Errorf("%s: unreadable maxlength %q: %v", path, match[1], convErr)
+				continue
+			}
+			if declared != MaxDayNotesLength {
+				t.Errorf("%s: the notes textarea declares maxlength=%d but the server caps at %d", path, declared, MaxDayNotesLength)
+				continue
+			}
+			// The unit check. "б" is one character the browser counts once and
+			// two bytes the server used to count twice, so a byte-measured cap
+			// returns roughly half of what was typed.
+			atDeclaredLimit := strings.Repeat("б", declared)
+			if got := TrimDayNotes(atDeclaredLimit); got != atDeclaredLimit {
+				t.Errorf(
+					"%s: maxlength=%d and MaxDayNotesLength=%d agree on the number but not on the unit: %d characters the browser accepts came back as %d.\n"+
+						"maxlength counts UTF-16 code units, so the server cap has to be a character cap, not a byte cap.",
+					path, declared, MaxDayNotesLength,
+					utf8.RuneCountInString(atDeclaredLimit), utf8.RuneCountInString(got),
+				)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk embedded templates: %v", err)
+	}
+	for _, surface := range dayNotesTextareaSurfaces {
+		if found[surface] == 0 {
+			t.Fatalf("no notes textarea found in %s: the data-dashboard-notes hook moved and this guard stopped checking anything (found: %v)", surface, found)
+		}
 	}
 }
 


### PR DESCRIPTION
## The defect

`MaxDayNotesLength = 2000` was compared against `len(value)` — **bytes** —
while both notes textareas declare `maxlength="2000"`, which the browser counts
in **characters** (UTF-16 code units). The truncation loop only walked back to a
rune start, so the stored value stayed valid UTF-8 and stayed silently short:

- 2000 typed Cyrillic characters = 4000 bytes -> ~1000 characters kept
- 2000 typed emoji = 8000 bytes -> 500 characters kept

Nothing reported the loss. `NormalizeDayEntryInput` assigns `TrimDayNotes` and
returns a nil error, and the day-payload helpers only `strings.TrimSpace` the
field, so the overflow was neither rejected nor surfaced — the note simply came
back shortened on reload. On a bilingual product this is ordinary use, not an
edge case.

`notes` is `TEXT` (`migrations/001_init.sql`), so 2000 is a product limit rather
than a storage bound. No migration is involved.

## The fix

`TrimDayNotes` counts runes and cuts on a character boundary. The constant stays
`2000` and both templates stay at `maxlength="2000"` — only the unit changes.

A comment on the function records why a rune count is the safe reading: HTML
`maxlength` counts UTF-16 code units, so a rune count is at worst *more*
permissive than the browser (an astral character is one rune, two code units)
and the server therefore never truncates a value the browser was willing to
submit.

## The guard

Both guards were written first and run against the unfixed code; both failed and
named the defect.

1. `TestTrimDayNotes` gains at-limit and over-limit cases in Cyrillic and emoji:
   a value at the limit must survive whole, a value above it is cut to exactly
   the limit **in characters**, and the result is always a prefix of the input.
   Against the old code: `expected a value of 2000 characters to survive whole,
   got 1000 characters (2000 of 4000 bytes)`.
2. `TestDayNotesTextareaMaxlengthMatchesTheServerCapInCharacters` scans the
   embedded templates for the notes textareas (`data-dashboard-notes`), asserts
   the declared `maxlength` equals `MaxDayNotesLength`, and then checks the unit
   **behaviorally**: the largest value the browser will hand over, spelled in a
   non-Latin script, has to reach the server untouched. Comparing the two
   numbers alone would have passed throughout the defect — both read 2000. The
   scan walks all templates, so a notes field on a new surface is covered
   automatically, and it fails loudly if the markup hook moves and nothing is
   matched.

The invalid-UTF-8 mutation kill moves to the new boundary: a run of bare
continuation bytes decodes as one replacement character per byte, so it now pins
the character count and the cut agreeing on that reading, instead of the removed
rewind loop's lower bound.

## Validation

- `gofmt -l` on the changed files: clean
- `go build ./...`: ok
- `go test ./internal/services/...`: ok (97.7 s)
- `go test ./internal/api/...`: ok (541.6 s)
- `go test ./scripts/changelogd/...`: ok
- `staticcheck ./internal/services/...` and `golangci-lint run
  ./internal/services/...`: 0 issues

## Rollback

Single-commit revert; nothing persisted changes shape, so no data migration is
involved either way. This is an api-contract change, so after a revert re-run the
dialect-parity and OpenAPI contract suites before relying on the reverted state.
