### PR TITLE
fix: anchor the calendar month on the requested month, not the zone's midnight

### DIFF
--- a/changelog.d/fix-calendar-month-query-anchor.md
+++ b/changelog.d/fix-calendar-month-query-anchor.md
@@ -1,0 +1,16 @@
+### Fixed
+
+- **The calendar no longer opens the wrong month in time zones whose clock jump
+  lands on the first of a month.** In zones west of UTC where daylight saving
+  starts at 00:00 on a first-of-month (America/Asuncion 2023-10-01,
+  America/Havana 2012-04-01), local midnight does not exist that day. The month
+  the page anchors on was parsed and built directly in the request zone, so the
+  missing midnight resolved one calendar day backward: asking for that month
+  rendered the whole grid, the heading and the month value for the *previous*
+  month instead. The month links inherited it — "previous" skipped a month, and
+  "next" pointed back at the page already shown, so the affected month could not
+  be reached at all — and the same construction shifted the lower navigation
+  bound a month past the account's own history. Month anchors are now stepped as
+  calendar dates and resolved through the single day-construction point, so the
+  requested month is the month that renders. Zones and months without such a
+  transition, including UTC, behave exactly as before.

--- a/internal/services/calendar_view_policy.go
+++ b/internal/services/calendar_view_policy.go
@@ -31,7 +31,7 @@ func ResolveCalendarMonthAndSelectedDateWithinBounds(monthQueryRaw string, selec
 		if selectedDay, parseErr := parseCalendarDayParam(selectedDayRaw, location); parseErr == nil {
 			selectedDate = selectedDay.Format("2006-01-02")
 			if monthQuery == "" {
-				activeMonth = time.Date(selectedDay.Year(), selectedDay.Month(), 1, 0, 0, 0, 0, location)
+				activeMonth = calendarMonthAnchor(selectedDay, location)
 			}
 		}
 	}
