### PR TITLE
ci: stop repeating on main what the merge queue already ran

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,17 +36,19 @@ jobs:
   # everything basic pass" (e2e, e2e-postgres-smoke) depend on both.
   test-go:
     runs-on: ubuntu-latest
-    # Whole-job docs-only skip (see the `changes` job): coverage-upload and
-    # patch-coverage cascade off this job's skip through their needs edge, and
-    # the thin `test` gate job follows both unit jobs the same way.
+    # Whole-job skip on `run_core` (see the `changes` job), which now clears
+    # for TWO reasons: a docs-only diff, and a `push` to `main`, where the
+    # merge queue already ran this lane on the identical commit. coverage-upload
+    # and patch-coverage cascade off this job's skip through their needs edge,
+    # and the thin `test` gate job follows both unit jobs the same way.
     #
     # The shape the whole battery shares: run unless `changes` positively
-    # determined this diff is irrelevant. A detection job that failed leaves
+    # determined this run does not need it. A detection job that failed leaves
     # the output empty, which is not 'false', so the lane still runs — a
     # skipped required check would otherwise pass the merge on no evidence.
     needs:
       - changes
-    if: ${{ !cancelled() && needs.changes.outputs.run_battery != 'false' }}
+    if: ${{ !cancelled() && needs.changes.outputs.run_core != 'false' }}
     permissions:
       contents: read
 
@@ -249,7 +251,7 @@ jobs:
     needs:
       - changes
     # Same fail-safe gate as test-go above.
-    if: ${{ !cancelled() && needs.changes.outputs.run_battery != 'false' }}
+    if: ${{ !cancelled() && needs.changes.outputs.run_core != 'false' }}
     permissions:
       contents: read
 
@@ -336,11 +338,13 @@ jobs:
         run: |
           set -euo pipefail
           echo "test-go=$GO_RESULT test-frontend=$FRONTEND_RESULT"
-          # `skipped` is a PASS here and only here: the `changes` job judged the
-          # diff irrelevant to the battery, which is a decision not to run, not
-          # a failure to run. Anything else — failure, cancelled, or a state
-          # this gate has never seen — is this context's failure, because the
-          # whole point of the job is to have a verdict to report.
+          # `skipped` is a PASS here and only here: the `changes` job cleared
+          # `run_core` — the diff was docs-only, or this is a `push` whose core
+          # suite the merge queue already ran on the identical commit. Either
+          # way it is a decision not to run, not a failure to run. Anything else
+          # — failure, cancelled, or a state this gate has never seen — is this
+          # context's failure, because the whole point of the job is to have a
+          # verdict to report.
           for result in "$GO_RESULT" "$FRONTEND_RESULT"; do
             case "$result" in
               success|skipped) ;;
@@ -368,7 +372,7 @@ jobs:
     needs:
       - changes
     # Same fail-safe gate as test-go above.
-    if: ${{ !cancelled() && needs.changes.outputs.run_battery != 'false' }}
+    if: ${{ !cancelled() && needs.changes.outputs.run_core != 'false' }}
     permissions:
       contents: read
     strategy:
@@ -411,7 +415,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - changes
-    if: ${{ !cancelled() && needs.changes.outputs.run_battery != 'false' }}
+    if: ${{ !cancelled() && needs.changes.outputs.run_core != 'false' }}
     permissions:
       contents: read
 
@@ -479,8 +483,8 @@ jobs:
           set -euo pipefail
           echo "race-services=$SERVICES_RESULT race-rest=$REST_RESULT"
           # `skipped` is a PASS here and only here, for the same reason as in
-          # the other two gates: the `changes` job judged the diff irrelevant,
-          # which is a decision not to run rather than a failure to run.
+          # the other two gates: the `changes` job cleared `run_core`, which is
+          # a decision not to run rather than a failure to run.
           for result in "$SERVICES_RESULT" "$REST_RESULT"; do
             case "$result" in
               success|skipped) ;;
@@ -490,6 +494,15 @@ jobs:
           echo "every race lane passed."
 
   coverage-upload:
