### PR TITLE
fix: compare calendar days as calendar days, not as instants

### DIFF
--- a/changelog.d/fix-calendar-day-comparisons.md
+++ b/changelog.d/fix-calendar-day-comparisons.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- **Predictions no longer jump a whole cycle, or drop a day's own entry, outside
+  UTC.** On the estimated ovulation day itself, accounts west of UTC saw the
+  dashboard, the calendar, the reminder and the `.ics` feed skip that estimate and
+  advertise the next cycle's instead, and the feed lost its ovulation event for
+  the day; accounts east of UTC had today's entry ignored when deciding whether a
+  temperature shift had been observed. The Insights cycle stack also left the
+  first or last fertile day unshaded, depending on the time zone, and never marked
+  the peak day at all.

--- a/internal/services/calendar_day_comparison_regression_test.go
+++ b/internal/services/calendar_day_comparison_regression_test.go
@@ -1,0 +1,259 @@
+package services
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+)
+
+// Regression locks for the mixed-midnight comparison class (issue #48 family).
+//
+// A calendar day built in the request/owner zone (DateAtLocation, CalendarDay
+// with a non-UTC location) and a calendar day built at UTC midnight (dateOnly,
+// every PredictCycleWindow output) name the SAME date but are DIFFERENT
+// instants: local midnight in a UTC-minus zone lands hours AFTER UTC midnight,
+// and in a UTC-plus zone hours before it. Comparing the pair with raw
+// Before/After/Equal therefore misreads the same calendar day, every day, in
+// every non-UTC zone — no DST transition is involved.
+//
+// Each test below drives the zone whose sign makes its site break (west of UTC
+// for the "ovulation already passed" shape, east for the "log is in the future"
+// shape, both for the ribbon) and carries a UTC control that must stay
+// unchanged. The sanctioned instrument is CalendarDaysBetween, which re-anchors
+// both operands to UTC midnight of their own calendar day.
+
+// calendarDayComparisonZone loads a named zone for these regressions. A missing
+// zone is a hard failure, not a skip: a skipped guard proves nothing about the
+// defect it was written for.
+func calendarDayComparisonZone(t *testing.T, name string) *time.Location {
+	t.Helper()
+	location, err := time.LoadLocation(name)
+	if err != nil {
+		t.Fatalf("load %s: %v", name, err)
+	}
+	return location
+}
+
+// calendarDayComparisonToday builds "today" the way every request path does:
+// DateAtLocation over a real instant, which yields local midnight.
+func calendarDayComparisonToday(t *testing.T, day string, location *time.Location) time.Time {
+	t.Helper()
+	// Midday UTC sits inside the same calendar day in every zone used here.
+	return DateAtLocation(mustParseDashboardDay(t, day).Add(12*time.Hour), location)
+}
+
+// TestDashboardUpcomingPredictionsKeepsTodaysOvulation locks dashboard_cycle.go:
+// window.OvulationDate (UTC midnight) against today (location midnight). West of
+// UTC today's ovulation read as already past, ShiftCycleStartToFutureOvulation
+// fired, and every owner-facing surface rolled the anchor a FULL CYCLE forward.
+func TestDashboardUpcomingPredictionsKeepsTodaysOvulation(t *testing.T) {
+	t.Parallel()
+
+	// Cycle start 2026-03-02, length 28, luteal 14 → ovulation on cycle day 14,
+	// i.e. exactly 2026-03-15, the day the render sits on.
+	const cycleStart = "2026-03-02"
+	const ovulationDay = "2026-03-15"
+
+	for _, testCase := range []struct{ name, zone string }{
+		{name: "west of UTC", zone: "America/Lima"},
+		{name: "UTC control", zone: "UTC"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			location := calendarDayComparisonZone(t, testCase.zone)
+			today := calendarDayComparisonToday(t, ovulationDay, location)
+			stats := CycleStats{
+				LastPeriodStart: mustParseDashboardDay(t, cycleStart),
+				LutealPhase:     14,
+			}
+
+			prediction := DashboardUpcomingPredictions(stats, nil, today, 28)
+			if got := CalendarDayKey(prediction.OvulationDate); got != ovulationDay {
+				t.Fatalf("ovulation on the day itself = %s, want %s (the anchor must not roll a cycle forward)", got, ovulationDay)
+			}
+		})
+	}
+}
+
+// TestShiftCycleStartToFutureOvulationKeepsTodaysAnchor locks cycle_baseline.go:
+// the guard inside the shift itself. Its own lag arithmetic already counts
+// calendar days (CalendarDaysBetween); only the guard compared instants, so the
+// shift ran with a lag of zero and added a whole cycle.
+func TestShiftCycleStartToFutureOvulationKeepsTodaysAnchor(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range []struct{ name, zone string }{
+		{name: "west of UTC", zone: "America/New_York"},
+		{name: "UTC control", zone: "UTC"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			location := calendarDayComparisonZone(t, testCase.zone)
+			today := calendarDayComparisonToday(t, "2026-03-15", location)
+			cycleStart := CalendarDay(mustParseDashboardDay(t, "2026-03-02"), location)
+			ovulationDate := dateOnly(mustParseDashboardDay(t, "2026-03-15"))
+
+			shifted := ShiftCycleStartToFutureOvulation(cycleStart, ovulationDate, 28, today)
+			if got := CalendarDayKey(shifted); got != "2026-03-02" {
+				t.Fatalf("anchor after an ovulation that is today = %s, want 2026-03-02 (no shift)", got)
+			}
+
+			// Positive anchor: an ovulation genuinely in the past still shifts.
+			pastOvulation := dateOnly(mustParseDashboardDay(t, "2026-03-14"))
+			if got := CalendarDayKey(ShiftCycleStartToFutureOvulation(cycleStart, pastOvulation, 28, today)); got != "2026-03-30" {
+				t.Fatalf("anchor after a past ovulation = %s, want 2026-03-30", got)
+			}
+		})
+	}
+}
+
+// TestFilterLogsNotAfterKeepsTodaysLogEastOfUTC locks cycles.go: dateOnly(log.Date)
+// (UTC midnight) against a cutoff its callers build at location midnight
+// (calendar_days.go, cycle_start_policy.go, stats_cycle_insights.go). East of UTC
+// today's own entry was dropped, so a same-day BBT shift was never detected and
+// the calendar kept painting a tentative ovulation.
+func TestFilterLogsNotAfterKeepsTodaysLogEastOfUTC(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range []struct{ name, zone string }{
+		{name: "east of UTC", zone: "Europe/Moscow"},
+		{name: "far east of UTC", zone: "Asia/Tokyo"},
+		{name: "UTC control", zone: "UTC"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			location := calendarDayComparisonZone(t, testCase.zone)
+			cutoff := calendarDayComparisonToday(t, "2026-03-15", location)
+			logs := []models.DailyLog{
+				{Date: mustParseDashboardDay(t, "2026-03-14")},
+				{Date: mustParseDashboardDay(t, "2026-03-15")},
+				{Date: mustParseDashboardDay(t, "2026-03-16")},
+			}
+
+			filtered := filterLogsNotAfter(logs, cutoff)
+			kept := make([]string, 0, len(filtered))
+			for _, entry := range filtered {
+				kept = append(kept, CalendarDayKey(entry.Date))
+			}
+			if strings.Join(kept, ",") != "2026-03-14,2026-03-15" {
+				t.Fatalf("logs kept up to and including today = %v, want [2026-03-14 2026-03-15]", kept)
+			}
+		})
+	}
+}
+
+// TestCalendarFeedKeepsTodaysOvulationEventWestOfUTC locks calendar_feed_ics.go:
+// west of UTC the ovulation event vanished from the .ics on the ovulation day
+// itself, while the period event one line above it — both operands already
+// location midnight — stayed. One function, two shapes.
+func TestCalendarFeedKeepsTodaysOvulationEventWestOfUTC(t *testing.T) {
+	t.Parallel()
+
+	// dayBoundaryFeedLogs puts the current cycle's projected ovulation exactly on
+	// 2026-03-10, the calendar day the feed is rendered on.
+	const ovulationEvent = "DTSTART;VALUE=DATE:20260310"
+
+	for _, testCase := range []struct{ name, zone string }{
+		{name: "west of UTC", zone: "America/Lima"},
+		{name: "UTC control", zone: "UTC"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			location := calendarDayComparisonZone(t, testCase.zone)
+			body := string(BuildCalendarFeedICS(CalendarFeedICSInput{
+				User:       predictableFeedUser(t, "2026-02-25"),
+				Logs:       dayBoundaryFeedLogs(t),
+				Now:        mustParseDashboardDay(t, "2026-03-10").Add(12 * time.Hour),
+				Location:   location,
+				Disclaimer: "Predictions are estimates, not medical advice or a method of contraception.",
+			}))
+
+			if !strings.Contains(body, ovulationEvent) {
+				t.Fatalf("the ovulation event on the ovulation day must stay in the feed, got:\n%s", body)
+			}
+		})
+	}
+}
+
+// TestOvulationCycleAnchorKeepsTodaysCycleWestOfUTC locks webhook_reminder.go:
+// the same shift guard feeding the OUTBOUND reminder's anchor, which must stay
+// in lockstep with the date the dashboard shows.
+func TestOvulationCycleAnchorKeepsTodaysCycleWestOfUTC(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range []struct{ name, zone string }{
+		{name: "west of UTC", zone: "America/Lima"},
+		{name: "UTC control", zone: "UTC"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			location := calendarDayComparisonZone(t, testCase.zone)
+			today := calendarDayComparisonToday(t, "2026-03-15", location)
+			stats := CycleStats{
+				LastPeriodStart: mustParseDashboardDay(t, "2026-03-02"),
+				LutealPhase:     14,
+			}
+
+			if got := CalendarDayKey(ovulationCycleAnchor(stats, today, 28)); got != "2026-03-02" {
+				t.Fatalf("reminder anchor on the ovulation day = %s, want 2026-03-02", got)
+			}
+		})
+	}
+}
+
+// TestStatsCycleRibbonFertileWindowIsCalendarBound locks stats_cycle_ribbon.go,
+// the one site that breaks in BOTH directions: the row's dates are location
+// midnights while the window bounds are UTC midnights, so west of UTC the last
+// fertile day fell outside the window and east of UTC the first one did — and
+// date.Equal(window.OvulationDate) was never true outside UTC, so IsFertilePeak
+// never rendered while the neighbouring phase axis, which already routes through
+// CalendarDaysBetween, coloured that same cell "ovulation".
+func TestStatsCycleRibbonFertileWindowIsCalendarBound(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range []struct{ name, zone string }{
+		{name: "west of UTC", zone: "America/Lima"},
+		{name: "east of UTC", zone: "Asia/Tokyo"},
+		{name: "UTC control", zone: "UTC"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			location := calendarDayComparisonZone(t, testCase.zone)
+			start := CalendarDay(mustParseDashboardDay(t, "2026-03-02"), location)
+			span := completedCycleSpan{
+				Start:        start,
+				NextStart:    CalendarDay(mustParseDashboardDay(t, "2026-03-30"), location),
+				CycleLength:  28,
+				PeriodLength: 5,
+			}
+
+			row := statsCycleRibbonRow(span, 28, 14, true, map[string]bool{})
+
+			// Cycle length 28, luteal 14 → ovulation on day 14, fertile window
+			// days 9..14 (ovulation minus five days through ovulation itself).
+			for _, day := range []int{9, 14} {
+				if !row.Days[day-1].IsFertile {
+					t.Fatalf("day %d must be inside the fertile window", day)
+				}
+			}
+			if row.Days[7].IsFertile {
+				t.Fatalf("day 8 must sit outside the fertile window")
+			}
+			if !row.Days[13].IsFertilePeak {
+				t.Fatalf("day 14 must be the fertile peak")
+			}
+			// The two axes of the same cell must agree.
+			if row.Days[13].Phase != "ovulation" {
+				t.Fatalf("day 14 phase = %q, want \"ovulation\"", row.Days[13].Phase)
+			}
+		})
+	}
+}