@@ -54,12 +54,19 @@ func ResolveCalendarMonthAndSelectedDateWithinBounds(monthQueryRaw string, selec
 // values for the navigation controls; the previous one is empty when it would
 // fall before minMonth. A zero minMonth means no lower bound.
 func CalendarAdjacentMonthValuesWithinBounds(monthStart time.Time, minMonth time.Time) (string, string) {
-	prevMonth := monthStart.AddDate(0, -1, 0)
+	// Stepping a month sideways is pure calendar arithmetic, so it runs on a
+	// UTC-anchored copy — the convention calendarGridBounds already follows. Run
+	// in the request zone instead, AddDate lands on a wall clock that a DST jump
+	// on the target month's FIRST does not have, and resolves it backward into
+	// the month before: the "previous month" link then skips a month entirely,
+	// and the "next" link points back at the page the reader is already on.
+	base := CalendarDay(monthStart, time.UTC)
+	prevMonth := base.AddDate(0, -1, 0)
 	prevValue := prevMonth.Format("2006-01")
 	if calendarMonthBefore(prevMonth, minMonth) {
 		prevValue = ""
 	}
-	return prevValue, monthStart.AddDate(0, 1, 0).Format("2006-01")
+	return prevValue, base.AddDate(0, 1, 0).Format("2006-01")
 }
 
 func CalendarMinimumNavigableMonth(user *models.User, location *time.Location) time.Time {
@@ -70,20 +77,41 @@ func CalendarMinimumNavigableMonth(user *models.User, location *time.Location) t
 		location = time.UTC
 	}
 
-	minDate := DateAtLocation(user.CreatedAt, location).AddDate(-3, 0, 0)
-	return time.Date(minDate.Year(), minDate.Month(), 1, 0, 0, 0, 0, location)
+	// The three-year step is calendar arithmetic on a date, so it too runs
+	// UTC-anchored: taken in the request zone it can land on a first-of-month
+	// whose local midnight a DST jump skipped and slide the bound a month
+	// earlier than the account's own history justifies.
+	createdDay := CalendarDay(DateAtLocation(user.CreatedAt, location), time.UTC)
+	return calendarMonthAnchor(createdDay.AddDate(-3, 0, 0), location)
 }
 
 func parseCalendarMonthQuery(raw string, now time.Time, location *time.Location) (time.Time, error) {
 	if raw == "" {
-		current := DateAtLocation(now, location)
-		return time.Date(current.Year(), current.Month(), 1, 0, 0, 0, 0, location), nil
+		return calendarMonthAnchor(DateAtLocation(now, location), location), nil
 	}
-	parsed, err := time.ParseInLocation("2006-01", raw, location)
+	// Parsed in UTC, which has no transitions, so the requested year and month
+	// survive the parse untouched — the same reason ParseDayDate parses there.
+	// time.ParseInLocation resolves a nonexistent local midnight exactly as
+	// time.Date does, so in a UTC-minus zone whose DST jump lands on the first
+	// of the requested month it returned the LAST day of the previous month, and
+	// the whole page then rendered that month instead.
+	parsed, err := time.Parse("2006-01", raw)
 	if err != nil {
 		return time.Time{}, err
 	}
-	return time.Date(parsed.Year(), parsed.Month(), 1, 0, 0, 0, 0, location), nil
+	return calendarMonthAnchor(parsed, location), nil
+}
+
+// calendarMonthAnchor returns the first day of value's calendar month, resolved
+// in location through the package's single day-construction point
+// (startOfCalendarDay, via CalendarDay): midnight, or the day's first existing
+// instant when a DST jump skipped it. The month step itself is taken on a
+// UTC-anchored copy, where no midnight is ever missing, so the year and month
+// of the result always equal those of value. A zero value stays zero: CalendarDay
+// passes it through, and the day step is a no-op on it.
+func calendarMonthAnchor(value time.Time, location *time.Location) time.Time {
+	utcDay := CalendarDay(value, time.UTC)
+	return CalendarDay(utcDay.AddDate(0, 0, 1-utcDay.Day()), location)
 }
 
 func parseCalendarDayParam(raw string, location *time.Location) (time.Time, error) {
@@ -92,7 +120,7 @@ func parseCalendarDayParam(raw string, location *time.Location) (time.Time, erro
 
 func clampCalendarMonthToMinimum(monthStart time.Time, minMonth time.Time, location *time.Location) time.Time {
 	if calendarMonthBefore(monthStart, minMonth) {
-		return time.Date(minMonth.Year(), minMonth.Month(), 1, 0, 0, 0, 0, resolveCalendarLocation(location, minMonth))
+		return calendarMonthAnchor(minMonth, resolveCalendarLocation(location, minMonth))
 	}
 	return monthStart
 }

--- a/internal/services/calendar_view_policy_test.go
+++ b/internal/services/calendar_view_policy_test.go
@@ -140,3 +140,164 @@ func TestCalendarMinimumNavigableMonth(t *testing.T) {
 		t.Fatalf("expected minimum month 2023-03-01, got %s", minMonth.Format("2006-01-02"))
 	}
 }
+
+// TestCalendarMonthAnchorsSurviveASkippedFirstOfMonthMidnight pins the whole
+// month-anchoring surface of this file against the one date shape that breaks
+// it: a UTC-minus zone whose DST jump lands exactly on the FIRST of a month.
+// No instant exists at 00:00 local that day, and a plain time.Date /
+// ParseInLocation resolves the missing wall clock BACKWARD into the last day of
+// the PREVIOUS month. Every value derived from that anchor then names the wrong
+// month — the rendered grid, the month label, the ?month= value, both
+// navigation links, and the lower navigation bound.
+//
+// The two reproducing pairs come from a full scan of the zone database shipped
+// with the toolchain (598 zones, tzdata 2025c, every date 1970-01-01..2040-12-31):
+// 66 zone/date pairs skip midnight on the 1st, all of them west of UTC.
+//
+//	America/Asuncion 2023-10-01 → time.Date(...) = 2023-09-30 23:00 -04:00
+//	America/Havana   2012-04-01 → time.Date(...) = 2012-03-31 23:00 -05:00
+//
+// East-of-UTC zones normalize FORWARD and keep the date, so a test on one of
+// them goes green while proving nothing; both controls below therefore hold the
+// ordinary path instead — the same zone in a month with no transition, and UTC.
+func TestCalendarMonthAnchorsSurviveASkippedFirstOfMonthMidnight(t *testing.T) {
+	asuncion, err := time.LoadLocation("America/Asuncion")
+	if err != nil {
+		t.Fatalf("load America/Asuncion: %v", err)
+	}
+	havana, err := time.LoadLocation("America/Havana")
+	if err != nil {
+		t.Fatalf("load America/Havana: %v", err)
+	}
+
+	testCases := []struct {
+		name        string
+		location    *time.Location
+		month       string
+		selectedDay string
+		prevMonth   string
+		nextMonth   string
+		skipsFirst  bool
+	}{
+		{
+			name:        "asuncion october 2023 skips the first midnight",
+			location:    asuncion,
+			month:       "2023-10",
+			selectedDay: "2023-10-15",
+			prevMonth:   "2023-09",
+			nextMonth:   "2023-11",
+			skipsFirst:  true,
+		},
+		{
+			name:        "havana april 2012 skips the first midnight",
+			location:    havana,
+			month:       "2012-04",
+			selectedDay: "2012-04-15",
+			prevMonth:   "2012-03",
+			nextMonth:   "2012-05",
+			skipsFirst:  true,
+		},
+		{
+			// November 2023 has an ordinary first, so its own anchor is fine; the
+			// PREVIOUS-month link steps onto 2023-10-01 and is not.
+			name:        "asuncion november 2023 steps back onto a skipped first",
+			location:    asuncion,
+			month:       "2023-11",
+			selectedDay: "2023-11-15",
+			prevMonth:   "2023-10",
+			nextMonth:   "2023-12",
+		},
+		{
+			name:        "control: asuncion june 2023, no transition in reach",
+			location:    asuncion,
+			month:       "2023-06",
+			selectedDay: "2023-06-15",
+			prevMonth:   "2023-05",
+			nextMonth:   "2023-07",
+		},
+		{
+			name:        "control: utc october 2023",
+			location:    time.UTC,
+			month:       "2023-10",
+			selectedDay: "2023-10-15",
+			prevMonth:   "2023-09",
+			nextMonth:   "2023-11",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			requested, err := time.Parse("2006-01", testCase.month)
+			if err != nil {
+				t.Fatalf("parse the requested month %q: %v", testCase.month, err)
+			}
+			// Re-measure the premise against the tzdata actually linked into this
+			// run rather than trusting the table: a zone-database revision that
+			// moves either transition must fail loudly here, not turn the case
+			// into a control that silently proves nothing.
+			probe := time.Date(requested.Year(), requested.Month(), 1, 0, 0, 0, 0, testCase.location)
+			skipped := probe.Month() != requested.Month()
+			if skipped != testCase.skipsFirst {
+				t.Fatalf("premise drifted: time.Date(1st of %s, %s) = %s, so midnight-skipped=%t but the case expects %t — rescan the zone database and repin",
+					testCase.month, testCase.location, probe.Format(time.RFC3339), skipped, testCase.skipsFirst)
+			}
+
+			now := time.Date(2026, time.August, 17, 12, 0, 0, 0, time.UTC)
+
+			t.Run("month query", func(t *testing.T) {
+				month, _, err := ResolveCalendarMonthAndSelectedDateWithinBounds(testCase.month, "", now, testCase.location, time.Time{})
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got := month.Format("2006-01"); got != testCase.month {
+					t.Fatalf("?month=%s rendered %s", testCase.month, got)
+				}
+
+				prev, next := CalendarAdjacentMonthValuesWithinBounds(month, time.Time{})
+				if prev != testCase.prevMonth {
+					t.Fatalf("previous month link for %s = %q, want %q", testCase.month, prev, testCase.prevMonth)
+				}
+				if next != testCase.nextMonth {
+					t.Fatalf("next month link for %s = %q, want %q", testCase.month, next, testCase.nextMonth)
+				}
+			})
+
+			t.Run("month derived from the selected day", func(t *testing.T) {
+				month, selectedDate, err := ResolveCalendarMonthAndSelectedDateWithinBounds("", testCase.selectedDay, now, testCase.location, time.Time{})
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if selectedDate != testCase.selectedDay {
+					t.Fatalf("selected date = %q, want %q", selectedDate, testCase.selectedDay)
+				}
+				if got := month.Format("2006-01"); got != testCase.month {
+					t.Fatalf("selected day %s put the grid on %s, want %s", testCase.selectedDay, got, testCase.month)
+				}
+			})
+
+			t.Run("minimum navigable month", func(t *testing.T) {
+				// The bound is the month of CreatedAt minus three years, so an
+				// account created three years after the transition date has its
+				// lower bound land on exactly that first-of-month.
+				user := &models.User{
+					CreatedAt: time.Date(requested.Year()+3, requested.Month(), 14, 12, 0, 0, 0, time.UTC),
+				}
+				minMonth := CalendarMinimumNavigableMonth(user, testCase.location)
+				if got := minMonth.Format("2006-01"); got != testCase.month {
+					t.Fatalf("minimum navigable month = %s, want %s", got, testCase.month)
+				}
+			})
+
+			t.Run("clamp to the minimum month", func(t *testing.T) {
+				minMonth := time.Date(requested.Year(), requested.Month(), 1, 0, 0, 0, 0, time.UTC)
+				month, _, err := ResolveCalendarMonthAndSelectedDateWithinBounds("2001-01", "", now, testCase.location, minMonth)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got := month.Format("2006-01"); got != testCase.month {
+					t.Fatalf("month clamped to the lower bound = %s, want %s", got, testCase.month)
+				}
+			})
+		})
+	}
+}


