### PR TITLE
fix: emit each calendar day of the month grid exactly once

### DIFF
--- a/changelog.d/fix-calendar-grid-duplicate-day.md
+++ b/changelog.d/fix-calendar-grid-duplicate-day.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- **The calendar grid no longer prints one day twice and drops the last one in
+  time zones whose clock jump lands on midnight.** In zones west of UTC where
+  daylight saving starts at 00:00 (America/Santiago, America/Havana), local
+  midnight does not exist on the transition date. The grid stepped from day to
+  day as an instant, so that missing midnight resolved one calendar day
+  backward: a month whose displayed range crossed the transition rendered the
+  preceding day in two cells and never rendered the final day of the range at
+  all — the cell for it was the duplicate. The grid now counts and steps its
+  cells as calendar days, so every day in the range appears exactly once, in
+  order. Zones without such a transition, including UTC, render identically to
+  before.

--- a/internal/services/calendar_days.go
+++ b/internal/services/calendar_days.go
@@ -44,23 +44,45 @@ func BuildCalendarDayStates(user *models.User, monthStart time.Time, logs []mode
 	}
 	gridStart, gridEnd := calendarGridBounds(monthStart, weekStart)
 	latestLogByDate, hasDataMap := buildCalendarLogMaps(logs)
-	predictionMaps := buildCalendarPredictionMaps(user, logs, stats, gridEnd, now, location)
+	// The projection bound keeps the request-local shape it has always had:
+	// appendPredictedCycles compares it against a CalendarDay value built in
+	// the same location, so both operands stay start-of-day in one zone.
+	predictionMaps := buildCalendarPredictionMaps(user, logs, stats, CalendarDay(gridEnd, location), now, location)
 
 	todayKey := DateAtLocation(now, location).Format("2006-01-02")
 
-	days := make([]CalendarDayState, 0, 42)
-	for day := gridStart; !day.After(gridEnd); day = day.AddDate(0, 0, 1) {
+	// The grid is a run of CALENDAR days, so it is counted and stepped as
+	// calendar days rather than by adding 24h-ish increments to an instant and
+	// testing that instant against a bound. CalendarDaysBetween compares only
+	// the calendar components of the two bounds, and the step runs over
+	// UTC-anchored days, where no midnight is ever skipped.
+	gridDayCount := CalendarDaysBetween(gridStart, gridEnd) + 1
+	days := make([]CalendarDayState, 0, gridDayCount)
+	for offset := range gridDayCount {
+		day := gridStart.AddDate(0, 0, offset)
 		days = append(days, buildCalendarDayState(day, monthStart, todayKey, latestLogByDate, hasDataMap, predictionMaps))
 	}
 
 	return days
 }
 
+// calendarGridBounds returns the first and last calendar day of the month grid,
+// both inclusive and both anchored at UTC midnight — the package's canonical
+// shape for a date-only value.
+//
+// The arithmetic deliberately leaves the request timezone: in a UTC-minus zone
+// whose DST jump lands on midnight (America/Santiago 2026-09-06,
+// America/Havana 2026-03-08) local midnight does not exist on that date, and
+// AddDate resolves the missing wall clock BACKWARD into the previous calendar
+// day. A bound built that way names the wrong day, and a grid stepped from it
+// emits that day twice and drops the last day of the range. UTC has no
+// transitions, so the same arithmetic there is exact for every zone.
 func calendarGridBounds(monthStart time.Time, weekStart string) (time.Time, time.Time) {
-	monthEnd := monthStart.AddDate(0, 1, -1)
-	startOffset := weekStartOffset(monthStart.Weekday(), weekStart)
+	firstOfMonth := CalendarDay(monthStart, time.UTC)
+	monthEnd := firstOfMonth.AddDate(0, 1, -1)
+	startOffset := weekStartOffset(firstOfMonth.Weekday(), weekStart)
 	endOffset := weekStartOffset(monthEnd.Weekday(), weekStart)
-	gridStart := monthStart.AddDate(0, 0, -startOffset)
+	gridStart := firstOfMonth.AddDate(0, 0, -startOffset)
 	gridEnd := monthEnd.AddDate(0, 0, 6-endOffset)
 	return gridStart, gridEnd
 }

