### PR TITLE
fix: walk the period streak over calendar days, not instants

### DIFF
--- a/changelog.d/fix-day-feedback-calendar-walk.md
+++ b/changelog.d/fix-day-feedback-calendar-walk.md
@@ -1,0 +1,14 @@
+### Fixed
+
+- **The long-period warning is now counted over calendar days in time zones
+  whose clock jump lands on midnight.** The backward walk that measures how many
+  consecutive days the current period has run stepped its cursor inside the
+  request time zone. In zones west of UTC where daylight saving starts at 00:00
+  (America/Santiago, America/Havana) that step skipped the transition date
+  entirely: a continuous period spanning it counted one day short, so a nine-day
+  period stayed one day below the threshold and the "period running long" notice
+  never appeared. When the transition date carried no period at all, the walk
+  jumped that gap instead of stopping there and merged two separate periods, so
+  the notice was anchored to — and acknowledged against — the previous period's
+  start date. The walk now steps over calendar days, visiting each exactly once.
+  Zones without such a transition, including UTC, are unaffected.

--- a/internal/services/day_feedback_dst_walk_test.go
+++ b/internal/services/day_feedback_dst_walk_test.go
@@ -1,0 +1,264 @@
+package services
+
+// day_feedback_dst_walk_test.go — the backward period-streak walk must visit
+// every calendar day exactly once, whatever the request zone does to the clock.
+//
+// currentPeriodStreakAtDay stepped its cursor with AddDate inside the request
+// location. AddDate re-enters time.Date there, and in a UTC-minus zone whose
+// DST jump lands on midnight (America/Santiago 2026-09-06) the missing wall
+// clock normalizes BACKWARD into the previous calendar day: stepping back from
+// 2026-09-07 00:00-03 lands on 2026-09-05 23:00-04, so the day key 2026-09-06
+// was never queried at all while the log map built from CalendarDay carried it
+// correctly.
+//
+// Two outcomes followed, and both are covered here:
+//   - a continuous period spanning that day counted one day short, so a nine-day
+//     run read as eight and the `streak > 8` gate suppressed the long-period
+//     warning;
+//   - a day that is NOT a period day no longer stopped the walk, so two separate
+//     periods merged and the earlier cluster's start was reported — and then
+//     written to long_period_warning_cycle_start by the acknowledgement path.
+//
+// The zone must be west of UTC: east-of-UTC zones normalize a missing midnight
+// forward and keep the date, so the same fixture there is green about nothing.
+// Controls: the identical fixtures in a transition-free month of the same zone,
+// and in UTC, must be unchanged.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+)
+
+func santiagoTestLocation(t *testing.T) *time.Location {
+	t.Helper()
+	location, err := time.LoadLocation("America/Santiago")
+	if err != nil {
+		t.Fatalf("load America/Santiago: %v", err)
+	}
+	return location
+}
+
+// seedPeriodDays writes IsPeriod logs for each YYYY-MM-DD in days, using the
+// canonical UTC-midnight date-only shape the repository stores.
+func seedPeriodDays(t *testing.T, logs *dayLogRepositoryStub, days ...string) {
+	t.Helper()
+	for _, day := range days {
+		logs.entries[day] = models.DailyLog{
+			UserID:   10,
+			Date:     mustParseDayFeedbackDate(t, day),
+			IsPeriod: true,
+		}
+	}
+}
+
+func continuousPeriodDays() []string {
+	return []string{
+		"2026-09-01", "2026-09-02", "2026-09-03", "2026-09-04", "2026-09-05",
+		"2026-09-06", "2026-09-07", "2026-09-08", "2026-09-09",
+	}
+}
+
+// TestCurrentPeriodStreakCountsTheDSTMidnightDay walks a nine-day continuous
+// period whose middle day is America/Santiago's skipped midnight. Pre-fix the
+// walk jumped straight from 09-07 to 09-05 and returned 8.
+func TestCurrentPeriodStreakCountsTheDSTMidnightDay(t *testing.T) {
+	santiago := santiagoTestLocation(t)
+	logs := newDayLogRepositoryStub()
+	seedPeriodDays(t, logs, continuousPeriodDays()...)
+
+	entries, err := logs.ListByUser(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("ListByUser() unexpected error: %v", err)
+	}
+
+	day := time.Date(2026, time.September, 9, 12, 0, 0, 0, santiago)
+	streak, cycleStart, ok := currentPeriodStreakAtDay(entries, day, santiago)
+	if !ok {
+		t.Fatal("expected the requested day to be recognized as a period day")
+	}
+	if streak != 9 {
+		t.Fatalf("streak = %d, want 9: the walk must visit 2026-09-06 even though local midnight does not exist there", streak)
+	}
+	if got := CalendarDayKey(cycleStart); got != "2026-09-01" {
+		t.Fatalf("cycle start = %s, want 2026-09-01", got)
+	}
+}
+
+// TestCurrentPeriodStreakStopsAtTheDSTMidnightGap is the other half: 2026-09-06
+// carries no period log, so the walk must stop there. Pre-fix it skipped the
+// gap and merged the 08-28..09-05 period into the 09-07..09-09 one.
+func TestCurrentPeriodStreakStopsAtTheDSTMidnightGap(t *testing.T) {
+	santiago := santiagoTestLocation(t)
+	logs := newDayLogRepositoryStub()
+	seedPeriodDays(t, logs,
+		"2026-08-28", "2026-08-29", "2026-08-30", "2026-08-31",
+		"2026-09-01", "2026-09-02", "2026-09-03", "2026-09-04", "2026-09-05",
+		"2026-09-07", "2026-09-08", "2026-09-09",
+	)
+
+	entries, err := logs.ListByUser(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("ListByUser() unexpected error: %v", err)
+	}
+
+	day := time.Date(2026, time.September, 9, 12, 0, 0, 0, santiago)
+	streak, cycleStart, ok := currentPeriodStreakAtDay(entries, day, santiago)
+	if !ok {
+		t.Fatal("expected the requested day to be recognized as a period day")
+	}
+	if streak != 3 {
+		t.Fatalf("streak = %d, want 3: the walk must stop at the gap on 2026-09-06 instead of merging the earlier period", streak)
+	}
+	if got := CalendarDayKey(cycleStart); got != "2026-09-07" {
+		t.Fatalf("cycle start = %s, want 2026-09-07 (the current period), not the earlier cluster's start", got)
+	}
+}
+
+// TestResolveDayFeedbackWarnsForALongPeriodSpanningTheDSTMidnightDay is the
+// end-to-end consequence of the undercount: the nine-day run is the first that
+// trips the `streak > 8` gate, so losing one day silences the warning the owner
+// should see.
+func TestResolveDayFeedbackWarnsForALongPeriodSpanningTheDSTMidnightDay(t *testing.T) {
+	santiago := santiagoTestLocation(t)
+	logs := newDayLogRepositoryStub()
+	users := &dayUserRepositoryStub{}
+	service := NewDayService(logs, users)
+	seedPeriodDays(t, logs, continuousPeriodDays()...)
+
+	day := time.Date(2026, time.September, 9, 12, 0, 0, 0, santiago)
+	state, err := service.ResolveDayFeedback(context.Background(), &models.User{ID: 10}, day, day, santiago)
+	if err != nil {
+		t.Fatalf("ResolveDayFeedback() unexpected error: %v", err)
+	}
+	if !state.ShowLongPeriodWarning {
+		t.Fatal("expected the long-period warning after nine consecutive period days spanning the skipped midnight")
+	}
+	if got := CalendarDayKey(state.LongPeriodCycleStart); got != "2026-09-01" {
+		t.Fatalf("long-period cycle start = %s, want 2026-09-01", got)
+	}
+}
+
+// TestResolveDayFeedbackDoesNotMergeTwoPeriodsAcrossTheDSTMidnightGap follows
+// the merged-period outcome all the way to the persisted column: pre-fix the
+// three-day current period read as a twelve-day one, the warning fired, and
+// AcknowledgeLongPeriodWarning wrote the PREVIOUS period's start (2026-08-28)
+// into long_period_warning_cycle_start.
+func TestResolveDayFeedbackDoesNotMergeTwoPeriodsAcrossTheDSTMidnightGap(t *testing.T) {
+	santiago := santiagoTestLocation(t)
+	logs := newDayLogRepositoryStub()
+	users := &dayUserRepositoryStub{}
+	service := NewDayService(logs, users)
+	seedPeriodDays(t, logs,
+		"2026-08-28", "2026-08-29", "2026-08-30", "2026-08-31",
+		"2026-09-01", "2026-09-02", "2026-09-03", "2026-09-04", "2026-09-05",
+		"2026-09-07", "2026-09-08", "2026-09-09",
+	)
+
+	day := time.Date(2026, time.September, 9, 12, 0, 0, 0, santiago)
+	state, err := service.ResolveDayFeedback(context.Background(), &models.User{ID: 10}, day, day, santiago)
+	if err != nil {
+		t.Fatalf("ResolveDayFeedback() unexpected error: %v", err)
+	}
+	if state.ShowLongPeriodWarning {
+		t.Fatalf("expected no long-period warning for a three-day period, got one anchored at %s", CalendarDayKey(state.LongPeriodCycleStart))
+	}
+
+	// The acknowledgement path is what persists the value, so drive it exactly
+	// as the day-write handler does and assert nothing was written.
+	if state.ShowLongPeriodWarning && !state.LongPeriodCycleStart.IsZero() {
+		if err := service.AcknowledgeLongPeriodWarning(context.Background(), 10, state.LongPeriodCycleStart, santiago); err != nil {
+			t.Fatalf("AcknowledgeLongPeriodWarning() unexpected error: %v", err)
+		}
+	}
+	if stored := users.settings.LongPeriodWarnedAt; stored != nil {
+		t.Fatalf("long_period_warning_cycle_start = %s, want no write at all", stored.Format("2006-01-02"))
+	}
+}
+
+// TestCurrentPeriodStreakIsUnchangedWithoutATransition is the control pair: the
+// same shapes in a transition-free month of the same west-of-UTC zone, and in
+// UTC, must produce exactly the same answers as before the fix.
+func TestCurrentPeriodStreakIsUnchangedWithoutATransition(t *testing.T) {
+	santiago := santiagoTestLocation(t)
+
+	continuousAugust := []string{
+		"2026-08-01", "2026-08-02", "2026-08-03", "2026-08-04", "2026-08-05",
+		"2026-08-06", "2026-08-07", "2026-08-08", "2026-08-09",
+	}
+	gapAugust := []string{
+		"2026-07-24", "2026-07-25", "2026-07-26", "2026-07-27", "2026-07-28",
+		"2026-07-29", "2026-07-30", "2026-07-31", "2026-08-01",
+		"2026-08-03", "2026-08-04", "2026-08-05",
+	}
+
+	cases := []struct {
+		name           string
+		location       *time.Location
+		days           []string
+		requested      time.Time
+		wantStreak     int
+		wantCycleStart string
+	}{
+		{
+			name:           "continuous run, Santiago, no transition in August",
+			location:       santiago,
+			days:           continuousAugust,
+			requested:      time.Date(2026, time.August, 9, 12, 0, 0, 0, santiago),
+			wantStreak:     9,
+			wantCycleStart: "2026-08-01",
+		},
+		{
+			name:           "gap, Santiago, no transition in August",
+			location:       santiago,
+			days:           gapAugust,
+			requested:      time.Date(2026, time.August, 5, 12, 0, 0, 0, santiago),
+			wantStreak:     3,
+			wantCycleStart: "2026-08-03",
+		},
+		{
+			name:           "continuous run across the same dates, UTC",
+			location:       time.UTC,
+			days:           continuousPeriodDays(),
+			requested:      time.Date(2026, time.September, 9, 12, 0, 0, 0, time.UTC),
+			wantStreak:     9,
+			wantCycleStart: "2026-09-01",
+		},
+		{
+			name:     "gap across the same dates, UTC",
+			location: time.UTC,
+			days: []string{
+				"2026-08-28", "2026-08-29", "2026-08-30", "2026-08-31",
+				"2026-09-01", "2026-09-02", "2026-09-03", "2026-09-04", "2026-09-05",
+				"2026-09-07", "2026-09-08", "2026-09-09",
+			},
+			requested:      time.Date(2026, time.September, 9, 12, 0, 0, 0, time.UTC),
+			wantStreak:     3,
+			wantCycleStart: "2026-09-07",
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			logs := newDayLogRepositoryStub()
+			seedPeriodDays(t, logs, testCase.days...)
+			entries, err := logs.ListByUser(context.Background(), 10)
+			if err != nil {
+				t.Fatalf("ListByUser() unexpected error: %v", err)
+			}
+
+			streak, cycleStart, ok := currentPeriodStreakAtDay(entries, testCase.requested, testCase.location)
+			if !ok {
+				t.Fatal("expected the requested day to be recognized as a period day")
+			}
+			if streak != testCase.wantStreak {
+				t.Fatalf("streak = %d, want %d", streak, testCase.wantStreak)
+			}
+			if got := CalendarDayKey(cycleStart); got != testCase.wantCycleStart {
+				t.Fatalf("cycle start = %s, want %s", got, testCase.wantCycleStart)
+			}
+		})
+	}
+}