### PR DESCRIPTION
## The construction

`internal/services/calendar_view_policy.go` resolved the month the calendar page opens on with a
bare `time.ParseInLocation("2006-01", raw, location)` and built every month anchor with a raw
`time.Date(year, month, 1, 0, 0, 0, 0, location)` — none of it through the package's single
day-resolution point (`startOfCalendarDay`, reached via `CalendarDay` / `DateAtLocation` /
`ParseDayDate`).

In a zone west of UTC whose DST jump starts at 00:00 on the **first of a month**, local midnight
does not exist that day. `time.Date` and `time.ParseInLocation` resolve the nonexistent wall clock
through the `utc >= end` branch, which normalizes **backward** — into the last day of the previous
month. Consequences, all of them whole-month rather than one day off:

- `?month=YYYY-MM` for such a month rendered the **previous** month: grid, heading and the
  `MonthValue` echoed back into the page.
- Both navigation links inherited it (`Format("2006-01")` off the same anchor). "Previous" from the
  month after skipped over it; "next" from the month before landed on it and rendered its
  predecessor. The month was unreachable from the UI in that zone.
- Selecting a day inside such a month with no `month` query put the grid on the previous month
  (`:34`).
- `CalendarMinimumNavigableMonth` slid the lower navigation bound one month earlier than the
  account's own history justifies.

