### PR TITLE
fix: fire the reminder pass on a day whose midnight the zone skipped

### DIFF
--- a/changelog.d/fix-scheduler-next-run-advance.md
+++ b/changelog.d/fix-scheduler-next-run-advance.md
@@ -1,0 +1,14 @@
+### Fixed
+
+- **The reminder scheduler no longer spins through a full notify pass every few
+  milliseconds on a daylight-saving night.** With the daily run hour set to `0`
+  and a server timezone whose clock jump lands on midnight (America/Santiago,
+  America/Havana), the next scheduled run resolved to 23:00 of the *current*
+  day — an instant already in the past. The wait until it was negative, so the
+  pass fired immediately, re-listed every account and re-decided its reminders,
+  and then computed the same past instant again, repeating from local 23:00
+  until the transition roughly an hour later. Outbound webhook delivery was
+  attempted on each turn; the per-reminder already-sent watermark kept duplicate
+  notifications from going out, but not the work. The schedule now keeps
+  advancing whole calendar days until it reaches an instant that really lies
+  ahead. Every other timezone and run hour is unaffected.

--- a/changelog.d/fix-scheduler-next-run-advance.md
+++ b/changelog.d/fix-scheduler-next-run-advance.md
@@ -9,6 +9,8 @@
   and then computed the same past instant again, repeating from local 23:00
   until the transition roughly an hour later. Outbound webhook delivery was
   attempted on each turn; the per-reminder already-sent watermark kept duplicate
-  notifications from going out, but not the work. The schedule now keeps
-  advancing whole calendar days until it reaches an instant that really lies
-  ahead. Every other timezone and run hour is unaffected.
+  notifications from going out, but not the work. On such a date the daily pass
+  now runs at the first moment the date actually has — the transition itself,
+  the same resolution the rest of the app already uses for a calendar day with
+  no midnight — so that day's reminders are still delivered rather than skipped.
+  Every other timezone and run hour is unaffected.

--- a/internal/reminders/next_run.go
+++ b/internal/reminders/next_run.go
@@ -1,8 +1,10 @@
 package reminders
 
 import (
-	"github.com/ovumcy/ovumcy-web/internal/models"
 	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+	"github.com/ovumcy/ovumcy-web/internal/services"
 )
 
 // markerKey is the app_state key under which the "ran today" local date is
@@ -15,26 +17,25 @@ const markerKey = models.AppStateKeyLastReminderRunDate
 // (no clock, no I/O) so it is exhaustively table-testable — including the two DST
 // edges.
 //
-// Granularity is hour-only: the target is always the top of the given hour. The
-// candidate is built with time.Date in location for today; while that instant is
-// not strictly in the future (the hour already passed, is exactly now, or the
-// zone normalized it into the past), the candidate is rebuilt one calendar day
-// later.
+// Granularity is hour-only: the target is always the top of the given hour, on a
+// day that really has one (fireOnCalendarDay). The candidate is built for today;
+// while that instant is not strictly in the future — the hour already passed, is
+// exactly now, or the day itself does not exist in this zone — the candidate is
+// rebuilt one calendar day later. The loop terminates because a calendar day
+// carries the candidate forward by 24h minus an offset delta always smaller than
+// a day.
 //
-// DST correctness comes from rebuilding the candidate with time.Date on the
-// TARGET day rather than adding 24h to a previous fire:
+// DST correctness comes from rebuilding the candidate on the TARGET day rather
+// than adding 24h to a previous fire:
 //
