### PR TITLE
docs: record why the settings draft shell never flushes on unload

### DIFF
--- a/changelog.d/fix-settings-unsaved-edit-on-unload.md
+++ b/changelog.d/fix-settings-unsaved-edit-on-unload.md
@@ -1,0 +1,13 @@
+none
+
+No user-visible change: the settings unsaved-leave guard keeps prompting and
+keeps sending nothing, and the reason it does not flush the way the dashboard
+journal does is now written down beside it. The settings cards are an explicit
+Save/Discard surface whose prompt asks whether to discard, so a flush would
+persist exactly what the owner chose to throw away — and would put a
+configuration the cycle guidance never validated in front of the prediction
+surfaces. A new unit test (`settings-unsaved-leave.test.mjs`) pins that no
+request leaves through `fetch`, `sendBeacon`, `XMLHttpRequest` or a native form
+submit while the page unwinds, and that no destructive or credential-bearing
+form (password change, data wipe, account deletion, webhook URL, calendar feed)
+is part of the dirty-tracked draft shell.

--- a/web/src/js/__tests__/settings-unsaved-leave.test.mjs
+++ b/web/src/js/__tests__/settings-unsaved-leave.test.mjs
@@ -1,0 +1,363 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { loadDOMWithScript, readAppBundle } from "./_helpers.mjs";
+
+const APP_BUNDLE = readAppBundle();
+
+// The settings page keeps an explicit Save/Discard shell: the save button is
+// disabled until a control differs from what the server rendered, and leaving
+// with an edit outstanding raises the unsaved-leave prompt. That prompt is a
+// question whose "yes" means discard, so the unload path must stay silent — no
+// request of any kind may leave the page while it is unwinding. This file pins
+// that, so a later change cannot quietly turn the settings shell into an
+// autosave surface the way the dashboard journal legitimately is.
+//
+// The three draft cards are the whole guarded set. Everything else on the page
+// — password change, data wipe, account deletion, the webhook URL, the calendar
+// feed — is rendered here too, precisely so the assertions below cover a page
+// where those forms are present and edited.
+function settingsPage() {
+  return `<!doctype html>
+<html lang="en"><head><meta name="csrf-token" content="test-token"></head>
+<body>
+  <div data-settings-sections>
+    <details id="settings-cycle" data-settings-cycle-form data-settings-section open>
+      <form
+        action="/api/v1/users/current/cycle"
+        method="post"
+        hx-patch="/api/v1/users/current/cycle"
+        data-settings-draft-form="cycle"
+        data-settings-unsaved-prompt="Leave without saving?"
+        data-settings-unsaved-accept="Discard">
+        <input type="hidden" name="csrf_token" value="test-token">
+        <input id="settings-cycle-length" type="range" min="15" max="90" name="cycle_length" value="28" data-settings-cycle-length>
+        <span data-settings-cycle-length-value>28</span>
+        <input id="settings-period-length" type="range" min="1" max="14" name="period_length" value="5" data-settings-period-length>
+        <span data-settings-period-length-value>5</span>
+        <label data-binary-toggle data-active="false">
+          <input type="checkbox" name="unpredictable_cycle" value="true" data-binary-toggle-input>
+        </label>
+        <p data-settings-cycle-message="error" hidden></p>
+        <p data-settings-cycle-message="warning" hidden></p>
+        <p data-settings-cycle-message="adjusted" hidden></p>
+        <p data-settings-cycle-message="period-long" hidden></p>
+        <p data-settings-cycle-message="cycle-short" hidden></p>
+        <button type="submit" data-settings-cycle-save>Save</button>
+        <button type="button" data-settings-cycle-discard>Discard</button>
+      </form>
+    </details>
+
+    <details id="settings-tracking" data-settings-section open>
+      <form
+        action="/api/v1/users/current/tracking"
+        method="post"
+        hx-patch="/api/v1/users/current/tracking"
+        data-settings-draft-form="tracking"
+        data-settings-unsaved-prompt="Leave without saving?"
+        data-settings-unsaved-accept="Discard">
+        <input type="hidden" name="csrf_token" value="test-token">
+        <label data-binary-toggle data-active="false" data-tracking-setting="track-bbt">
+          <input type="checkbox" name="track_bbt" value="true" data-binary-toggle-input>
+        </label>
+        <button type="submit" data-settings-tracking-save>Save</button>
+        <button type="button" data-settings-tracking-discard>Discard</button>
+      </form>
+    </details>
+
+    <details id="settings-interface" data-settings-section open>
+      <form
+        action="/api/v1/users/current/interface"
+        method="post"
+        hx-patch="/api/v1/users/current/interface"
+        data-settings-draft-form="interface"
+        data-settings-interface-form
+        data-settings-unsaved-prompt="Leave without saving?"
+        data-settings-unsaved-accept="Discard">
+        <input type="hidden" name="csrf_token" value="test-token">
+        <label data-settings-interface-language-option="en" data-selected="true">
+          <input type="radio" name="language" value="en" checked>
+        </label>
+        <label data-settings-interface-language-option="ru" data-selected="false">
+          <input type="radio" name="language" value="ru">
+        </label>
+        <label data-settings-interface-theme-option="light" data-selected="true">
+          <input type="radio" name="theme" value="light" checked>
+        </label>
+        <label data-settings-interface-theme-option="dark" data-selected="false">
+          <input type="radio" name="theme" value="dark">
+        </label>
+        <button type="submit" data-settings-interface-save>Save</button>
+        <button type="button" data-settings-interface-discard>Discard</button>
+      </form>
+    </details>
+
+    <details id="settings-account" data-settings-section open>
+      <form id="settings-change-password-form" action="/api/v1/users/current/password" method="post" hx-put="/api/v1/users/current/password" novalidate>
+        <input type="hidden" name="csrf_token" value="test-token">
+        <input type="password" id="settings-current-password" name="current_password" autocomplete="current-password">
+        <input type="password" id="settings-new-password" name="new_password" autocomplete="new-password">
+        <button type="submit">Change password</button>
+      </form>
+    </details>
+
+    <details id="settings-webhook" data-settings-section open>
+      <form action="/api/v1/users/current/webhook" method="post" hx-post="/api/v1/users/current/webhook" data-settings-webhook-form>
+        <input type="hidden" name="csrf_token" value="test-token">
+        <input type="url" id="settings-webhook-url" name="webhook_url" value="">
+        <button type="submit">Save webhook</button>
+      </form>
+    </details>
+
+    <details id="settings-calendar-feed" data-settings-section open>
+      <form hx-post="/api/v1/users/current/calendar-feed">
+        <input type="hidden" name="csrf_token" value="test-token">
+        <button type="submit">Enable feed</button>
+      </form>
+      <form hx-delete="/api/v1/users/current/calendar-feed" hx-confirm="Revoke?">
+        <input type="hidden" name="csrf_token" value="test-token">
+        <button type="submit">Revoke feed</button>
+      </form>
+    </details>
+
+    <details id="settings-danger-zone" data-settings-section open>
+      <form action="/api/v1/users/current/data-wipe" method="post" data-clear-data-verify-form data-clear-data-validate-action="/api/v1/users/current/data-wipe/validate">
+        <input type="hidden" name="csrf_token" value="test-token">
+        <input type="password" id="settings-clear-data-password" name="password" autocomplete="current-password">
+        <button type="submit">Clear data</button>
+      </form>
+      <form hx-delete="/api/v1/users/current" hx-confirm="Delete account?">
+        <input type="hidden" name="csrf_token" value="test-token">
+        <input type="password" id="settings-delete-account-password" name="password" autocomplete="current-password">
+        <button type="submit">Delete account</button>
+      </form>
+    </details>
+  </div>
+</body></html>`;
+}
+
+// Every outbound channel the bundle could reach for, not only `fetch`: a flush
+// smuggled out through `sendBeacon`, an XHR or a native form submit would be the
+// same defect wearing a different API.
+function installEgressRecorder(window) {
+  const calls = [];
+
+  window.fetch = (url, init) => {
+    calls.push({ channel: "fetch", url: String(url), init: init || {} });
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      headers: { get: () => null },
+      text: () => Promise.resolve(""),
+    });
+  };
+
+  Object.defineProperty(window.navigator, "sendBeacon", {
+    configurable: true,
+    value: (url) => {
+      calls.push({ channel: "sendBeacon", url: String(url), init: {} });
+      return true;
+    },
+  });
+
+  const nativeOpen = window.XMLHttpRequest.prototype.open;
+  window.XMLHttpRequest.prototype.open = function (method, url, ...rest) {
+    calls.push({ channel: "xhr", url: String(url), init: { method: String(method) } });
+    return nativeOpen.call(this, method, url, ...rest);
+  };
+
+  window.HTMLFormElement.prototype.submit = function () {
+    calls.push({ channel: "form.submit", url: String(this.getAttribute("action") || ""), init: {} });
+  };
+
+  return calls;
+}
+
+async function loadSettings() {
+  let calls = [];
+  const dom = await loadDOMWithScript(APP_BUNDLE, {
+    html: settingsPage(),
+    url: "https://ovumcy.test/settings",
+    beforeRun: (window) => {
+      calls = installEgressRecorder(window);
+    },
+  });
+  return { dom, calls: () => calls };
+}
+
+function draftForm(window, name) {
+  return window.document.querySelector(`form[data-settings-draft-form="${name}"]`);
+}
+
+function fire(node, type) {
+  node.dispatchEvent(new node.ownerDocument.defaultView.Event(type, { bubbles: true }));
+}
+
+// Returns whether the unsaved-leave prompt was raised: the handler cancels the
+// event, which is the only signal a page gets to hand the browser.
+function unload(window) {
+  const event = new window.Event("beforeunload", { cancelable: true });
+  window.dispatchEvent(event);
+  return event.defaultPrevented;
+}
+
+function settle() {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function describe(calls) {
+  return calls.map((call) => `${call.channel} ${call.init.method || ""} ${call.url}`.trim());
+}
+
+test("a dirty cycle draft arms the leave prompt and puts nothing on the wire", async () => {
+  const { dom, calls } = await loadSettings();
+  try {
+    const cycleLength = dom.window.document.querySelector("#settings-cycle-length");
+    cycleLength.value = "31";
+    fire(cycleLength, "input");
+
+    assert.equal(
+      draftForm(dom.window, "cycle").dataset.settingsDraftDirty,
+      "true",
+      "an edited cycle length is an outstanding draft"
+    );
+    assert.equal(unload(dom.window), true, "leaving with an unsaved draft must raise the prompt");
+    await settle();
+
+    assert.deepEqual(
+      describe(calls()),
+      [],
+      "the settings shell writes on Save only: an unload must not persist a value the owner never confirmed"
+    );
+    assert.equal(
+      dom.window.document.querySelector("#settings-cycle-length").value,
+      "31",
+      "the edit stays on screen for a cancelled navigation"
+    );
+  } finally {
+    dom.window.close();
+  }
+});
+
+test("a dirty tracking draft arms the leave prompt and puts nothing on the wire", async () => {
+  const { dom, calls } = await loadSettings();
+  try {
+    const bbt = draftForm(dom.window, "tracking").querySelector('input[name="track_bbt"]');
+    bbt.checked = true;
+    fire(bbt, "change");
+
+    assert.equal(draftForm(dom.window, "tracking").dataset.settingsDraftDirty, "true");
+    assert.equal(unload(dom.window), true);
+    await settle();
+
+    assert.deepEqual(describe(calls()), []);
+  } finally {
+    dom.window.close();
+  }
+});
+
+// The interface card previews the theme live and persists it only on Save, so a
+// flush here would record a theme the owner was merely looking at — and a
+// language they had not chosen yet.
+test("a dirty interface draft arms the leave prompt and puts nothing on the wire", async () => {
+  const { dom, calls } = await loadSettings();
+  try {
+    const dark = draftForm(dom.window, "interface").querySelector('input[name="theme"][value="dark"]');
+    dark.checked = true;
+    fire(dark, "change");
+
+    assert.equal(draftForm(dom.window, "interface").dataset.settingsDraftDirty, "true");
+    assert.equal(unload(dom.window), true);
+    await settle();
+
+    assert.deepEqual(describe(calls()), []);
+  } finally {
+    dom.window.close();
+  }
+});
+
+test("an untouched settings page neither prompts nor sends", async () => {
+  const { dom, calls } = await loadSettings();
+  try {
+    // Real time, well past the dashboard journal's 2 s debounce: nothing on this
+    // page arms a timer that would fire behind the owner.
+    await new Promise((resolve) => setTimeout(resolve, 2400));
+
+    assert.equal(unload(dom.window), false, "a page with no outstanding edit must not block navigation");
+    await settle();
+
+    assert.deepEqual(describe(calls()), []);
+  } finally {
+    dom.window.close();
+  }
+});
+
+// The destructive and security-relevant forms are outside the draft shell by
+// construction: none of them carries `data-settings-draft-form`, so none is
+// dirty-tracked, and the unload path cannot reach a credential, a wipe, an
+// account deletion, a webhook URL or the calendar feed even in principle. Both
+// halves are asserted — the membership rule, and the behaviour with every one of
+// those fields filled in.
+test("no destructive or security-relevant settings form joins the draft shell", async () => {
+  const { dom, calls } = await loadSettings();
+  try {
+    const guarded = Array.from(
+      dom.window.document.querySelectorAll("form[data-settings-draft-form]")
+    ).map((form) => form.getAttribute("data-settings-draft-form"));
+    assert.deepEqual(
+      guarded.sort(),
+      ["cycle", "interface", "tracking"],
+      "only the three preference cards are dirty-tracked; adding a credential or erasure form here would put it on the unsaved-leave path"
+    );
+
+    for (const selector of [
+      "#settings-current-password",
+      "#settings-new-password",
+      "#settings-webhook-url",
+      "#settings-clear-data-password",
+      "#settings-delete-account-password",
+    ]) {
+      const field = dom.window.document.querySelector(selector);
+      field.value = selector === "#settings-webhook-url" ? "https://example.test/hook" : "correct horse battery staple";
+      fire(field, "input");
+      fire(field, "change");
+    }
+
+    assert.equal(
+      dom.window.document.querySelectorAll('form[data-settings-draft-form][data-settings-draft-dirty="true"]').length,
+      0
+    );
+    assert.equal(unload(dom.window), false, "a filled password field is not an unsaved draft");
+    await settle();
+
+    assert.deepEqual(
+      describe(calls()),
+      [],
+      "no credential, wipe, deletion, webhook or feed request may ever leave on navigation"
+    );
+  } finally {
+    dom.window.close();
+  }
+});
+
+// A save already under way is the one moment the guard stands down (the form is
+// marked navigating for 1.5 s so the prompt does not fight htmx). Leaving in that
+// window must still add nothing of its own to the wire.
+test("leaving while a settings save is under way adds no second request", async () => {
+  const { dom, calls } = await loadSettings();
+  try {
+    const form = draftForm(dom.window, "tracking");
+    const bbt = form.querySelector('input[name="track_bbt"]');
+    bbt.checked = true;
+    fire(bbt, "change");
+    fire(form, "submit");
+
+    assert.equal(form.dataset.settingsDraftNavigating, "1", "the submit hands the save to htmx");
+    assert.equal(unload(dom.window), false, "a save in flight is not an unsaved draft");
+    await settle();
+
+    assert.deepEqual(describe(calls()), [], "htmx owns that request; the unload path issues none of its own");
+  } finally {
+    dom.window.close();
+  }
+});

--- a/web/src/js/app/54-settings-forms.js
+++ b/web/src/js/app/54-settings-forms.js
@@ -329,6 +329,44 @@
     }
   }
 