## What the tzdata run showed

The zone database shipped with the toolchain was scanned in full — every IANA zone, every date
1970-01-01..2040-12-31, classifying each date as A (midnight missing, date normalized backward),
B (whole calendar day skipped) or C (midnight missing but the date survived, i.e. normalized
forward).

```
zone source: zoneinfo.zip: <GOROOT>/lib/time/zoneinfo.zip
zones loaded: 598
tzdata version: tzcode 2025c / tzdata 2025c
go: go1.26.4
dates per zone: 25933 (1970-01-01..2040-12-31, no gaps)

TOTAL findings: 2074  (type A: 1066, type B: 7, type C forward-kept-date: 1001,
                       first-of-month A/B: 66)
zones with findings: 199
```

So this was **not** a latent construction: **66 zone/date pairs skip midnight on the first of a
month, every one of them west of UTC**, and none of them are type B. The most reachable, and the
two the regression pins:

| zone | date | `time.Date(y,m,1,0,0,0,0,loc)` returns |
|---|---|---|
| `America/Asuncion` | 2023-10-01 | `2023-09-30 23:00:00 -04:00` |
| `America/Havana`   | 2012-04-01 | `2012-03-31 23:00:00 -05:00` |

`America/Asuncion 2023-10-01` is the most recent first-of-month case in tzdata 2025c — Paraguay
dropped DST after it, and the database holds no first-of-month case beyond 2023. It is still a
live defect rather than a latent one: 2023-10 sits inside the page's own navigable range for any
account whose lower bound reaches it, so an owner in that zone could not open October 2023 at all.
Every such case now lies in the past, so the class shrinks over time but does not disappear from
the history the calendar lets an owner walk back through.

