### PR TITLE
ci: shard the Go unit lane and merge its coverage back into one artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,24 +28,263 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  # Split from a single `test` job into test-go/test-frontend: the two halves
+  # Split from a single `test` job into a Go half and a frontend half: the two
   # never depended on each other's output, so running them as parallel jobs
   # instead of sequential steps shortens wall-clock to roughly max(go, frontend)
-  # instead of their sum. Downstream jobs that only need the Go side (coverage
-  # upload, patch-coverage) depend on test-go alone; jobs that gate on "did
-  # everything basic pass" (e2e, e2e-postgres-smoke) depend on both.
-  test-go:
+  # instead of their sum. Jobs that gate on "did everything basic pass" (e2e,
+  # e2e-postgres-smoke) depend on both.
+  #
+  # The Go half is now three jobs, because ONE package ruled it. Measured on
+  # run 32081716803: `Go test with coverage` was 369 s of a 463 s job, and
+  # internal/api alone reported 353.040 s of that 369 s — every other package
+  # in the module finished inside the remaining 16 s, in parallel with it. A
+  # split by PACKAGE would therefore have bought nothing at all: the wall-clock
+  # IS one package's test binary. So the split is by TEST NAME inside
+  # internal/api (test-go-shard, the same `-run` partition the race lane
+  # already runs on internal/services), with every other package in one whole
+  # lane beside it (test-go-rest) and the analysis tools in a third
+  # (test-go-analysis) — those are a fixed cost that must not be paid N times,
+  # and their binary cache key would be, too.
+  #
+  # Sharding a coverage run splits its profile with it, so the lanes hand their
+  # profiles to `coverage-merge`, which folds them back into the single
+  # `coverage-out` artifact that coverage-upload and the required patch-coverage
+  # gate have always consumed. Neither consumer learned about the split.
+  test-go-shard:
     runs-on: ubuntu-latest
-    # Whole-job skip on `run_core` (see the `changes` job), which now clears
-    # for TWO reasons: a docs-only diff, and a `push` to `main`, where the
-    # merge queue already ran this lane on the identical commit. coverage-upload
-    # and patch-coverage cascade off this job's skip through their needs edge,
-    # and the thin `test` gate job follows both unit jobs the same way.
+    # Whole-job skip on `run_unit` (see the `changes` job), the narrower slice
+    # of `run_core`: it clears for a docs-only diff, for a `push` to `main`
+    # where the merge queue already ran this lane on the identical commit, and
+    # for a diff that is browser specs alone — a Playwright spec is neither
+    # compiled into the Go binary nor go:embed'ed, so it can move no Go test,
+    # lint finding or coverage line. coverage-merge, and through it
+    # coverage-upload and patch-coverage, cascade off this job's skip along
+    # their needs edges, and the thin `test` gate job follows every unit lane
+    # the same way.
     #
     # The shape the whole battery shares: run unless `changes` positively
     # determined this run does not need it. A detection job that failed leaves
     # the output empty, which is not 'false', so the lane still runs — a
     # skipped required check would otherwise pass the merge on no evidence.