+  // The settings draft shell prompts on the way out and sends nothing. That is
+  // the opposite of what the dashboard journal does on unload
+  // (`flushDashboardAutosaveBeforeUnload`), and deliberately so — the two
+  // surfaces make opposite promises:
+  //
+  //   - The journal has no save button at all. Everything typed there is
+  //     already destined for the server, so the page leaving is the last chance
+  //     the newest value gets and a keepalive flush only keeps a promise the
+  //     surface already made.
+  //   - A settings card has a Save button that stays disabled until a control
+  //     differs from what the server rendered, a Discard beside it, and a
+  //     dirty/`navigating` state machine whose whole purpose is to make
+  //     "nothing is written until Save" true. Sending on unload would make Save
+  //     decorative.
+  //
+  // Three further reasons a flush would be wrong here, not merely redundant:
+  //
+  //   - The prompt is a question whose "yes" means discard, and its outcome is
+  //     not observable to the page. A flush could not be conditioned on the
+  //     answer, so it would persist exactly what the owner had just chosen to
+  //     throw away.
+  //   - A draft is not a partial record of a fact, the way a half-typed journal
+  //     entry is; it is a configuration under edit. The cycle card's fields are
+  //     read together — `cycleGuidanceState` clamps and cross-checks the two
+  //     lengths, and the submit handler refuses an invalid combination and an
+  //     incomplete `last_period_start`. Those three values move every ovulation
+  //     and next-period surface, so a value the owner never confirmed would
+  //     change a health display. The interface card previews the theme live and
+  //     records it only on Save, so a flush there would store a theme that was
+  //     merely being looked at.
+  //   - Membership in this shell is one attribute wide. Keeping the unload path
+  //     request-free means `data-settings-draft-form` never carries the power to
+  //     write, so nothing destructive or credential-bearing — password change,
+  //     data wipe, account deletion, webhook URL, calendar feed — can acquire
+  //     auto-submission on navigation by being given the marker later.
+  //
+  // Pinned by `web/src/js/__tests__/settings-unsaved-leave.test.mjs`, which
+  // asserts that no request leaves through any channel while the page unwinds.
   function bindSettingsDraftLeaveGuard() {
     if (document.body.dataset.settingsDraftLeaveGuardBound === "1") {
       return;
@@ -340,6 +378,11 @@
         return;
       }
 
+      // Cancelling the event is what raises the browser's own dialog; the
+      // wording is the browser's and cannot be set from here. The in-app link
+      // and submit interceptors below carry the localized prompt instead, so
+      // this handler covers only the exits they cannot see (tab close, address
+      // bar, history).
       event.preventDefault();
       event.returnValue = "";
     });

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -4514,6 +4514,44 @@
     }
   }
 
