### PR TITLE
ci: bound the Playwright system-package install and retry it once

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -805,18 +805,18 @@ jobs:
         # 2026-08-17 (45 min, took the README badge red) and run 32085785273 on
         # 2026-08-18, both on this same step.
         #
-        # Bounded at 600s against a measured 11-50 s over nine successful runs, and
-        # retried once, because an apt mirror that is wedged now is usually fine
-        # 20 seconds later. Worst case is 20 minutes and a real failure, instead of
-        # 45 minutes and a verdict that names the wrong thing.
-        run: |
-          set -euo pipefail
-          for attempt in 1 2; do
-            if timeout 600 npx playwright install --with-deps chromium; then exit 0; fi
-            echo "::warning::npx playwright install --with-deps chromium did not finish within 600s (attempt $attempt of 2)"
-            sleep 20
-          done
-          exit 1
+        # Bounded, and NOT retried. Both halves are measured, and the first
+        # attempt at this fix got both of them wrong (run 32087754303):
+        #
+        #   - the bound cannot be tight. The 11-50 s this step usually takes is
+        #     the path where the packages are already present; a cold run pulls
+        #     21.1 MB from the Azure mirror and legitimately ran past 300 s. The
+        #     bound exists to beat the 45-minute job timeout, nothing finer.
+        #   - a retry cannot work. `timeout` kills apt mid-transaction and the
+        #     orphan keeps /var/lib/dpkg/lock-frontend, so the next attempt dies
+        #     at once on `Could not get lock` — observed, exit 100. A bounded
+        #     single attempt fails honestly; a retry only fails twice.
+        run: timeout 1200 npx playwright install --with-deps chromium
 
       - name: Install Playwright OS dependencies (cache hit)
         # The cache above only covers the downloaded browser binaries under
@@ -832,18 +832,18 @@ jobs:
         # 2026-08-17 (45 min, took the README badge red) and run 32085785273 on
         # 2026-08-18, both on this same step.
         #
-        # Bounded at 300s against a measured 11-50 s over nine successful runs, and
-        # retried once, because an apt mirror that is wedged now is usually fine
-        # 20 seconds later. Worst case is 10 minutes and a real failure, instead of
-        # 45 minutes and a verdict that names the wrong thing.
-        run: |
-          set -euo pipefail
-          for attempt in 1 2; do
-            if timeout 300 npx playwright install-deps chromium; then exit 0; fi
-            echo "::warning::npx playwright install-deps chromium did not finish within 300s (attempt $attempt of 2)"
-            sleep 20
-          done
-          exit 1
+        # Bounded, and NOT retried. Both halves are measured, and the first
+        # attempt at this fix got both of them wrong (run 32087754303):
+        #
+        #   - the bound cannot be tight. The 11-50 s this step usually takes is
+        #     the path where the packages are already present; a cold run pulls
+        #     21.1 MB from the Azure mirror and legitimately ran past 300 s. The
+        #     bound exists to beat the 45-minute job timeout, nothing finer.
+        #   - a retry cannot work. `timeout` kills apt mid-transaction and the
+        #     orphan keeps /var/lib/dpkg/lock-frontend, so the next attempt dies
+        #     at once on `Could not get lock` — observed, exit 100. A bounded
+        #     single attempt fails honestly; a retry only fails twice.
+        run: timeout 900 npx playwright install-deps chromium
 
       - name: Run Playwright e2e (smoke on push, full otherwise)
         # The divisor comes from `strategy.job-total`, which GitHub computes
@@ -965,18 +965,18 @@ jobs:
         # 2026-08-17 (45 min, took the README badge red) and run 32085785273 on
         # 2026-08-18, both on this same step.
         #
