### PR TITLE
fix: compare the ovulation-in-past predicate as calendar days

### DIFF
--- a/changelog.d/fix-ovulation-in-past-calendar-day.md
+++ b/changelog.d/fix-ovulation-in-past-calendar-day.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- **The dashboard no longer calls today's ovulation estimate "already in the
+  past".** Accounts west of UTC saw the amber "this date is already in the past"
+  notice, and the prompt to update their cycle data, printed beside the ovulation
+  date the header had just named — on the ovulation day of every cycle, on an
+  ordinary account with no irregular mode and no daylight-saving change involved.

--- a/internal/api/dashboard_regressions_test.go
+++ b/internal/api/dashboard_regressions_test.go
@@ -780,6 +780,67 @@ func TestBuildDashboardViewDataOmitsReminderBannerForNonOwner(t *testing.T) {
 	}
 }
 
+// TestDashboardDoesNotFlagTodaysOvulationAsPastWestOfUTC is the rendered half of
+// the services-layer guard in calendar_day_comparison_regression_test.go: the
+// projected ovulation date is a UTC-midnight value while the request's "today"
+// is a location midnight, so west of UTC the ovulation day itself read as
+// already past and the amber prediction-past notice rendered beside the very
+// date the header had just named. One ordinary account, no irregular mode, no
+// DST date — the state appeared on the ovulation day of every cycle.
+//
+// The anchor is seeded relative to the live clock: the subject computes against
+// time.Now(), so a fixed calendar date would drift out of the cycle it was
+// written for.
+func TestDashboardDoesNotFlagTodaysOvulationAsPastWestOfUTC(t *testing.T) {
+	const timezoneName = "America/New_York"
+
+	location, err := time.LoadLocation(timezoneName)
+	if err != nil {
+		t.Fatalf("load %s: %v", timezoneName, err)
+	}
+
+	app, database, _ := newOnboardingTestAppWithLocation(t, time.UTC)
+	user := createOnboardingTestUser(t, database, "dashboard-ovulation-today@example.com", "StrongPass1", true)
+
+	// A 28-day cycle with the default 14-day luteal phase ovulates on cycle
+	// day 14, so an anchor 13 days back puts the predicted ovulation on today.
+	today := services.DateAtLocation(time.Now(), location)
+	currentStart := today.AddDate(0, 0, -13)
+	previousStart := currentStart.AddDate(0, 0, -28)
+	for _, cycleStart := range []time.Time{previousStart, currentStart} {
+		for offset := range 5 {
+			day := services.CalendarDay(cycleStart.AddDate(0, 0, offset), time.UTC)
+			entry := models.DailyLog{
+				UserID:     user.ID,
+				Date:       day,
+				IsPeriod:   true,
+				CycleStart: offset == 0,
+				Flow:       models.FlowMedium,
+			}
+			if err := database.Create(&entry).Error; err != nil {
+				t.Fatalf("seed period day %s: %v", day.Format("2006-01-02"), err)
+			}
+		}
+	}
+	if err := database.Model(&models.User{}).Where("id = ?", user.ID).Updates(map[string]any{
+		"cycle_length":      28,
+		"period_length":     5,
+		"last_period_start": services.CalendarDay(currentStart, time.UTC),
+	}).Error; err != nil {
+		t.Fatalf("update ovulation-today cycle context: %v", err)
+	}
+
+	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
+	response := dashboardWithTimezoneResponse(t, app, authCookie, timezoneName)
+	document := mustParseHTMLDocument(t, mustReadBodyString(t, response.Body))
+
+	if htmlFindElement(document, func(node *html.Node) bool {
+		return node.Type == html.ElementNode && htmlHasAttr(node, "data-dashboard-prediction-past")
+	}) != nil {
+		t.Fatal("did not expect the prediction-past notice on the ovulation day itself")
+	}
+}
+
 func newOnboardingTestAppWithLocation(t *testing.T, location *time.Location) (*fiber.App, *gorm.DB, *time.Location) {
 	t.Helper()
 

--- a/internal/services/calendar_day_comparison_regression_test.go
+++ b/internal/services/calendar_day_comparison_regression_test.go
@@ -208,6 +208,115 @@ func TestOvulationCycleAnchorKeepsTodaysCycleWestOfUTC(t *testing.T) {
 	}
 }
 