+    # Codecov's record of `main` is written from the MERGE-QUEUE run, not from
+    # the `push` that follows it. It always was — the queue run reaches Codecov
+    # first — and measurement says Codecov files it correctly: across 420
+    # branches it knows for this repository there is not one
+    # `gh-readonly-queue/*` entry, and commit 97f641e2… carries `branch: main`
+    # (api.codecov.io/api/v2/github/ovumcy/repos/ovumcy-web, queried
+    # 2026-08-18). The push run only ever added a second session for the same
+    # numbers. It no longer runs at all: this job cascades to skipped off
+    # test-go, which `run_core` clears on push.
     runs-on: ubuntu-latest
     needs:
       - test-go
@@ -510,13 +523,18 @@ jobs:
 
       - name: Upload coverage to Codecov
         id: codecov
-        # Tolerate a Codecov ingest failure on push AND on workflow_dispatch. The
-        # gate that actually protects coverage is the local patch-coverage job
-        # below; Codecov's own statuses are informational and no `codecov/*` check
-        # is required on main. Without workflow_dispatch here, re-running a green
-        # run by hand can fail on the very external flake the push path already
-        # forgives — the same failure mode, judged differently for no reason.
-        continue-on-error: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+        # Tolerate a Codecov ingest failure everywhere except a pull request.
+        # The gate that actually protects coverage is the local patch-coverage
+        # job below; Codecov's own statuses are informational and no `codecov/*`
+        # check is required on main. `merge_group` joined this list when the
+        # authoritative upload moved here: an external ingest flake must not
+        # colour the run that the README badge now reads, and it never had the
+        # standing to, since the same flake was forgiven one event later. The
+        # `push` arm stays for the fail-safe path — a `changes` job that dies
+        # leaves `run_core` empty and this job runs on push after all — and
+        # `workflow_dispatch` so that re-running a green run by hand cannot fail
+        # on a flake the other events forgive.
+        continue-on-error: ${{ github.event_name != 'pull_request' }}
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: coverage.out
@@ -530,7 +548,7 @@ jobs:
           use_pypi: true
 
       - name: Warn on non-blocking Codecov failure
-        if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && steps.codecov.outcome == 'failure' }}
+        if: ${{ github.event_name != 'pull_request' && steps.codecov.outcome == 'failure' }}
         run: echo "::warning::Codecov upload failed on ${{ github.event_name }}. Coverage artifact was generated successfully, but Codecov ingest returned an external error."
 
   patch-coverage:
@@ -578,14 +596,18 @@ jobs:
       contents: read
     outputs:
       run_e2e: ${{ steps.detect.outputs.run_e2e }}
-      # Same docs-only determination, consumed by the unit/race battery
-      # (test-go, test-frontend, race) as a whole-job gate. Kept as a separate
-      # output so the two allowlists can diverge later without re-wiring
-      # consumers. Unlike e2e's historical step-level gating below, the
-      # battery jobs skip at the job level: GitHub reports a skipped job as a
-      # satisfied required check (proven in practice on the sibling
-      # sync-community/managed repos, whose whole Go battery merges this way).
-      run_battery: ${{ steps.detect.outputs.run_battery }}
+      # "Run the core suite" — the unit halves, both race lanes and the browser
+      # shards: every lane whose evidence the merge queue has already produced
+      # for this exact tree. It is `run_e2e` minus the work the queue did, so it
+      # clears on a docs-only diff AND on a `push` to `main`; `run_e2e` above
+      # stays true on push, because e2e-cross-browser, image-smoke and the
+      # Postgres smoke are exactly the lanes the queue does NOT run.
+      #
+      # Unlike e2e's historical step-level gating below, the unit and race jobs
+      # skip at the job level: GitHub reports a skipped job as a satisfied
+      # required check (proven in practice on the sibling sync-community/managed
+      # repos, whose whole Go battery merges this way).
+      run_core: ${{ steps.detect.outputs.run_core }}
 
     steps:
       - name: Checkout
@@ -660,7 +682,7 @@ jobs:
               ;;
             *)
               base=""
-              verdict="$EVENT_NAME carries no base to diff against: running e2e and the battery."
+              verdict="$EVENT_NAME carries no base to diff against: nothing is judged irrelevant here."
               ;;
           esac
 
@@ -684,10 +706,34 @@ jobs:
           fi
 
           echo "$verdict"