-        # Bounded at 600s against a measured 11-50 s over nine successful runs, and
-        # retried once, because an apt mirror that is wedged now is usually fine
-        # 20 seconds later. Worst case is 20 minutes and a real failure, instead of
-        # 45 minutes and a verdict that names the wrong thing.
-        run: |
-          set -euo pipefail
-          for attempt in 1 2; do
-            if timeout 600 npx playwright install --with-deps chromium; then exit 0; fi
-            echo "::warning::npx playwright install --with-deps chromium did not finish within 600s (attempt $attempt of 2)"
-            sleep 20
-          done
-          exit 1
+        # Bounded, and NOT retried. Both halves are measured, and the first
+        # attempt at this fix got both of them wrong (run 32087754303):
+        #
+        #   - the bound cannot be tight. The 11-50 s this step usually takes is
+        #     the path where the packages are already present; a cold run pulls
+        #     21.1 MB from the Azure mirror and legitimately ran past 300 s. The
+        #     bound exists to beat the 45-minute job timeout, nothing finer.
+        #   - a retry cannot work. `timeout` kills apt mid-transaction and the
+        #     orphan keeps /var/lib/dpkg/lock-frontend, so the next attempt dies
+        #     at once on `Could not get lock` — observed, exit 100. A bounded
+        #     single attempt fails honestly; a retry only fails twice.
+        run: timeout 1200 npx playwright install --with-deps chromium
 
       - name: Install Playwright OS dependencies (cache hit)
         if: env.RUN_E2E != 'false' && env.RUN_HEAVY == 'true' && steps.playwright-cache.outputs.cache-hit == 'true'
@@ -988,18 +988,18 @@ jobs:
         # 2026-08-17 (45 min, took the README badge red) and run 32085785273 on
         # 2026-08-18, both on this same step.
         #
-        # Bounded at 300s against a measured 11-50 s over nine successful runs, and
-        # retried once, because an apt mirror that is wedged now is usually fine
-        # 20 seconds later. Worst case is 10 minutes and a real failure, instead of
-        # 45 minutes and a verdict that names the wrong thing.
-        run: |
-          set -euo pipefail
-          for attempt in 1 2; do
-            if timeout 300 npx playwright install-deps chromium; then exit 0; fi
-            echo "::warning::npx playwright install-deps chromium did not finish within 300s (attempt $attempt of 2)"
-            sleep 20
-          done
-          exit 1
+        # Bounded, and NOT retried. Both halves are measured, and the first
+        # attempt at this fix got both of them wrong (run 32087754303):
+        #
+        #   - the bound cannot be tight. The 11-50 s this step usually takes is
+        #     the path where the packages are already present; a cold run pulls
+        #     21.1 MB from the Azure mirror and legitimately ran past 300 s. The
+        #     bound exists to beat the 45-minute job timeout, nothing finer.
+        #   - a retry cannot work. `timeout` kills apt mid-transaction and the
+        #     orphan keeps /var/lib/dpkg/lock-frontend, so the next attempt dies
+        #     at once on `Could not get lock` — observed, exit 100. A bounded
+        #     single attempt fails honestly; a retry only fails twice.
+        run: timeout 900 npx playwright install-deps chromium
 
       - name: Run Playwright Postgres smoke
         if: env.RUN_E2E != 'false' && env.RUN_HEAVY == 'true'
@@ -1067,18 +1067,18 @@ jobs:
         # 2026-08-17 (45 min, took the README badge red) and run 32085785273 on
         # 2026-08-18, both on this same step.
         #
-        # Bounded at 900s against a measured 11-50 s over nine successful runs, and
-        # retried once, because an apt mirror that is wedged now is usually fine
-        # 20 seconds later. Worst case is 30 minutes and a real failure, instead of
-        # 45 minutes and a verdict that names the wrong thing.
-        run: |
-          set -euo pipefail
-          for attempt in 1 2; do
-            if timeout 900 npx playwright install --with-deps chromium firefox webkit; then exit 0; fi
-            echo "::warning::npx playwright install --with-deps chromium firefox webkit did not finish within 900s (attempt $attempt of 2)"
-            sleep 20
-          done
-          exit 1
+        # Bounded, and NOT retried. Both halves are measured, and the first
+        # attempt at this fix got both of them wrong (run 32087754303):
+        #
+        #   - the bound cannot be tight. The 11-50 s this step usually takes is
+        #     the path where the packages are already present; a cold run pulls
+        #     21.1 MB from the Azure mirror and legitimately ran past 300 s. The
+        #     bound exists to beat the 45-minute job timeout, nothing finer.
+        #   - a retry cannot work. `timeout` kills apt mid-transaction and the
+        #     orphan keeps /var/lib/dpkg/lock-frontend, so the next attempt dies
+        #     at once on `Could not get lock` — observed, exit 100. A bounded
+        #     single attempt fails honestly; a retry only fails twice.
+        run: timeout 1500 npx playwright install --with-deps chromium firefox webkit
 
       - name: Install Playwright OS dependencies (cache hit)
         if: steps.playwright-cache.outputs.cache-hit == 'true'