+  // The settings draft shell prompts on the way out and sends nothing. That is
+  // the opposite of what the dashboard journal does on unload
+  // (`flushDashboardAutosaveBeforeUnload`), and deliberately so — the two
+  // surfaces make opposite promises:
+  //
+  //   - The journal has no save button at all. Everything typed there is
+  //     already destined for the server, so the page leaving is the last chance
+  //     the newest value gets and a keepalive flush only keeps a promise the
+  //     surface already made.
+  //   - A settings card has a Save button that stays disabled until a control
+  //     differs from what the server rendered, a Discard beside it, and a
+  //     dirty/`navigating` state machine whose whole purpose is to make
+  //     "nothing is written until Save" true. Sending on unload would make Save
+  //     decorative.
+  //
+  // Three further reasons a flush would be wrong here, not merely redundant:
+  //
+  //   - The prompt is a question whose "yes" means discard, and its outcome is
+  //     not observable to the page. A flush could not be conditioned on the
+  //     answer, so it would persist exactly what the owner had just chosen to
+  //     throw away.
+  //   - A draft is not a partial record of a fact, the way a half-typed journal
+  //     entry is; it is a configuration under edit. The cycle card's fields are
+  //     read together — `cycleGuidanceState` clamps and cross-checks the two
+  //     lengths, and the submit handler refuses an invalid combination and an
+  //     incomplete `last_period_start`. Those three values move every ovulation
+  //     and next-period surface, so a value the owner never confirmed would
+  //     change a health display. The interface card previews the theme live and
+  //     records it only on Save, so a flush there would store a theme that was
+  //     merely being looked at.
+  //   - Membership in this shell is one attribute wide. Keeping the unload path
+  //     request-free means `data-settings-draft-form` never carries the power to
+  //     write, so nothing destructive or credential-bearing — password change,
+  //     data wipe, account deletion, webhook URL, calendar feed — can acquire
+  //     auto-submission on navigation by being given the marker later.
+  //
+  // Pinned by `web/src/js/__tests__/settings-unsaved-leave.test.mjs`, which
+  // asserts that no request leaves through any channel while the page unwinds.
   function bindSettingsDraftLeaveGuard() {
     if (document.body.dataset.settingsDraftLeaveGuardBound === "1") {
       return;
@@ -4525,6 +4563,11 @@
         return;
       }
 
+      // Cancelling the event is what raises the browser's own dialog; the
+      // wording is the browser's and cannot be set from here. The in-app link
+      // and submit interceptors below carry the localized prompt instead, so
+      // this handler covers only the exits they cannot see (tab close, address
+      // bar, history).
       event.preventDefault();
       event.returnValue = "";
     });