+
+          # `run_core` starts from the same allowlist verdict — diverge here,
+          # never in a consumer, if the two ever need different file sets — and
+          # then drops the work the merge queue has already done.
+          #
+          # A `push` to `main` can only be a merge the queue built: the «Protect
+          # main» rule requires a pull request and the queue, and its bypass
+          # list is empty, so no other write reaches this branch. On this rebase
+          # queue the merge_group run's headSha is byte for byte the commit that
+          # becomes `main` — measured 2026-08-18, 97f641e2… identical in run
+          # 32081210308 and at the head of `main` — so the unit, frontend, race
+          # and browser-shard lanes here would re-test a tree proven minutes
+          # earlier. What the queue does NOT run stays: e2e-cross-browser and
+          # image-smoke gate themselves on the event, and e2e-postgres-smoke's
+          # own RUN_HEAVY keeps its work off pull requests and off the queue, so
+          # `push` is the only place it ever executes.
+          #
+          # Fail-safe in the same direction as everything above: the clear is
+          # written only inside the `push` branch, so an unknown event, a
+          # crashed job or an empty output all leave the core suite RUNNING.
+          run_core="$run_e2e"
+          if [ "$EVENT_NAME" = "push" ]; then
+            run_core=false
+            echo "push to main: the merge queue already ran the core suite on this exact commit; running only the lanes it skips."
+          fi
+
           echo "run_e2e=$run_e2e" >> "$GITHUB_OUTPUT"
-          # The battery shares the e2e allowlist verbatim today; diverge here
-          # (not in consumers) if that ever changes.
-          echo "run_battery=$run_e2e" >> "$GITHUB_OUTPUT"
+          echo "run_core=$run_core" >> "$GITHUB_OUTPUT"
 
   # The browser suite runs here, split across shards, and the required status
   # check named `e2e` is the thin gate job below — the same shape branch
@@ -756,39 +802,44 @@ jobs:
     # verdict.
     env:
       RUN_E2E: ${{ needs.changes.outputs.run_e2e }}
-      # On `push` the browser lane is a three-spec smoke, which is smaller than
-      # a single shard's share — so it runs whole on shard 1 and the other
-      # shards stand down rather than paying setup to run a fraction of it.
+      # The browser lane no longer runs on `push` at all. It used to run a
+      # three-spec smoke there, whole on shard 1 with the other two standing
+      # down; the merge queue now runs the FULL sharded suite on the identical
+      # commit (see `run_core` in the `changes` job), so the smoke re-proved a
+      # strict subset of what had already passed. Cross-browser coverage, which
+      # the queue genuinely does not run, is e2e-cross-browser's job and gates
+      # itself on the event.
+      #
       # Written in the fail-safe direction (`!= 'false'` at every use) like
       # RUN_E2E: an expression that ever evaluates empty must leave the work
       # running, never silently drop it.
-      SHARD_ACTIVE: ${{ github.event_name != 'push' || matrix.shard == 1 }}
+      RUN_SHARDS: ${{ needs.changes.outputs.run_core }}
 
     steps:
       - name: Checkout
-        if: env.RUN_E2E != 'false' && env.SHARD_ACTIVE != 'false'
+        if: env.RUN_E2E != 'false' && env.RUN_SHARDS != 'false'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Go
-        if: env.RUN_E2E != 'false' && env.SHARD_ACTIVE != 'false'
+        if: env.RUN_E2E != 'false' && env.RUN_SHARDS != 'false'
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache: false
 
       - name: Setup Node.js
-        if: env.RUN_E2E != 'false' && env.SHARD_ACTIVE != 'false'
+        if: env.RUN_E2E != 'false' && env.RUN_SHARDS != 'false'
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: npm
 
       - name: Install frontend and e2e dependencies
-        if: env.RUN_E2E != 'false' && env.SHARD_ACTIVE != 'false'
+        if: env.RUN_E2E != 'false' && env.RUN_SHARDS != 'false'
         run: npm ci
 
       - name: Cache Playwright browsers
-        if: env.RUN_E2E != 'false' && env.SHARD_ACTIVE != 'false'
+        if: env.RUN_E2E != 'false' && env.RUN_SHARDS != 'false'
         id: playwright-cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -796,7 +847,7 @@ jobs:
           key: ${{ runner.os }}-playwright-chromium-${{ hashFiles('package-lock.json') }}
 
       - name: Install Playwright browser