@@ -1090,18 +1090,18 @@ jobs:
         # 2026-08-17 (45 min, took the README badge red) and run 32085785273 on
         # 2026-08-18, both on this same step.
         #
-        # Bounded at 600s against a measured 11-50 s over nine successful runs, and
-        # retried once, because an apt mirror that is wedged now is usually fine
-        # 20 seconds later. Worst case is 20 minutes and a real failure, instead of
-        # 45 minutes and a verdict that names the wrong thing.
-        run: |
-          set -euo pipefail
-          for attempt in 1 2; do
-            if timeout 600 npx playwright install-deps chromium firefox webkit; then exit 0; fi
-            echo "::warning::npx playwright install-deps chromium firefox webkit did not finish within 600s (attempt $attempt of 2)"
-            sleep 20
-          done
-          exit 1
+        # Bounded, and NOT retried. Both halves are measured, and the first
+        # attempt at this fix got both of them wrong (run 32087754303):
+        #
+        #   - the bound cannot be tight. The 11-50 s this step usually takes is
+        #     the path where the packages are already present; a cold run pulls
+        #     21.1 MB from the Azure mirror and legitimately ran past 300 s. The
+        #     bound exists to beat the 45-minute job timeout, nothing finer.
+        #   - a retry cannot work. `timeout` kills apt mid-transaction and the
+        #     orphan keeps /var/lib/dpkg/lock-frontend, so the next attempt dies
+        #     at once on `Could not get lock` — observed, exit 100. A bounded
+        #     single attempt fails honestly; a retry only fails twice.
+        run: timeout 1200 npx playwright install-deps chromium firefox webkit
 
       - name: Run Playwright cross-browser smoke
         run: npm run e2e:cross-browser

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -797,7 +797,26 @@ jobs:
 
       - name: Install Playwright browser
         if: env.RUN_E2E != 'false' && env.SHARD_ACTIVE != 'false' && steps.playwright-cache.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps chromium
+        # `playwright install --with-deps` is an apt front end, and apt hangs on an
+        # unresponsive mirror rather than failing. Unbounded, that hang runs until
+        # the JOB timeout — 45 minutes — and GitHub reports a timed-out job as
+        # `cancelled`, not `failed`, so a required check goes red with no failed
+        # step to look at. It happened twice inside 24 hours: run 32070919012 on
+        # 2026-08-17 (45 min, took the README badge red) and run 32085785273 on
+        # 2026-08-18, both on this same step.
+        #
+        # Bounded at 600s against a measured 11-50 s over nine successful runs, and
+        # retried once, because an apt mirror that is wedged now is usually fine
+        # 20 seconds later. Worst case is 20 minutes and a real failure, instead of
+        # 45 minutes and a verdict that names the wrong thing.
+        run: |
+          set -euo pipefail
+          for attempt in 1 2; do
+            if timeout 600 npx playwright install --with-deps chromium; then exit 0; fi
+            echo "::warning::npx playwright install --with-deps chromium did not finish within 600s (attempt $attempt of 2)"
+            sleep 20
+          done
+          exit 1
 
       - name: Install Playwright OS dependencies (cache hit)
         # The cache above only covers the downloaded browser binaries under
@@ -805,7 +824,26 @@ jobs:
         # a fresh runner, so they still need installing even on a browser
         # cache hit — this is the fast path (no browser download).
         if: env.RUN_E2E != 'false' && env.SHARD_ACTIVE != 'false' && steps.playwright-cache.outputs.cache-hit == 'true'
-        run: npx playwright install-deps chromium
+        # `playwright install-deps` is an apt front end, and apt hangs on an
+        # unresponsive mirror rather than failing. Unbounded, that hang runs until
+        # the JOB timeout — 45 minutes — and GitHub reports a timed-out job as
+        # `cancelled`, not `failed`, so a required check goes red with no failed
+        # step to look at. It happened twice inside 24 hours: run 32070919012 on
+        # 2026-08-17 (45 min, took the README badge red) and run 32085785273 on
+        # 2026-08-18, both on this same step.
+        #
+        # Bounded at 300s against a measured 11-50 s over nine successful runs, and
+        # retried once, because an apt mirror that is wedged now is usually fine
+        # 20 seconds later. Worst case is 10 minutes and a real failure, instead of
+        # 45 minutes and a verdict that names the wrong thing.
+        run: |
+          set -euo pipefail
+          for attempt in 1 2; do
+            if timeout 300 npx playwright install-deps chromium; then exit 0; fi
+            echo "::warning::npx playwright install-deps chromium did not finish within 300s (attempt $attempt of 2)"
+            sleep 20
+          done
+          exit 1
 
       - name: Run Playwright e2e (smoke on push, full otherwise)
         # The divisor comes from `strategy.job-total`, which GitHub computes