### PR DESCRIPTION
`web/src/js/app/54-settings-forms.js` carries the bundle's only other
`beforeunload` listener. Unlike the dashboard journal, which flushes its newest
edit with a keepalive request, this one only prompts — and if the prompt is
accepted the outstanding settings edit is dropped. This PR argues that dropping
it is correct, records the argument beside the code, and pins the behaviour so a
later change cannot quietly reverse it.

## What the settings forms actually submit

Exactly three forms carry `data-settings-draft-form` and are therefore
dirty-tracked and covered by the leave guard. All three are full-section
`PATCH`es, not per-field patches:

| card | verb + endpoint | fields |
| --- | --- | --- |
| cycle | `PATCH /api/v1/users/current/cycle` | `cycle_length`, `period_length`, `last_period_start`, `unpredictable_cycle` |
| tracking | `PATCH /api/v1/users/current/tracking` | the field-visibility toggles |
| interface | `PATCH /api/v1/users/current/interface` | `language`, `theme` |

Every other form on the page — profile, password change, symptoms, reminders,
webhook, calendar feed, import, data wipe, account deletion — is outside the
draft shell: no marker, no dirty tracking, no participation in the guard.

## Why a flush is wrong here (outcome b)

**The two surfaces make opposite promises.** The journal has no save button, so
everything typed there is already destined for the server and the keepalive
flush merely keeps a promise the surface already made. A settings card has a
Save button that stays disabled until a control differs from what the server
rendered, a Discard beside it, and a dirty/`navigating` state machine whose
whole purpose is to make "nothing is written until Save" true. Sending on unload
would make Save decorative.