-        if: env.RUN_E2E != 'false' && env.SHARD_ACTIVE != 'false' && steps.playwright-cache.outputs.cache-hit != 'true'
+        if: env.RUN_E2E != 'false' && env.RUN_SHARDS != 'false' && steps.playwright-cache.outputs.cache-hit != 'true'
         # NO `--with-deps`: this downloads the browser binary and touches apt not
         # at all. This lane is CHROMIUM-ONLY, which is what makes that safe — see
         # the paragraph at the end. The apt half used to live here and in a second
@@ -838,19 +889,14 @@ jobs:
         # image could drop a dependency this no longer installs.
         run: timeout 600 npx playwright install chromium
 
-      - name: Run Playwright e2e (smoke on push, full otherwise)
+      - name: Run Playwright e2e
         # The divisor comes from `strategy.job-total`, which GitHub computes
         # from the matrix above — never a second literal to keep in step with
         # it. `--shard` splits by spec file, and each shard gets its own app
         # and database, so the runner's own `--workers=1` still holds inside
         # one shard.
-        if: env.RUN_E2E != 'false' && env.SHARD_ACTIVE != 'false'
-        run: |
-          if [ "${{ github.event_name }}" = "push" ]; then
-            npm run e2e:ci -- e2e/auth-login-register.spec.ts e2e/dashboard.spec.ts e2e/theme-dark-mode.spec.ts
-          else
-            npm run e2e:ci -- --shard=${{ matrix.shard }}/${{ strategy.job-total }}
-          fi
+        if: env.RUN_E2E != 'false' && env.RUN_SHARDS != 'false'
+        run: npm run e2e:ci -- --shard=${{ matrix.shard }}/${{ strategy.job-total }}
         env:
           E2E_APP_PORT: 18080
 
@@ -891,8 +937,8 @@ jobs:
           set -euo pipefail
           echo "e2e-shard=$SHARDS_RESULT"
           # `skipped` is a PASS here and only here, for the same reason it is in
-          # the `test` gate: the `changes` job judged the diff irrelevant, which
-          # is a decision not to run rather than a failure to run. Anything else
+          # the `test` gate: the `changes` job cleared `run_core`, which is a
+          # decision not to run rather than a failure to run. Anything else
           # — failure, cancelled, or a state this gate has never seen — is this
           # context's failure.
           case "$SHARDS_RESULT" in
@@ -913,6 +959,12 @@ jobs:
     # without leaving this required check unsatisfied. The Postgres/multi-locale
     # coverage this job adds over the plain `e2e` job is also only needed on
     # push/release/dispatch, not on every PR, so RUN_HEAVY gates it further.
+    #
+    # RUN_HEAVY excludes `merge_group` too, which makes this the ONE core-looking
+    # lane that `push` must keep: measured 2026-08-18, the job took 3 s in queue
+    # run 32081210308 (every step gated off) and 240 s in push run 32081716803
+    # doing the real work. Reading it as a third repeat of the browser suite and
+    # trimming it would delete the only Postgres evidence this repository has.
     env:
       RUN_E2E: ${{ needs.changes.outputs.run_e2e }}
       RUN_HEAVY: ${{ github.event_name == 'push' || github.event_name == 'release' || github.event_name == 'workflow_dispatch' }}

--- a/changelog.d/ci-trim-duplicate-main-run.md
+++ b/changelog.d/ci-trim-duplicate-main-run.md
@@ -1,0 +1,7 @@
+none
+
+CI change with no user-visible effect: a push to `main` no longer repeats the
+unit, frontend, race and browser-shard lanes that the merge queue already ran
+on the identical commit. It keeps the lanes the queue does not run —
+cross-browser e2e, the Postgres smoke, the runtime-image smoke and the image
+publish.


### PR DESCRIPTION
## What this changes

A push to `main` stops re-running the lanes the merge queue has already run on the identical commit. `changes` emits **`run_core`** in place of `run_battery` — the same docs-only allowlist verdict, minus the work the queue did — and clears it on `push`. The rename tracks the meaning: it now covers the browser shards as well as the unit and race lanes.

## Why this is safe