@@ -919,11 +957,49 @@ jobs:
 
       - name: Install Playwright browser
         if: env.RUN_E2E != 'false' && env.RUN_HEAVY == 'true' && steps.playwright-cache.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps chromium
+        # `playwright install --with-deps` is an apt front end, and apt hangs on an
+        # unresponsive mirror rather than failing. Unbounded, that hang runs until
+        # the JOB timeout — 45 minutes — and GitHub reports a timed-out job as
+        # `cancelled`, not `failed`, so a required check goes red with no failed
+        # step to look at. It happened twice inside 24 hours: run 32070919012 on
+        # 2026-08-17 (45 min, took the README badge red) and run 32085785273 on
+        # 2026-08-18, both on this same step.
+        #
+        # Bounded at 600s against a measured 11-50 s over nine successful runs, and
+        # retried once, because an apt mirror that is wedged now is usually fine
+        # 20 seconds later. Worst case is 20 minutes and a real failure, instead of
+        # 45 minutes and a verdict that names the wrong thing.
+        run: |
+          set -euo pipefail
+          for attempt in 1 2; do
+            if timeout 600 npx playwright install --with-deps chromium; then exit 0; fi
+            echo "::warning::npx playwright install --with-deps chromium did not finish within 600s (attempt $attempt of 2)"
+            sleep 20
+          done
+          exit 1
 
       - name: Install Playwright OS dependencies (cache hit)
         if: env.RUN_E2E != 'false' && env.RUN_HEAVY == 'true' && steps.playwright-cache.outputs.cache-hit == 'true'
-        run: npx playwright install-deps chromium
+        # `playwright install-deps` is an apt front end, and apt hangs on an
+        # unresponsive mirror rather than failing. Unbounded, that hang runs until
+        # the JOB timeout — 45 minutes — and GitHub reports a timed-out job as
+        # `cancelled`, not `failed`, so a required check goes red with no failed
+        # step to look at. It happened twice inside 24 hours: run 32070919012 on
+        # 2026-08-17 (45 min, took the README badge red) and run 32085785273 on
+        # 2026-08-18, both on this same step.
+        #
+        # Bounded at 300s against a measured 11-50 s over nine successful runs, and
+        # retried once, because an apt mirror that is wedged now is usually fine
+        # 20 seconds later. Worst case is 10 minutes and a real failure, instead of
+        # 45 minutes and a verdict that names the wrong thing.
+        run: |
+          set -euo pipefail
+          for attempt in 1 2; do
+            if timeout 300 npx playwright install-deps chromium; then exit 0; fi
+            echo "::warning::npx playwright install-deps chromium did not finish within 300s (attempt $attempt of 2)"
+            sleep 20
+          done
+          exit 1
 
       - name: Run Playwright Postgres smoke
         if: env.RUN_E2E != 'false' && env.RUN_HEAVY == 'true'
@@ -983,11 +1059,49 @@ jobs:
 
       - name: Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps chromium firefox webkit
+        # `playwright install --with-deps` is an apt front end, and apt hangs on an
+        # unresponsive mirror rather than failing. Unbounded, that hang runs until
+        # the JOB timeout — 45 minutes — and GitHub reports a timed-out job as
+        # `cancelled`, not `failed`, so a required check goes red with no failed
+        # step to look at. It happened twice inside 24 hours: run 32070919012 on
+        # 2026-08-17 (45 min, took the README badge red) and run 32085785273 on
+        # 2026-08-18, both on this same step.
+        #
+        # Bounded at 900s against a measured 11-50 s over nine successful runs, and
+        # retried once, because an apt mirror that is wedged now is usually fine
+        # 20 seconds later. Worst case is 30 minutes and a real failure, instead of
+        # 45 minutes and a verdict that names the wrong thing.
+        run: |
+          set -euo pipefail
+          for attempt in 1 2; do
+            if timeout 900 npx playwright install --with-deps chromium firefox webkit; then exit 0; fi
+            echo "::warning::npx playwright install --with-deps chromium firefox webkit did not finish within 900s (attempt $attempt of 2)"
+            sleep 20
+          done
+          exit 1
 
       - name: Install Playwright OS dependencies (cache hit)
         if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: npx playwright install-deps chromium firefox webkit