+// TestDashboardOvulationInPastIsCalendarBound locks the non-range branch of
+// dashboard_cycle.go's dashboardOvulationInPast: display.ovulationDate is the
+// PredictCycleWindow output (UTC midnight) while today is a location midnight.
+// West of UTC the ovulation day itself read as already past, so the dashboard
+// named the ovulation date and printed the amber "date is already in the past"
+// warning beside it.
+//
+// The range branch one line above is the control that must stay untouched: both
+// of its operands come from DashboardOvulationRange, built with CalendarDay in
+// the request location, so they already share a shape.
+func TestDashboardOvulationInPastIsCalendarBound(t *testing.T) {
+	t.Parallel()
+
+	const renderDay = "2026-02-16"
+
+	for _, testCase := range []struct{ name, zone string }{
+		{name: "west of UTC", zone: "America/New_York"},
+		{name: "east of UTC", zone: "Asia/Tokyo"},
+		{name: "UTC control", zone: "UTC"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			location := calendarDayComparisonZone(t, testCase.zone)
+			today := calendarDayComparisonToday(t, renderDay, location)
+
+			todaysOvulation := dashboardPredictionDisplay{
+				ovulationDate: dateOnly(mustParseDashboardDay(t, renderDay)),
+			}
+			if dashboardOvulationInPast(todaysOvulation, today) {
+				t.Fatalf("an ovulation predicted for today must not read as already past")
+			}
+
+			// Positive anchor: an ovulation genuinely on an earlier calendar day
+			// still reports true, so the guard cannot be satisfied by disabling
+			// the state altogether.
+			pastOvulation := dashboardPredictionDisplay{
+				ovulationDate: dateOnly(mustParseDashboardDay(t, "2026-02-15")),
+			}
+			if !dashboardOvulationInPast(pastOvulation, today) {
+				t.Fatalf("an ovulation on an earlier calendar day must still read as past")
+			}
+
+			// The range branch, unchanged: same-shape operands on both sides.
+			todaysRangeEnd := dashboardPredictionDisplay{
+				ovulationUseRange:   true,
+				ovulationRangeEnd:   CalendarDay(mustParseDashboardDay(t, renderDay), location),
+				ovulationRangeStart: CalendarDay(mustParseDashboardDay(t, "2026-02-12"), location),
+			}
+			if dashboardOvulationInPast(todaysRangeEnd, today) {
+				t.Fatalf("an ovulation range ending today must not read as already past")
+			}
+			pastRangeEnd := todaysRangeEnd
+			pastRangeEnd.ovulationRangeEnd = CalendarDay(mustParseDashboardDay(t, "2026-02-15"), location)
+			if !dashboardOvulationInPast(pastRangeEnd, today) {
+				t.Fatalf("an ovulation range that ended yesterday must still read as past")
+			}
+		})
+	}
+}
+
+// TestBuildDashboardCycleContextKeepsTodaysOvulationOutOfThePastWarning drives
+// the same site through the surface that renders it: an ordinary account, no
+// irregular mode, no DST date, whose projected ovulation falls on the day the
+// dashboard is rendered. The context must name the date AND leave
+// OvulationInPast false — naming the date while flagging it as past is the pair
+// the owner saw.
+func TestBuildDashboardCycleContextKeepsTodaysOvulationOutOfThePastWarning(t *testing.T) {
+	t.Parallel()
+
+	// Anchor 2026-02-03 with a 28-day cycle and a 14-day luteal phase puts
+	// ovulation on cycle day 14, i.e. exactly 2026-02-16.
+	const cycleStart = "2026-02-03"
+	const ovulationDay = "2026-02-16"
+
+	for _, testCase := range []struct{ name, zone string }{
+		{name: "west of UTC", zone: "America/New_York"},
+		{name: "east of UTC", zone: "Asia/Tokyo"},
+		{name: "UTC control", zone: "UTC"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			location := calendarDayComparisonZone(t, testCase.zone)
+			today := calendarDayComparisonToday(t, ovulationDay, location)
+			user := &models.User{Role: models.RoleOwner, CycleLength: 28, PeriodLength: 5}
+			stats := CycleStats{
+				LastPeriodStart:     CalendarDay(mustParseDashboardDay(t, cycleStart), location),
+				MedianCycleLength:   28,
+				AverageCycleLength:  28,
+				AveragePeriodLength: 5,
+				LutealPhase:         14,
+				CurrentCycleDay:     14,
+			}
+
+			context := BuildDashboardCycleContext(user, stats, today, location)
+			if got := CalendarDayKey(context.DisplayOvulationDate); got != ovulationDay {
+				t.Fatalf("displayed ovulation date = %s, want %s", got, ovulationDay)
+			}
+			if context.OvulationInPast {
+				t.Fatalf("the dashboard must not flag today's ovulation date as already in the past")
+			}
+			if context.NextPeriodInPast {
+				t.Fatalf("the next-period warning is a separate predicate and must stay false here")
+			}
+		})
+	}
+}
+
 // TestStatsCycleRibbonFertileWindowIsCalendarBound locks stats_cycle_ribbon.go,
 // the one site that breaks in BOTH directions: the row's dates are location
 // midnights while the window bounds are UTC midnights, so west of UTC the last

