### PR TITLE
fix: resolve calendar days that start on a skipped midnight

### DIFF
--- a/changelog.d/fix-dst-midnight-calendar-day.md
+++ b/changelog.d/fix-dst-midnight-calendar-day.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- **The spring-forward date can now be entered in time zones whose clock jump
+  lands on midnight.** In zones west of UTC where daylight saving starts at
+  00:00 (America/Santiago, America/Havana), local midnight does not exist on
+  that date, and every date input resolved it one calendar day backward: the
+  day picked was stored, shown and exported as the previous day, and an
+  onboarding cycle start recorded on it anchored every later prediction to the
+  wrong day. Calendar days now resolve to the first instant that really exists
+  on the requested day. Zones without such a transition, including UTC, are
+  unaffected.

--- a/internal/services/calendar_days.go
+++ b/internal/services/calendar_days.go
@@ -231,7 +231,13 @@ func appendPredictedCycles(predictedPeriodMap map[string]bool, preFertileMap map
 
 	predictedCycleLength := predictedCycleLength(stats.MedianCycleLength, stats.AverageCycleLength)
 	predictedPeriodLength := predictedPeriodLength(stats.AveragePeriodLength)
-	for cycleStart := CalendarDay(stats.NextPeriodStart, location); !cycleStart.After(gridEnd); cycleStart = cycleStart.AddDate(0, 0, predictedCycleLength) {
+	// The bound is a CALENDAR-DAY comparison, not an instant one: cycleStart
+	// comes from CalendarDay and gridEnd from plain AddDate arithmetic, and in
+	// a zone whose DST jump skips midnight the two carry different start-of-day
+	// shapes (01:00 local against 00:00). Compared as instants, a projected
+	// cycle falling exactly on the last grid day reads as past the grid and its
+	// markers are never painted.
+	for cycleStart := CalendarDay(stats.NextPeriodStart, location); CalendarDaysBetween(cycleStart, gridEnd) >= 0; cycleStart = cycleStart.AddDate(0, 0, predictedCycleLength) {
 		appendPredictedPeriod(predictedPeriodMap, cycleStart, predictedPeriodLength)
 		appendPredictedWindow(preFertileMap, fertilityEdgeMap, fertilityPeakMap, ovulationMap, cycleStart, predictedCycleLength, predictedPeriodLength, stats.LutealPhase)
 	}

--- a/internal/services/calendar_days_test.go
+++ b/internal/services/calendar_days_test.go
@@ -99,6 +99,56 @@ func TestBuildCalendarDayStatesProjectsOvulationIntoFutureCycles(t *testing.T) {
 	}
 }
 
+// TestBuildCalendarDayStatesPaintsAProjectedCycleOnTheLastGridDay pins the
+// projection loop's boundary against the shape mismatch a midnight-skipping
+// DST zone creates. In America/Santiago no instant exists at 2026-09-06 00:00,
+// so a cycle anchored on that date starts at 01:00-03 and every cycle chained
+// after it carries the same 01:00 wall clock, while the grid bounds are plain
+// AddDate arithmetic sitting at 00:00. Compared as instants, a projected cycle
+// falling exactly on the last grid day looks like it is past the grid: the
+// loop stops one iteration early and that cycle's predicted-period and
+// fertile markers are never painted. The boundary is a calendar-day question,
+// not an instant one.
+//
+// October 2026 with a Monday week start is the reproducing month: its grid
+// ends on Sunday 2026-11-01, which is 2026-09-06 plus two 28-day cycles. The
+// grid deliberately starts after the transition date — a rendered range that
+// spans a skipped midnight loses a cell to the day loop's own AddDate
+// arithmetic, which is a separate defect this test must not depend on.
+func TestBuildCalendarDayStatesPaintsAProjectedCycleOnTheLastGridDay(t *testing.T) {
+	santiago, err := time.LoadLocation("America/Santiago")
+	if err != nil {
+		t.Fatalf("load America/Santiago: %v", err)
+	}
+
+	user := &models.User{WeekStartsOn: models.WeekStartMonday}
+	monthStart := time.Date(2026, time.October, 1, 0, 0, 0, 0, santiago)
+	now := time.Date(2026, time.October, 20, 15, 0, 0, 0, time.UTC)
+
+	stats := CycleStats{
+		MedianCycleLength:   28,
+		AveragePeriodLength: 5,
+		CurrentCycleDay:     12,
+		LastPeriodStart:     time.Date(2026, time.August, 9, 0, 0, 0, 0, time.UTC),
+		NextPeriodStart:     time.Date(2026, time.September, 6, 0, 0, 0, 0, time.UTC),
+	}
+
+	days := BuildCalendarDayStates(user, monthStart, nil, stats, now, santiago)
+
+	last := days[len(days)-1]
+	if last.DateString != "2026-11-01" {
+		t.Fatalf("expected the grid to end on 2026-11-01, got %s", last.DateString)
+	}
+	if !last.IsPredicted {
+		t.Fatalf("expected the projected cycle starting on the last grid day 2026-11-01 to be painted")
+	}
+
+	// The cycle before it, comfortably inside the grid, must stay painted too.
+	if middle := findCalendarDayStateByDateString(t, days, "2026-10-04"); !middle.IsPredicted {
+		t.Fatalf("expected the projected cycle starting on 2026-10-04 to be painted")
+	}
+}
+
 func TestBuildCalendarDayStatesIncludesCurrentBaselinePeriodWindow(t *testing.T) {
 	monthStart := time.Date(2026, time.March, 1, 0, 0, 0, 0, time.UTC)
 	now := time.Date(2026, time.March, 12, 0, 0, 0, 0, time.UTC)

--- a/internal/services/date_parse_policy.go
+++ b/internal/services/date_parse_policy.go
@@ -9,7 +9,8 @@ import (
 var ErrDayDateRequired = errors.New("date is required")
 
 // ParseDayDate parses a YYYY-MM-DD form value as a calendar day on the
-// request-local calendar and returns midnight of that day in `location`.
+// request-local calendar and returns the start of that day in `location` —
+// midnight, or the day's first existing instant when a DST jump skips it.
 // This is the single parse entry point for date inputs: every other
 // "2006-01-02" parse in the package routes through it, so the
 // canonicalization shape stays a one-place decision. For values destined
@@ -22,10 +23,19 @@ func ParseDayDate(raw string, location *time.Location) (time.Time, error) {
 		return time.Time{}, ErrDayDateRequired
 	}
 
-	parsed, err := time.ParseInLocation("2006-01-02", value, location)
+	// Parsed in UTC, which has no transitions, so the calendar components
+	// survive the parse untouched; the day is then resolved in `location`
+	// through the package's single midnight-construction point. Parsing in
+	// `location` directly would lose the day before that point is ever
+	// reached: time.ParseInLocation resolves a nonexistent local midnight the
+	// same way time.Date does, and in a UTC-minus zone whose DST jump lands on
+	// midnight that resolution normalizes backward into the previous day.
+	parsed, err := time.Parse("2006-01-02", value)
 	if err != nil {
 		return time.Time{}, err
 	}
 
-	return DateAtLocation(parsed, location), nil
+	year, month, day := parsed.Date()
+
+	return startOfCalendarDay(year, month, day, location), nil
 }

--- a/internal/services/day_utils.go
+++ b/internal/services/day_utils.go
@@ -9,8 +9,9 @@ import (
 )
 
 // DateAtLocation projects an instant-in-time `value` onto the calendar of
-// `location` and returns midnight of that calendar day. Use this for
-// time.Time values that represent a real instant (time.Now(),
+// `location` and returns the start of that calendar day — midnight, or the
+// day's first existing instant when a DST jump skips it (startOfCalendarDay).
+// Use this for time.Time values that represent a real instant (time.Now(),
 // user.CreatedAt) where the in-location calendar day is what you want.
 //
 // Do NOT use this for date-only stored values (DailyLog.Date,
@@ -24,16 +25,50 @@ func DateAtLocation(value time.Time, location *time.Location) time.Time {
 	}
 	localized := value.In(location)
 	year, month, day := localized.Date()
-	return time.Date(year, month, day, 0, 0, 0, 0, location)
+	return startOfCalendarDay(year, month, day, location)
 }
 
-// CalendarDay rebuilds a date-only stored value at midnight in `location`,
-// preserving the calendar components of `value` exactly as stored. Use this
-// for time.Time values whose semantics is "a calendar date" rather than
-// "an instant in time" — DailyLog.Date, User.LastPeriodStart, derived stats
-// fields. Unlike DateAtLocation, this does not apply In(location) and
-// therefore does not shift the calendar day across timezones, which matters
-// when stored values were persisted with a UTC-midnight timestamp.
+// startOfCalendarDay returns the first instant that actually exists on the
+// given calendar day in `location`. It is the one construction point for
+// every "midnight of this calendar day" value in the package, so the
+// YYYY-MM-DD key a helper is handed always round-trips.
+//
+// Plain time.Date cannot be used directly: in a UTC-minus zone whose DST jump
+// lands exactly on midnight (America/Santiago, America/Havana), local midnight
+// does not exist and time.Date resolves the nonexistent wall clock through its
+// `utc >= end` branch, which normalizes BACKWARD into the previous calendar
+// day — the spring-forward date could then not be entered at all. Positive
+// offsets take the `utc < start` branch and normalize forward within the same
+// day, so they were never affected and are left byte-for-byte alone here, as
+// are zones without transitions (UTC included): the fallback below only fires
+// when the requested day did not survive the construction.
+func startOfCalendarDay(year int, month time.Month, day int, location *time.Location) time.Time {
+	candidate := time.Date(year, month, day, 0, 0, 0, 0, location)
+	if y, m, d := candidate.Date(); y == year && m == month && d == day {
+		return candidate
+	}
+
+	// Midnight was skipped: the day really begins at the transition ending the
+	// zone period the normalized candidate fell back into.
+	if _, transition := candidate.ZoneBounds(); !transition.IsZero() {
+		if y, m, d := transition.Date(); y == year && m == month && d == day {
+			return transition
+		}
+	}
+
+	// No instant on the requested day exists (a zone that skips a whole
+	// calendar day, e.g. Pacific/Apia 2011-12-30). Keep time.Date's own answer.
+	return candidate
+}
+
+// CalendarDay rebuilds a date-only stored value at the start of its calendar
+// day in `location` (startOfCalendarDay), preserving the calendar components
+// of `value` exactly as stored. Use this for time.Time values whose semantics
+// is "a calendar date" rather than "an instant in time" — DailyLog.Date,
+// User.LastPeriodStart, derived stats fields. Unlike DateAtLocation, this
+// does not apply In(location) and therefore does not shift the calendar day
+// across timezones, which matters when stored values were persisted with a
+// UTC-midnight timestamp.
 func CalendarDay(value time.Time, location *time.Location) time.Time {
 	if location == nil {
 		location = time.UTC
@@ -42,7 +77,7 @@ func CalendarDay(value time.Time, location *time.Location) time.Time {
 		return time.Time{}
 	}
 	year, month, day := value.Date()
-	return time.Date(year, month, day, 0, 0, 0, 0, location)
+	return startOfCalendarDay(year, month, day, location)
 }
 
 // CalendarDayKey returns the YYYY-MM-DD ISO string for a date-only stored

--- a/internal/services/day_utils_test.go
+++ b/internal/services/day_utils_test.go
@@ -213,6 +213,107 @@ func TestDateAtLocationShiftsToNextLocalDayAcrossUTCBoundary(t *testing.T) {
 	}
 }
 
+// TestCalendarDayKeyRoundTripsAcrossMidnightDSTTransitions pins the one
+// property every date-only surface depends on: the YYYY-MM-DD key a helper is
+// handed must be the YYYY-MM-DD key it returns. In a UTC-minus zone whose DST
+// jump lands exactly on midnight, local midnight does not exist and time.Date
+// normalizes the nonexistent wall clock BACKWARD into the previous calendar
+// day, so the spring-forward date could not be entered at all: the onboarding
+// anchor, the day entry and the export row all shifted one day earlier.
+//
+// The list carries three midnight-transition zones on their own transition
+// dates, a positive-offset zone (which normalizes forward and was never
+// affected), a zone whose jump is at 02:00 (midnight exists), and UTC (no
+// transitions at all) so a future change that breaks the unaffected zones is
+// caught here too.
+func TestCalendarDayKeyRoundTripsAcrossMidnightDSTTransitions(t *testing.T) {
+	cases := []struct {
+		zone string
+		day  string
+		note string
+	}{
+		{zone: "America/Santiago", day: "2026-09-06", note: "UTC-4 -> UTC-3 jump at 00:00"},
+		{zone: "America/Havana", day: "2026-03-08", note: "UTC-5 -> UTC-4 jump at 00:00"},
+		{zone: "America/Asuncion", day: "2024-10-06", note: "UTC-4 -> UTC-3 jump at 00:00 (last DST year)"},
+		{zone: "Asia/Beirut", day: "2026-03-29", note: "control: positive offset, jump at 00:00"},
+		{zone: "Europe/Berlin", day: "2026-03-29", note: "control: jump at 02:00, midnight exists"},
+		{zone: "UTC", day: "2026-03-08", note: "control: no transitions"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.zone+" "+tc.day, func(t *testing.T) {
+			location, err := time.LoadLocation(tc.zone)
+			if err != nil {
+				t.Fatalf("load %s: %v", tc.zone, err)
+			}
+			reference, err := time.Parse("2006-01-02", tc.day)
+			if err != nil {
+				t.Fatalf("parse reference day %s: %v", tc.day, err)
+			}
+			year, month, day := reference.Date()
+
+			// The single parse entry point for date inputs.
+			parsed, err := ParseDayDate(tc.day, location)
+			if err != nil {
+				t.Fatalf("ParseDayDate(%s, %s): %v", tc.day, tc.zone, err)
+			}
+			if got := parsed.Format("2006-01-02"); got != tc.day {
+				t.Errorf("ParseDayDate(%s, %s) = %s, want %s (%s)", tc.day, tc.zone, got, tc.day, tc.note)
+			}
+			// The returned instant is the day's FIRST existing instant: one
+			// nanosecond earlier is already the previous calendar day.
+			if got := parsed.Add(-time.Nanosecond).Format("2006-01-02"); got == tc.day {
+				t.Errorf("ParseDayDate(%s, %s) = %s is not the first instant of the day",
+					tc.day, tc.zone, parsed.Format(time.RFC3339))
+			}
+
+			// A date-only stored value (persisted at UTC-midnight) rebuilt in
+			// the request-local zone.
+			stored := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			if got := CalendarDay(stored, location).Format("2006-01-02"); got != tc.day {
+				t.Errorf("CalendarDay(%s, %s) = %s, want %s (%s)", tc.day, tc.zone, got, tc.day, tc.note)
+			}
+
+			// An instant inside the local calendar day projected back onto it.
+			instant := time.Date(year, month, day, 12, 0, 0, 0, location).UTC()
+			if got := DateAtLocation(instant, location).Format("2006-01-02"); got != tc.day {
+				t.Errorf("DateAtLocation(local noon of %s, %s) = %s, want %s (%s)",
+					tc.day, tc.zone, got, tc.day, tc.note)
+			}
+
+			// The canonical storage shape: parse in the request zone, persist
+			// at UTC-midnight, read the key back.
+			if got := CalendarDayKey(CalendarDay(parsed, time.UTC)); got != tc.day {
+				t.Errorf("CalendarDayKey(CalendarDay(ParseDayDate(%s, %s), UTC)) = %s, want %s",
+					tc.day, tc.zone, got, tc.day)
+			}
+		})
+	}
+}
+
+// TestCalendarDayKeepsStdlibResolutionForACalendarDayThatNeverExisted covers
+// the one case the transition lookup cannot repair: a zone that skips a whole
+// calendar day. Pacific/Apia jumped from 2011-12-29 23:59:59 UTC-10 straight
+// to 2011-12-31 00:00 UTC+14, so no instant at all exists on 2011-12-30. The
+// helper must not reach for the next transition there (that lands on a
+// different day) and keeps time.Date's own resolution instead.
+func TestCalendarDayKeepsStdlibResolutionForACalendarDayThatNeverExisted(t *testing.T) {
+	apia, err := time.LoadLocation("Pacific/Apia")
+	if err != nil {
+		t.Fatalf("load Pacific/Apia: %v", err)
+	}
+
+	stored := time.Date(2011, time.December, 30, 0, 0, 0, 0, time.UTC)
+	got := CalendarDay(stored, apia)
+
+	if key := got.Format("2006-01-02"); key != "2011-12-29" {
+		t.Fatalf("CalendarDay(2011-12-30, Pacific/Apia) = %s, want the stdlib resolution 2011-12-29", key)
+	}
+	if got.Location() != apia {
+		t.Fatalf("expected location Pacific/Apia, got %s", got.Location())
+	}
+}
+
 func TestSymptomIDSet(t *testing.T) {
 	set := SymptomIDSet([]uint{3, 3, 5})
 	if len(set) != 2 {


### PR DESCRIPTION
## Defect

In a zone west of UTC whose DST jump lands exactly on midnight, local midnight does not exist on the transition date, and `time.Date` resolves that nonexistent wall clock through its `utc >= end` branch — normalizing **backward**. `2026-09-06 00:00` in `America/Santiago` becomes `2026-09-06T03:00Z`, which renders locally as `2026-09-05T23:00-04`, so `.Date()` reports the **previous** day.

Every date-only construction in `internal/services` ended in that call:

- `DateAtLocation` and `CalendarDay` (`internal/services/day_utils.go`) both closed with `time.Date(year, month, day, 0, 0, 0, 0, location)`;
- `ParseDayDate` (`internal/services/date_parse_policy.go`), the single parse entry point for date inputs, lost the day inside `time.ParseInLocation` before either helper ran.

Observed keys before the fix: `America/Santiago 2026-09-06 -> 2026-09-05`, `America/Havana 2026-03-08 -> 2026-03-07`, `America/Asuncion 2024-10-06 -> 2024-10-05`. Consequence for an account in such a zone: the spring-forward date cannot be entered at all — the day entry, the export row and the onboarding cycle start every later prediction is measured from all shift one day back. Positive-offset zones take the `utc < start` branch and normalize forward inside the same day, so they were never affected.

## Fix

All three sites now route through one construction point, `startOfCalendarDay` (`internal/services/day_utils.go:45`): it keeps `time.Date`'s answer when the requested day survived the construction, and otherwise re-resolves to the day's first instant that really exists — the transition itself, read from `ZoneBounds`. `ParseDayDate` parses in UTC (no transitions, so the calendar components survive) and hands the components to the same helper.

Deliberately unchanged:

- zones without a midnight transition, positive-offset zones and UTC take the first branch and are byte-for-byte identical;
- the `In(location)` semantics documented for issue #48 — this is about the `time.Date` construction only;
- date-only stored values still persist as UTC-midnight via `CalendarDay(parsed, time.UTC)`;
- a zone that skips a whole calendar day (`Pacific/Apia` 2011-12-30) keeps the stdlib resolution, since no instant on the requested day exists to move to.

## Guard

`TestCalendarDayKeyRoundTripsAcrossMidnightDSTTransitions` (`internal/services/day_utils_test.go:229`) asserts YYYY-MM-DD key round-trip identity through `ParseDayDate`, `CalendarDay` and `DateAtLocation`, plus that the returned instant is the day's *first* existing one (one nanosecond earlier is already the previous day). Zones: `America/Santiago 2026-09-06`, `America/Havana 2026-03-08`, `America/Asuncion 2024-10-06`, with `Asia/Beirut 2026-03-29` (positive offset), `Europe/Berlin 2026-03-29` (02:00 jump) and `UTC` as controls, so a future change that breaks the unaffected zones is caught here too. Zones load through `time.LoadLocation` with `t.Fatalf` on failure, matching the package's existing timezone tests — the guard fails rather than skips if tzdata is missing.

Written first and run against the unfixed helpers, it failed on exactly the three affected zones and passed on all three controls:

```
    day_utils_test.go:261: ParseDayDate(2026-09-06, America/Santiago) = 2026-09-05, want 2026-09-06 (UTC-4 -> UTC-3 jump at 00:00)
    day_utils_test.go:274: CalendarDay(2026-09-06, America/Santiago) = 2026-09-05, want 2026-09-06 (UTC-4 -> UTC-3 jump at 00:00)
    day_utils_test.go:280: DateAtLocation(local noon of 2026-09-06, America/Santiago) = 2026-09-05, want 2026-09-06 (UTC-4 -> UTC-3 jump at 00:00)
    day_utils_test.go:287: CalendarDayKey(CalendarDay(ParseDayDate(2026-09-06, America/Santiago), UTC)) = 2026-09-05, want 2026-09-06
    --- FAIL: .../America/Santiago_2026-09-06 (0.10s)
    --- FAIL: .../America/Havana_2026-03-08 (0.01s)
    --- FAIL: .../America/Asuncion_2024-10-06 (0.00s)
    --- PASS: .../Asia/Beirut_2026-03-29 (0.02s)
    --- PASS: .../Europe/Berlin_2026-03-29 (0.02s)
    --- PASS: .../UTC_2026-03-08 (0.00s)
```

`TestCalendarDayKeepsStdlibResolutionForACalendarDayThatNeverExisted` pins the skipped-whole-day fallback.

## Follow-up commit: the calendar projection loop

The new start-of-day shape is visible to one comparison that mixed it with the calendar grid's own `AddDate` arithmetic. `appendPredictedCycles` (`internal/services/calendar_days.go:240`, `:234` before the change) bounded its loop with `!cycleStart.After(gridEnd)`, where `cycleStart` comes from `CalendarDay` and `gridEnd` from plain date arithmetic. In `America/Santiago` a cycle anchored on 2026-09-06 now starts at `01:00-03`, every cycle chained after it keeps that wall clock, and `gridEnd` sits at `00:00` — so a projected cycle landing exactly on the last grid day read as *past* the grid, the loop stopped one iteration early, and that cycle's predicted-period and fertile markers were never painted.

The bound is a calendar-day question and is now asked as one: `CalendarDaysBetween(cycleStart, gridEnd) >= 0`, which re-anchors both operands and is immune to the midnight shape each carries.

Guard: `TestBuildCalendarDayStatesPaintsAProjectedCycleOnTheLastGridDay` renders the October 2026 grid for `America/Santiago` (its last day, 2026-11-01, is two 28-day cycles after the skipped midnight) and asserts that cycle and the one before it are painted. Against the first commit it failed with:

```
    calendar_days_test.go:143: expected the projected cycle starting on the last grid day 2026-11-01 to be painted
```

The file's other loop — `BuildCalendarDayStates` over the grid days themselves, `calendar_days.go:52` — compares two raw `AddDate` values and is unaffected by the start-of-day change, so it is left alone. It does carry a separate, pre-existing weakness: when a rendered range spans a skipped midnight, `AddDate` normalizes that day backward, so the grid emits the previous day twice and drops the last one. That reproduces identically on `main`'s helpers and is its own finding; the guard above deliberately uses a month whose grid starts after the transition so it does not depend on it.

## Validation

- `gofmt -l` on every touched file — clean.
- `go build ./...` — OK.
- `go test ./internal/services/...` — OK; the cycle reference suites (`cycles_reference_test.go`, `cycle_projection_reference_test.go`) run inside it and pass unchanged.
- `go test ./... -timeout 20m` — all packages OK (first commit); `go test ./internal/api/` re-run after the follow-up — OK.
- `golangci-lint run ./internal/services/...` — 0 issues, both commits.
- `scripts/patchcov` against `origin/main` on a profile generated for the same tree — every modified coverable line covered, both commits.

## Rollback

Revert the two commits (or the branch's merge); the helpers return to the plain `time.Date` construction, the projection loop to its instant comparison, and the guards revert with them. This is an api-contract change, so a revert additionally wants the dialect-parity and OpenAPI contract suites re-run before it lands.
