### PR TITLE
fix: step calendar prediction ranges by calendar day

### DIFF
--- a/changelog.d/fix-calendar-range-stepping.md
+++ b/changelog.d/fix-calendar-range-stepping.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- **A shaded range on the calendar no longer loses a day in time zones whose
+  clock jump lands on midnight.** In zones west of UTC where daylight saving
+  starts at 00:00 (America/Santiago, America/Havana), the builders that paint a
+  predicted period, a fertile window or the pre-fertile band stepped through the
+  range by adding a day to an instant, and the missing midnight resolved
+  backward into the previous calendar day: the range painted that day twice and
+  dropped one of its own — the transition day itself, or the range's last day.
+  Ranges are now stepped and bounded by calendar day. The same change restores
+  the closing day of the projected and historical pre-fertile bands, which every
+  zone west of UTC lost in every month because the band's two ends were measured
+  from different midnights. UTC and zones east of it are unaffected.

--- a/internal/services/calendar_days.go
+++ b/internal/services/calendar_days.go
@@ -192,16 +192,53 @@ func appendCurrentBaselinePreFertile(preFertileMap map[string]bool, stats CycleS
 	appendCalendarDateRange(preFertileMap, preFertileStart, preFertileEnd)
 }
 
-func appendCalendarDateRange(target map[string]bool, start time.Time, end time.Time) {
+// forEachCalendarDay visits `count` consecutive calendar days starting on the
+// calendar date of `start`, ascending, each day exactly once. It is the single
+// stepping point for the builders that fill the prediction maps.
+//
+// The walk is calendar-day arithmetic, never instant arithmetic. Adding 24h-ish
+// increments to a location-midnight instant breaks in a zone whose DST jump
+// lands on midnight (America/Santiago 2026-09-06, America/Havana 2026-03-08):
+// the missing wall clock resolves BACKWARD into the previous calendar day, so
+// the step writes that day's key a second time and the range loses a day — the
+// transition day itself when the caller indexes by offset, the range's last day
+// when it walks to a bound. Re-anchoring to UTC midnight — the same move
+// CalendarDaysBetween makes on its operands — removes the transition from the
+// walk entirely. The visited days carry calendar components only; every caller
+// reads them through CalendarDayKey or CalendarDaysBetween, so the anchoring
+// zone is not observable.
+func forEachCalendarDay(start time.Time, count int, visit func(day time.Time)) {
+	if start.IsZero() || count <= 0 {
+		return
+	}
+	day := CalendarDay(start, time.UTC)
+	for range count {
+		visit(day)
+		day = day.AddDate(0, 0, 1)
+	}
+}
+
+// calendarRangeLength is the number of calendar days in the inclusive range
+// [start, end], or zero when the range is empty. The comparison is by calendar
+// day, not by instant: the two bounds routinely carry different midnight shapes
+// (a request-location midnight against the UTC midnight PredictCycleWindow
+// produces), and compared as instants in a UTC-minus zone the location-midnight
+// bound sits hours past the UTC-midnight one on the same date.
+func calendarRangeLength(start time.Time, end time.Time) int {
 	if start.IsZero() || end.IsZero() {
-		return
+		return 0
 	}
-	if end.Before(start) {
-		return
+	span := CalendarDaysBetween(start, end)
+	if span < 0 {
+		return 0
 	}
-	for day := start; !day.After(end); day = day.AddDate(0, 0, 1) {
-		target[day.Format("2006-01-02")] = true
-	}
+	return span + 1
+}
+
+func appendCalendarDateRange(target map[string]bool, start time.Time, end time.Time) {
+	forEachCalendarDay(start, calendarRangeLength(start, end), func(day time.Time) {
+		target[CalendarDayKey(day)] = true
+	})
 }
 
 func appendCalendarSingleDate(target map[string]bool, day time.Time) {
@@ -211,17 +248,14 @@ func appendCalendarSingleDate(target map[string]bool, day time.Time) {
 }
 
 func appendFertilityWindow(fertilityEdgeMap map[string]bool, fertilityPeakMap map[string]bool, start time.Time, end time.Time, ovulationDate time.Time) {
-	if start.IsZero() || end.IsZero() || end.Before(start) {
-		return
-	}
-	for day := start; !day.After(end); day = day.AddDate(0, 0, 1) {
+	forEachCalendarDay(start, calendarRangeLength(start, end), func(day time.Time) {
 		offset := CalendarDaysBetween(day, ovulationDate)
 		if offset >= 0 && offset <= 2 {
-			fertilityPeakMap[day.Format("2006-01-02")] = true
-			continue
+			fertilityPeakMap[CalendarDayKey(day)] = true
+			return
 		}
-		fertilityEdgeMap[day.Format("2006-01-02")] = true
-	}
+		fertilityEdgeMap[CalendarDayKey(day)] = true
+	})
 }
 
 func appendPredictedCycles(predictedPeriodMap map[string]bool, preFertileMap map[string]bool, fertilityEdgeMap map[string]bool, fertilityPeakMap map[string]bool, ovulationMap map[string]bool, stats CycleStats, gridEnd time.Time, location *time.Location) {
@@ -288,10 +322,9 @@ func appendHistoricalCycles(preFertileMap map[string]bool, fertilityEdgeMap map[
 }
 
 func appendPredictedPeriod(predictedPeriodMap map[string]bool, cycleStart time.Time, predictedPeriodLength int) {
-	for offset := range predictedPeriodLength {
-		day := cycleStart.AddDate(0, 0, offset)
-		predictedPeriodMap[day.Format("2006-01-02")] = true
-	}
+	forEachCalendarDay(cycleStart, predictedPeriodLength, func(day time.Time) {
+		predictedPeriodMap[CalendarDayKey(day)] = true
+	})
 }
 
 func appendPredictedWindow(preFertileMap map[string]bool, fertilityEdgeMap map[string]bool, fertilityPeakMap map[string]bool, ovulationMap map[string]bool, cycleStart time.Time, predictedCycleLength int, predictedPeriodLength int, lutealPhase int) {

--- a/internal/services/calendar_days_test.go
+++ b/internal/services/calendar_days_test.go
@@ -1,6 +1,8 @@
 package services
 
 import (
+	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -146,6 +148,213 @@ func TestBuildCalendarDayStatesPaintsAProjectedCycleOnTheLastGridDay(t *testing.
 	// The cycle before it, comfortably inside the grid, must stay painted too.
 	if middle := findCalendarDayStateByDateString(t, days, "2026-10-04"); !middle.IsPredicted {
 		t.Fatalf("expected the projected cycle starting on 2026-10-04 to be painted")
+	}
+}
+
+// expectedCalendarDayKeys lists the ISO keys of the inclusive calendar range
+// [first, last], computed in UTC — a zone with no transitions — so the
+// expectation never inherits the arithmetic it is meant to check.
+func expectedCalendarDayKeys(first time.Time, last time.Time) []string {
+	keys := make([]string, 0, 16)
+	end := dateOnly(last)
+	for day := dateOnly(first); !day.After(end); day = day.AddDate(0, 0, 1) {
+		keys = append(keys, day.Format("2006-01-02"))
+	}
+	return keys
+}
+
+// assertCalendarDayKeySet compares the marked keys as one ordered list, so a
+// dropped day, a repeated one collapsing into its neighbour and a day painted
+// past the range all surface in a single message. It reports rather than
+// aborts: each builder is an independent subject of the same case.
+func assertCalendarDayKeySet(t *testing.T, subject string, actual map[string]bool, expected []string) {
+	t.Helper()
+
+	got := strings.Join(sortedCalendarDayKeys(actual), " ")
+	want := strings.Join(expected, " ")
+	if got != want {
+		t.Errorf("%s: expected calendar days [%s], got [%s]", subject, want, got)
+	}
+}
+
+func sortedCalendarDayKeys(source map[string]bool) []string {
+	keys := make([]string, 0, len(source))
+	for key, marked := range source {
+		if marked {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// TestCalendarRangeBuildersCoverEveryCalendarDayOfTheirRange pins the three
+// builders that write the prediction maps — appendCalendarDateRange,
+// appendPredictedPeriod and appendFertilityWindow — against the shape mismatch
+// a midnight-skipping DST zone creates. Adding 24h-ish increments to an instant
+// and testing that instant against a bound is not calendar-day arithmetic: in
+// America/Santiago (2026-09-06) and America/Havana (2026-03-08) local midnight
+// does not exist, and AddDate resolves the missing wall clock BACKWARD into the
+// previous calendar day. The step then writes that day's key a second time and
+// the range loses a day — the transition day itself for an offset-indexed
+// builder, its own last day for one that walks to a bound.
+//
+// The maps are sets, so a repeat write collapses and the observable damage is
+// the missing day plus the day-count mismatch; the visit ORDER is pinned
+// separately on the shared iterator below.
+func TestCalendarRangeBuildersCoverEveryCalendarDayOfTheirRange(t *testing.T) {
+	testCases := []struct {
+		name  string
+		zone  string
+		first time.Time
+		last  time.Time
+	}{
+		{
+			name:  "santiago range spanning the skipped midnight",
+			zone:  "America/Santiago",
+			first: time.Date(2026, time.September, 3, 0, 0, 0, 0, time.UTC),
+			last:  time.Date(2026, time.September, 9, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:  "havana range spanning the skipped midnight",
+			zone:  "America/Havana",
+			first: time.Date(2026, time.March, 5, 0, 0, 0, 0, time.UTC),
+			last:  time.Date(2026, time.March, 11, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:  "santiago control month without a transition",
+			zone:  "America/Santiago",
+			first: time.Date(2026, time.November, 3, 0, 0, 0, 0, time.UTC),
+			last:  time.Date(2026, time.November, 9, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:  "utc control",
+			zone:  "UTC",
+			first: time.Date(2026, time.September, 3, 0, 0, 0, 0, time.UTC),
+			last:  time.Date(2026, time.September, 9, 0, 0, 0, 0, time.UTC),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			location, err := time.LoadLocation(testCase.zone)
+			if err != nil {
+				t.Fatalf("load %s: %v", testCase.zone, err)
+			}
+
+			start := CalendarDay(testCase.first, location)
+			end := CalendarDay(testCase.last, location)
+			expected := expectedCalendarDayKeys(testCase.first, testCase.last)
+
+			dateRange := make(map[string]bool)
+			appendCalendarDateRange(dateRange, start, end)
+			assertCalendarDayKeySet(t, "appendCalendarDateRange", dateRange, expected)
+
+			predictedPeriod := make(map[string]bool)
+			appendPredictedPeriod(predictedPeriod, start, len(expected))
+			assertCalendarDayKeySet(t, "appendPredictedPeriod", predictedPeriod, expected)
+
+			// The ovulation date sits on the last day of the window, so the
+			// closing three days are the peak and everything before them the edge.
+			fertilityEdge := make(map[string]bool)
+			fertilityPeak := make(map[string]bool)
+			appendFertilityWindow(fertilityEdge, fertilityPeak, start, end, end)
+
+			window := make(map[string]bool, len(fertilityEdge)+len(fertilityPeak))
+			for key := range fertilityEdge {
+				window[key] = true
+			}
+			for key := range fertilityPeak {
+				if window[key] {
+					t.Fatalf("appendFertilityWindow: %s marked as both edge and peak", key)
+				}
+				window[key] = true
+			}
+			assertCalendarDayKeySet(t, "appendFertilityWindow", window, expected)
+			assertCalendarDayKeySet(t, "appendFertilityWindow peak", fertilityPeak, expected[len(expected)-3:])
+		})
+	}
+}
+
+// TestCalendarDateRangeEndsOnItsLastDayWithMixedMidnightShapes covers the same
+// bound with operands built from different midnights: the projected and
+// historical pre-fertile bands start on a request-location midnight and end on
+// the UTC midnight PredictCycleWindow produces. Compared as instants in any
+// UTC-minus zone, the location-midnight step passes the UTC-midnight bound a
+// few hours early and the band loses its closing day in every month, not only
+// across a transition.
+func TestCalendarDateRangeEndsOnItsLastDayWithMixedMidnightShapes(t *testing.T) {
+	santiago, err := time.LoadLocation("America/Santiago")
+	if err != nil {
+		t.Fatalf("load America/Santiago: %v", err)
+	}
+
+	first := time.Date(2026, time.November, 17, 0, 0, 0, 0, time.UTC)
+	last := time.Date(2026, time.November, 19, 0, 0, 0, 0, time.UTC)
+
+	dateRange := make(map[string]bool)
+	appendCalendarDateRange(dateRange, CalendarDay(first, santiago), dateOnly(last))
+
+	assertCalendarDayKeySet(t, "appendCalendarDateRange", dateRange, expectedCalendarDayKeys(first, last))
+}
+
+// TestForEachCalendarDayVisitsEveryDayOnceInOrder pins the property the three
+// range builders share through their one stepping point: ascending, one visit
+// per calendar day, ending on the range's last day whatever the zone does to
+// the clock inside it. The span deliberately spans both hemispheres' 2026
+// transitions.
+func TestForEachCalendarDayVisitsEveryDayOnceInOrder(t *testing.T) {
+	for _, zone := range []string{"America/Santiago", "America/Havana", "UTC"} {
+		t.Run(zone, func(t *testing.T) {
+			location, err := time.LoadLocation(zone)
+			if err != nil {
+				t.Fatalf("load %s: %v", zone, err)
+			}
+
+			first := time.Date(2026, time.March, 4, 0, 0, 0, 0, time.UTC)
+			expected := expectedCalendarDayKeys(first, time.Date(2026, time.September, 10, 0, 0, 0, 0, time.UTC))
+
+			visited := make([]string, 0, len(expected))
+			forEachCalendarDay(CalendarDay(first, location), len(expected), func(day time.Time) {
+				visited = append(visited, CalendarDayKey(day))
+			})
+
+			if strings.Join(visited, " ") != strings.Join(expected, " ") {
+				t.Fatalf("expected visits [%s], got [%s]", strings.Join(expected, " "), strings.Join(visited, " "))
+			}
+		})
+	}
+}
+
+// TestBuildCalendarDayStatesShadesThePredictedPeriodDayThatSkipsMidnight is the
+// owner-visible half of the same defect: a predicted period running across
+// 2026-09-06 in America/Santiago left that day unshaded on the grid.
+func TestBuildCalendarDayStatesShadesThePredictedPeriodDayThatSkipsMidnight(t *testing.T) {
+	santiago, err := time.LoadLocation("America/Santiago")
+	if err != nil {
+		t.Fatalf("load America/Santiago: %v", err)
+	}
+
+	user := &models.User{WeekStartsOn: models.WeekStartMonday}
+	monthStart := time.Date(2026, time.September, 1, 0, 0, 0, 0, santiago)
+	now := time.Date(2026, time.September, 12, 15, 0, 0, 0, time.UTC)
+
+	stats := CycleStats{
+		MedianCycleLength:   28,
+		AveragePeriodLength: 5,
+		CurrentCycleDay:     10,
+		LastPeriodStart:     CalendarDay(time.Date(2026, time.September, 3, 0, 0, 0, 0, time.UTC), santiago),
+	}
+
+	days := BuildCalendarDayStates(user, monthStart, nil, stats, now, santiago)
+
+	for _, dateString := range []string{"2026-09-03", "2026-09-04", "2026-09-05", "2026-09-06", "2026-09-07"} {
+		if day := findCalendarDayStateByDateString(t, days, dateString); !day.IsPredicted {
+			t.Fatalf("expected predicted period day %s to be shaded, got %#v", dateString, day)
+		}
+	}
+	if day := findCalendarDayStateByDateString(t, days, "2026-09-08"); day.IsPredicted {
+		t.Fatalf("expected 2026-09-08 to sit past the predicted period, got %#v", day)
 	}
 }
 


### PR DESCRIPTION
## The defect

The three builders that fill the calendar's prediction maps walked a date range by adding a day to an **instant** and comparing that instant against a bound:

- `appendCalendarDateRange` — pre-fertile bands, predicted start window
- `appendFertilityWindow` — fertile edge and peak
- `appendPredictedPeriod` — projected bleeding days

That is not calendar-day arithmetic. In a zone whose DST jump lands on midnight (America/Santiago 2026-09-06, America/Havana 2026-03-08) local midnight does not exist, and `AddDate` resolves the missing wall clock **backward** into the previous calendar day. The step then writes that day's key a second time and the range loses a day: the transition day itself for the offset-indexed predicted period, the range's own last day for the two builders that walk to a bound.

Owner-visible: a predicted period, a fertile window or a pre-fertile band crossing such a date rendered one day short, with one day painted from the wrong key.

This is the **third instance of the class in this file**. Already fixed and merged: the projection loop's bound (#496, `bba057b`) and the calendar-day resolution behind it (`a6e36ff`); still open at the time of writing: the grid's own stepping and bounds (#498), whose code (`BuildCalendarDayStates`, `calendarGridBounds`) this branch deliberately does not touch.

## The fix

`internal/services/calendar_days.go`: one iterator, `forEachCalendarDay`, plus `calendarRangeLength` for the inclusive bound. Both work on calendar days only — the walk re-anchors to UTC midnight, the same move `CalendarDaysBetween` makes on its operands, so no transition can fall inside it, and keys are read out through `CalendarDayKey`. All three builders now route through it. No new convention: the existing instruments (`CalendarDay`, `CalendarDayKey`, `CalendarDaysBetween`) do the work, and which days a range covers is unchanged.

### A second case the instant comparison hid

The calendar-day bound also corrects a defect that was not DST-specific. The projected and historical pre-fertile bands take their **start** from a request-location midnight (`cycleStart.AddDate(...)`) and their **end** from the UTC midnight `PredictCycleWindow` produces. Compared as instants in any zone west of UTC, the location-midnight step passes the UTC-midnight bound a few hours early, so those bands lost their closing day **in every month**, transition or not. Measured on America/Santiago and America/Havana against the UTC baseline: before, `preFertile` held 2 days per band where UTC held 3; after, every zone paints exactly the days UTC does. This is the same instant-versus-calendar comparison, so no fix of the DST case can leave it in place.

## Caller sweep

Producers of the seven maps (`predictedPeriod`, `predictedStartRange`, `preFertile`, `fertilityEdge`, `fertilityPeak`, `ovulation`, `tentativeOvulation`), all in `calendar_days.go`:

| Producer | Route | Verdict |
| --- | --- | --- |
| `appendCurrentBaselinePeriod` | `appendPredictedPeriod` | fixed — transition day was dropped |
| `appendCurrentBaselinePreFertile` | `appendCalendarDateRange` | fixed — both bounds are location midnights, so only the DST case applied |
| `appendPredictedCycles` | `appendPredictedPeriod`, `appendPredictedWindow` | fixed |
| `appendPredictedWindow` | `appendCalendarDateRange`, `appendFertilityWindow` | fixed — pre-fertile band also regains its closing day (mixed midnights) |
| `appendHistoricalCycles` | `appendCalendarDateRange`, `appendFertilityWindow` | fixed — same mixed-midnight band |
| `appendPredictedStartRange` | `appendCalendarDateRange` | fixed; bounds come from `DashboardPredictionRange`, both through `CalendarDay(..., location)`, so only the DST case applied |
| `appendCalendarSingleDate`, `appendCurrentCycleBBTSignal` | single key via `CalendarDayKey` | untouched, no range |

Consumers: `buildCalendarDayState` reads every map by key into `CalendarDayState`; `BuildCalendarDayStates` has exactly one production caller (`CalendarViewService.BuildCalendarPageViewData`), and the states reach the template through `internal/api/calendar_days_view_helpers.go` (shading class + flags) and `internal/api/handler_types.go`. No other package reads the builders or the maps; the `.ics` feed and the webhook reminders read the projected dates from `CycleStats`, not from these maps, so they are outside the blast radius.

**Non-transition months:** unchanged for every map except the projected/historical pre-fertile band described above, whose closing day is restored in zones west of UTC. Zones at or east of UTC, including UTC itself, are byte-identical before and after — verified by dumping all seven maps for UTC, Europe/Moscow, America/Santiago (September and the transition-free November) and America/Havana before and after the change.

## Guard

`internal/services/calendar_days_test.go`:

- `TestCalendarRangeBuildersCoverEveryCalendarDayOfTheirRange` — the three builders directly, over Santiago 2026-09-06, Havana 2026-03-08, a transition-free Santiago control month and a UTC control. Expectations are computed in UTC, so they never inherit the arithmetic under test.
- `TestCalendarDateRangeEndsOnItsLastDayWithMixedMidnightShapes` — the mixed-midnight bound.
- `TestForEachCalendarDayVisitsEveryDayOnceInOrder` — ascending, once per day, ending on the last day, across both hemispheres' 2026 transitions.
- `TestBuildCalendarDayStatesShadesThePredictedPeriodDayThatSkipsMidnight` — the owner-visible half, end to end.

Zones load through `time.LoadLocation` with `t.Fatalf` on error, so a missing tzdata fails rather than skips. Run against the unfixed code, the guard fails and names each culprit, e.g.

```
appendCalendarDateRange: expected calendar days [2026-09-03 ... 2026-09-09], got [2026-09-03 ... 2026-09-08]
appendPredictedPeriod:   expected calendar days [... 2026-09-05 2026-09-06 2026-09-07 ...], got [... 2026-09-05 2026-09-07 ...]
appendFertilityWindow peak: expected calendar days [2026-09-07 2026-09-08 2026-09-09], got [2026-09-07 2026-09-08]
```

## Separate finding, not fixed here

The same class sits one level up, in the code that **computes** a boundary date rather than steps a range: a calendar date derived by `AddDate` on a location-midnight value silently moves back a day when it lands on a skipped midnight. Measured in America/Santiago: a cycle anchored on 2026-08-09 with a 28-day median projects `NextPeriodStart = 2026-09-05` instead of 2026-09-06 (`cycle_baseline.go:83`). The same shape appears at `dashboard_cycle.go:207-217` and `:227-228`, and for the boundary dates handed to the builders here (`calendar_days.go:179`, `:191`, `:274`, `:316`, `:336` after this change). That shifts *which* days a range covers on every surface fed by `CycleStats` — deliberately out of this branch's scope.

## Validation

- `gofmt -l` on both touched files — clean (three unrelated files under `internal/services/` carry pre-existing alignment drift and were left alone)
- `go build ./...` — OK
- `go test ./internal/services/...` — ok, 73 s
- `golangci-lint run ./internal/services/...` — 0 issues
- `go test ./internal/api/ -timeout 20m` — ok, 320 s
- `go run ./scripts/changelogd check` — OK; `scripts/patchcov` — every modified coverable line covered

## Rollback

Single commit; `git revert` restores the previous stepping with no schema, contract or migration involvement.