--- a/internal/services/calendar_days_test.go
+++ b/internal/services/calendar_days_test.go
@@ -600,3 +600,152 @@ func TestBuildCalendarDayStatesHidesHistoricalFertileWindowsByDefault(t *testing
 		}
 	}
 }
+
+// TestBuildCalendarDayStatesEmitsEveryCalendarDayOnce pins the grid's own
+// shape invariant, independent of anything painted on it: one cell per
+// calendar day of the grid range, in ascending order, no day repeated, and
+// both the first and the last day of the range present.
+//
+// The zones that break it are the UTC-minus ones whose DST jump lands on
+// midnight — America/Santiago on 2026-09-06, America/Havana on 2026-03-08.
+// No instant exists at 00:00 local on those dates, and stepping the grid with
+// plain AddDate resolved the missing midnight BACKWARD into the previous
+// calendar day: that day was emitted twice, every later step carried its 23:00
+// wall clock, and the instant-valued loop bound then stopped one step early so
+// the last day of the range never rendered. The two controls — the same zone
+// in a month nowhere near a transition, and UTC — hold the ordinary path.
+func TestBuildCalendarDayStatesEmitsEveryCalendarDayOnce(t *testing.T) {
+	santiago, err := time.LoadLocation("America/Santiago")
+	if err != nil {
+		t.Fatalf("load America/Santiago: %v", err)
+	}
+	havana, err := time.LoadLocation("America/Havana")
+	if err != nil {
+		t.Fatalf("load America/Havana: %v", err)
+	}
+
+	testCases := []struct {
+		name       string
+		location   *time.Location
+		weekStart  string
+		year       int
+		month      time.Month
+		firstDay   string
+		lastDay    string
+		crossesDST string
+	}{
+		{
+			name:       "santiago september crosses a skipped midnight",
+			location:   santiago,
+			weekStart:  models.WeekStartSunday,
+			year:       2026,
+			month:      time.September,
+			firstDay:   "2026-08-30",
+			lastDay:    "2026-10-03",
+			crossesDST: "2026-09-06",
+		},
+		{
+			name:       "santiago september with a monday week start",
+			location:   santiago,
+			weekStart:  models.WeekStartMonday,
+			year:       2026,
+			month:      time.September,
+			firstDay:   "2026-08-31",
+			lastDay:    "2026-10-04",
+			crossesDST: "2026-09-06",
+		},
+		{
+			name:       "havana march crosses a skipped midnight",
+			location:   havana,
+			weekStart:  models.WeekStartSunday,
+			year:       2026,
+			month:      time.March,
+			firstDay:   "2026-03-01",
+			lastDay:    "2026-04-04",
+			crossesDST: "2026-03-08",
+		},
+		{
+			name:      "control: santiago november, no transition in range",
+			location:  santiago,
+			weekStart: models.WeekStartSunday,
+			year:      2026,
+			month:     time.November,
+			firstDay:  "2026-11-01",
+			lastDay:   "2026-12-05",
+		},
+		{
+			name:      "control: utc september",
+			location:  time.UTC,
+			weekStart: models.WeekStartSunday,
+			year:      2026,
+			month:     time.September,
+			firstDay:  "2026-08-30",
+			lastDay:   "2026-10-03",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			user := &models.User{WeekStartsOn: testCase.weekStart}
+			monthStart := time.Date(testCase.year, testCase.month, 1, 0, 0, 0, 0, testCase.location)
+			now := time.Date(testCase.year, testCase.month, 15, 12, 0, 0, 0, time.UTC)
+
+			days := BuildCalendarDayStates(user, monthStart, nil, CycleStats{}, now, testCase.location)
+
+			assertCalendarGridCoversEachDayOnce(t, days, testCase.firstDay, testCase.lastDay)
+
+			if testCase.crossesDST != "" {
+				// The transition date itself must be one of the cells: it is the
+				// day the broken step resolved backward and never emitted.
+				findCalendarDayStateByDateString(t, days, testCase.crossesDST)
+			}
+		})
+	}
+}
+
+// assertCalendarGridCoversEachDayOnce checks the grid emits exactly the
+// calendar days of [firstDay, lastDay], one cell each, in ascending order. The
+// per-cell comparison is what names the culprit: it reports the first cell
+// whose date is not the one the calendar demands, which is the repeated day.
+func assertCalendarGridCoversEachDayOnce(t *testing.T, days []CalendarDayState, firstDay string, lastDay string) {
+	t.Helper()
+
+	first, err := time.Parse("2006-01-02", firstDay)
+	if err != nil {
+		t.Fatalf("parse first grid day %s: %v", firstDay, err)
+	}
+	last, err := time.Parse("2006-01-02", lastDay)
+	if err != nil {
+		t.Fatalf("parse last grid day %s: %v", lastDay, err)
+	}
+
+	wantCount := CalendarDaysBetween(first, last) + 1
+	if len(days) != wantCount {
+		t.Fatalf("grid cell count: want %d (%s..%s), got %d", wantCount, firstDay, lastDay, len(days))
+	}
+
+	seen := make(map[string]int, len(days))
+	for index, day := range days {
+		want := first.AddDate(0, 0, index).Format("2006-01-02")
+		if day.DateString != want {
+			t.Fatalf("grid cell %d: want %s, got %s — the grid must run in ascending calendar-day order with no day repeated", index, want, day.DateString)
+		}
+		if got := day.Date.Format("2006-01-02"); got != day.DateString {
+			t.Fatalf("grid cell %d: Date %s disagrees with DateString %s", index, got, day.DateString)
+		}
+		if day.Day != day.Date.Day() {
+			t.Fatalf("grid cell %d (%s): Day %d disagrees with its own date", index, day.DateString, day.Day)
+		}
+		seen[day.DateString]++
+	}
+
+	for _, day := range days {
+		if seen[day.DateString] > 1 {
+			t.Fatalf("grid repeats %s %d times", day.DateString, seen[day.DateString])
+		}
+	}
+
+	if days[len(days)-1].DateString != lastDay {
+		t.Fatalf("last grid day: want %s, got %s", lastDay, days[len(days)-1].DateString)
+	}
+}