--- a/internal/services/dashboard_cycle.go
+++ b/internal/services/dashboard_cycle.go
@@ -454,9 +454,20 @@ func dashboardNextPeriodInPast(display dashboardPredictionDisplay, today time.Ti
 
 func dashboardOvulationInPast(display dashboardPredictionDisplay, today time.Time) bool {
 	if display.ovulationUseRange {
+		// Both bounds come from DashboardOvulationRange, which builds them with
+		// CalendarDay in the request location, so this pair already shares
+		// today's midnight shape and compares directly.
 		return !display.ovulationRangeEnd.IsZero() && display.ovulationRangeEnd.Before(today)
 	}
-	return !display.ovulationImpossible && !display.ovulationDate.IsZero() && display.ovulationDate.Before(today)
+	// ovulationDate is the PredictCycleWindow output — a UTC-midnight date-only
+	// value — while today is a location midnight, so the two are compared as
+	// calendar days, exactly as the shift guard in DashboardUpcomingPredictions
+	// that decides this same date already does. As instants, local midnight in a
+	// UTC-minus zone falls hours after UTC midnight of the same date, which read
+	// the ovulation day itself as past and printed the amber "date is already in
+	// the past" notice beside the date the header had just named (issue #48
+	// class).
+	return !display.ovulationImpossible && !display.ovulationDate.IsZero() && CalendarDaysBetween(display.ovulationDate, today) > 0
 }
 
 func CompletedCycleTrendLengths(logs []models.DailyLog, now time.Time, location *time.Location) []int {


### PR DESCRIPTION
## What was wrong

`dashboardOvulationInPast`'s non-range branch compared `display.ovulationDate` —
a UTC-midnight `PredictCycleWindow` output — against `today`, a location
midnight built by `DateAtLocation`. West of UTC local midnight is a later instant
than UTC midnight of the same date, so on the ovulation day itself the predicate
returned true.

What that looked like: the dashboard named the ovulation date and, directly
beside it, printed the amber "this date is already in the past" notice
(`data-dashboard-prediction-past`) and the prompt to update cycle data. Ordinary
account, no irregular mode, no daylight-saving date involved. The window is **one
calendar day per cycle, every cycle, for every account west of UTC**.

## This is a regression from the previous change in the same family

`b9b05ae0` ("compare calendar days as calendar days, not as instants") converted
six sites to `CalendarDaysBetween` and left this one on raw `.Before`. Before that
change the branch was unreachable: the shift guard in
`DashboardUpcomingPredictions` used the *identical* instant comparison, so an
ovulation still falling on today had already been rolled a whole cycle forward by
the time this predicate ran, and its operand was never a past date. Converting the
guard and not this line made the two predicates disagree, and the one-day window
opened. The defect is live on `main`.

## The fix

`internal/services/dashboard_cycle.go` — the site now routes through
`CalendarDaysBetween`, in the shape the six converted sites established, with the
same explanatory comment style.

The range branch one line above is deliberately **not** touched: both of its
operands come from `DashboardOvulationRange`, which builds them with `CalendarDay`
in the request location, so they already share a midnight shape. Same for
`dashboardNextPeriodInPast`, whose only date operand is `nextPeriodRangeEnd` from
`DashboardPredictionRange` — also a location midnight. Both were re-verified, not
assumed.

## Sweep

Every `Before` / `After` / `Equal` on a `time.Time` in `internal/services` (76
sites) was checked for a mixed pair — one operand a UTC-midnight calendar value
(`dateOnly`, `PredictCycleWindow`, stored `DailyLog.Date` / `LastPeriodStart`),
the other a location midnight (`DateAtLocation`, `CalendarDay(…, location)`).

**One provable defect**, fixed here: `dashboard_cycle.go` `dashboardOvulationInPast`.

**Deliberately left, mixed shape but provably behaviour-neutral:**

- `cycles.go:157` — `fertilityStart.Before(periodStart)` inside
  `PredictCycleWindow`. `fertilityStart` is `dateOnly` (UTC midnight); `periodStart`
  is the raw parameter, a location midnight from most callers. The two readings can
  only diverge when both name the *same* calendar day, and there the clamp assigns
  `dateOnly(periodStart)`, which is bit-for-bit the value already held. Days that
  genuinely differ are ≥ 24 h apart, beyond every UTC offset. No failing guard can
  be written for it, which is the tell that it is not a defect site; converting it
  would be a robustness change, not a fix.

**Deliberately left, carve-outs (same list as the previous change):** TTL / expiry /
freshness comparisons at sub-day resolution — `attempt_limiter.go:112,141,193`,
`auth_reset_policy.go:98`, `oidc_login_service.go:219`,
`oidc_logout_state_service.go:93` — and `day_utils.go:123`
(`FilterLogsByDateRange`, whose `toEnd` is an exclusive next-day bound).
`policy_fuzz_libfuzzer.go:68,84` compares two invocations of the same policy.

**Both operands already share a shape — listed, untouched:** `calendar_days.go:96,372`;
`calendar_feed_ics.go:167`; `cycle_anchor.go:33,47,66`; `cycle_baseline.go:132`;
`cycle_signals.go:153,190,207`; `cycle_start_policy.go:44,179,208`;
`cycles.go:150,271,284,296,430,437,440,462,471,501,607`;
`dashboard_cycle.go:157,229,452,457,473`; `dashboard_cycle_hero.go:209,244`;
`dashboard_view_service.go:354,475,479,484`; `day_feedback_policy.go:103`;
`day_range_policy.go:23`; `day_service.go:628`; `export_range_policy.go:37`;
`export_service.go:229,232`; `import_service.go:367,370`;
`onboarding_service.go:48,205`; `pregnancy_pause.go:24,29,38`;
`settings_cycle_policy.go:72`; `settings_view_service.go:215`;
`stats_cycle_factor_context.go:87,119,198`;
`stats_cycle_insights.go:94,255,266,341`; `stats_phase_insights.go:92,112`.

`cycles.go:76` and `cycle_baseline.go:29` deserve a note: `ResolveFertilityStatus`
looks like the same shape hazard, but each of its two call paths is internally
consistent — `BuildCycleStats` keeps both `today` and the window bounds at UTC
midnight, `ApplyUserCycleBaseline` re-anchors both to the request location.
Likewise `resolveCyclePhase`, where the same-calendar-day case is taken by the
`sameDay` helper before the `Before` on line 440 is reached.

`internal/api` was spot-checked for the same class: its only six sites are cookie
TTL checks. `internal/reminders` and `calendar_view_policy.go` were left alone —
open PRs are on them.

## Guards, and their failures against the unfixed code

Written before the fix, in `internal/services/calendar_day_comparison_regression_test.go`
(beside the previous change's guards) and the `internal/api` dashboard aggregator.

`go test ./internal/services -run 'TestDashboardOvulationInPastIsCalendarBound|TestBuildDashboardCycleContextKeepsTodaysOvulationOutOfThePastWarning' -v`:

```
=== NAME  TestDashboardOvulationInPastIsCalendarBound/west_of_UTC
    calendar_day_comparison_regression_test.go:241: an ovulation predicted for today must not read as already past
--- FAIL: TestDashboardOvulationInPastIsCalendarBound (0.00s)
    --- PASS: TestDashboardOvulationInPastIsCalendarBound/UTC_control (0.00s)
    --- PASS: TestDashboardOvulationInPastIsCalendarBound/east_of_UTC (0.00s)
    --- FAIL: TestDashboardOvulationInPastIsCalendarBound/west_of_UTC (0.00s)
=== NAME  TestBuildDashboardCycleContextKeepsTodaysOvulationOutOfThePastWarning/west_of_UTC
    calendar_day_comparison_regression_test.go:311: the dashboard must not flag today's ovulation date as already in the past
--- FAIL: TestBuildDashboardCycleContextKeepsTodaysOvulationOutOfThePastWarning (0.00s)
    --- PASS: TestBuildDashboardCycleContextKeepsTodaysOvulationOutOfThePastWarning/UTC_control (0.00s)
    --- PASS: TestBuildDashboardCycleContextKeepsTodaysOvulationOutOfThePastWarning/east_of_UTC (0.00s)
    --- FAIL: TestBuildDashboardCycleContextKeepsTodaysOvulationOutOfThePastWarning/west_of_UTC (0.00s)
```

`go test ./internal/api -run TestDashboardDoesNotFlagTodaysOvulationAsPastWestOfUTC -v`:

```
=== RUN   TestDashboardDoesNotFlagTodaysOvulationAsPastWestOfUTC
    dashboard_regressions_test.go:840: did not expect the prediction-past notice on the ovulation day itself
--- FAIL: TestDashboardDoesNotFlagTodaysOvulationAsPastWestOfUTC (0.55s)
```

Every failure is west of UTC; the UTC and east-of-UTC controls pass unchanged, so
the guards fail for the defect rather than for the fixture.

Nothing anywhere pinned this state as **true**, so the fix could otherwise have
passed by disabling the notice altogether. Two things close that: the service
guard carries an explicit positive anchor (an ovulation on an earlier calendar day
must still report true, plus the range branch in both directions), and the api
guard's own pre-fix failure is what proves the
`data-dashboard-prediction-past` element is reachable at all.

## Commands

| Command | Verdict |
| --- | --- |
| `gofmt -l` on the touched files | clean (five files elsewhere in the tree were already divergent on `main` and are untouched here) |
| `go build ./...` | pass |
| `go test ./... -timeout 20m` | pass, whole tree |
| `golangci-lint run` | `0 issues.` |
| `go run ./scripts/patchcov` (profile regenerated in the same invocation, after committing) | `patch coverage gate OK: every modified coverable line is covered by tests.` |

Re-run after rebasing onto current `origin/main`: `go build ./...`,
`go test ./internal/services ./internal/api -timeout 20m`, `golangci-lint run` —
all green.

## Rollback

Single production line. Reverting the commit restores
`display.ovulationDate.Before(today)` and the defect with it; the three guards
then fail west of UTC exactly as quoted above, which is the check that the revert
landed. No schema, no config, no stored data is touched — the predicate is
computed per render, so a revert or a re-apply takes effect on the next page load
with nothing to migrate.
