### PR TITLE
ci: fuzz a pull request only when it can reach a fuzz target

### DIFF
--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -14,8 +14,27 @@ on:
     # "PR" context is not a required check, so a workflow-level paths filter
     # is safe here (nothing waits on a report that never comes). The daily
     # batch workflow still fuzzes every target regardless.
+    #
+    # Scoped to what the targets can actually reach, not to every Go file. All
+    # six targets are `internal/services` policy parsers — `build.sh` compiles
+    # exactly `github.com/ovumcy/ovumcy-web/internal/services` and nothing else
+    # — and `go list -deps ./internal/services` resolves inside this repository
+    # to three packages: services, security, models (measured 2026-08-18, Go
+    # 1.26.6). A pull request touching none of them cannot change what these
+    # binaries execute, so fuzzing it re-runs the same harness over the same
+    # code. That was 30 of the last 59 merged pull requests, at 7.9 minutes
+    # each.
+    #
+    # Listed as directory globs rather than `**.go` on purpose: a filter is
+    # fail-DANGEROUS in the narrow direction — too tight and the check silently
+    # stops running — so the glob is deliberately wider than the file type it
+    # cares about. Widen this list whenever a target is added outside
+    # `internal/services`, or when that package gains an intra-repo import; the
+    # `go list -deps` line above is the command that settles it.
     paths:
-      - "**.go"
+      - "internal/services/**"
+      - "internal/security/**"
+      - "internal/models/**"
       - "go.mod"
       - "go.sum"
       - ".clusterfuzzlite/**"

--- a/changelog.d/ci-fuzz-only-what-the-targets-reach.md
+++ b/changelog.d/ci-fuzz-only-what-the-targets-reach.md
@@ -1,0 +1,5 @@
+none
+
+CI change with no user-visible effect: pull-request fuzzing now runs only for
+changes that can reach the fuzz targets, instead of for every Go file. The
+scheduled batch run still fuzzes every target.


### PR DESCRIPTION
## The filter was wider than the targets

PR fuzzing was gated on `**.go` — every Go file in the repository. The fuzz targets do not span the repository:

- all six live in `internal/services/policy_fuzz_libfuzzer.go` (and its `_test.go` mirror);
- `.clusterfuzzlite/build.sh` compiles exactly `github.com/ovumcy/ovumcy-web/internal/services`, one package, and nothing else;
- `go list -deps ./internal/services` resolves inside this repository to **three** packages — `internal/services`, `internal/security`, `internal/models` (measured 2026-08-18, Go 1.26.6).

A pull request touching none of those three cannot change what the fuzz binaries execute. The run re-fuzzed the same harness over the same code.

## Frequency

Over the last **59** merged pull requests, **30** — **51%** — touched nothing in that closure. The job costs **7.9 minutes** each time.

## Nothing loses coverage

The `PR` context is **not a required status check**, and the daily batch workflow still fuzzes every target over the whole tree. A regression reachable only through a path this filter now skips is caught there rather than never.

## Why directory globs and not `**.go`

A paths filter fails *dangerously* in the narrow direction: too tight and the check simply stops running, with nothing to report that it did. So the globs are deliberately wider than the file type they care about — `internal/services/**` rather than `internal/services/**.go`.

The comment left in the workflow names `go list -deps ./internal/services` as the command that settles the list. The day that package gains an intra-repo import, this filter becomes wrong and nothing else in CI will say so.

## Not in this PR

`security.yml` on push to `main` looked like the same kind of duplicate and is not. Its `push` run is what writes the default-branch code-scanning alerts: the analyses API carries entries on `refs/heads/main` and `refs/pull/N/merge` and **none** on `gh-readonly-queue/*`, so the queue run's SARIF never reaches `main`. Same reason CodeQL's push run stays.

Independent of #509 and #511.