### PR DESCRIPTION
## The defect

`BuildCalendarDayStates` stepped the month grid with plain `AddDate` on an instant and bounded the
loop with `After` on that same instant:

```go
for day := gridStart; !day.After(gridEnd); day = day.AddDate(0, 0, 1) {
```

In a UTC-minus zone whose DST jump lands on midnight — America/Santiago on 2026-09-06,
America/Havana on 2026-03-08 — no instant exists at 00:00 local on the transition date, and
`time.Date` resolves the missing wall clock **backward** into the previous calendar day. So the
grid emitted that previous day twice; every later step then carried its 23:00 wall clock, the
instant bound tripped one step early, and the last day of the range was never rendered at all.
Both grid bounds were built the same way, so a bound falling on such a date named the wrong day
too.

Measured on `main`, September 2026 in America/Santiago (Sunday week start): **35 cells, 34
distinct days, `2026-09-05` twice, last cell `2026-10-02`** where the grid ends on `2026-10-03`.

This is not caused by #496 and predates it: the loop and the bounds are untouched by that branch,
which changes the projection loop further down the file and `day_utils.go`. It was found while
reviewing #496.

## The fix

The grid is a run of **calendar days**, so it is counted and stepped as calendar days rather than
as instants:

- `calendarGridBounds` builds the month's first day with `CalendarDay(monthStart, time.UTC)` and
  does its offset arithmetic there. UTC has no transitions, so no midnight can be skipped and both
  bounds always name the day they mean.
- the cell count comes from `CalendarDaysBetween(gridStart, gridEnd) + 1`, which compares calendar
  components rather than instants, and the loop indexes off `gridStart` instead of accumulating
  steps.
- the projection bound handed to `buildCalendarPredictionMaps` is re-anchored with
  `CalendarDay(gridEnd, location)` at the call site, so `appendPredictedCycles` keeps comparing two
  start-of-day values in the same zone exactly as it does today. That comparison is untouched.

Grid size and shape are unchanged: the same inclusive `[gridStart, gridEnd]` range, the same
week-start preference, the same 5- or 6-week span. Zones without such a transition, including UTC,
produce byte-identical grids.

## The guard

`TestBuildCalendarDayStatesEmitsEveryCalendarDayOnce` renders the grid and asserts the property
itself — one cell per calendar day of the range, ascending, no repeat, first and last day present,
and `Date`/`DateString`/`Day` agreeing per cell. Five cases: America/Santiago September 2026 with
both week starts, America/Havana March 2026, plus two controls (America/Santiago November 2026,
away from any transition, and UTC September 2026). Zone data is loaded with `time.LoadLocation` +
`t.Fatalf`, following the package's precedent, so a host without tzdata fails rather than skips.