**The prompt is a question whose "yes" means discard.** Its copy is
`settings.draft.unsaved_prompt` with the accept label `settings.draft.discard`,
and a `beforeunload` dialog's outcome is not observable to the page. A flush
could not be conditioned on the answer, so it would persist precisely what was
just chosen to be thrown away. There is no honest way to have both.

**A draft is a configuration under edit, not a partial record of a fact.** A
journal upsert is idempotent and each field is an independent observation about
one day. The cycle card's fields are read together: `cycleGuidanceState` clamps
and cross-checks the two lengths, and the submit handler refuses an invalid
combination as well as an incomplete `last_period_start` (segmented date field).
Those three values move every ovulation and next-period surface, so an
unconfirmed value would change a health display — a flush that skipped those
checks would write an unvalidated configuration, and one that replicated them
would still write a state nobody confirmed. The interface card previews the
theme live (`applyTheme` on change) and records it only on Save
(`writeStoredTheme` in the submit handler), so a flush there would store a theme
that was merely being looked at, and a language that had not been chosen.

**Membership in the shell is one attribute wide.** Keeping the unload path
request-free means `data-settings-draft-form` never carries the power to write.
With a flush in place, any form later given the marker would inherit
auto-submission on navigation.

Nothing destructive or credential-bearing is in the guarded set today, and the
test below asserts that as a membership rule rather than leaving it to
inspection: password change, data wipe, account deletion, webhook URL and the
calendar feed are all outside it.