The scan reports its own toolchain as `go1.26.4`; the regression re-measures both pinned
transitions under the toolchain this repository builds with and agrees with the table above.

## The fix

All month anchoring in the file now goes through one helper:

```go
func calendarMonthAnchor(value time.Time, location *time.Location) time.Time {
	utcDay := CalendarDay(value, time.UTC)
	return CalendarDay(utcDay.AddDate(0, 0, 1-utcDay.Day()), location)
}
```

The month step runs on a **UTC-anchored** copy, where no midnight is ever missing — the convention
`calendarGridBounds` in `calendar_days.go` already follows — and the result is resolved in the
request zone through `CalendarDay`, i.e. `startOfCalendarDay`: midnight, or the day's first
existing instant when one is skipped. The query is parsed with `time.Parse` (UTC, no transitions)
for the same reason `ParseDayDate` parses there. The adjacent-month links and the three-year step
in `CalendarMinimumNavigableMonth` are likewise taken UTC-anchored. There is no longer a raw
`time.Date(..., location)` or a `ParseInLocation` in the file.

The returned anchor keeps the request-zone shape it has always had, so no consumer sees a changed
value shape — only a correctly named month.

## Caller sweep

Everything that consumes this file's outputs, with a verdict each:

| consumer | reads | verdict |
|---|---|---|
| `handlers_calendar_page.go:21,26` | `minMonth`, `activeMonth`, `selectedDate` | unchanged; the invalid-month error path (`time.Parse` vs `ParseInLocation`) rejects exactly the same inputs |
| `calendar_view_service.go:55` → `CalendarLogRange(monthStart)` | the anchor as an **instant** (`AddDate ±70d` → `DayRange`) | the only shape-sensitive consumer; shape is preserved, so the fetched range is identical for ordinary months and now centred on the right month for the defective ones |
| `calendar_view_service.go:68` → `BuildCalendarDayStates(..., monthStart, ...)` | `calendarGridBounds` re-anchors via `CalendarDay(monthStart, time.UTC)`; `buildCalendarDayState` reads `monthStart.Month()` | component-only, shape-insensitive; grid identical for ordinary months |
| `calendar_view_service.go:67` → `CalendarAdjacentMonthValuesWithinBounds` | `AddDate(0,±1,0).Format("2006-01")` | **fixed**: now stepped UTC-anchored, so a link onto a skipped first-of-month names that month |
| `calendar_view_service.go:74,75` | `LocalizedMonthYear`, `monthStart.Format("2006-01")` | component-only; unchanged |
| `calendarMonthBefore` (clamp + selected-date reset) | `month.Date()` components | component-only; unchanged except that both operands now carry the correct month |
| selected-day handling (`:31-48`) | `ParseDayDate` → already sanctioned; month derived from it | **fixed** at `:34`; the `selectedDate` string itself was already correct |

