### PR TITLE
fix: refuse a calendar date the request zone never had

### DIFF
--- a/changelog.d/fix-refuse-nonexistent-calendar-date.md
+++ b/changelog.d/fix-refuse-nonexistent-calendar-date.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- **A date your time zone never had is now refused instead of quietly saving the
+  day before.** A zone that crosses the date line skips a whole calendar day
+  (Pacific/Apia had no 2011-12-30, Pacific/Kiritimati no 1994-12-31). Entering
+  one used to parse as the previous day and report success, so the save, the
+  onboarding anchor or the imported row landed on a day nobody named. Date input
+  now reports it as invalid, on the same validation path an empty or malformed
+  date already takes; an import counts such a row as rejected and imports the
+  rest of the file. Dates that do exist are unaffected — a day whose midnight a
+  daylight-saving jump skips still resolves to that day's first real instant.

--- a/internal/api/day_upsert_canonicalization_regression_test.go
+++ b/internal/api/day_upsert_canonicalization_regression_test.go
@@ -108,6 +108,76 @@ func TestUpsertDayCanonicalizesStoredDateToUTCMidnightForRequestTimezone(t *test
 	}
 }
 
+// TestUpsertDayRefusesACalendarDayTheRequestZoneNeverHad is the transport-level
+// lock for the whole-day-skipped case. Pacific/Apia crossed the date line at the
+// end of 2011 and never had a 2011-12-30 at all; parsing that path parameter used
+// to yield 2011-12-29 with no error, so the save landed on a day the request had
+// not named and the client had no way to tell. The route must answer a mapped
+// validation refusal — the same one an empty or malformed date already gets —
+// and must not write a row.
+func TestUpsertDayRefusesACalendarDayTheRequestZoneNeverHad(t *testing.T) {
+	const zoneName = "Pacific/Apia"
+
+	if _, err := time.LoadLocation(zoneName); err != nil {
+		t.Fatalf("zoneinfo for %s unavailable: %v", zoneName, err)
+	}
+
+	app, database, _ := newOnboardingTestAppWithLocation(t, time.UTC)
+	user := createOnboardingTestUser(t, database, "upsert-nonexistent-day@example.com", "StrongPass1", true)
+	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
+
+	body, err := json.Marshal(map[string]any{
+		"is_period":   true,
+		"flow":        models.FlowMedium,
+		"symptom_ids": []uint{},
+		"notes":       "",
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	request := httptest.NewRequest(http.MethodPut, "/api/v1/days/2011-12-30", bytes.NewReader(body))
+	request.Header.Set("Content-Type", fiber.MIMEApplicationJSON)
+	request.Header.Set("Cookie", joinCookieHeader(authCookie, timezoneCookieName+"="+zoneName))
+	request.Header.Set(timezoneHeaderName, zoneName)
+
+	response, err := app.Test(request, testConfigNoTimeout)
+	if err != nil {
+		t.Fatalf("upsert request failed: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+
+	if response.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected status 400 for a day %s never had, got %d", zoneName, response.StatusCode)
+	}
+
+	var envelope struct {
+		Error       string `json:"error"`
+		ErrorDetail struct {
+			Key      string `json:"key"`
+			Category string `json:"category"`
+		} `json:"error_detail"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&envelope); err != nil {
+		t.Fatalf("decode error envelope: %v", err)
+	}
+	if envelope.ErrorDetail.Category != string(APIErrorCategoryValidation) {
+		t.Fatalf("expected a validation refusal the client can act on, got category %q (key %q)",
+			envelope.ErrorDetail.Category, envelope.ErrorDetail.Key)
+	}
+	if envelope.Error == "" {
+		t.Fatal("expected a mapped error message in the envelope")
+	}
+
+	var stored int64
+	if err := database.Raw("SELECT COUNT(*) FROM daily_logs WHERE user_id = ?", user.ID).Row().Scan(&stored); err != nil {
+		t.Fatalf("count daily_logs: %v", err)
+	}
+	if stored != 0 {
+		t.Fatalf("expected no day written for a refused date, found %d row(s) — the save shifted to a day the request never named", stored)
+	}
+}
+
 func assertUpsertUTCDate(t *testing.T, rawDate, expectedPrefix string) {
 	t.Helper()
 	if !strings.HasPrefix(rawDate, expectedPrefix) {

--- a/internal/services/date_parse_policy.go
+++ b/internal/services/date_parse_policy.go
@@ -6,11 +6,23 @@ import (
 	"time"
 )
 
-var ErrDayDateRequired = errors.New("date is required")
+var (
+	ErrDayDateRequired = errors.New("date is required")
+
+	// ErrDayDateNonexistent reports a syntactically valid date that the request
+	// zone never had — a zone crossing the date line skips a whole calendar day
+	// (Pacific/Apia 2011-12-30, Pacific/Kiritimati 1994-12-31). It is invalid
+	// input, not a date to resolve: there is no instant to resolve it to.
+	ErrDayDateNonexistent = errors.New("date does not exist in this timezone")
+)
 
 // ParseDayDate parses a YYYY-MM-DD form value as a calendar day on the
 // request-local calendar and returns the start of that day in `location` —
 // midnight, or the day's first existing instant when a DST jump skips it.
+// A date the zone never had at all is refused with ErrDayDateNonexistent.
+// The two cases are deliberately different: a missing MIDNIGHT still names a
+// real day and resolves forward to its first instant, while a missing DAY has
+// no instant to resolve to and is therefore invalid input.
 // This is the single parse entry point for date inputs: every other
 // "2006-01-02" parse in the package routes through it, so the
 // canonicalization shape stays a one-place decision. For values destined
@@ -37,5 +49,16 @@ func ParseDayDate(raw string, location *time.Location) (time.Time, error) {
 
 	year, month, day := parsed.Date()
 
-	return startOfCalendarDay(year, month, day, location), nil
+	// startOfCalendarDay returns the first instant that exists on the requested
+	// day whenever one does, so a resolved value carrying a DIFFERENT calendar
+	// date is the signal that the zone skipped the whole day: it is time.Date's
+	// backward normalization into the previous day, kept there for the stored-
+	// value helpers that have no error channel. Reading it as a parsed date is
+	// the silent one-day shift, so the input boundary refuses it here instead.
+	resolved := startOfCalendarDay(year, month, day, location)
+	if resolvedYear, resolvedMonth, resolvedDay := resolved.Date(); resolvedYear != year || resolvedMonth != month || resolvedDay != day {
+		return time.Time{}, ErrDayDateNonexistent
+	}
+
+	return resolved, nil
 }

--- a/internal/services/date_parse_policy_test.go
+++ b/internal/services/date_parse_policy_test.go
@@ -22,6 +22,96 @@ func TestParseDayDateRejectsInvalidValue(t *testing.T) {
 	}
 }
 
+// TestParseDayDateRefusesACalendarDayTheZoneNeverHad pins the refusal half of
+// the parse contract. A zone that crosses the date line skips a WHOLE calendar
+// day: Pacific/Apia jumped from 2011-12-29 23:59:59 UTC-10 straight to
+// 2011-12-31 00:00 UTC+14, and Pacific/Kiritimati did the same over 1994-12-31.
+// No instant at all exists on those days, so time.Date normalizes backward into
+// the previous one. Returning that with a nil error is indistinguishable from a
+// successful parse and silently saves the wrong day, which is the shift the
+// skipped-midnight fix removed everywhere else — the parse entry point must
+// report the input as invalid instead.
+func TestParseDayDateRefusesACalendarDayTheZoneNeverHad(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		zone string
+		day  string
+		note string
+	}{
+		{zone: "Pacific/Apia", day: "2011-12-30", note: "UTC-10 -> UTC+14 date-line crossing"},
+		{zone: "Pacific/Kiritimati", day: "1994-12-31", note: "UTC-10 -> UTC+14 date-line crossing"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.zone+" "+tc.day, func(t *testing.T) {
+			t.Parallel()
+
+			location, err := time.LoadLocation(tc.zone)
+			if err != nil {
+				t.Fatalf("load %s: %v", tc.zone, err)
+			}
+
+			got, err := ParseDayDate(tc.day, location)
+			if !errors.Is(err, ErrDayDateNonexistent) {
+				t.Fatalf("ParseDayDate(%s, %s) = %s, %v; want ErrDayDateNonexistent (%s)",
+					tc.day, tc.zone, got.Format(time.RFC3339), err, tc.note)
+			}
+			if !got.IsZero() {
+				t.Fatalf("ParseDayDate(%s, %s) returned %s alongside the refusal; want the zero time",
+					tc.day, tc.zone, got.Format(time.RFC3339))
+			}
+		})
+	}
+}
+
+// TestParseDayDateResolvesADayWhoseMidnightIsSkipped is the other half of the
+// same distinction: a missing MIDNIGHT is not a missing day. In a UTC-minus zone
+// whose DST jump lands exactly on midnight the day still exists — it simply
+// begins at the transition — so the parse must succeed and return that first
+// existing instant. The list carries the two midnight-transition zones plus a
+// positive-offset zone and UTC as controls, so a future tightening of the
+// refusal that swallows an existing day is caught here.
+func TestParseDayDateResolvesADayWhoseMidnightIsSkipped(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		zone string
+		day  string
+		note string
+	}{
+		{zone: "America/Santiago", day: "2026-09-06", note: "UTC-4 -> UTC-3 jump at 00:00"},
+		{zone: "America/Havana", day: "2026-03-08", note: "UTC-5 -> UTC-4 jump at 00:00"},
+		{zone: "Asia/Beirut", day: "2026-03-29", note: "control: positive offset, jump at 00:00"},
+		{zone: "UTC", day: "2026-03-08", note: "control: no transitions"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.zone+" "+tc.day, func(t *testing.T) {
+			t.Parallel()
+
+			location, err := time.LoadLocation(tc.zone)
+			if err != nil {
+				t.Fatalf("load %s: %v", tc.zone, err)
+			}
+
+			parsed, err := ParseDayDate(tc.day, location)
+			if err != nil {
+				t.Fatalf("ParseDayDate(%s, %s): %v (%s)", tc.day, tc.zone, err, tc.note)
+			}
+			if got := parsed.Format("2006-01-02"); got != tc.day {
+				t.Fatalf("ParseDayDate(%s, %s) = %s, want %s (%s)", tc.day, tc.zone, got, tc.day, tc.note)
+			}
+			// The returned instant is the day's FIRST existing instant: one
+			// nanosecond earlier is already the previous calendar day.
+			if got := parsed.Add(-time.Nanosecond).Format("2006-01-02"); got == tc.day {
+				t.Fatalf("ParseDayDate(%s, %s) = %s is not the first instant of the day",
+					tc.day, tc.zone, parsed.Format(time.RFC3339))
+			}
+		})
+	}
+}
+
 func TestParseDayDateNormalizesToLocationDate(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/day_utils.go
+++ b/internal/services/day_utils.go
@@ -57,7 +57,11 @@ func startOfCalendarDay(year int, month time.Month, day int, location *time.Loca
 	}
 
 	// No instant on the requested day exists (a zone that skips a whole
-	// calendar day, e.g. Pacific/Apia 2011-12-30). Keep time.Date's own answer.
+	// calendar day, e.g. Pacific/Apia 2011-12-30). Keep time.Date's own answer:
+	// the callers reached from here (CalendarDay, DateAtLocation) rebuild stored
+	// values and have no error channel. The returned value therefore carries a
+	// DIFFERENT calendar date than the one requested, which is exactly how
+	// ParseDayDate detects the case and refuses the input instead.
 	return candidate
 }
 

--- a/internal/services/day_utils_test.go
+++ b/internal/services/day_utils_test.go
@@ -297,6 +297,12 @@ func TestCalendarDayKeyRoundTripsAcrossMidnightDSTTransitions(t *testing.T) {
 // to 2011-12-31 00:00 UTC+14, so no instant at all exists on 2011-12-30. The
 // helper must not reach for the next transition there (that lands on a
 // different day) and keeps time.Date's own resolution instead.
+//
+// This is the contract for a STORED value being rebuilt, where there is no
+// error channel to report the gap on. It is not the contract for user input:
+// ParseDayDate refuses the same date with ErrDayDateNonexistent rather than
+// returning the previous day as a successful parse
+// (TestParseDayDateRefusesACalendarDayTheZoneNeverHad).
 func TestCalendarDayKeepsStdlibResolutionForACalendarDayThatNeverExisted(t *testing.T) {
 	apia, err := time.LoadLocation("Pacific/Apia")
 	if err != nil {

--- a/internal/services/import_service_test.go
+++ b/internal/services/import_service_test.go
@@ -208,6 +208,50 @@ func TestImportServiceRejectsDuplicateDatesWithinFile(t *testing.T) {
 	}
 }
 
+// TestImportServiceRejectsADateTheRequestZoneNeverHad keeps a row naming a
+// calendar day the request zone skipped entirely (Pacific/Apia crossed the date
+// line and never had 2011-12-30) on the same per-row path as any other invalid
+// row: counted as rejected and skipped, never silently written onto the previous
+// day. The neighbouring valid row still imports, so one bad row does not refuse
+// the file.
+func TestImportServiceRejectsADateTheRequestZoneNeverHad(t *testing.T) {
+	apia, err := time.LoadLocation("Pacific/Apia")
+	if err != nil {
+		t.Fatalf("load Pacific/Apia: %v", err)
+	}
+
+	_, database := newDayServiceIntegration(t)
+	repositories := db.NewRepositories(database)
+	symptomService := NewSymptomService(repositories.Symptoms)
+	user := createDayServiceTestUser(t, database, "import-nonexistent-day@example.com")
+
+	payload := importPayload{Entries: []ExportJSONEntry{
+		{Date: "2011-12-30", Period: true, Flow: models.FlowMedium, CycleFactors: []string{}},
+		{Date: "2011-12-28", Period: true, Flow: models.FlowMedium, CycleFactors: []string{}},
+	}}
+	raw, _ := json.Marshal(payload)
+
+	importService := newImportServiceIntegration(t, database, symptomService)
+	result, err := importService.ImportJSON(context.Background(), user.ID, raw, apia)
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if result.Added != 1 || result.Rejected != 1 {
+		t.Fatalf("expected 1 added / 1 rejected, got %+v", result)
+	}
+
+	var stored []models.DailyLog
+	if err := database.Where("user_id = ?", user.ID).Find(&stored).Error; err != nil {
+		t.Fatalf("load days: %v", err)
+	}
+	if len(stored) != 1 {
+		t.Fatalf("expected exactly one imported day, got %d", len(stored))
+	}
+	if key := CalendarDayKey(stored[0].Date); key != "2011-12-28" {
+		t.Fatalf("expected only 2011-12-28 imported, got %s — the rejected row landed on a day the file never named", key)
+	}
+}
+
 func TestImportServiceRejectsMalformedPayload(t *testing.T) {
 	importService := NewImportService(nil, nil, nil, nil)
 	if _, err := importService.ImportJSON(context.Background(), 1, []byte("{not json"), time.UTC); err != ErrImportMalformed {


### PR DESCRIPTION
## The defect

`ParseDayDate` is the single parse entry point for date input. For a date the
request zone never had, it returned the *previous* day and a `nil` error, so a
caller could not distinguish it from a successful parse.

A zone that crosses the date line skips a whole calendar day: Pacific/Apia went
from `2011-12-29 23:59:59 UTC-10` straight to `2011-12-31 00:00 UTC+14`, and
Pacific/Kiritimati did the same over `1994-12-31`. `ParseDayDate("2011-12-30",
Pacific/Apia)` answered `2011-12-29T00:00:00-10:00, <nil>`. The day save, the
onboarding anchor and an imported row therefore landed on a day the input never
named — the same silent one-day shift #496 removed everywhere else.

## Midnight vs. whole day

The two cases stay deliberately different, and this is the whole point of the
change:

- **Midnight missing → resolve forward.** In a UTC-minus zone whose DST jump
  lands on 00:00 (America/Santiago 2026-09-06, America/Havana 2026-03-08) the
  day exists; it simply begins at the transition. `startOfCalendarDay` returns
  that first existing instant and `ParseDayDate` still succeeds. Unchanged.
- **Whole day missing → refuse.** There is no instant to resolve to, so the
  value is invalid input. `ParseDayDate` now returns `ErrDayDateNonexistent`, a
  sibling of the existing `ErrDayDateRequired`.

`startOfCalendarDay` is untouched. It also serves `CalendarDay` and
`DateAtLocation`, which rebuild *stored* values and have no error channel, so it
keeps `time.Date`'s backward normalization — and that differing calendar date is
exactly the signal `ParseDayDate` reads to detect the case.

## Caller sweep

Every call site already had a treatment for a rejected date; the new sentinel
rides the same branch, so none needed a new code path and no new user-facing
string was introduced.

| Call site | Treatment |
| --- | --- |
| `internal/api/handlers_days_write.go:62` (day save) | `invalidDateErrorSpec()` → 400, `validation` category |
| `internal/api/handlers_days_write.go:154` (mark cycle start) | same, via `failMutation` |
| `internal/api/handlers_days_delete.go:22` (day delete) | same, via `failMutation` |
| `internal/api/handlers_days_read.go:34`, `:53` (day read, day-has-data) | same |
| `internal/api/handlers_calendar_day_panel.go:21` (day editor partial) | same |
| `internal/services/onboarding_service.go:61` (onboarding step 1 anchor) | `ErrOnboardingStartDateInvalid` → `onboarding.error.invalid_last_period_start` |
| `internal/services/settings_cycle_policy.go:66` (settings cycle start) | `ErrSettingsCycleStartDateInvalid` → `settings.error.invalid_last_period_start` |
| `internal/services/day_range_policy.go:15`, `:19` | `ErrDayRangeFromInvalid` / `ErrDayRangeToInvalid` → 400 per field |
| `internal/services/export_range_policy.go:21`, `:30` | `ErrExportFromDateInvalid` / `ErrExportToDateInvalid` → 400 per field |
| `internal/services/import_service.go:177` (restore) | row counted as rejected and skipped; the rest of the file imports |
| `internal/services/calendar_view_policy.go:90` (calendar `?day=`) | selection dropped, month falls back — as for any unparseable `day=` |
| `internal/services/settings_view_service.go:368`, `:381` (export-summary display) | raw ISO string / nil bound, display-only fallbacks |
| `internal/services/policy_fuzz_test.go`, `policy_fuzz_libfuzzer.go` | fuzz targets, `time.UTC` only — contract unchanged there |

The import behaviour is the convention the path already documents at
`internal/services/import_service.go:131-135` ("Malformed or duplicate day
records are counted as rejected and skipped without aborting the restore") and
which `TestImportServiceRejectsDuplicateDatesWithinFile` pins; no third
behaviour was invented.

## Guard

- `TestParseDayDateRefusesACalendarDayTheZoneNeverHad` — Pacific/Apia
  2011-12-30, Pacific/Kiritimati 1994-12-31.
- `TestParseDayDateResolvesADayWhoseMidnightIsSkipped` — America/Santiago
  2026-09-06 and America/Havana 2026-03-08 still parse to the day's first
  existing instant, with Asia/Beirut and UTC as controls.
- `TestUpsertDayRefusesACalendarDayTheRequestZoneNeverHad` — `PUT
  /api/v1/days/2011-12-30` under Pacific/Apia answers a mapped 400 validation
  refusal and writes no row.
- `TestImportServiceRejectsADateTheRequestZoneNeverHad` — the row is counted as
  rejected while its neighbour still imports.

Against the unfixed code the first and third fail:

```
--- FAIL: TestParseDayDateRefusesACalendarDayTheZoneNeverHad/Pacific/Apia_2011-12-30
    ParseDayDate(2011-12-30, Pacific/Apia) = 2011-12-29T00:00:00-10:00, <nil>; want ErrDayDateNonexistent
--- FAIL: TestUpsertDayRefusesACalendarDayTheRequestZoneNeverHad
    expected status 400 for a day Pacific/Apia never had, got 200
```

`TestCalendarDayKeepsStdlibResolutionForACalendarDayThatNeverExisted` (added by
#496) is kept: it pins `CalendarDay`, the stored-value half, which this change
does not alter. Its doc comment now states that the input boundary refuses the
same date, so the file cannot be read as endorsing the shift for user input.

## Rollback

Single-commit revert. This widens the contract of the single date-parse entry
point, so reverting restores the silent previous-day answer for a date the zone
never had; nothing else in the repository depends on the new sentinel.

## Validation

`gofmt` (no new offenders), `go build ./...`, `go vet`, `go test ./... -timeout
20m` — all green; `golangci-lint run` — 0 issues; `scripts/patchcov` — every
modified coverable line covered; `changelogd check` — OK. No locale catalogue
changed, so the parity and reachability guards are unaffected.