--- a/internal/services/calendar_feed_ics.go
+++ b/internal/services/calendar_feed_ics.go
@@ -169,7 +169,12 @@ func calendarFeedEvents(input CalendarFeedICSInput) []calendarFeedEvent {
 		}
 
 		window := PredictCycleWindow(anchor, cycleLength, stats.LutealPhase)
-		if window.Calculable && !window.OvulationDate.Before(today) {
+		// nextPeriodStart above is a location midnight like today, so it compares
+		// directly; window.OvulationDate is a UTC-midnight date-only value and
+		// needs a calendar-day comparison, or the ovulation event disappears from
+		// the feed on the ovulation day itself in every UTC-minus zone (issue #48
+		// class).
+		if window.Calculable && CalendarDaysBetween(window.OvulationDate, today) <= 0 {
 			appendEvent("ovulation", CalendarDay(window.OvulationDate, input.Location))
 		}
 	}

--- a/internal/services/cycle_baseline.go
+++ b/internal/services/cycle_baseline.go
@@ -140,8 +140,14 @@ func ProjectCycleStart(lastPeriodStart time.Time, cycleLength int, today time.Ti
 	return projectedStart, projectedCycleDay, true
 }
 
+// ShiftCycleStartToFutureOvulation rolls the cycle anchor forward whole cycles
+// until the predicted ovulation is no longer in the past. The guard counts
+// calendar days, matching the lag arithmetic below it: ovulationDate arrives as
+// a UTC-midnight date-only value and today as a location-midnight working
+// value, so comparing them as instants fired the shift on the ovulation day
+// itself in every non-UTC zone (issue #48 class).
 func ShiftCycleStartToFutureOvulation(cycleStart time.Time, ovulationDate time.Time, cycleLength int, today time.Time) time.Time {
-	if cycleLength <= 0 || !ovulationDate.Before(today) {
+	if cycleLength <= 0 || CalendarDaysBetween(ovulationDate, today) <= 0 {
 		return cycleStart
 	}
 	lagDays := CalendarDaysBetween(ovulationDate, today)

--- a/internal/services/cycles.go
+++ b/internal/services/cycles.go
@@ -625,6 +625,13 @@ func dateOnly(t time.Time) time.Time {
 	return time.Date(y, m, d, 0, 0, 0, 0, time.UTC)
 }
 
+// filterLogsNotAfter drops the logs whose calendar day falls after cutoff.
+// The comparison is a calendar-day one because the two operands carry
+// different midnight shapes: DailyLog.Date is stored at UTC midnight while
+// callers hand a cutoff built at location midnight (calendar_days.go,
+// cycle_start_policy.go, stats_cycle_insights.go). Compared as instants, a
+// UTC-plus zone reads today's own entry as belonging to tomorrow and drops it
+// (issue #48 class).
 func filterLogsNotAfter(logs []models.DailyLog, cutoff time.Time) []models.DailyLog {
 	if len(logs) == 0 || cutoff.IsZero() {
 		return logs
@@ -632,7 +639,7 @@ func filterLogsNotAfter(logs []models.DailyLog, cutoff time.Time) []models.Daily
 
 	filtered := make([]models.DailyLog, 0, len(logs))
 	for _, log := range logs {
-		if dateOnly(log.Date).After(cutoff) {
+		if CalendarDaysBetween(cutoff, log.Date) > 0 {
 			continue
 		}
 		filtered = append(filtered, log)

--- a/internal/services/dashboard_cycle.go
+++ b/internal/services/dashboard_cycle.go
@@ -265,7 +265,12 @@ func DashboardUpcomingPredictions(stats CycleStats, user *models.User, today tim
 
 	prediction.NextPeriodStart = CalendarDay(cycleStart.AddDate(0, 0, cycleLength), today.Location())
 	window := PredictCycleWindow(cycleStart, cycleLength, stats.LutealPhase)
-	if window.Calculable && window.OvulationDate.Before(today) {
+	// window.OvulationDate is a UTC-midnight date-only value while today is a
+	// location-midnight working value, so the two are compared as calendar days
+	// rather than as instants: local midnight in a UTC-minus zone falls hours
+	// after UTC midnight of the same date, which read today's ovulation as past
+	// and rolled the anchor a full cycle forward (issue #48 class).
+	if window.Calculable && CalendarDaysBetween(window.OvulationDate, today) > 0 {
 		cycleStart = ShiftCycleStartToFutureOvulation(cycleStart, window.OvulationDate, cycleLength, today)
 		window = PredictCycleWindow(cycleStart, cycleLength, stats.LutealPhase)
 	}

--- a/internal/services/stats_cycle_ribbon.go
+++ b/internal/services/stats_cycle_ribbon.go
@@ -145,8 +145,16 @@ func statsCycleRibbonRow(cycle completedCycleSpan, axisDays int, luteal int, sho
 		if showPhases {
 			cell.Phase = statsCycleRibbonPhase(day, cycle.PeriodLength, window, cycle.Start)
 			if window.Calculable {
-				cell.IsFertile = !date.Before(window.FertilityWindowStart) && !date.After(window.FertilityWindowEnd)
-				cell.IsFertilePeak = date.Equal(window.OvulationDate)
+				// date is a location midnight (cycle.Start carries the row's own
+				// location) while the window bounds are UTC-midnight date-only
+				// values, so both ends are compared as calendar days — exactly as
+				// the phase axis above already does through CalendarDaysBetween.
+				// As instants the pair drops the last fertile day in a UTC-minus
+				// zone and the first one in a UTC-plus zone, and the peak equality
+				// is never true outside UTC at all (issue #48 class).
+				cell.IsFertile = CalendarDaysBetween(window.FertilityWindowStart, date) >= 0 &&
+					CalendarDaysBetween(date, window.FertilityWindowEnd) >= 0
+				cell.IsFertilePeak = CalendarDaysBetween(date, window.OvulationDate) == 0
 			}
 		} else if isPeriod {
 			// With inferred phases off, the observed period days are still a

--- a/internal/services/webhook_reminder.go
+++ b/internal/services/webhook_reminder.go
@@ -289,7 +289,12 @@ func ovulationCycleAnchor(stats CycleStats, today time.Time, cycleLength int) ti
 		return time.Time{}
 	}
 	window := PredictCycleWindow(cycleStart, cycleLength, stats.LutealPhase)
-	if window.Calculable && window.OvulationDate.Before(today) {
+	// The same calendar-day comparison DashboardUpcomingPredictions makes:
+	// window.OvulationDate is a UTC-midnight date-only value, today an owner
+	// location midnight, and comparing them as instants shifted the outbound
+	// reminder's anchor a full cycle on the ovulation day itself in every
+	// UTC-minus zone (issue #48 class).
+	if window.Calculable && CalendarDaysBetween(window.OvulationDate, today) > 0 {
 		cycleStart = ShiftCycleStartToFutureOvulation(cycleStart, window.OvulationDate, cycleLength, today)
 	}
 	return CalendarDay(cycleStart, today.Location())


### PR DESCRIPTION
## The defect class

A calendar day built in the request/owner zone (`DateAtLocation`, `CalendarDay(…, location)`) and a
calendar day built at UTC midnight (`dateOnly`, every `PredictCycleWindow` output) name the SAME date
but are DIFFERENT instants: local midnight in a UTC−X zone falls hours AFTER UTC midnight of that
date, and in a UTC+X zone hours before it. Six sites compared such a pair with raw
`Before`/`After`/`Equal`, so each of them misread the same calendar day.

**This needs no DST transition.** It misbehaves on an ordinary day, every day, in every non-UTC
zone — which is what separates this class from the DST-midnight fix (`startOfCalendarDay`) that
preceded it.

The property this restores: a comparison between two calendar days is made on calendar days, never on
instants. `CalendarDaysBetween` (`internal/services/day_utils.go`) re-anchors BOTH operands to UTC
midnight of their own calendar day and is the sanctioned instrument;
`internal/services/cycle_start_policy.go:100` was already the working precedent, and each site now
follows its shape with the reasoning in a comment above it.

## Per-site consequence

Line numbers below name the pre-change source.

| Site | Consequence before this change |
| --- | --- |
| `internal/services/dashboard_cycle.go:268` — `window.OvulationDate.Before(today)` | West of UTC, today's ovulation read as past, `ShiftCycleStartToFutureOvulation` fired and rolled the anchor a FULL CYCLE forward on every owner-facing surface. Highest impact. |
| `internal/services/cycle_baseline.go:144` — the guard inside that shift | Same misread at the shared entry point; the function's own lag arithmetic already counted calendar days, so the shift ran with a lag of zero and still added a whole cycle. |
| `internal/services/cycles.go:635` — `filterLogsNotAfter` | East of UTC today's own entry was dropped, so a same-day BBT shift was never detected and the calendar kept painting a tentative ovulation. |
| `internal/services/calendar_feed_ics.go:172` — `!window.OvulationDate.Before(today)` | West of UTC the ovulation event was missing from the `.ics` on the ovulation day. The period line directly above it (`:167`) was already correct — both operands location midnights — so one function carried two shapes. |
| `internal/services/webhook_reminder.go:292` — `ovulationCycleAnchor` | The same cycle-forward roll, feeding the OUTBOUND reminder's anchor, so the reminder and the dashboard could disagree. |
| `internal/services/stats_cycle_ribbon.go:148-149` | Breaks in both directions: the first (east) or last (west) fertile day went unshaded, and `date.Equal(window.OvulationDate)` was **never** true outside UTC, so `IsFertilePeak` never rendered — while the neighbouring line `:146`, which already routes through `CalendarDaysBetween`, coloured that same cell as ovulation. The function contradicted itself. |

## Caller sweep

`filterLogsNotAfter` has four callers, not three: `calendar_days.go:343`, `cycle_start_policy.go:80`
and `stats_cycle_insights.go:264` all pass a location midnight and were all affected;
`cycles.go:53` passes `dateOnly(now)` and was already safe. Fixing the comparison inside the callee
covers all four without touching a caller.

## Guards

`internal/services/calendar_day_comparison_regression_test.go` — one per confirmed site, each driving
a real non-UTC zone chosen by the direction the site breaks in (an ordinary day; no DST transition
involved), each with a UTC control that must stay unchanged. Against the unfixed code every one fails
and every UTC control passes:

```
--- FAIL: TestDashboardUpcomingPredictionsKeepsTodaysOvulation/west_of_UTC
    ovulation on the day itself = 2026-04-12, want 2026-03-15 (the anchor must not roll a cycle forward)
--- FAIL: TestShiftCycleStartToFutureOvulationKeepsTodaysAnchor/west_of_UTC
    anchor after an ovulation that is today = 2026-03-30, want 2026-03-02 (no shift)
--- FAIL: TestFilterLogsNotAfterKeepsTodaysLogEastOfUTC/east_of_UTC
    logs kept up to and including today = [2026-03-14], want [2026-03-14 2026-03-15]
--- FAIL: TestFilterLogsNotAfterKeepsTodaysLogEastOfUTC/far_east_of_UTC
    logs kept up to and including today = [2026-03-14], want [2026-03-14 2026-03-15]
--- FAIL: TestCalendarFeedKeepsTodaysOvulationEventWestOfUTC/west_of_UTC
    the ovulation event on the ovulation day must stay in the feed, got: <feed carrying ovulation-20260407, not 20260310>
--- FAIL: TestOvulationCycleAnchorKeepsTodaysCycleWestOfUTC/west_of_UTC
    reminder anchor on the ovulation day = 2026-03-30, want 2026-03-02
--- FAIL: TestStatsCycleRibbonFertileWindowIsCalendarBound/west_of_UTC
    day 14 must be inside the fertile window
--- FAIL: TestStatsCycleRibbonFertileWindowIsCalendarBound/east_of_UTC
    day 9 must be inside the fertile window
```

The shift guard also carries a positive anchor — an ovulation genuinely in the past still shifts the
anchor a cycle forward — so the guard cannot pass by disabling the shift.

## Carve-outs deliberately left alone

- **Every TTL / expiry / freshness comparison** — sessions, `attempt_limiter`, OIDC state, cookie
  lifetimes. Those compare true instants at sub-day resolution; routing them through calendar days
  would truncate to 0 and keep an expired session valid all day.
- `day_utils.go` `FilterLogsByDateRange` — `toEnd` is an exclusive next-day bound from `DayRange`, so
  a calendar-day rewrite would silently turn the half-open range inclusive by a day. Left
  instant-based.
- Sites where both operands already share a shape, where a rewrite is a no-op:
  `calendar_feed_ics.go:167`, `dashboard_cycle.go:447/452`, `cycle_baseline.go:132`,
  `cycles.go:471/614` and `ResolveFertilityStatus`'s `betweenInclusive`.
- `calendar_days.go` and `date_parse_policy.go` are untouched. Their own instances of the family
  landed separately (`0d08897b`, `63a40d7a`); this branch is rebased on top of them and shares no
  file with either.

## Known non-finding, not fixed here

`dashboard_cycle.go:454` carries the same mixed pair but is unreachable-true: the value it tests has
already passed the predicate at `:268-271`, so the post-shift ovulation is always ≥ today +
cycleLength. That is dead code, a different defect, and it belongs to its own change.

## Validation

All run on the rebased tree:

- `gofmt -l internal/` — the file list is identical to `main`'s (five files diverge on a doc-comment
  rule under the pinned toolchain, none of them in a region this change edits).
- `go build ./...` — clean.
- `go test ./... -timeout 20m` — every package `ok`.
- `golangci-lint run` — `0 issues`.
- `go run ./scripts/patchcov` against a profile regenerated in the same invocation — every modified
  coverable line is covered.
- Egress regressions: `TestResolveFeedPrefersOwnerStoredTimezoneOverRequestChain` (which pins the
  correct behaviour at UTC+14, where the ovulation day genuinely IS yesterday and the event must
  still drop), `TestVerifyCalendarFeedTokenPrefersMACOverBcrypt`,
  `TestResolveFeedBackfillsMACForPre032RowAndLeavesBcryptBehind`,
  `TestNotifyOverdueCycleLeavesNoWatermarkAndResumesOnce`,
  `TestResolveOwnerLocationPrefersPersistedTimezone`, plus the whole `internal/cli` notify suite.

## Rollback

Revert the commit. The change is six comparison expressions plus one test file — no schema, no
migration, no persisted value, no stored format, and no exported signature changes; a revert restores
the previous behaviour exactly.