## What changed

- `web/src/js/app/54-settings-forms.js` — the reasoning above, as a comment on
  `bindSettingsDraftLeaveGuard`, plus a short note inside the handler on what
  cancelling the event does and which exits the in-app link/submit interceptors
  cover instead. No behaviour change.
- `web/src/js/__tests__/settings-unsaved-leave.test.mjs` — six cases over the
  built bundle in jsdom: a dirty cycle / tracking / interface draft raises the
  prompt and issues nothing; an untouched page neither prompts nor sends (real
  time, past the journal's 2 s debounce); leaving while a save is under way adds
  no request of its own; and the destructive/credential-bearing forms stay
  outside the dirty-tracked set even with every one of their fields filled in.
  The recorder covers `fetch`, `navigator.sendBeacon`, `XMLHttpRequest` and a
  native form submit — a flush smuggled out through any of them is the same
  defect wearing a different API.
- `web/static/js/app.js` — rebuilt (`npm run build`); the comment is the only
  delta.
- `changelog.d/fix-settings-unsaved-edit-on-unload.md` — `none`, with the reason.

The prompt itself was left as it is. Cancelling the event is what the HTML spec
makes raise the dialog, and no reliability gap turned up across the six cases,
so no speculative browser-compat change was made.

## Guard, proven on the defect

Injecting the flush into the built bundle — a keepalive `PATCH` per dirty draft
form, in the journal's shape — turns the three draft tests red and names the
endpoint:

```
✖ a dirty cycle draft arms the leave prompt and puts nothing on the wire
  AssertionError: the settings shell writes on Save only: an unload must not
  persist a value the owner never confirmed
  + actual - expected
  + [ 'fetch PATCH /api/v1/users/current/cycle' ]
  - []
```

with the same failure for `/api/v1/users/current/tracking` and
`/api/v1/users/current/interface`. The bundle was restored afterwards; the
membership test stays green under the injected defect, which is right — its
subject is which forms may ever be reached, not what the guard sends.

## Validation

| command | verdict |
| --- | --- |
| `npm run test:unit` | pass — 73 tests, 0 failures |
| `npm run lint` (eslint over sources and built bundles, `tsc --noEmit`) | clean |
| `npm run build` | no unexpected diff — CSS byte-identical, `app.js` carries only the new comment |

Out of scope: `53-dashboard-autosave.js` is untouched, as is everything under
`internal/`. An htmx save that is still on the wire when the tab closes is
aborted by the browser — a separate question from this one, and it belongs to
the submit path rather than to the leave guard.