--- a/internal/services/day_feedback_policy.go
+++ b/internal/services/day_feedback_policy.go
@@ -124,13 +124,25 @@ func currentPeriodStreakAtDay(logs []models.DailyLog, day time.Time, location *t
 		return 0, time.Time{}, false
 	}
 
-	targetDay := DateAtLocation(day, location)
+	// The walk below is a run of CALENDAR days, so it is stepped as calendar
+	// days: the requested day is re-anchored to UTC midnight and the cursor
+	// moves there, the same convention BuildCalendarDayStates uses for the
+	// month grid. Stepping inside the request zone re-enters time.Date there,
+	// and in a UTC-minus zone whose DST jump lands on midnight
+	// (America/Santiago 2026-09-06) the missing wall clock normalizes BACKWARD
+	// into the previous calendar day: the step off 2026-09-07 landed on
+	// 2026-09-05 and 2026-09-06 was never queried, undercounting a continuous
+	// period by a day and jumping the gap that should have ended the walk. UTC
+	// has no transitions, so the same arithmetic there visits every calendar
+	// day exactly once for every request zone. Only the cursor's shape changes:
+	// the calendar day it names on any other date is the one it named before.
+	targetDay := CalendarDay(DateAtLocation(day, location), time.UTC)
 	logByDay := make(map[string]models.DailyLog, len(logs))
 	for _, logEntry := range sortDailyLogs(logs) {
-		logByDay[CalendarDay(logEntry.Date, location).Format("2006-01-02")] = logEntry
+		logByDay[CalendarDayKey(logEntry.Date)] = logEntry
 	}
 