-//   - Spring-forward (a local hour is skipped, e.g. 02:00→03:00): time.Date for
-//     the missing wall-clock hour resolves to a concrete real instant, but the
-//     DIRECTION is not guaranteed. It normalizes forward only in some zones;
-//     where the skipped hour is midnight (America/Santiago 2025-09-07,
-//     America/Havana 2026-03-08, both west of UTC) it normalizes BACKWARD, to
-//     23:00 of the previous local day. With hour 0 that lands before now, which
-//     is why the advance is a loop and not a single step: a candidate in the past
-//     would make the scheduler's delay negative and fire a full notify pass over
-//     every owner on every loop turn until the transition. The loop terminates
-//     because a calendar day carries the candidate forward by 24h minus an offset
-//     delta that is always smaller than a day.
+//   - Spring-forward (a local hour is skipped, e.g. 02:00→03:00): the wall clock
+//     the schedule asks for may not exist, and time.Date's normalization DIRECTION
+//     is not guaranteed. Where the skipped hour is midnight (America/Santiago
+//     2025-09-07, America/Havana 2026-03-08, both west of UTC) it normalizes
+//     BACKWARD, to 23:00 of the PREVIOUS local day. Left alone with hour 0, that
+//     candidate sits before now: the scheduler's delay goes negative, the timer
+//     fires at once, and a full notify pass over every owner repeats until the
+//     transition. fireOnCalendarDay keeps the pass on its intended day instead.
 //   - Fall-back (a local hour repeats, e.g. 02:00 occurs twice): time.Date
 //     resolves the target to one concrete instant; the pass fires once for that
 //     local date. The once-per-local-day marker guarantees the repeated wall-
@@ -48,12 +49,39 @@ func nextRun(now time.Time, hour int, location *time.Location) time.Time {
 	if location == nil {
 		location = time.UTC
 	}
-	local := now.In(location)
+	day := now.In(location)
 
-	candidate := time.Date(local.Year(), local.Month(), local.Day(), hour, 0, 0, 0, location)
+	candidate := fireOnCalendarDay(day, hour, location)
 	for !candidate.After(now) {
-		local = local.AddDate(0, 0, 1)
-		candidate = time.Date(local.Year(), local.Month(), local.Day(), hour, 0, 0, 0, location)
+		day = day.AddDate(0, 0, 1)
+		candidate = fireOnCalendarDay(day, hour, location)
 	}
 	return candidate
+}
+
+// fireOnCalendarDay returns the instant on day's calendar date whose local clock
+// reads hour:00:00 — or, when that wall clock does not exist because a DST jump
+// swallowed it and time.Date normalized the result off the requested date, the
+// first instant that date really has.
+//
+// Skipping such a date instead would drop a whole day of reminders for every
+// owner, and nothing downstream compensates: a reminder due only on that day is
+// decided against a lead-day window, and the already-sent watermark cannot help
+// when no pass ran at all. Resolving to the day's first existing instant is the
+// convention the rest of the tree already follows for a day with no midnight, so
+// this defers to services.StartOfCalendarDay rather than re-deriving the rule —
+// a second implementation of it is how this class of defect returns.
+//
+// Only hour 0 can reach that branch in practice (a later wall clock exists on
+// every day these zones have), and a date that has no instant at all — a zone
+// that skips a whole calendar day, e.g. Pacific/Apia 2011-12-30 — falls through
+// with time.Date's own answer, which the caller's loop then steps past.
+func fireOnCalendarDay(day time.Time, hour int, location *time.Location) time.Time {
+	year, month, date := day.Date()
+
+	candidate := time.Date(year, month, date, hour, 0, 0, 0, location)
+	if y, m, d := candidate.Date(); y == year && m == month && d == date {
+		return candidate
+	}
+	return services.StartOfCalendarDay(year, month, date, location)
 }

--- a/internal/reminders/next_run.go
+++ b/internal/reminders/next_run.go
@@ -16,17 +16,25 @@ const markerKey = models.AppStateKeyLastReminderRunDate
 // edges.
 //
 // Granularity is hour-only: the target is always the top of the given hour. The
-// candidate is built with time.Date in location for today; if that instant is
-// not strictly in the future (the hour already passed, or is exactly now), the
-// candidate for the next calendar day is used.
+// candidate is built with time.Date in location for today; while that instant is
+// not strictly in the future (the hour already passed, is exactly now, or the
+// zone normalized it into the past), the candidate is rebuilt one calendar day
+// later.
 //
 // DST correctness comes from rebuilding the candidate with time.Date on the
 // TARGET day rather than adding 24h to a previous fire:
 //
 //   - Spring-forward (a local hour is skipped, e.g. 02:00→03:00): time.Date for