The queue does not test an approximation of the merge, it tests the merge. On this REBASE queue the `merge_group` run's `headSha` is byte for byte the commit that becomes `main` — measured 2026-08-18, `97f641e2…` identical in run `32081210308` and at the head of `main`. Nothing else reaches the branch: «Protect main» requires a pull request and the queue, and its bypass list is empty. So the push run's unit, frontend, race and browser-shard lanes re-tested a tree proven minutes earlier.

## What `push` keeps, and why each one earns it

| lane | why it stays |
| --- | --- |
| `e2e-cross-browser` | not run on PR or in the queue — it gates on the event already |
| `image-smoke` | the image is not built on pull requests at all |
| `e2e-postgres-smoke` | **not a duplicate.** Its own `RUN_HEAVY` excludes `merge_group`, so `push` is the only event where it executes: **3 s** in queue run `32081210308` with every step gated off, **240 s** in push run `32081716803` doing the real work. Reading it as a third repeat of the browser suite and trimming it would delete the only Postgres evidence this repository has. |
| `publish-image` | unchanged, and still gated on `test`, `race`, `e2e`, `e2e-postgres-smoke`, `image-smoke` — every one of which still reports on push |

The three-spec browser smoke that used to run on `push` (whole on shard 1, the other two standing down) goes away. It existed because `push` had no other browser evidence; the queue now runs the full sharded suite on that commit, so the smoke re-proved a strict subset of what had already passed.

## The gate behind `publish-image`

`test`, `race` and `e2e` are thin gate jobs that judge their dependencies under `!cancelled()` and already treat `skipped` as a pass. They keep running and keep reporting; what changes is where their evidence comes from — the queue run rather than a second execution of the same tests. That is the one thing in this PR worth a second opinion, and it rests entirely on the empty bypass list: if a direct push to `main` ever becomes possible, this reasoning fails with it.

## Coverage

Codecov's record of `main` was always written from the queue run — it reaches Codecov first — and Codecov files it under `main`, not under the queue branch:

- across the **420** branches Codecov knows for this repository there is **not one** `gh-readonly-queue/*` entry, although it happily records throwaway branches like `probe/race-profile`;
- commit `97f641e2…` carries `"branch": "main"` and `sessions: 2` — the second session is the push upload this PR removes.

Queried via `api.codecov.io/api/v2/github/ovumcy/repos/ovumcy-web` on 2026-08-18.

The ingest-failure tolerance moves with the upload: `continue-on-error` now covers every event except a pull request. An external Codecov flake must not colour the queue run — and it never had the standing to, since the same flake was forgiven one event later. The `push` arm stays because the fail-safe path still exists: a `changes` job that dies leaves `run_core` empty, and the core suite runs on push after all.

## Measured saving

Against push run `32081716803`:

| job | duration |
| --- | --- |
| `test-go` | 463 s |
| `race-services` ×3 | 663 s |
| `race-rest` | 178 s |
| `e2e-shard (1)` | 237 s |
| `test-frontend` | 30 s |
| `coverage-upload` | 15 s |

≈ **26 runner-minutes per merge**. `test-go` was also the critical path into `publish-image`, so `:latest` should land roughly **3.5 minutes sooner**.

## Verification after merge

This PR's own run exercises the `pull_request` path only; the `push` behaviour cannot be observed until it lands. On the first push to `main` that carries it:

1. **The push run contains only** `changes`, `e2e-cross-browser`, `image-smoke`, `e2e-postgres-smoke`, `publish-image` and the three gates, with `test-go`/`test-frontend`/`race-*`/`coverage-upload` reported `skipped` and the `e2e-shard` jobs green with no steps run.
2. **`publish-image` still runs and publishes** — `docker pull ghcr.io/ovumcy/ovumcy-web:latest` anonymously resolves to the new `sha-<short>`.
3. **Codecov still updates.** The new commit reports `"branch": "main"` with **`sessions: 1`** (it was 2). A `sessions: 0` or a missing commit means the queue upload is not standing on its own and this half must be reverted.

## Out of scope, deliberately

`codeql`, `gitleaks` and `security.yml` also run on push to `main`. CodeQL's push run is what populates the default-branch code-scanning alerts and Scorecard requires a push event, so those are not duplicates in the same sense. The remainder is a separate measurement and a separate PR.