-	current, ok := logByDay[targetDay.Format("2006-01-02")]
+	current, ok := logByDay[CalendarDayKey(targetDay)]
 	if !ok || !current.IsPeriod {
 		return 0, time.Time{}, false
 	}
@@ -138,7 +150,7 @@ func currentPeriodStreakAtDay(logs []models.DailyLog, day time.Time, location *t
 	streak := 0
 	cycleStart := targetDay
 	for cursor := targetDay; ; cursor = cursor.AddDate(0, 0, -1) {
-		logEntry, exists := logByDay[cursor.Format("2006-01-02")]
+		logEntry, exists := logByDay[CalendarDayKey(cursor)]
 		if !exists || !logEntry.IsPeriod {
 			break
 		}


### PR DESCRIPTION
## The defect

`currentPeriodStreakAtDay` (`internal/services/day_feedback_policy.go`) measures how many
consecutive days the current period has run by walking backwards from the requested day. The
cursor was stepped with `AddDate(0, 0, -1)` on a value carrying the request zone, so every step
re-entered `time.Date` there. In a UTC-minus zone whose DST jump lands on midnight
(America/Santiago 2026-09-06, America/Havana 2026-03-08) local midnight does not exist and the
missing wall clock normalizes **backward** into the previous calendar day: stepping off
`2026-09-07 00:00-03` lands on `2026-09-05 23:00-04`.

The day key `2026-09-06` was therefore never queried, while the log map — built from the stored
calendar components — carried it correctly.

## Two consequences, both user-visible

- **A suppressed warning.** A continuous period spanning that day counted one day short, so a
  true nine-day run reported eight. Nine is exactly the first length past the `streak > 8` gate,
  so the "period running long" notice never fired for the owner it was meant for.
- **A wrongly persisted cycle start.** When the transition date carried no period log, the walk
  jumped the gap instead of stopping there and merged two separate periods. The reported cycle
  start was then the *earlier* cluster's start, and that value flows out of `ResolveDayFeedback`
  as `LongPeriodCycleStart` into `AcknowledgeLongPeriodWarning`, which canonicalizes it and
  **writes** it to the `long_period_warning_cycle_start` column. With the fixture in the guard,
  a three-day period reported twelve days anchored at `2026-08-28`.

## The fix

The walk is a run of calendar days, so it is now stepped as calendar days: the requested day is
re-anchored to UTC midnight and the cursor moves there — the convention `BuildCalendarDayStates`
already uses for the month grid. UTC has no transitions, so the same arithmetic visits every
calendar day exactly once for every request zone. Day keys come from `CalendarDayKey` on both
sides, so the key a lookup is handed always round-trips.

The early-exit condition, the `streak > 8` and acknowledgement gates, and what counts as a period
day are untouched.

## Caller sweep

Every consumer of the values this function produces, down to the persisted column:

| Consumer | Reads | Verdict |
| --- | --- | --- |
| `ResolveDayFeedback` (`day_feedback_policy.go`) | `streak > 8`; `sameCalendarDay(CalendarDay(user.LongPeriodWarnedAt, loc), cycleStart)` | Calendar components only (`Format`-based). Unchanged outside a midnight-skipping zone. |
| `shouldShowSpottingCycleWarning` (`day_feedback_policy.go`) | discards `streak`; `sameCalendarDay(cycleStart, DateAtLocation(day, loc))` | Same. Boolean result unchanged. |
| `dashboardSpottingCycleWarning` → `DashboardViewData.ShowSpottingCycleWarning` (`dashboard_view_service.go`) | the boolean above | Unchanged. |
| `BuildDayEditorViewData` → `DayEditorViewData.ShowSpottingCycleWarning` (`dashboard_view_service.go`) | the boolean above | Unchanged. |
| `Handler.resolveDayFeedback` (`internal/api/handlers_days_write.go`) | `ShowLongPeriodWarning`, `!LongPeriodCycleStart.IsZero()` | Non-zero either way; the warning now fires on the right periods. |
| `AcknowledgeLongPeriodWarning` (`day_feedback_policy.go`) | `CalendarDay(cycleStart, loc)` then rebuilds at UTC midnight from `.Date()` | Reads calendar components only; the persisted value is byte-for-byte identical for the same calendar day. |
| `request.user.LongPeriodWarnedAt` (in-memory, same request) | re-read only by the `sameCalendarDay` comparison above | Unchanged. Nothing renders or exports this field. |
| `long_period_warning_cycle_start` column | `LoadSettingsByID` select whitelist; `ClearAllDataAndResetSettings` reset (`internal/db/user_repository.go`) | Untouched; shape and semantics of the column are unchanged. |

**Zones with no transition are unaffected.** There, `startOfCalendarDay` returns plain local
midnight and `AddDate(0, 0, -1)` yields local midnight of the previous calendar day, so the
sequence of day keys the walk queries is identical to the UTC-anchored one — same `streak`, same
`ok`, same calendar day for `cycleStart`. The same holds for zones whose DST jump lands anywhere
other than midnight (02:00 in the US zones), where `AddDate` already normalized within the day.
Only the returned value's *instant shape* changes (UTC midnight rather than location midnight),
and every consumer above reads its calendar components alone.

## Guard

`internal/services/day_feedback_dst_walk_test.go`, written before the fix. The zone is west of
UTC as required — east-of-UTC zones normalize a missing midnight forward and prove nothing.

- `TestCurrentPeriodStreakCountsTheDSTMidnightDay` — nine continuous period days across
  2026-09-06 in America/Santiago.
- `TestCurrentPeriodStreakStopsAtTheDSTMidnightGap` — 2026-09-06 is *not* a period day; the walk
  must stop instead of merging the 08-28..09-05 period into 09-07..09-09.
- `TestResolveDayFeedbackWarnsForALongPeriodSpanningTheDSTMidnightDay` — the suppressed-warning
  consequence end to end.
- `TestResolveDayFeedbackDoesNotMergeTwoPeriodsAcrossTheDSTMidnightGap` — the merged-period
  consequence followed to the persisted column, asserting no write at all.
- `TestCurrentPeriodStreakIsUnchangedWithoutATransition` — the controls: the same shapes in a
  transition-free month of the same zone, and in UTC. Green before and after.

Against the unfixed code:

```
--- FAIL: TestCurrentPeriodStreakCountsTheDSTMidnightDay (0.01s)
    day_feedback_dst_walk_test.go:83: streak = 8, want 9: the walk must visit 2026-09-06 even though local midnight does not exist there
--- FAIL: TestCurrentPeriodStreakStopsAtTheDSTMidnightGap (0.00s)
    day_feedback_dst_walk_test.go:113: streak = 12, want 3: the walk must stop at the gap on 2026-09-06 instead of merging the earlier period
--- FAIL: TestResolveDayFeedbackWarnsForALongPeriodSpanningTheDSTMidnightDay (0.00s)
    day_feedback_dst_walk_test.go:137: expected the long-period warning after nine consecutive period days spanning the skipped midnight
--- FAIL: TestResolveDayFeedbackDoesNotMergeTwoPeriodsAcrossTheDSTMidnightGap (0.00s)
    day_feedback_dst_walk_test.go:166: expected no long-period warning for a three-day period, got one anchored at 2026-08-28
--- PASS: TestCurrentPeriodStreakIsUnchangedWithoutATransition (0.00s)
```

## Validation

| Command | Verdict |
| --- | --- |
| `gofmt -l internal/services/` | Neither changed file listed. Three untouched files (`day_service.go`, `settings_view_service.go`, `webhook_reminder.go`) are flagged on the base commit too — pre-existing, out of scope here. |
| `go build ./...` | pass |
| `go test ./internal/services/... ./internal/api/... -timeout 20m` | pass (services 124 s, api 549 s) |
| `go test ./... -timeout 20m` | pass, every package |
| `golangci-lint run ./internal/services/...` | `0 issues.` |
| `COVERAGE_FILE=… BASE_REF=origin/main go run ./scripts/patchcov` (profile regenerated in the same invocation) | `patch coverage gate OK` |

## Rollback

Revert the single commit. The change is confined to one function's cursor arithmetic and its day
keys; it adds no migration, no schema change and no new column value, so reverting restores the
previous behaviour exactly. Rows already written by the defective path keep whatever calendar day
they carry — the acknowledgement comparison is calendar-day equality, so a stale value simply
stops matching and the warning re-arms on the next long period.