Against the unfixed code the three transition cases fail and both controls pass:

```
--- FAIL: TestBuildCalendarDayStatesEmitsEveryCalendarDayOnce/santiago_september_crosses_a_skipped_midnight
    calendar_days_test.go:695: grid cell 7: want 2026-09-06, got 2026-09-05 — the grid must run in ascending calendar-day order with no day repeated
--- FAIL: TestBuildCalendarDayStatesEmitsEveryCalendarDayOnce/santiago_september_with_a_monday_week_start
    calendar_days_test.go:695: grid cell 6: want 2026-09-06, got 2026-09-05 — the grid must run in ascending calendar-day order with no day repeated
--- FAIL: TestBuildCalendarDayStatesEmitsEveryCalendarDayOnce/havana_march_crosses_a_skipped_midnight
    calendar_days_test.go:695: grid cell 7: want 2026-03-08, got 2026-03-07 — the grid must run in ascending calendar-day order with no day repeated
--- PASS: TestBuildCalendarDayStatesEmitsEveryCalendarDayOnce/control:_santiago_november,_no_transition_in_range
--- PASS: TestBuildCalendarDayStatesEmitsEveryCalendarDayOnce/control:_utc_september
```

## Consumer sweep

Every reader of the values this loop produces, and of the two changed helpers:

| Consumer | Verdict |
| --- | --- |
| `buildCalendarDayState` (`internal/services/calendar_days.go`) — reads `day.Format`, `day.Day()`, `day.Month()` and stores `Date` | Affected as intended: the key, the day number and the in-month test now come from the day the grid means. |
| `CalendarDayState.DateString` → `IsToday` / `IsFuture` string compares against `todayKey` | Affected positively; both sides stay `YYYY-MM-DD` strings, `todayKey` is unchanged. |
| Log and prediction map lookups (`latestLogByDate`, `hasDataMap`, `calendarPredictionMaps`) | Keyed `YYYY-MM-DD`; a lookup on the transition date now hits the right entry. See the separate finding below. |
| `gridEnd` → `buildCalendarPredictionMaps` → `appendPredictedCycles` bound | Shape preserved by re-anchoring at the call site; no behavior change. Only consumer of `gridEnd`. |
| `calendarGridBounds` — other callers | Only `BuildCalendarDayStates` and `calendar_days_coverage_test.go`, which passes UTC months; results unchanged. |
| `CalendarLogRange` (same file) | Not fed by the loop and untouched; its ±70-day pad around the month is unaffected. |
| `CalendarViewService.BuildCalendarPageViewData` → `CalendarPageViewData.DayStates` | Pass-through. |
| `Handler.buildCalendarDays` (`internal/api/calendar_days_view_helpers.go`) → `api.CalendarDay` | Pass-through; the class ladder reads booleans only. |
| `internal/templates/calendar.html` — `.DateString` (`data-day`, `hx-get /calendar/day/…`, selection) | Unchanged convention, correct day. |
| `internal/templates/calendar.html` — `{{formatLocalizedDate $.Lang .Date "display"}}` (cell aria-label) | Affected: `LocalizedDateDisplay` reads only `Day()`/`Month()`/`Year()`/`Weekday()` of the value, never `In(location)`, so the label is location-independent and now names the right day. |
| `internal/api/calendar_days_view_helpers_test.go` | Builds its own `CalendarDayState` literals; unaffected. |

## Separate finding — not fixed here

The prediction-map builders in the same file step by instant in exactly the same way
(`appendCalendarDateRange`, `appendFertilityWindow`, `appendPredictedPeriod`, and the cycle chain in
`appendPredictedCycles`). Starting from a `CalendarDay(…, location)` value, a range crossing a
skipped midnight writes the day before the transition twice and, because every later step carries
a 23:00 wall clock, its `!day.After(end)` bound drops the **last** day of the range: a predicted
period, fertile window or pre-fertile band loses its final day's shading in those zones. It is a
distinct defect from the grid's own cell sequence and is left for its own change; #496 addresses
only the projection loop's bound, not these steppers.

## Rollback

Single commit, no schema or contract change: `git revert` of this commit restores the previous
behavior exactly.