+    needs:
+      - changes
+    if: ${{ !cancelled() && needs.changes.outputs.run_unit != 'false' }}
+    permissions:
+      contents: read
+    outputs:
+      # coverage-merge has to know how many profiles it is owed, and the shard
+      # count lives in exactly ONE place: the matrix below. Every shard writes
+      # the same value here, so last-writer-wins is the value all of them
+      # wrote; a literal in the merge job would be a count keyed on a SPELLING,
+      # silently wrong on the day the matrix grows and reading only as a
+      # coverage drop.
+      shard-total: ${{ steps.shard-total.outputs.value }}
+    strategy:
+      # One shard's failure must not cancel its siblings: the point of the
+      # split is to learn everything the Go suite knows in one run.
+      fail-fast: false
+      matrix:
+        shard:
+          - 1
+          - 2
+          - 3
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Record the shard count for the merge job
+        id: shard-total
+        run: echo "value=${{ strategy.job-total }}" >> "$GITHUB_OUTPUT"
+
+      - name: Go test with coverage — internal/api shard
+        # The names come from `go test -list`, never from a hand-written
+        # pattern: a pattern keyed on a SPELLING would leave a new test
+        # matching no shard at all, running NOWHERE while every shard reported
+        # success. scripts/racepartition owns that split, and its tests pin
+        # exhaustiveness and disjointness against a synthesised listing. The
+        # divisor comes from `strategy.job-total`, computed from the matrix
+        # above, so adding a shard cannot leave a second literal behind.
+        #
+        # `set -e` is what makes a failing listing stop the shard: the pattern
+        # is taken through a command substitution, whose status the assignment
+        # carries, and a shard that silently fell back to an empty pattern
+        # would report success having run nothing at all.
+        #
+        # `-coverpkg` and `-timeout 20m` are the whole lane's, unchanged — see
+        # test-go-rest below, which carries the note for both. What `-run`
+        # changes is only WHICH tests credit those packages, which is what
+        # coverage-merge puts back together.
+        shell: bash
+        run: |
+          set -euo pipefail
+          go test -list '.*' ./internal/api/ > "$RUNNER_TEMP/tests.txt"
+          run_pattern="$(go run ./scripts/racepartition -shard=${{ matrix.shard }} -of=${{ strategy.job-total }} < "$RUNNER_TEMP/tests.txt")"
+          echo "shard ${{ matrix.shard }}/${{ strategy.job-total }} selects its share of $(grep -cE '^(Test|Example|Fuzz)' "$RUNNER_TEMP/tests.txt") listed tests"
+          go test ./internal/api/ -timeout 20m -run "$run_pattern" -coverprofile=coverage.out -covermode=atomic -coverpkg=./cmd/...,./internal/...,./migrations/...,./scripts/...,./web/...
+
+      - name: Upload the shard coverage profile
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-shard-api-${{ matrix.shard }}
+          path: coverage.out
+          if-no-files-found: error
+          retention-days: 1
+
+  test-go-rest:
+    runs-on: ubuntu-latest
+    needs:
+      - changes
+    # Same fail-safe gate, and the same slice, as test-go-shard above: the
+    # three Go lanes are one suite and are excused together or not at all.
+    if: ${{ !cancelled() && needs.changes.outputs.run_unit != 'false' }}
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Go test with coverage — every package but the sharded one
+        # The package list is DERIVED from the toolchain and one exclusion,
+        # never written out: a hand-kept list is a rule keyed on a spelling, and
+        # here its failure would be a new package tested by no lane at all while
+        # both lanes stayed green. `go list` over the same trees `-coverpkg`
+        # names is the full set; internal/api is removed because test-go-shard
+        # runs it. The count check is what makes the exclusion honest — if it
+        # ever drops none, or more than one, this step fails instead of quietly
+        # testing less. (Renaming internal/api would land it back HERE, whole
+        # and slow: visible, never silent.)
+        #
+        # -coverpkg credits a line when ANY test exercises it (including
+        # cross-package integration tests), not only its own package's unit
+        # tests. The patch-coverage gate consumes the merged profile. Scoped to
+        # the module trees (see the note above the Staticcheck step in
+        # test-go-analysis).
+        #
+        # `-timeout 20m` declares a budget that was previously left implicit.
+        # Go's default is 10 minutes PER PACKAGE, and internal/api sits right at
+        # that edge: measured 2026-08-15 on a dev host, 603 s run alone and 610 s
+        # inside `go test ./...`, with coverage instrumentation slower still
+        # (-covermode=atomic adds an atomic counter per block). The lane passed
+        # only because the runner happens to be faster than a dev host, which is
+        # not a margin anyone chose. Sharding does not retire the budget: a
+        # shard runs a third of one package, and the budget is per package in
+        # every other lane too.
+        #
+        # What the budget prevents does not read as "this needed more time": the
+        # runtime panics with `test timed out after 10m0s` and dumps every
+        # goroutine, so a required check fails with a stack trace that reads like
+        # a product bug. Every `go test` in this file that runs a suite declares
+        # the same budget — fixing only the lane where the pressure was measured
+        # would leave the identical default armed in the other spellings.
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Both listings go through a command substitution first: `set -e`
+          # carries a failing `go list` out of one, and would NOT out of a
+          # process substitution feeding `mapfile` — there the status read is
+          # mapfile's, so a listing that died half-way would arrive as a
+          # shorter package set and test less, quietly.
+          sharded="$(go list ./internal/api)"
+          all="$(go list ./cmd/... ./internal/... ./migrations/... ./scripts/... ./web/...)"
+          rest="$(printf '%s\n' "$all" | grep -vFx "$sharded")"
+          mapfile -t rest_packages <<< "$rest"
+          dropped=$(( $(printf '%s\n' "$all" | wc -l) - ${#rest_packages[@]} ))
+          if [ "$dropped" -ne 1 ]; then
+            echo "::error::excluding $sharded dropped $dropped package(s), expected exactly 1"
+            exit 1
+          fi
+          echo "testing ${#rest_packages[@]} package(s); $sharded runs in test-go-shard"
+          go test "${rest_packages[@]}" -timeout 20m -coverprofile=coverage.out -covermode=atomic -coverpkg=./cmd/...,./internal/...,./migrations/...,./scripts/...,./web/...
+
+      - name: Upload the whole-package coverage profile
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-shard-rest
+          path: coverage.out
+          if-no-files-found: error
+          retention-days: 1
+
+  # Sharding a coverage run splits its profile with it. This job folds the
+  # pieces back into the single `coverage-out` artifact that coverage-upload
+  # and the required patch-coverage gate have always downloaded, so neither of
+  # them learned anything about the split.
+  #
+  # A UNION with summed counts, not a concatenation: every lane runs with the
+  # same `-coverpkg` over the whole module, so every profile lists every
+  # coverable block, and a block its own lane did not execute is present at 0.
+  # Dropping those zeros would be the expensive mistake — patchcov treats a
+  # line ABSENT from the profile as non-coverable and ignores it, so a lost
+  # block turns an uncovered modified line into one the required gate never
+  # judges. scripts/covmerge owns the fold and its tests pin both halves.
+  coverage-merge:
+    runs-on: ubuntu-latest
+    needs:
+      - test-go-shard
+      - test-go-rest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Download the lane coverage profiles
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: coverage-shard-*
+          path: .coverage-shards
+
+      - name: Merge the lane coverage profiles
+        # `-expect` is the guard for the failure that leaves no other trace: an
+        # artifact that never arrived merges into a profile which parses
+        # cleanly, covers less, and reads downstream as a coverage drop this
+        # pull request caused. The matrix half of the count is read from the
+        # matrix itself; `+ 1` is test-go-rest, the one whole-package lane.
+        env:
+          SHARD_TOTAL: ${{ needs.test-go-shard.outputs.shard-total }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "$SHARD_TOTAL" ]; then
+            echo "::error::the shard matrix reported no size — refusing to guess how many profiles are owed"
+            exit 1
+          fi
+          go run ./scripts/covmerge -in .coverage-shards -glob coverage.out -out coverage.out -expect "$((SHARD_TOTAL + 1))"
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-out
+          path: coverage.out
+          if-no-files-found: error
+          retention-days: 1
+
+  test-go-analysis:
+    runs-on: ubuntu-latest
+    # Same fail-safe gate, and the same slice, as test-go-shard above, for the
+    # same reason: this lane's skip is judged by the `test` gate, never taken
+    # for a pass. The analysis tools read Go sources too, so a browser-spec-only
+    # diff excuses them exactly as it excuses the suite.
     needs:
       - changes
     if: ${{ !cancelled() && needs.changes.outputs.run_unit != 'false' }}
@@ -216,41 +455,11 @@ jobs:
       - name: Go vet
         run: go vet ./cmd/... ./internal/... ./migrations/... ./scripts/... ./web/...
 
-      - name: Go test with coverage
-        # -coverpkg credits a line when ANY test exercises it (including
-        # cross-package integration tests), not only its own package's unit
-        # tests. The patch-coverage gate consumes this profile. Scoped to the
-        # module trees (see the note above the Staticcheck step).
-        #
-        # `-timeout 20m` declares a budget that was previously left implicit.
-        # Go's default is 10 minutes PER PACKAGE, and internal/api sits right at
-        # that edge: measured 2026-08-15 on a dev host, 603 s run alone and 610 s
-        # inside `go test ./...`, with coverage instrumentation slower still
-        # (-covermode=atomic adds an atomic counter per block). The lane passed
-        # only because the runner happens to be faster than a dev host, which is
-        # not a margin anyone chose.
-        #
-        # What the budget prevents does not read as "this needed more time": the
-        # runtime panics with `test timed out after 10m0s` and dumps every
-        # goroutine, so a required check fails with a stack trace that reads like
-        # a product bug. Every `go test` in this file that runs a suite declares
-        # the same budget — fixing only the lane where the pressure was measured
-        # would leave the identical default armed in three other spellings.
-        run: go test ./cmd/... ./internal/... ./migrations/... ./scripts/... ./web/... -timeout 20m -coverprofile=coverage.out -covermode=atomic -coverpkg=./cmd/...,./internal/...,./migrations/...,./scripts/...,./web/...
-
-      - name: Upload coverage artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: coverage-out
-          path: coverage.out
-          if-no-files-found: error
-          retention-days: 1
-
   test-frontend:
     runs-on: ubuntu-latest
     needs:
       - changes
-    # Same fail-safe gate as test-go above.
+    # Same fail-safe gate as test-go-shard above.
     if: ${{ !cancelled() && needs.changes.outputs.run_core != 'false' }}
     permissions:
       contents: read
@@ -310,11 +519,14 @@ jobs:
   # repos/ovumcy/ovumcy-web/rules/branches/main`). Renaming or removing the
   # `test` job outright would leave that required check permanently
   # unsatisfied and block every future PR; this job keeps the name while the
-  # actual work runs in the parallel test-go/test-frontend jobs above.
+  # actual work runs in the parallel Go and frontend lanes above.
   test:
     runs-on: ubuntu-latest
     needs:
-      - test-go
+      - test-go-shard
+      - test-go-rest
+      - test-go-analysis
+      - coverage-merge
       - test-frontend
     # WITHOUT AN `if`, A FAILED DEPENDENCY SKIPS THIS JOB — and a skipped
     # required check counts as satisfied, so a failing Go suite left no required
@@ -327,17 +539,27 @@ jobs:
     # `!cancelled()` makes this job RUN whatever its dependencies did, and the
     # step below turns their results into this context's verdict. A cancelled
     # run is still excluded: a superseded PR run must not report a failure.
+    #
+    # `coverage-merge` is judged here for the same measured reason, one layer
+    # further down: patch-coverage consumes its artifact, so a merge that
+    # FAILED would skip patch-coverage, and a skipped required check is
+    # satisfied. Judging it here is what keeps a broken coverage hand-off red
+    # somewhere. It has no `if:` of its own, so it is skipped whenever a lane
+    # it needs failed — and the lane's own result is what colours this gate then.
     if: ${{ !cancelled() }}
     permissions:
       contents: read
     steps:
-      - name: Judge the two unit halves
+      - name: Judge the unit lanes
         env:
-          GO_RESULT: ${{ needs.test-go.result }}
+          SHARD_RESULT: ${{ needs.test-go-shard.result }}
+          REST_RESULT: ${{ needs.test-go-rest.result }}
+          ANALYSIS_RESULT: ${{ needs.test-go-analysis.result }}
+          MERGE_RESULT: ${{ needs.coverage-merge.result }}
           FRONTEND_RESULT: ${{ needs.test-frontend.result }}
         run: |
           set -euo pipefail
-          echo "test-go=$GO_RESULT test-frontend=$FRONTEND_RESULT"
+          echo "test-go-shard=$SHARD_RESULT test-go-rest=$REST_RESULT test-go-analysis=$ANALYSIS_RESULT coverage-merge=$MERGE_RESULT test-frontend=$FRONTEND_RESULT"
           # `skipped` is a PASS here and only here: the `changes` job cleared
           # `run_core` — the diff was docs-only, or this is a `push` whose core
           # suite the merge queue already ran on the identical commit. Either
@@ -345,13 +567,13 @@ jobs:
           # — failure, cancelled, or a state this gate has never seen — is this
           # context's failure, because the whole point of the job is to have a
           # verdict to report.
-          for result in "$GO_RESULT" "$FRONTEND_RESULT"; do
+          for result in "$SHARD_RESULT" "$REST_RESULT" "$ANALYSIS_RESULT" "$MERGE_RESULT" "$FRONTEND_RESULT"; do
             case "$result" in
               success|skipped) ;;
-              *) echo "::error::a unit half reported \"$result\""; exit 1 ;;
+              *) echo "::error::a unit lane reported \"$result\""; exit 1 ;;
             esac
           done