-//     the missing wall-clock hour normalizes forward to the equivalent real
-//     instant, so the pass still fires that day near the intended time and the
-//     schedule does not stall.
+//     the missing wall-clock hour resolves to a concrete real instant, but the
+//     DIRECTION is not guaranteed. It normalizes forward only in some zones;
+//     where the skipped hour is midnight (America/Santiago 2025-09-07,
+//     America/Havana 2026-03-08, both west of UTC) it normalizes BACKWARD, to
+//     23:00 of the previous local day. With hour 0 that lands before now, which
+//     is why the advance is a loop and not a single step: a candidate in the past
+//     would make the scheduler's delay negative and fire a full notify pass over
+//     every owner on every loop turn until the transition. The loop terminates
+//     because a calendar day carries the candidate forward by 24h minus an offset
+//     delta that is always smaller than a day.
 //   - Fall-back (a local hour repeats, e.g. 02:00 occurs twice): time.Date
 //     resolves the target to one concrete instant; the pass fires once for that
 //     local date. The once-per-local-day marker guarantees the repeated wall-
@@ -43,9 +51,9 @@ func nextRun(now time.Time, hour int, location *time.Location) time.Time {
 	local := now.In(location)
 
 	candidate := time.Date(local.Year(), local.Month(), local.Day(), hour, 0, 0, 0, location)
-	if !candidate.After(now) {
-		tomorrow := local.AddDate(0, 0, 1)
-		candidate = time.Date(tomorrow.Year(), tomorrow.Month(), tomorrow.Day(), hour, 0, 0, 0, location)
+	for !candidate.After(now) {
+		local = local.AddDate(0, 0, 1)
+		candidate = time.Date(local.Year(), local.Month(), local.Day(), hour, 0, 0, 0, location)
 	}
 	return candidate
 }

--- a/internal/reminders/next_run_test.go
+++ b/internal/reminders/next_run_test.go
@@ -73,6 +73,66 @@ func TestNextRunHourZeroAccepted(t *testing.T) {
 	}
 }
 