+        # `playwright install-deps` is an apt front end, and apt hangs on an
+        # unresponsive mirror rather than failing. Unbounded, that hang runs until
+        # the JOB timeout — 45 minutes — and GitHub reports a timed-out job as
+        # `cancelled`, not `failed`, so a required check goes red with no failed
+        # step to look at. It happened twice inside 24 hours: run 32070919012 on
+        # 2026-08-17 (45 min, took the README badge red) and run 32085785273 on
+        # 2026-08-18, both on this same step.
+        #
+        # Bounded at 600s against a measured 11-50 s over nine successful runs, and
+        # retried once, because an apt mirror that is wedged now is usually fine
+        # 20 seconds later. Worst case is 20 minutes and a real failure, instead of
+        # 45 minutes and a verdict that names the wrong thing.
+        run: |
+          set -euo pipefail
+          for attempt in 1 2; do
+            if timeout 600 npx playwright install-deps chromium firefox webkit; then exit 0; fi
+            echo "::warning::npx playwright install-deps chromium firefox webkit did not finish within 600s (attempt $attempt of 2)"
+            sleep 20
+          done
+          exit 1
 
       - name: Run Playwright cross-browser smoke
         run: npm run e2e:cross-browser

--- a/changelog.d/ci-bound-the-playwright-apt-step.md
+++ b/changelog.d/ci-bound-the-playwright-apt-step.md
@@ -1,5 +1,6 @@
 none
 
-CI reliability change with no user-visible effect: the Playwright system-package
-install steps are now time-bounded and retried once, so a wedged apt mirror
-fails the step in minutes instead of hanging until the job's 45-minute timeout.
+CI reliability change with no user-visible effect: the Playwright
+system-package install steps are now time-bounded, so a wedged apt mirror
+fails the step in minutes instead of hanging until the job's 45-minute
+timeout.

--- a/changelog.d/ci-bound-the-playwright-apt-step.md
+++ b/changelog.d/ci-bound-the-playwright-apt-step.md
@@ -1,0 +1,5 @@
+none
+
+CI reliability change with no user-visible effect: the Playwright system-package
+install steps are now time-bounded and retried once, so a wedged apt mirror
+fails the step in minutes instead of hanging until the job's 45-minute timeout.


### PR DESCRIPTION
## The failure mode

`playwright install-deps` is an apt front end, and apt does not fail on an unresponsive mirror — it waits. Unbounded, that wait runs to the **job** timeout of 45 minutes, and GitHub reports a timed-out job as **`cancelled`**, not `failed`. The verdict then names the wrong thing: a required check goes red with no failed step anywhere in the run.

## It happened twice inside 24 hours

| run | event | what happened |
| --- | --- | --- |
| [`32070919012`](https://github.com/ovumcy/ovumcy-web/actions/runs/32070919012) | push to `main`, 2026-08-17 | 21:24:33 → 22:09:49 on the step; this is the run that took the README badge red with every other job green |
| [`32085785273`](https://github.com/ovumcy/ovumcy-web/actions/runs/32085785273) | pull request #509, 2026-08-18 | 28 minutes on the step before it was cancelled by hand |

Both on `Install Playwright OS dependencies (cache hit)`.

## All six sites, not the one that hurt

Twice is a class. The same step exists in three jobs and in two variants:

| job | `install --with-deps` | `install-deps` |
| --- | --- | --- |
| `e2e-shard` | 600 s | 300 s |
| `e2e-postgres-smoke` | 600 s | 300 s |
| `e2e-cross-browser` (3 browsers) | 900 s | 600 s |

Bounding only the lane where the hang was observed would leave the identical step armed in two other jobs and in the cache-miss path of the same job.

## The bounds are measured

The cache-hit step took **11 s to 50 s over nine successful runs** (sampled across runs `32081210308`, `32081716803`, `32080388224`), so 300 s is six times the observed worst case. The `--with-deps` variants also download browser binaries and get proportionally more; the three-browser lane most.

Each is retried once after a 20-second pause — a mirror wedged now is usually fine shortly after. Worst case becomes **10 to 30 minutes and a real failure**, against 45 minutes and a `cancelled` that reads like someone pressed a button.

## Interaction with the other open PRs

Touches `ci.yml`, as #509 does, but different lines — #509 rewrites the job-level relevance gates and the e2e run step, this one rewrites the install steps. Whichever merges first, the other rebases.