-          echo "test-go and test-frontend passed."
+          echo "every unit lane passed."
 
   # internal/services alone was 461 s of the race lane's 589 s (measured
   # 2026-08-15), and 75% of THAT sits in the 99 tests whose files hash
@@ -371,7 +593,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - changes
-    # Same fail-safe gate as test-go above.
+    # Same shape as the Go lanes above, on the slice of its own: `run_race`
+    # clears when a diff carries no compiled Go and no workflow change.
     if: ${{ !cancelled() && needs.changes.outputs.run_race != 'false' }}
     permissions:
       contents: read
@@ -444,7 +667,7 @@ jobs:
         # whole — splitting them would buy nothing and cost a job.
         env:
           CGO_ENABLED: "1"
-        # `-timeout 20m`: the declared budget from the coverage step in test-go.
+        # `-timeout 20m`: the declared budget from the coverage lanes above.
         # The race detector is strictly slower per test, so an undeclared
         # 10-minute default is armed harder here than where it was measured.
         run: go test -race -timeout 20m ./internal/db/... ./internal/security/... ./internal/i18n/... ./internal/httpx/...
@@ -501,11 +724,14 @@ jobs:
     # `gh-readonly-queue/*` entry, and commit 97f641e2… carries `branch: main`
     # (api.codecov.io/api/v2/github/ovumcy/repos/ovumcy-web, queried
     # 2026-08-18). The push run only ever added a second session for the same