+// TestNextRunHourZeroAcrossMissingMidnight is the regression for the hot loop a
+// single-day advance produced. In a zone whose spring-forward transition lands on
+// MIDNIGHT, tomorrow's 00:00 does not exist and time.Date normalizes it BACKWARD
+// — to 23:00 of the current day, i.e. before now. A single advance returned that
+// past instant, untilNextRun went negative, the timer fired immediately and the
+// loop recomputed the same negative delay: a full notify pass over every owner,
+// repeated from local 23:00 until the transition.
+//
+// The zones are west of UTC on purpose: only there does Go normalize a missing
+// midnight backward. East-of-UTC zones normalize forward and would prove nothing.
+// Verified against this host's tzdata:
+// time.Date(2025,9,7,0,0,0,0,Santiago) -> 2025-09-06T23:00:00-04:00 and
+// time.Date(2026,3,8,0,0,0,0,Havana)   -> 2026-03-07T23:00:00-05:00.
+func TestNextRunHourZeroAcrossMissingMidnight(t *testing.T) {
+	cases := []struct {
+		name string
+		zone string
+		// now is expressed as local wall-clock fields on the day BEFORE the
+		// transition, shortly before the midnight that does not exist.
+		year  int
+		month time.Month
+		day   int
+		hour  int
+		min   int
+	}{
+		{name: "America/Santiago 2025-09-07", zone: "America/Santiago", year: 2025, month: 9, day: 6, hour: 23, min: 30},
+		{name: "America/Havana 2026-03-08", zone: "America/Havana", year: 2026, month: 3, day: 7, hour: 23, min: 30},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			loc := mustLoadLocation(t, tc.zone)
+			now := time.Date(tc.year, tc.month, tc.day, tc.hour, tc.min, 0, 0, loc)
+
+			// Guard the premise: the next calendar day's midnight really is missing
+			// in this zone, and time.Date resolves it to an instant at or before now.
+			missing := time.Date(tc.year, tc.month, tc.day+1, 0, 0, 0, 0, loc)
+			if missing.After(now) {
+				t.Fatalf("premise broken: local midnight of the transition day resolved to %s, which is after now %s (tzdata may have changed)", missing.Format(time.RFC3339), now.Format(time.RFC3339))
+			}
+
+			got := nextRun(now, 0, loc)
+			if !got.After(now) {
+				t.Fatalf("nextRun must return an instant strictly after now: got %s, now %s", got.Format(time.RFC3339), now.Format(time.RFC3339))
+			}
+			// It must also read as midnight locally: the schedule keeps its hour.
+			if h, m, s := got.In(loc).Clock(); h != 0 || m != 0 || s != 0 {
+				t.Fatalf("expected the fire to stay at local 00:00:00, got %s", got.In(loc).Format(time.RFC3339))
+			}
+
+			// Scheduler seam, no real clock involved: the armed delay must be
+			// positive, which is what stops the timer from firing in a tight loop.
+			scheduler := New(nil, nil, Config{Hour: 0, Location: loc})
+			if delay := scheduler.untilNextRun(now); delay <= 0 {
+				t.Fatalf("untilNextRun must arm a positive delay, got %s (next %s, now %s)", delay, got.Format(time.RFC3339), now.Format(time.RFC3339))
+			}
+		})
+	}
+}
+
 // TestNextRunNilLocationDefaultsUTC covers the defensive nil-location branch.
 func TestNextRunNilLocationDefaultsUTC(t *testing.T) {
 	now := time.Date(2026, 3, 10, 6, 0, 0, 0, time.UTC)

--- a/internal/reminders/next_run_test.go
+++ b/internal/reminders/next_run_test.go
@@ -81,11 +81,18 @@ func TestNextRunHourZeroAccepted(t *testing.T) {
 // loop recomputed the same negative delay: a full notify pass over every owner,
 // repeated from local 23:00 until the transition.
 //
+// Advancing past such a day is not the answer either: that skips the day's pass
+// for every owner, and a reminder due only on that day is then never delivered
+// (nothing ran, so no watermark can compensate). The day resolves to its FIRST
+// EXISTING INSTANT — the transition — which is the convention the rest of the
+// tree already follows through services.StartOfCalendarDay.
+//
 // The zones are west of UTC on purpose: only there does Go normalize a missing
 // midnight backward. East-of-UTC zones normalize forward and would prove nothing.
 // Verified against this host's tzdata:
-// time.Date(2025,9,7,0,0,0,0,Santiago) -> 2025-09-06T23:00:00-04:00 and
-// time.Date(2026,3,8,0,0,0,0,Havana)   -> 2026-03-07T23:00:00-05:00.
+// time.Date(2025,9,7,0,0,0,0,Santiago) -> 2025-09-06T23:00:00-04:00, whose day
+// really begins at 2025-09-07T01:00:00-03:00; time.Date(2026,3,8,0,0,0,0,Havana)
+// -> 2026-03-07T23:00:00-05:00, day begins 2026-03-08T01:00:00-04:00.
 func TestNextRunHourZeroAcrossMissingMidnight(t *testing.T) {
 	cases := []struct {
 		name string
@@ -97,9 +104,11 @@ func TestNextRunHourZeroAcrossMissingMidnight(t *testing.T) {
 		day   int
 		hour  int
 		min   int
+		// want is the first instant the transition day really has, in RFC3339.
+		want string
 	}{
-		{name: "America/Santiago 2025-09-07", zone: "America/Santiago", year: 2025, month: 9, day: 6, hour: 23, min: 30},
-		{name: "America/Havana 2026-03-08", zone: "America/Havana", year: 2026, month: 3, day: 7, hour: 23, min: 30},
+		{name: "America/Santiago 2025-09-07", zone: "America/Santiago", year: 2025, month: 9, day: 6, hour: 23, min: 30, want: "2025-09-07T01:00:00-03:00"},
+		{name: "America/Havana 2026-03-08", zone: "America/Havana", year: 2026, month: 3, day: 7, hour: 23, min: 30, want: "2026-03-08T01:00:00-04:00"},
 	}
 
 	for _, tc := range cases {
@@ -118,9 +127,17 @@ func TestNextRunHourZeroAcrossMissingMidnight(t *testing.T) {
 			if !got.After(now) {
 				t.Fatalf("nextRun must return an instant strictly after now: got %s, now %s", got.Format(time.RFC3339), now.Format(time.RFC3339))
 			}
-			// It must also read as midnight locally: the schedule keeps its hour.
-			if h, m, s := got.In(loc).Clock(); h != 0 || m != 0 || s != 0 {
-				t.Fatalf("expected the fire to stay at local 00:00:00, got %s", got.In(loc).Format(time.RFC3339))
+			// The pass must still happen ON the transition day: skipping it drops a
+			// day of reminders for every owner.
+			if y, m, d := got.In(loc).Date(); y != tc.year || m != tc.month || d != tc.day+1 {
+				t.Fatalf("expected the fire to land on the transition day %d-%02d-%02d, got %s", tc.year, tc.month, tc.day+1, got.In(loc).Format(time.RFC3339))
+			}
+			want, err := time.Parse(time.RFC3339, tc.want)
+			if err != nil {
+				t.Fatalf("bad want literal %q: %v", tc.want, err)
+			}
+			if !got.Equal(want) {
+				t.Fatalf("expected the transition day's first existing instant %s, got %s", want.Format(time.RFC3339), got.In(loc).Format(time.RFC3339))
 			}
 
 			// Scheduler seam, no real clock involved: the armed delay must be

--- a/internal/services/date_parse_policy.go
+++ b/internal/services/date_parse_policy.go
@@ -49,13 +49,13 @@ func ParseDayDate(raw string, location *time.Location) (time.Time, error) {
 
 	year, month, day := parsed.Date()
 
-	// startOfCalendarDay returns the first instant that exists on the requested
+	// StartOfCalendarDay returns the first instant that exists on the requested
 	// day whenever one does, so a resolved value carrying a DIFFERENT calendar
 	// date is the signal that the zone skipped the whole day: it is time.Date's
 	// backward normalization into the previous day, kept there for the stored-
 	// value helpers that have no error channel. Reading it as a parsed date is
 	// the silent one-day shift, so the input boundary refuses it here instead.
-	resolved := startOfCalendarDay(year, month, day, location)
+	resolved := StartOfCalendarDay(year, month, day, location)
 	if resolvedYear, resolvedMonth, resolvedDay := resolved.Date(); resolvedYear != year || resolvedMonth != month || resolvedDay != day {
 		return time.Time{}, ErrDayDateNonexistent
 	}

--- a/internal/services/day_utils.go
+++ b/internal/services/day_utils.go
@@ -10,7 +10,7 @@ import (
 
 // DateAtLocation projects an instant-in-time `value` onto the calendar of
 // `location` and returns the start of that calendar day — midnight, or the
-// day's first existing instant when a DST jump skips it (startOfCalendarDay).
+// day's first existing instant when a DST jump skips it (StartOfCalendarDay).
 // Use this for time.Time values that represent a real instant (time.Now(),
 // user.CreatedAt) where the in-location calendar day is what you want.
 //
@@ -25,13 +25,19 @@ func DateAtLocation(value time.Time, location *time.Location) time.Time {
 	}
 	localized := value.In(location)
 	year, month, day := localized.Date()
-	return startOfCalendarDay(year, month, day, location)
+	return StartOfCalendarDay(year, month, day, location)
 }
 
-// startOfCalendarDay returns the first instant that actually exists on the
+// StartOfCalendarDay returns the first instant that actually exists on the
 // given calendar day in `location`. It is the one construction point for
 // every "midnight of this calendar day" value in the package, so the
-// YYYY-MM-DD key a helper is handed always round-trips.
+// YYYY-MM-DD key a helper is handed always round-trips. It is exported for
+// the same reason it exists: the reminder scheduler resolves the day of its
+// daily pass the same way, and a second implementation of this rule is how
+// the class of defects it fixes comes back.
+//
+// `location` must not be nil — every caller resolves that first (the wrappers
+// below and reminders.nextRun default it to UTC).
 //
 // Plain time.Date cannot be used directly: in a UTC-minus zone whose DST jump
 // lands exactly on midnight (America/Santiago, America/Havana), local midnight
@@ -42,7 +48,7 @@ func DateAtLocation(value time.Time, location *time.Location) time.Time {
 // day, so they were never affected and are left byte-for-byte alone here, as
 // are zones without transitions (UTC included): the fallback below only fires
 // when the requested day did not survive the construction.
-func startOfCalendarDay(year int, month time.Month, day int, location *time.Location) time.Time {
+func StartOfCalendarDay(year int, month time.Month, day int, location *time.Location) time.Time {
 	candidate := time.Date(year, month, day, 0, 0, 0, 0, location)
 	if y, m, d := candidate.Date(); y == year && m == month && d == day {
 		return candidate
@@ -66,7 +72,7 @@ func startOfCalendarDay(year int, month time.Month, day int, location *time.Loca
 }
 
 // CalendarDay rebuilds a date-only stored value at the start of its calendar
-// day in `location` (startOfCalendarDay), preserving the calendar components
+// day in `location` (StartOfCalendarDay), preserving the calendar components
 // of `value` exactly as stored. Use this for time.Time values whose semantics
 // is "a calendar date" rather than "an instant in time" — DailyLog.Date,
 // User.LastPeriodStart, derived stats fields. Unlike DateAtLocation, this
@@ -81,7 +87,7 @@ func CalendarDay(value time.Time, location *time.Location) time.Time {
 		return time.Time{}
 	}
 	year, month, day := value.Date()
-	return startOfCalendarDay(year, month, day, location)
+	return StartOfCalendarDay(year, month, day, location)
 }
 
 // CalendarDayKey returns the YYYY-MM-DD ISO string for a date-only stored


### PR DESCRIPTION
## The defect

`nextRun` (`internal/reminders/next_run.go`) builds the next scheduled pass with
`time.Date(y, m, d, hour, 0, 0, 0, location)` on the target calendar day and, when today's
candidate had already passed, advanced exactly **once** to the next day. The doc comment justified
that with a claim about Go's normalization of a missing wall-clock hour — that it "normalizes
forward … so the pass still fires that day".

That claim is false for zones west of UTC whose spring-forward transition lands on **midnight**.
There the absent local `00:00` normalizes **backward**, to 23:00 of the previous local day
(verified against this host's tzdata: `time.Date(2025,9,7,0,0,0,0, America/Santiago)` →
`2025-09-06T23:00:00-04:00`; `time.Date(2026,3,8,0,0,0,0, America/Havana)` →
`2026-03-07T23:00:00-05:00`).

`REMINDER_SCHEDULER_HOUR=0` is an accepted value. Combined with such a zone, the single advance
returned an instant **before** `now`, and nothing re-checked it.

## The hot loop and its blast radius

`untilNextRun` (`internal/reminders/scheduler.go:238`) subtracts `now` from that past instant and
returns a negative duration. `time.NewTimer` with a non-positive duration fires immediately,
`runScheduledPass` runs a full `RunOnce` notify pass, and the loop (`scheduler.go:144-159`)
recomputes the same negative delay. The once-per-local-day marker is consulted only by the
start-up catch-up (`scheduler.go:176`), never inside that loop, so nothing damps it.

Effect on an affected instance: from local 23:00 until the transition — roughly an hour — the
scheduler re-lists every owner and re-decides every owner's reminders thousands of times, and
attempts outbound webhook delivery on each turn. The per-reminder already-sent watermark is what
kept duplicate notifications from actually going out; it never stopped the passes, the database
work, or the outbound attempts.

## The fix

Two properties, not one:

1. **The next run is strictly after `now`.** The advance is a loop over whole calendar days rather
   than a single step, so a candidate the zone pushed into the past can never be returned. It
   terminates because a calendar day carries the candidate forward by 24h minus an offset delta
   always smaller than a day.
2. **The pass still happens on the day it was scheduled for.** Simply advancing past a day whose
   midnight does not exist trades the hot loop for a quieter defect: a whole day of reminders
   skipped for every owner. A reminder is decided against a lead-day window, so one due only on
   that date is never delivered at all, and the already-sent watermark cannot compensate for a
   pass that never ran. `fireOnCalendarDay` builds the wall clock for the intended day and, when
   `time.Date` normalizes it off that date, resolves to the first instant the date really has —
   the transition. Only a date with no instant at all (a zone that skips a whole calendar day,
   e.g. Pacific/Apia 2011-12-30) still advances.

Hour > 0 is unaffected: those wall clocks exist on the days these zones have, so the resolution
branch is unreachable for them.

The duration is deliberately **not** clamped in `untilNextRun`: a clamp would turn a hot loop into
a fast loop and leave the wrong next-run time in place.

The doc comment that asserted the forward-normalization behaviour is corrected in the same change —
it is what made the defect read as handled.

## Why the services helper is reused rather than reimplemented

`startOfCalendarDay` (`internal/services/day_utils.go`, #496) already answers "what is the first
instant of this calendar day when its midnight does not exist", and `DateAtLocation`,
`CalendarDay` and `ParseDayDate` all route through it. Two shapes were available:

- **Reuse it, exported** — taken. The helper is renamed to `StartOfCalendarDay` and called from
  `fireOnCalendarDay`. `internal/reminders` already imports `internal/services` (its `PassRunner`
  returns `services.NotifyReport`), so no dependency edge is added and no layering is inverted: the
  scheduler is a trigger above the service layer, and this is a service-layer calendar rule. The
  API widens by exactly one identifier whose signature — `(year, month, day, location)` — is the
  primitive the two exported neighbours in that file already take their answer from, and the rename
  keeps **one** name for one rule. Three internal call sites move; nothing else changes.
- **A local copy in `next_run.go`** — rejected. It would put a second implementation of a
  transition-day rule in the tree, and this whole class of defect exists because the rule was
  derived in more than one place. A copy is also the version that rots silently: the services
  helper's `ZoneBounds` fallback could gain a case and the scheduler's copy would not.

An additive exported wrapper delegating to a private twin was considered and dropped as the more
awkward widening: same API surface, two names for one rule.

`StartOfCalendarDay` documents that `location` must not be nil, which is what its existing callers
(and `nextRun`, which defaults it to UTC first) already guarantee. No nil-branch was added, so no
behaviour changed for any current caller.

## The guard

`TestNextRunHourZeroAcrossMissingMidnight` drives hour 0 in America/Santiago (2025-09-07) and
America/Havana (2026-03-08) from 23:30 local on the day before, and asserts four things: the
returned instant is strictly after `now`; it lands on the **intended** calendar day; it equals that
day's first existing instant (`2025-09-07T01:00:00-03:00` and `2026-03-08T01:00:00-04:00`, read
from `ZoneBounds` on this host's tzdata and pinned as literals rather than recomputed by the
implementation); and — at the scheduler seam, no real clock, since `untilNextRun` takes `now` as an
argument — that the armed delay is positive. It also checks its own premise first, that the
transition day's local midnight really does resolve at or before `now`, so a tzdata change turns it
into an explicit failure rather than a silent vacuous pass. The zones are west of UTC on purpose:
east-of-UTC zones normalize a missing midnight forward and would prove nothing.

No existing test covered this. `TestNextRunHourZeroAccepted` ran in `time.UTC`, and the DST tests
use America/New_York with hours 2, 1 and 9 — New York transitions at 02:00, never at midnight. All
of them, plus the non-DST rollover table, keep their current answers.

Failure of the guard against each defect it pins:

```
# against the single-step advance (hot loop)
--- FAIL: TestNextRunHourZeroAcrossMissingMidnight/America/Santiago_2025-09-07
    next_run_test.go:119: nextRun must return an instant strictly after now: got 2025-09-06T23:00:00-04:00, now 2025-09-06T23:30:00-04:00
--- FAIL: TestNextRunHourZeroAcrossMissingMidnight/America/Havana_2026-03-08
    next_run_test.go:119: nextRun must return an instant strictly after now: got 2026-03-07T23:00:00-05:00, now 2026-03-07T23:30:00-05:00

# against the loop that advanced past the day instead of resolving it
--- FAIL: TestNextRunHourZeroAcrossMissingMidnight/America/Santiago_2025-09-07
    next_run_test.go:133: expected the fire to land on the transition day 2025-09-07, got 2025-09-08T00:00:00-03:00
--- FAIL: TestNextRunHourZeroAcrossMissingMidnight/America/Havana_2026-03-08
    next_run_test.go:133: expected the fire to land on the transition day 2026-03-08, got 2026-03-09T00:00:00-04:00
```

## Rollback

Revert both commits. The change is confined to one pure function's day resolution, one helper
rename inside `internal/services`, the test file and a changelog fragment: no schema, no
configuration, no persisted state, no wire format, no route. Reverting restores the previous
schedule math exactly, along with the defect.

## Validation

- `gofmt -l internal/` — none of the touched files listed (five unrelated files deviate on `main`
  already and are untouched here)
- `go build ./...` — clean
- `go test ./internal/reminders/...` — ok
- `go test ./... -timeout 20m` — all packages ok, run once per commit
- `golangci-lint run` — 0 issues
- `go run ./scripts/patchcov` after committing, profile regenerated in the same invocation across
  `internal/reminders` and `internal/services` — every modified coverable line covered
- `go test -race` could not run on the development host: no C toolchain (`cgo: C compiler "gcc" not
  found`), so `-race` is left to CI's race shard.
