### PR TITLE
docs: point the CI badge at the run that decides the merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,14 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/ovumcy/ovumcy-web/actions/workflows/ci.yml"><img src="https://github.com/ovumcy/ovumcy-web/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <!-- The CI badge reads the MERGE-QUEUE run, not the push that follows it: `main` is
+       written only through the queue, so that run is the last attempt to enter the branch
+       and it tests the exact commit that lands. The unfiltered badge read the push run,
+       where any cancellation renders as failing — a job that hits `timeout-minutes` is
+       reported `cancelled`, which took the badge red on 2026-08-17 with no failed job in
+       the run. Do not add `branch=main`: queue runs live on `gh-readonly-queue/...`, and
+       that pair returns "no status". -->
+  <a href="https://github.com/ovumcy/ovumcy-web/actions/workflows/ci.yml?query=event%3Amerge_group"><img src="https://github.com/ovumcy/ovumcy-web/actions/workflows/ci.yml/badge.svg?event=merge_group" alt="CI"></a>
   <a href="https://github.com/ovumcy/ovumcy-web/actions/workflows/codeql.yml"><img src="https://github.com/ovumcy/ovumcy-web/actions/workflows/codeql.yml/badge.svg" alt="CodeQL"></a>
   <a href="https://securityscorecards.dev/viewer/?uri=github.com/ovumcy/ovumcy-web"><img src="https://api.securityscorecards.dev/projects/github.com/ovumcy/ovumcy-web/badge" alt="OpenSSF Scorecard"></a>
   <a href="https://www.bestpractices.dev/projects/13130"><img src="https://www.bestpractices.dev/projects/13130/badge" alt="OpenSSF Best Practices"></a>

--- a/changelog.d/ci-badge-reads-the-merge-queue.md
+++ b/changelog.d/ci-badge-reads-the-merge-queue.md
@@ -1,0 +1,5 @@
+none
+
+Documentation change with no user-visible effect on the application: the CI
+badge in the README now reports the merge-queue run — the last attempt to
+enter `main` — instead of the push that follows it.


### PR DESCRIPTION
## The badge was answering the wrong question

Filtered by nothing, `ci.yml/badge.svg` reports the newest run on the default branch — which is the **`push`** run, i.e. the post-merge re-test of a commit that has already merged. Whether that run finished cleanly is not what a visitor reads the badge for.

Worse, it goes red without a failure. Any non-success conclusion renders as *failing*, and a job that hits its own `timeout-minutes` is reported **`cancelled`**, not `failed`. Measured: run [`32070919012`](https://github.com/ovumcy/ovumcy-web/actions/runs/32070919012) sat **45 minutes** in `npx playwright install-deps chromium` (21:24:33 → 22:09:49) and timed out. Every other job in that run was green. The badge showed failing, and a visitor clicking through would have found nothing to look at.

## What it points at now

`main` is written only through the merge queue — «Protect main» requires a pull request and the queue, and its bypass list is empty. So the `merge_group` run is the **last attempt to enter the branch**, and on this rebase queue it tests the exact commit that lands (`headSha` is byte for byte the new head of `main`; measured 2026-08-18). That is the state worth putting on the front page.

```
badge.svg?event=merge_group
```

and the link goes to the same filter, so clicking the badge lands on the runs it is reporting.

## Why not also `branch=main`

Because it silently empties the badge. Measured 2026-08-18:

| URL | badge |
| --- | --- |
| `badge.svg` | `CI - passing` |
| `badge.svg?event=merge_group` | `CI - passing` |
| `badge.svg?branch=main` | `CI - passing` |
| `badge.svg?branch=main&event=merge_group` | **`CI - no status`** |

Queue runs live on `gh-readonly-queue/...` refs, never on `main`, so the pair matches nothing. An HTML comment beside the badge records this, so the obvious-looking tightening is not re-attempted by the next person to read the line.

## Scope

README only. The `ci.md` note recording what the badge now means — "the state of the last attempt to merge" — lands in the rules layer, which is not tracked in this repository.

Independent of #509; either can merge first.