-    # numbers. It no longer runs at all: this job cascades to skipped off
-    # test-go, which `run_core` clears on push.
+    # numbers. It no longer runs at all: this job cascades to skipped off the
+    # unit lanes, which `run_core` clears on push.
+    #
+    # `coverage-merge` rather than a test lane: the artifact name and contents
+    # are unchanged, only the job that produces `coverage-out` moved.
     runs-on: ubuntu-latest
     needs:
-      - test-go
+      - coverage-merge
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: read
@@ -553,8 +779,13 @@ jobs:
 
   patch-coverage:
     runs-on: ubuntu-latest
+    # The profile this gate reads is now merged from the sharded lanes
+    # (coverage-merge above); the artifact it downloads, `coverage-out`, is the
+    # same name carrying the same whole-suite coverage it always did. This is a
+    # REQUIRED check, and a failed dependency would skip it into a satisfied
+    # state — the `test` gate judges coverage-merge for exactly that reason.
     needs:
-      - test-go
+      - coverage-merge
     if: github.event_name == 'pull_request'
     permissions:
       contents: read
@@ -616,13 +847,14 @@ jobs:
       # `run_race` — the race lanes. The detector instruments COMPILED Go, so a
       # change carrying no `.go`, no `go.mod` and no `go.sum` cannot introduce a
       # data race: the binaries are identical and the same tests still run
-      # unraced in test-go. Locales, templates and web assets are go:embed'ed
+      # unraced in the Go lanes. Locales, templates and web assets are go:embed'ed
       # DATA — changing them changes what the binary contains, never how it
       # synchronises. `.github/**` is carved back IN even though it compiles
       # nothing: a pull request editing the race job itself must not be judged
       # irrelevant by the job it is editing.
       run_race: ${{ steps.detect.outputs.run_race }}
-      # `run_unit` — test-go. A Playwright spec is neither compiled into the Go
+      # `run_unit` — the three Go lanes (test-go-shard, test-go-rest,
+      # test-go-analysis). A Playwright spec is neither compiled into the Go
       # binary nor go:embed'ed, so an `e2e/**`-only change cannot alter a Go
       # test, a lint finding or a coverage line. test-FRONTEND deliberately
       # keeps gating on `run_core` instead: its `lint:types` step type-checks

--- a/changelog.d/ci-shard-the-go-unit-lane.md
+++ b/changelog.d/ci-shard-the-go-unit-lane.md
@@ -1,0 +1,9 @@
+none
+
+CI change with no user-visible effect: the Go unit lane is sharded. `internal/api`
+— 353 s of the lane's 369 s of testing — is split across three jobs by test name,
+every other package runs in one lane beside it, and the analysis tools (staticcheck,
+golangci-lint, actionlint, deadcode, vet) move into a third so they are paid once
+rather than per shard. The per-lane coverage profiles are merged back into the
+single artifact the Codecov upload and the patch-coverage gate already consumed,
+so both read the same whole-suite coverage as before.