**Ordinary months in ordinary zones are unchanged.** For any month whose first-of-month midnight
exists in the request zone — which is every month in UTC and every month in a zone with no
00:00 transition on a 1st, i.e. all but 66 zone/date pairs in tzdata 2025c —
`calendarMonthAnchor` returns bit-for-bit what the previous `time.Date(y, m, 1, 0, 0, 0, 0, loc)`
returned. Which month the page shows, the navigation bounds (still the month of
`CreatedAt - 3 years`) and the fallback behaviour when the query is absent or unparseable are all
untouched.

## The guard

`TestCalendarMonthAnchorsSurviveASkippedFirstOfMonthMidnight` drives all four anchors — the month
query, the month derived from a selected day, the minimum navigable month and the clamp — across a
table of west-of-UTC zones, plus the previous/next links. East-of-UTC zones normalize forward and
keep the date, so a test on one proves nothing; the controls are an ordinary month in the same
zone (`America/Asuncion` 2023-06) and UTC instead. Each case **re-measures its own premise** against
the tzdata actually linked into the run and fails loudly if a zone-database revision moved a
transition, rather than silently degrading into a control.

Run against the unfixed code, it failed and named the culprit:

```
--- FAIL: .../asuncion_october_2023_skips_the_first_midnight/month_query
    calendar_view_policy_test.go:253: ?month=2023-10 rendered 2023-09
--- FAIL: .../asuncion_october_2023_skips_the_first_midnight/month_derived_from_the_selected_day
    calendar_view_policy_test.go:274: selected day 2023-10-15 put the grid on 2023-09, want 2023-10
--- FAIL: .../asuncion_october_2023_skips_the_first_midnight/minimum_navigable_month
    calendar_view_policy_test.go:287: minimum navigable month = 2023-09, want 2023-10
--- FAIL: .../asuncion_october_2023_skips_the_first_midnight/clamp_to_the_minimum_month
    calendar_view_policy_test.go:298: month clamped to the lower bound = 2023-09, want 2023-10
--- FAIL: .../havana_april_2012_skips_the_first_midnight/month_query
    calendar_view_policy_test.go:253: ?month=2012-04 rendered 2012-03
--- FAIL: .../havana_april_2012_skips_the_first_midnight/month_derived_from_the_selected_day
    calendar_view_policy_test.go:274: selected day 2012-04-15 put the grid on 2012-03, want 2012-04
--- FAIL: .../havana_april_2012_skips_the_first_midnight/minimum_navigable_month
    calendar_view_policy_test.go:287: minimum navigable month = 2012-03, want 2012-04
--- FAIL: .../havana_april_2012_skips_the_first_midnight/clamp_to_the_minimum_month
    calendar_view_policy_test.go:298: month clamped to the lower bound = 2012-03, want 2012-04
--- FAIL: .../asuncion_november_2023_steps_back_onto_a_skipped_first/month_query
    calendar_view_policy_test.go:258: previous month link for 2023-11 = "2023-09", want "2023-10"
```

Both controls passed unfixed and pass fixed, which is what makes the nine failures above mean
something. The November case was drafted as a control and turned out to be a finding — an
*ordinary* month whose "previous" link steps onto a skipped first — so it is labelled as one.

## Validation

| command | verdict |
|---|---|
| `gofmt -l internal/services/calendar_view_policy.go internal/services/calendar_view_policy_test.go` | clean |
| `go build ./...` | ok |
| `go test ./internal/services/... -timeout 20m` | ok (105.6 s) |
| `go test ./internal/api/... -timeout 20m` | ok (442.9 s) |
| `golangci-lint run ./internal/services/...` | 0 issues |
| `scripts/patchcov` (profile regenerated in the same invocation) | every modified coverable line covered |

## Rollback

Revert the commit. The change is confined to `internal/services/calendar_view_policy.go`, its test
file and one changelog fragment; it touches no schema, no persisted value, no route and no exported
signature, so a revert restores the previous behaviour exactly — including the defect.