--- a/scripts/covmerge/main.go
+++ b/scripts/covmerge/main.go
@@ -1,0 +1,340 @@
+// Command covmerge combines the per-shard Go coverage profiles produced by the
+// sharded unit lane (.github/workflows/ci.yml, jobs test-go-shard and
+// test-go-rest) into the single profile its two consumers read: the Codecov
+// upload and the required patch-coverage gate (scripts/patchcov).
+//
+// It exists because sharding a `go test` run splits its coverage with it. Both
+// consumers used to receive ONE artifact produced by ONE run; with the lane
+// split they receive one profile per shard, and a consumer handed a single
+// shard's profile would report the coverage of a fraction of the suite as
+// though it were the whole. patchcov would then fail a pull request for lines
+// another shard covered.
+//
+// The lane runs with `-coverpkg` over every module tree, so each shard's
+// profile lists every coverable block in the module — including blocks in
+// packages that shard never executed, at count 0. Merging is therefore a union
+// over block keys with the counts summed, and the union is what keeps a
+// package that only one shard ran from reading as uncovered in the merged
+// profile.
+//
+// Three properties are refused rather than papered over, because each one
+// means the profiles being merged did not come from the same tree, and a
+// merged profile that quietly disagrees with the source is worse than no
+// profile at all: a mode line that differs between inputs, the same block
+// carrying a different statement count in two inputs, and a line this command
+// cannot parse. `-expect` refuses the failure that leaves no trace at all — an
+// artifact that never arrived, which would silently merge fewer shards than
+// the matrix produced and read as a coverage drop in the consumers.
+//
+// Usage: covmerge -in <dir> -glob <pattern> -out <file> -expect <n>
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"flag"
+)
+
+// blockKey identifies one coverable block exactly as the profile line spells
+// it: the file (module-relative import path plus file name, as `go test`
+// writes it) and the source span. The statement count is deliberately NOT part
+// of the key — two inputs disagreeing about it is the mismatch this command
+// reports, and folding it into the key would turn that mismatch into two
+// separate blocks nobody would notice.
+type blockKey struct {
+	file      string
+	startLine int
+	startCol  int
+	endLine   int
+	endCol    int
+}
+
+type blockValue struct {
+	numStmt int
+	count   int64
+	source  string // the input that first carried this block, named in a mismatch
+}
+
+func main() {
+	inDir := flag.String("in", "", "directory to search for shard coverage profiles")
+	pattern := flag.String("glob", "coverage.out", "glob matched against each file's BASENAME under -in")
+	outPath := flag.String("out", "", "path to write the merged profile")
+	expect := flag.Int("expect", 0, "exact number of profiles that must be found (0 disables the check)")
+	flag.Parse()
+
+	if *inDir == "" || *outPath == "" {
+		fatalf("usage: covmerge -in <dir> -glob <pattern> -out <file> [-expect <n>]")
+	}
+
+	matches, err := findProfiles(*inDir, *pattern)
+	if err != nil {
+		fatalf("find shard profiles: %v", err)
+	}
+	if len(matches) == 0 {
+		fatalf("no coverage profile matched %s under %s — nothing to merge", *pattern, *inDir)
+	}
+	if err := RequireCount(matches, *expect); err != nil {
+		fatalf("under %s: %v", *inDir, err)
+	}
+
+	mode, blocks, err := mergeProfiles(matches)
+	if err != nil {
+		fatalf("%v", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(*outPath), 0o755); err != nil {
+		fatalf("create output dir: %v", err)
+	}
+	if err := os.WriteFile(*outPath, []byte(Render(mode, blocks)), 0o644); err != nil {
+		fatalf("write merged profile: %v", err)
+	}
+
+	fmt.Printf("merged %d shard profile(s), %d block(s), into %s\n", len(matches), len(blocks), *outPath)
+}
+
+func fatalf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "covmerge: "+format+"\n", args...)
+	os.Exit(1)
+}
+
+// RequireCount refuses a set of inputs that is not the size the caller was
+// promised. The check is against what the matrix was supposed to produce, not
+// against "more than zero": a shard whose upload never arrived leaves the
+// remaining profiles parsing cleanly and covering less, which reads downstream
+// as a coverage drop rather than as a missing shard — and the required patch
+// gate would fail a pull request over lines the absent shard had covered.
+//
+// `expect` of 0 disables the check, for a caller that genuinely does not know
+// the count. CI always knows it: it is the matrix size plus the whole-package
+// lane, both read from the workflow rather than written as a literal.
+func RequireCount(matches []string, expect int) error {
+	if expect <= 0 || len(matches) == expect {
+		return nil
+	}
+	return fmt.Errorf("found %d profile(s), expected exactly %d: %s",
+		len(matches), expect, strings.Join(matches, " "))
+}
+
+// findProfiles walks dir and returns every regular file whose BASENAME matches
+// pattern, sorted. Shard profiles land in per-artifact subdirectories after
+// actions/download-artifact, so the walk is the part that matters; the same
+// shape as scripts/mutationmerge, which solves this for the mutation matrix.
+func findProfiles(dir, pattern string) ([]string, error) {
+	var matches []string
+	err := filepath.WalkDir(dir, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		ok, err := filepath.Match(pattern, entry.Name())
+		if err != nil {
+			return err
+		}
+		if ok {
+			matches = append(matches, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(matches)
+	return matches, nil
+}
+
+// mergeProfiles reads every profile and folds them into one block table.
+func mergeProfiles(paths []string) (string, map[blockKey]blockValue, error) {
+	mode := ""
+	modeSource := ""
+	blocks := map[blockKey]blockValue{}
+
+	for _, path := range paths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return "", nil, fmt.Errorf("read %s: %w", path, err)
+		}
+		fileMode, err := Accumulate(blocks, string(data), path)
+		if err != nil {
+			return "", nil, err
+		}
+		if mode == "" {
+			mode, modeSource = fileMode, path
+			continue
+		}
+		// Mixing modes is refused rather than resolved. `set` records 0/1 and
+		// `atomic`/`count` record executions, so there is no combination rule
+		// that is right for both, and picking one would silently rewrite what
+		// half the inputs meant.
+		if fileMode != mode {
+			return "", nil, fmt.Errorf("mode mismatch: %s declares %q, %s declares %q",
+				path, fileMode, modeSource, mode)
+		}
+	}
+
+	return mode, blocks, nil
+}
+
+// Accumulate folds one profile's blocks into blocks and returns its mode.
+//
+// `set` mode is combined with a logical OR rather than a sum: its counts are
+// booleans, and 1+1=2 would produce a profile whose own mode line says such a
+// value cannot exist. `count` and `atomic` are execution counts and add.
+func Accumulate(blocks map[blockKey]blockValue, profile, source string) (string, error) {
+	scanner := bufio.NewScanner(strings.NewReader(profile))
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+
+	mode := ""
+	for lineNumber := 1; scanner.Scan(); lineNumber++ {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		if rest, found := strings.CutPrefix(line, "mode: "); found {
+			if mode != "" {
+				return "", fmt.Errorf("%s:%d: a second mode line %q", source, lineNumber, line)
+			}
+			mode = rest
+			continue
+		}
+		if mode == "" {
+			return "", fmt.Errorf("%s:%d: a block line before the mode line: %q", source, lineNumber, line)
+		}
+
+		key, numStmt, count, err := parseBlock(line)
+		if err != nil {
+			return "", fmt.Errorf("%s:%d: %w", source, lineNumber, err)
+		}
+
+		previous, seen := blocks[key]
+		if seen && previous.numStmt != numStmt {
+			// The same span carrying a different statement count means the two
+			// profiles were produced from different source trees. Summing them
+			// would hand the consumers a profile that matches neither tree.
+			return "", fmt.Errorf("%s:%d: block %s:%d.%d,%d.%d has %d statements here and %d in %s — profiles from different trees",
+				source, lineNumber, key.file, key.startLine, key.startCol, key.endLine, key.endCol,
+				numStmt, previous.numStmt, previous.source)
+		}
+
+		merged := blockValue{numStmt: numStmt, count: count, source: source}
+		if seen {
+			merged.source = previous.source
+			if mode == "set" {
+				merged.count = max(previous.count, count)
+			} else {
+				merged.count = previous.count + count
+			}
+		}
+		blocks[key] = merged
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("read %s: %w", source, err)
+	}
+	if mode == "" {
+		return "", fmt.Errorf("%s: no mode line — not a Go coverage profile", source)
+	}
+
+	return mode, nil
+}
+
+// parseBlock reads one profile line: `<file>:<line>.<col>,<line>.<col> <numStmt> <count>`.
+//
+// Every part is parsed rather than pattern-matched loosely: a line this
+// command cannot fully account for is an error, because a profile it silently
+// dropped a block from would understate coverage in the required patch gate.
+func parseBlock(line string) (blockKey, int, int64, error) {
+	fields := strings.Fields(line)
+	if len(fields) != 3 {
+		return blockKey{}, 0, 0, fmt.Errorf("unrecognised profile line: %q", line)
+	}
+
+	span := fields[0]
+	colon := strings.LastIndex(span, ":")
+	if colon < 1 {
+		return blockKey{}, 0, 0, fmt.Errorf("unrecognised profile line: %q", line)
+	}
+	file := span[:colon]
+
+	start, end, found := strings.Cut(span[colon+1:], ",")
+	if !found {
+		return blockKey{}, 0, 0, fmt.Errorf("unrecognised profile line: %q", line)
+	}
+	startLine, startCol, err := parsePosition(start)
+	if err != nil {
+		return blockKey{}, 0, 0, fmt.Errorf("unrecognised profile line: %q", line)
+	}
+	endLine, endCol, err := parsePosition(end)
+	if err != nil {
+		return blockKey{}, 0, 0, fmt.Errorf("unrecognised profile line: %q", line)
+	}
+
+	numStmt, err := strconv.Atoi(fields[1])
+	if err != nil || numStmt < 0 {
+		return blockKey{}, 0, 0, fmt.Errorf("unrecognised statement count in %q", line)
+	}
+	count, err := strconv.ParseInt(fields[2], 10, 64)
+	if err != nil || count < 0 {
+		return blockKey{}, 0, 0, fmt.Errorf("unrecognised execution count in %q", line)
+	}
+
+	return blockKey{file: file, startLine: startLine, startCol: startCol, endLine: endLine, endCol: endCol},
+		numStmt, count, nil
+}
+
+func parsePosition(position string) (int, int, error) {
+	line, column, found := strings.Cut(position, ".")
+	if !found {
+		return 0, 0, fmt.Errorf("not a line.column position: %q", position)
+	}
+	lineNumber, err := strconv.Atoi(line)
+	if err != nil || lineNumber < 1 {
+		return 0, 0, fmt.Errorf("not a line number: %q", line)
+	}
+	columnNumber, err := strconv.Atoi(column)
+	if err != nil || columnNumber < 1 {
+		return 0, 0, fmt.Errorf("not a column number: %q", column)
+	}
+	return lineNumber, columnNumber, nil
+}
+
+// Render writes the merged table back in profile syntax, sorted by file and
+// then by position. `go tool cover` and Codecov both accept any order, and
+// determinism is for the humans: a merged profile that reorders itself between
+// runs cannot be diffed when a coverage number moves unexpectedly.
+func Render(mode string, blocks map[blockKey]blockValue) string {
+	keys := make([]blockKey, 0, len(blocks))
+	for key := range blocks {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		left, right := keys[i], keys[j]
+		switch {
+		case left.file != right.file:
+			return left.file < right.file
+		case left.startLine != right.startLine:
+			return left.startLine < right.startLine
+		case left.startCol != right.startCol:
+			return left.startCol < right.startCol
+		case left.endLine != right.endLine:
+			return left.endLine < right.endLine
+		default:
+			return left.endCol < right.endCol
+		}
+	})
+
+	var out strings.Builder
+	fmt.Fprintf(&out, "mode: %s\n", mode)
+	for _, key := range keys {
+		block := blocks[key]
+		fmt.Fprintf(&out, "%s:%d.%d,%d.%d %d %d\n",
+			key.file, key.startLine, key.startCol, key.endLine, key.endCol, block.numStmt, block.count)
+	}
+	return out.String()
+}

--- a/scripts/covmerge/main_test.go
+++ b/scripts/covmerge/main_test.go
@@ -1,0 +1,260 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// merge is the whole command minus its file handling: it folds the given
+// profiles in the order they are written and renders the result.
+func merge(t *testing.T, profiles ...string) string {
+	t.Helper()
+
+	blocks := map[blockKey]blockValue{}
+	mode := ""
+	for index, profile := range profiles {
+		profileMode, err := Accumulate(blocks, profile, sourceName(index))
+		if err != nil {
+			t.Fatalf("accumulate profile %d: %v", index, err)
+		}
+		mode = profileMode
+	}
+	return Render(mode, blocks)
+}
+
+func sourceName(index int) string {
+	return "shard-" + string(rune('1'+index)) + "/coverage.out"
+}
+
+func mergeError(t *testing.T, profiles ...string) string {
+	t.Helper()
+
+	blocks := map[blockKey]blockValue{}
+	for index, profile := range profiles {
+		if _, err := Accumulate(blocks, profile, sourceName(index)); err != nil {
+			return err.Error()
+		}
+	}
+	t.Fatalf("merging %d profile(s) succeeded, want an error", len(profiles))
+	return ""
+}
+
+// The counting property the consumers rest on: a line executed by two shards
+// is credited with what both of them did, not with the last writer's number.
+func TestCountsForTheSameBlockAreSummed(t *testing.T) {
+	first := "mode: atomic\ngithub.com/o/w/internal/api/a.go:10.2,12.3 2 4\n"
+	second := "mode: atomic\ngithub.com/o/w/internal/api/a.go:10.2,12.3 2 3\n"
+
+	got := merge(t, first, second)
+
+	want := "mode: atomic\ngithub.com/o/w/internal/api/a.go:10.2,12.3 2 7\n"
+	if got != want {
+		t.Fatalf("merged profile:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// The `-coverpkg` property, and the reason the merge is a UNION rather than a
+// concatenation of what each shard executed: every shard's profile lists every
+// coverable block in the module, and a package only one shard ran is present
+// at count 0 in all the others. A merge that let a 0 overwrite a real count —
+// or that dropped the blocks nobody executed — would report a coverage drop
+// that no code change caused.
+func TestABlockOnlyOneShardExecutedKeepsItsCount(t *testing.T) {
+	ran := strings.Join([]string{
+		"mode: atomic",
+		"github.com/o/w/internal/api/a.go:10.2,12.3 2 5",
+		"github.com/o/w/internal/services/s.go:4.1,6.2 1 0",
+		"",
+	}, "\n")
+	didNotRun := strings.Join([]string{
+		"mode: atomic",
+		"github.com/o/w/internal/api/a.go:10.2,12.3 2 0",
+		"github.com/o/w/internal/services/s.go:4.1,6.2 1 9",
+		"",
+	}, "\n")
+
+	got := merge(t, ran, didNotRun)
+
+	want := strings.Join([]string{
+		"mode: atomic",
+		"github.com/o/w/internal/api/a.go:10.2,12.3 2 5",
+		"github.com/o/w/internal/services/s.go:4.1,6.2 1 9",
+		"",
+	}, "\n")
+	if got != want {
+		t.Fatalf("merged profile:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// A block no shard executed must survive the merge at 0. Dropping it would
+// silently shrink the denominator: patchcov treats a line absent from the
+// profile as NON-COVERABLE and ignores it, so a dropped zero block turns an
+// uncovered modified line into a line the required gate never judges.
+func TestABlockNoShardExecutedSurvivesAtZero(t *testing.T) {
+	profile := "mode: atomic\ngithub.com/o/w/internal/db/d.go:1.1,2.2 1 0\n"
+
+	got := merge(t, profile, profile)
+
+	if got != profile {
+		t.Fatalf("merged profile:\n%s\nwant:\n%s", got, profile)
+	}
+}
+
+// `set` mode records a boolean, so summing would produce a 2 that the profile's
+// own mode line says cannot exist. The lane pins `atomic`; this keeps the
+// command honest for anyone who points it at a `set` profile instead of
+// producing a value its consumers would misread.
+func TestSetModeCombinesWithOrRatherThanSum(t *testing.T) {
+	profile := "mode: set\ngithub.com/o/w/internal/api/a.go:10.2,12.3 2 1\n"
+
+	got := merge(t, profile, profile)
+
+	if got != profile {
+		t.Fatalf("merged profile:\n%s\nwant:\n%s", got, profile)
+	}
+}
+
+// Two profiles that disagree about how many statements a span holds were built
+// from different source trees. Merging them would hand the consumers a profile
+// matching neither, and the patch gate reads it against the diff of one of them.
+func TestABlockWithADifferentStatementCountIsRefused(t *testing.T) {
+	first := "mode: atomic\ngithub.com/o/w/internal/api/a.go:10.2,12.3 2 1\n"
+	second := "mode: atomic\ngithub.com/o/w/internal/api/a.go:10.2,12.3 3 1\n"
+
+	got := mergeError(t, first, second)
+
+	if !strings.Contains(got, "different trees") {
+		t.Fatalf("error %q does not name the cause", got)
+	}
+}
+
+func TestAModeMismatchIsRefused(t *testing.T) {
+	paths := []string{
+		writeProfile(t, "atomic", "mode: atomic\ngithub.com/o/w/a.go:1.1,2.2 1 1\n"),
+		writeProfile(t, "set", "mode: set\ngithub.com/o/w/a.go:1.1,2.2 1 1\n"),
+	}
+
+	_, _, err := mergeProfiles(paths)
+
+	if err == nil || !strings.Contains(err.Error(), "mode mismatch") {
+		t.Fatalf("merging atomic with set gave %v, want a mode mismatch", err)
+	}
+}
+
+// A line the command cannot fully account for is an error rather than
+// something to skip past: a silently dropped block understates coverage in a
+// required gate, which reads as the pull request's own fault.
+func TestAnUnaccountableLineIsRefused(t *testing.T) {
+	for name, line := range map[string]string{
+		"missing count":      "github.com/o/w/a.go:1.1,2.2 1",
+		"extra field":        "github.com/o/w/a.go:1.1,2.2 1 1 1",
+		"no span":            "github.com/o/w/a.go 1 1",
+		"no column":          "github.com/o/w/a.go:1,2 1 1",
+		"negative count":     "github.com/o/w/a.go:1.1,2.2 1 -1",
+		"non-numeric count":  "github.com/o/w/a.go:1.1,2.2 1 many",
+		"zero line number":   "github.com/o/w/a.go:0.1,2.2 1 1",
+		"a go test trailer":  "ok  \tgithub.com/o/w\t5.5s",
+		"a coverage summary": "coverage: 65.8% of statements",
+	} {
+		t.Run(name, func(t *testing.T) {
+			blocks := map[blockKey]blockValue{}
+			if _, err := Accumulate(blocks, "mode: atomic\n"+line+"\n", "shard/coverage.out"); err == nil {
+				t.Fatalf("line %q was accepted", line)
+			}
+		})
+	}
+}
+
+func TestAProfileWithoutAModeLineIsRefused(t *testing.T) {
+	blocks := map[blockKey]blockValue{}
+
+	if _, err := Accumulate(blocks, "github.com/o/w/a.go:1.1,2.2 1 1\n", "shard/coverage.out"); err == nil {
+		t.Fatal("a profile whose first line is a block was accepted")
+	}
+	if _, err := Accumulate(blocks, "\n", "shard/coverage.out"); err == nil {
+		t.Fatal("an empty profile was accepted")
+	}
+}
+
+// Determinism is for the humans: a merged profile that reorders itself between
+// runs cannot be diffed when a coverage number moves unexpectedly.
+func TestRenderSortsByFileThenPosition(t *testing.T) {
+	profile := strings.Join([]string{
+		"mode: atomic",
+		"github.com/o/w/b.go:1.1,2.2 1 1",
+		"github.com/o/w/a.go:10.1,11.2 1 1",
+		"github.com/o/w/a.go:2.5,3.2 1 1",
+		"github.com/o/w/a.go:2.1,3.2 1 1",
+		"",
+	}, "\n")
+
+	got := merge(t, profile)
+
+	want := strings.Join([]string{
+		"mode: atomic",
+		"github.com/o/w/a.go:2.1,3.2 1 1",
+		"github.com/o/w/a.go:2.5,3.2 1 1",
+		"github.com/o/w/a.go:10.1,11.2 1 1",
+		"github.com/o/w/b.go:1.1,2.2 1 1",
+		"",
+	}, "\n")
+	if got != want {
+		t.Fatalf("rendered profile:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// actions/download-artifact lands each artifact in its own subdirectory, and
+// every shard's file is called coverage.out — so the search is a walk matched
+// on the BASENAME, never a flat listing of the download directory.
+func TestProfilesAreFoundInPerArtifactSubdirectories(t *testing.T) {
+	root := t.TempDir()
+	for _, shard := range []string{"coverage-shard-1", "coverage-shard-2"} {
+		dir := filepath.Join(root, shard)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("create %s: %v", dir, err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "coverage.out"), []byte("mode: atomic\n"), 0o644); err != nil {
+			t.Fatalf("write profile: %v", err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(root, "notes.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write decoy: %v", err)
+	}
+
+	matches, err := findProfiles(root, "coverage.out")
+	if err != nil {
+		t.Fatalf("find profiles: %v", err)
+	}
+
+	if len(matches) != 2 {
+		t.Fatalf("found %v, want the two shard profiles", matches)
+	}
+}
+
+// The failure this guard exists for leaves no other trace: an artifact that
+// never arrived merges into a profile that parses cleanly and covers less.
+func TestACountOtherThanTheExpectedOneIsRefused(t *testing.T) {
+	two := []string{"a/coverage.out", "b/coverage.out"}
+
+	if err := RequireCount(two, 3); err == nil {
+		t.Fatal("two profiles passed a check expecting three")
+	}
+	if err := RequireCount(two, 2); err != nil {
+		t.Fatalf("two profiles failed a check expecting two: %v", err)
+	}
+	if err := RequireCount(two, 0); err != nil {
+		t.Fatalf("an expectation of 0 must disable the check, got %v", err)
+	}
+}
+
+func writeProfile(t *testing.T, name, content string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), name+".out")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	return path
+}


### PR DESCRIPTION
## Why

`Go test with coverage` was **369 s of test-go's 463 s** (run 32081716803), and that step is one
package: `internal/api` reported **353.040 s** of it, while every other package in the module
finished inside the remaining 16 s, in parallel with it. A split by PACKAGE would therefore have
bought nothing — the lane's wall-clock IS one package's test binary. So the split is by TEST NAME
inside `internal/api`.

## Shape

Four jobs where `test-go` stood, and the required check `test` keeps its name:

| job | what it runs |
| --- | --- |
| `test-go-shard` (matrix ×3) | `internal/api`, split by `-run` through `scripts/racepartition` |
| `test-go-rest` | every other package, whole — list derived from `go list`, one exclusion, counted |
| `test-go-analysis` | staticcheck, deadcode, actionlint, golangci-lint, vet + the `~/go/bin` cache |
| `coverage-merge` | folds the four profiles into the `coverage-out` artifact both consumers already read |

`coverage-upload` and `patch-coverage` are unchanged apart from their `needs` edge: same artifact
name, same whole-suite profile inside it.

Nothing is keyed on a second literal. The shard divisor is `strategy.job-total`; the count
`coverage-merge` expects comes from the matrix through a job output, plus one for the whole-package
lane; the test names come from `go test -list`, never from a hand-written pattern, so a new test
lands in a shard by construction (`racepartition`'s tests pin exhaustiveness and disjointness).
`test-go-rest`'s package list is derived and the exclusion is asserted to drop exactly one package,
so a new package can never end up tested by no lane while both lanes stay green.

## Coverage

Sharding a coverage run splits its profile with it, and `-coverpkg` decides how they go back
together: every lane instruments the whole module, so every profile lists every coverable block and
a block its own lane did not execute is present at **0**. The merge is a union with the counts
summed — `scripts/covmerge`, with tests. Dropping the zero blocks would be the expensive mistake:
`patchcov` treats a line ABSENT from the profile as non-coverable, so a lost block turns an
uncovered modified line into one the required gate never judges.

Refused rather than papered over, each meaning the profiles did not come from one tree: a mode line
that differs, the same span carrying a different statement count, a line the parser cannot account
for, and a profile count other than the one the matrix promised (`-expect`, for the artifact that
silently never arrives).

**Measured on a dev host, this branch, `internal/api` with the lane's own flags:**

| | statements | blocks | covered blocks |
| --- | --- | --- | --- |
| unsharded run | 75.9% | 7095 | 5107 |
| three shards, merged | 75.9% | 7095 | 5107 |

Set difference in both directions: **0 blocks**. Shard test times 103.9 / 116.0 / 108.9 s against
297.5 s unsharded — 2.6× on a host where the round-robin had no cost model to work from.

## What it costs

Runner-minutes go up: the shards each re-instrument the module, and `test-go-rest`,
`test-go-analysis` and `coverage-merge` each pay their own checkout and `setup-go`. The trade is
roughly +4 runner-minutes per run against the lane's own wall-clock going from 463 s to about
max(shard, analysis) plus the ~40 s merge. `e2e-shard` (386 s) still sets the pull request's
wall-clock; this removes the other lane running level with it, and on `main` it also shortens the
path into `publish-image`.

## Gate shape

`test` now judges five lanes, `coverage-merge` among them. That edge is not decoration:
`patch-coverage` is required and consumes the merged artifact, so a FAILED merge would skip it into
a satisfied state — the same skipped-is-satisfied hole measured 2026-08-08, one layer further down.
`coverage-merge` carries no `if:` of its own, so a failed lane skips it and the lane's own result is
what colours the gate.

## Base

Written on top of #509 while it was still open. #509, #512 and #513 have since merged, so this
branch was rebased onto `main` — the already-landed parent commit dropped, this PR's own commit
replayed, and GitHub retargeted the pull request to `main` when its base branch went away. #514 is
still open and edits the same `test-go` block, so whichever of the two lands second owes a rebase;
the conflict is in `.github/workflows/ci.yml` and nowhere else.

## Verification

- `go test ./scripts/...` — green, including the new `scripts/covmerge` tests.
- `staticcheck ./scripts/...`, `golangci-lint run ./scripts/covmerge/` — 0 issues.
- `actionlint -shellcheck=` on the edited workflow — clean.
- The coverage equivalence above, run on this branch.
- What only CI can prove: the four artifacts arriving, `-expect` counting them, and the real
  per-shard timings on a runner.


