### PR TITLE
ci: take apt out of the browser lanes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -798,7 +798,9 @@ jobs:
       - name: Install Playwright browser
         if: env.RUN_E2E != 'false' && env.SHARD_ACTIVE != 'false' && steps.playwright-cache.outputs.cache-hit != 'true'
         # NO `--with-deps`: this downloads the browser binary and touches apt not
-        # at all. The apt half used to live here and in a second step below, and
+        # at all. This lane is CHROMIUM-ONLY, which is what makes that safe — see
+        # the paragraph at the end. The apt half used to live here and in a second
+        # step below, and
         # it was the single least reliable thing in CI — three hangs in 24 hours
         # on an unresponsive Azure mirror (runs 32070919012, 32085785273 and,
         # after the timeout bound landed, 32090266798 failing honestly at 905 s).
@@ -819,6 +821,17 @@ jobs:
         # geometry assertions, which is the one way a font could matter — so this
         # is a change the browser suite itself judges, and its verdict on this
         # pull request is the evidence for it.
+        #
+        # SCOPE: this removal is correct for the chromium-only lanes and WRONG for
+        # e2e-cross-browser, which therefore keeps its apt steps. The delta apt
+        # actually computes differs by an order of magnitude — measured on push run
+        # 32081716803, same commit, same image: `9 newly installed` here and in
+        # e2e-postgres-smoke, against `181 newly installed` in the cross-browser
+        # lane, of which 165 are real libraries (gstreamer1.0-*, libav*, libcairo-*
+        # — WebKit's media stack), not fonts. Evidence gathered on a chromium lane
+        # does not carry to a lane that also builds Firefox and WebKit, and the
+        # pull-request run cannot catch the difference: e2e-cross-browser runs only
+        # on push, release and workflow_dispatch, so it would have broken on `main`.
         #
         # If Chromium ever fails to LAUNCH rather than to render, look here first:
         # the claim above rests on one image's package list, and a future runner
@@ -938,7 +951,9 @@ jobs:
       - name: Install Playwright browser
         if: env.RUN_E2E != 'false' && env.RUN_HEAVY == 'true' && steps.playwright-cache.outputs.cache-hit != 'true'
         # NO `--with-deps`: this downloads the browser binary and touches apt not
-        # at all. The apt half used to live here and in a second step below, and
+        # at all. This lane is CHROMIUM-ONLY, which is what makes that safe — see
+        # the paragraph at the end. The apt half used to live here and in a second
+        # step below, and
         # it was the single least reliable thing in CI — three hangs in 24 hours
         # on an unresponsive Azure mirror (runs 32070919012, 32085785273 and,
         # after the timeout bound landed, 32090266798 failing honestly at 905 s).
@@ -959,6 +974,17 @@ jobs:
         # geometry assertions, which is the one way a font could matter — so this
         # is a change the browser suite itself judges, and its verdict on this
         # pull request is the evidence for it.
+        #
+        # SCOPE: this removal is correct for the chromium-only lanes and WRONG for
+        # e2e-cross-browser, which therefore keeps its apt steps. The delta apt
+        # actually computes differs by an order of magnitude — measured on push run
+        # 32081716803, same commit, same image: `9 newly installed` here and in
+        # e2e-postgres-smoke, against `181 newly installed` in the cross-browser
+        # lane, of which 165 are real libraries (gstreamer1.0-*, libav*, libcairo-*
+        # — WebKit's media stack), not fonts. Evidence gathered on a chromium lane
+        # does not carry to a lane that also builds Firefox and WebKit, and the
+        # pull-request run cannot catch the difference: e2e-cross-browser runs only
+        # on push, release and workflow_dispatch, so it would have broken on `main`.
         #
         # If Chromium ever fails to LAUNCH rather than to render, look here first:
         # the claim above rests on one image's package list, and a future runner
@@ -1023,33 +1049,49 @@ jobs:
 
       - name: Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        # NO `--with-deps`: this downloads the browser binary and touches apt not
-        # at all. The apt half used to live here and in a second step below, and
-        # it was the single least reliable thing in CI — three hangs in 24 hours
-        # on an unresponsive Azure mirror (runs 32070919012, 32085785273 and,
-        # after the timeout bound landed, 32090266798 failing honestly at 905 s).
+        # `playwright install --with-deps` is an apt front end, and apt hangs on an
+        # unresponsive mirror rather than failing. Unbounded, that hang runs until
+        # the JOB timeout — 45 minutes — and GitHub reports a timed-out job as
+        # `cancelled`, not `failed`, so a required check goes red with no failed
+        # step to look at. It happened twice inside 24 hours: run 32070919012 on
+        # 2026-08-17 (45 min, took the README badge red) and run 32085785273 on
+        # 2026-08-18, both on this same step.
         #
-        # What it was buying, read off the install log of run 32081716803:
-        # `0 upgraded, 9 newly installed, 0 to remove and 12 not upgraded`. Every
-        # real Playwright dependency is already on the ubuntu-latest image; the
-        # nine were all FONTS — fonts-ipafont-gothic (Japanese), fonts-wqy-zenhei
-        # (Chinese), fonts-tlwg-loma-otf (Thai), fonts-unifont, fonts-freefont-ttf
-        # and the xfonts-* set. This application ships six locales — de en es fr
-        # it ru — so no CJK or Thai text exists to render, no spec contains a CJK
-        # or Thai character, and Cyrillic is served by DejaVu, which the image
-        # already carries.
+        # Bounded, and NOT retried. Both halves are measured, and the first
+        # attempt at this fix got both of them wrong (run 32087754303):
         #
-        # Playwright asserts the DOM, not pixels: a missing glyph cannot fail
-        # `toHaveText`, and the suite makes no screenshot comparison at all
-        # (`toHaveScreenshot`/`toMatchSnapshot`: zero occurrences). It does make
-        # geometry assertions, which is the one way a font could matter — so this
-        # is a change the browser suite itself judges, and its verdict on this
-        # pull request is the evidence for it.
+        #   - the bound cannot be tight. The 11-50 s this step usually takes is
+        #     the path where the packages are already present; a cold run pulls
+        #     21.1 MB from the Azure mirror and legitimately ran past 300 s. The
+        #     bound exists to beat the 45-minute job timeout, nothing finer.
+        #   - a retry cannot work. `timeout` kills apt mid-transaction and the
+        #     orphan keeps /var/lib/dpkg/lock-frontend, so the next attempt dies
+        #     at once on `Could not get lock` — observed, exit 100. A bounded
+        #     single attempt fails honestly; a retry only fails twice.
+        run: timeout 1500 npx playwright install --with-deps chromium firefox webkit
+
+      - name: Install Playwright OS dependencies (cache hit)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        # `playwright install-deps` is an apt front end, and apt hangs on an
+        # unresponsive mirror rather than failing. Unbounded, that hang runs until
+        # the JOB timeout — 45 minutes — and GitHub reports a timed-out job as
+        # `cancelled`, not `failed`, so a required check goes red with no failed
+        # step to look at. It happened twice inside 24 hours: run 32070919012 on
+        # 2026-08-17 (45 min, took the README badge red) and run 32085785273 on
+        # 2026-08-18, both on this same step.
         #
-        # If Chromium ever fails to LAUNCH rather than to render, look here first:
-        # the claim above rests on one image's package list, and a future runner
-        # image could drop a dependency this no longer installs.
-        run: timeout 600 npx playwright install chromium firefox webkit
+        # Bounded, and NOT retried. Both halves are measured, and the first
+        # attempt at this fix got both of them wrong (run 32087754303):
+        #
+        #   - the bound cannot be tight. The 11-50 s this step usually takes is
+        #     the path where the packages are already present; a cold run pulls
+        #     21.1 MB from the Azure mirror and legitimately ran past 300 s. The
+        #     bound exists to beat the 45-minute job timeout, nothing finer.
+        #   - a retry cannot work. `timeout` kills apt mid-transaction and the
+        #     orphan keeps /var/lib/dpkg/lock-frontend, so the next attempt dies
+        #     at once on `Could not get lock` — observed, exit 100. A bounded
+        #     single attempt fails honestly; a retry only fails twice.
+        run: timeout 1200 npx playwright install-deps chromium firefox webkit
 
       - name: Run Playwright cross-browser smoke
         run: npm run e2e:cross-browser

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -797,53 +797,33 @@ jobs:
 
       - name: Install Playwright browser
         if: env.RUN_E2E != 'false' && env.SHARD_ACTIVE != 'false' && steps.playwright-cache.outputs.cache-hit != 'true'
-        # `playwright install --with-deps` is an apt front end, and apt hangs on an
-        # unresponsive mirror rather than failing. Unbounded, that hang runs until
-        # the JOB timeout — 45 minutes — and GitHub reports a timed-out job as
-        # `cancelled`, not `failed`, so a required check goes red with no failed
-        # step to look at. It happened twice inside 24 hours: run 32070919012 on
-        # 2026-08-17 (45 min, took the README badge red) and run 32085785273 on
-        # 2026-08-18, both on this same step.
+        # NO `--with-deps`: this downloads the browser binary and touches apt not
+        # at all. The apt half used to live here and in a second step below, and
+        # it was the single least reliable thing in CI — three hangs in 24 hours
+        # on an unresponsive Azure mirror (runs 32070919012, 32085785273 and,
+        # after the timeout bound landed, 32090266798 failing honestly at 905 s).
         #
-        # Bounded, and NOT retried. Both halves are measured, and the first
-        # attempt at this fix got both of them wrong (run 32087754303):
+        # What it was buying, read off the install log of run 32081716803:
+        # `0 upgraded, 9 newly installed, 0 to remove and 12 not upgraded`. Every
+        # real Playwright dependency is already on the ubuntu-latest image; the
+        # nine were all FONTS — fonts-ipafont-gothic (Japanese), fonts-wqy-zenhei
+        # (Chinese), fonts-tlwg-loma-otf (Thai), fonts-unifont, fonts-freefont-ttf
+        # and the xfonts-* set. This application ships six locales — de en es fr
+        # it ru — so no CJK or Thai text exists to render, no spec contains a CJK
+        # or Thai character, and Cyrillic is served by DejaVu, which the image
+        # already carries.
         #
-        #   - the bound cannot be tight. The 11-50 s this step usually takes is
-        #     the path where the packages are already present; a cold run pulls
-        #     21.1 MB from the Azure mirror and legitimately ran past 300 s. The
-        #     bound exists to beat the 45-minute job timeout, nothing finer.
-        #   - a retry cannot work. `timeout` kills apt mid-transaction and the
-        #     orphan keeps /var/lib/dpkg/lock-frontend, so the next attempt dies
-        #     at once on `Could not get lock` — observed, exit 100. A bounded
-        #     single attempt fails honestly; a retry only fails twice.
-        run: timeout 1200 npx playwright install --with-deps chromium
-
-      - name: Install Playwright OS dependencies (cache hit)
-        # The cache above only covers the downloaded browser binaries under
-        # ~/.cache/ms-playwright; system packages (apt) never persist across
-        # a fresh runner, so they still need installing even on a browser
-        # cache hit — this is the fast path (no browser download).
-        if: env.RUN_E2E != 'false' && env.SHARD_ACTIVE != 'false' && steps.playwright-cache.outputs.cache-hit == 'true'
-        # `playwright install-deps` is an apt front end, and apt hangs on an
-        # unresponsive mirror rather than failing. Unbounded, that hang runs until
-        # the JOB timeout — 45 minutes — and GitHub reports a timed-out job as
-        # `cancelled`, not `failed`, so a required check goes red with no failed
-        # step to look at. It happened twice inside 24 hours: run 32070919012 on
-        # 2026-08-17 (45 min, took the README badge red) and run 32085785273 on
-        # 2026-08-18, both on this same step.
+        # Playwright asserts the DOM, not pixels: a missing glyph cannot fail
+        # `toHaveText`, and the suite makes no screenshot comparison at all
+        # (`toHaveScreenshot`/`toMatchSnapshot`: zero occurrences). It does make
+        # geometry assertions, which is the one way a font could matter — so this
+        # is a change the browser suite itself judges, and its verdict on this
+        # pull request is the evidence for it.
         #
-        # Bounded, and NOT retried. Both halves are measured, and the first
-        # attempt at this fix got both of them wrong (run 32087754303):
-        #
-        #   - the bound cannot be tight. The 11-50 s this step usually takes is
-        #     the path where the packages are already present; a cold run pulls
-        #     21.1 MB from the Azure mirror and legitimately ran past 300 s. The
-        #     bound exists to beat the 45-minute job timeout, nothing finer.
-        #   - a retry cannot work. `timeout` kills apt mid-transaction and the
-        #     orphan keeps /var/lib/dpkg/lock-frontend, so the next attempt dies
-        #     at once on `Could not get lock` — observed, exit 100. A bounded
-        #     single attempt fails honestly; a retry only fails twice.
-        run: timeout 900 npx playwright install-deps chromium
+        # If Chromium ever fails to LAUNCH rather than to render, look here first:
+        # the claim above rests on one image's package list, and a future runner
+        # image could drop a dependency this no longer installs.
+        run: timeout 600 npx playwright install chromium
 
       - name: Run Playwright e2e (smoke on push, full otherwise)
         # The divisor comes from `strategy.job-total`, which GitHub computes
@@ -957,49 +937,33 @@ jobs:
 
       - name: Install Playwright browser
         if: env.RUN_E2E != 'false' && env.RUN_HEAVY == 'true' && steps.playwright-cache.outputs.cache-hit != 'true'
-        # `playwright install --with-deps` is an apt front end, and apt hangs on an
-        # unresponsive mirror rather than failing. Unbounded, that hang runs until
-        # the JOB timeout — 45 minutes — and GitHub reports a timed-out job as
-        # `cancelled`, not `failed`, so a required check goes red with no failed
-        # step to look at. It happened twice inside 24 hours: run 32070919012 on
-        # 2026-08-17 (45 min, took the README badge red) and run 32085785273 on
-        # 2026-08-18, both on this same step.
+        # NO `--with-deps`: this downloads the browser binary and touches apt not
+        # at all. The apt half used to live here and in a second step below, and
+        # it was the single least reliable thing in CI — three hangs in 24 hours
+        # on an unresponsive Azure mirror (runs 32070919012, 32085785273 and,
+        # after the timeout bound landed, 32090266798 failing honestly at 905 s).
         #
-        # Bounded, and NOT retried. Both halves are measured, and the first
-        # attempt at this fix got both of them wrong (run 32087754303):
+        # What it was buying, read off the install log of run 32081716803:
+        # `0 upgraded, 9 newly installed, 0 to remove and 12 not upgraded`. Every
+        # real Playwright dependency is already on the ubuntu-latest image; the
+        # nine were all FONTS — fonts-ipafont-gothic (Japanese), fonts-wqy-zenhei
+        # (Chinese), fonts-tlwg-loma-otf (Thai), fonts-unifont, fonts-freefont-ttf
+        # and the xfonts-* set. This application ships six locales — de en es fr
+        # it ru — so no CJK or Thai text exists to render, no spec contains a CJK
+        # or Thai character, and Cyrillic is served by DejaVu, which the image
+        # already carries.
         #
-        #   - the bound cannot be tight. The 11-50 s this step usually takes is
-        #     the path where the packages are already present; a cold run pulls
-        #     21.1 MB from the Azure mirror and legitimately ran past 300 s. The
-        #     bound exists to beat the 45-minute job timeout, nothing finer.
-        #   - a retry cannot work. `timeout` kills apt mid-transaction and the
-        #     orphan keeps /var/lib/dpkg/lock-frontend, so the next attempt dies
-        #     at once on `Could not get lock` — observed, exit 100. A bounded
-        #     single attempt fails honestly; a retry only fails twice.
-        run: timeout 1200 npx playwright install --with-deps chromium
-
-      - name: Install Playwright OS dependencies (cache hit)
-        if: env.RUN_E2E != 'false' && env.RUN_HEAVY == 'true' && steps.playwright-cache.outputs.cache-hit == 'true'
-        # `playwright install-deps` is an apt front end, and apt hangs on an
-        # unresponsive mirror rather than failing. Unbounded, that hang runs until
-        # the JOB timeout — 45 minutes — and GitHub reports a timed-out job as
-        # `cancelled`, not `failed`, so a required check goes red with no failed
-        # step to look at. It happened twice inside 24 hours: run 32070919012 on
-        # 2026-08-17 (45 min, took the README badge red) and run 32085785273 on
-        # 2026-08-18, both on this same step.
+        # Playwright asserts the DOM, not pixels: a missing glyph cannot fail
+        # `toHaveText`, and the suite makes no screenshot comparison at all
+        # (`toHaveScreenshot`/`toMatchSnapshot`: zero occurrences). It does make
+        # geometry assertions, which is the one way a font could matter — so this
+        # is a change the browser suite itself judges, and its verdict on this
+        # pull request is the evidence for it.
         #
-        # Bounded, and NOT retried. Both halves are measured, and the first
-        # attempt at this fix got both of them wrong (run 32087754303):
-        #
-        #   - the bound cannot be tight. The 11-50 s this step usually takes is
-        #     the path where the packages are already present; a cold run pulls
-        #     21.1 MB from the Azure mirror and legitimately ran past 300 s. The
-        #     bound exists to beat the 45-minute job timeout, nothing finer.
-        #   - a retry cannot work. `timeout` kills apt mid-transaction and the
-        #     orphan keeps /var/lib/dpkg/lock-frontend, so the next attempt dies
-        #     at once on `Could not get lock` — observed, exit 100. A bounded
-        #     single attempt fails honestly; a retry only fails twice.
-        run: timeout 900 npx playwright install-deps chromium
+        # If Chromium ever fails to LAUNCH rather than to render, look here first:
+        # the claim above rests on one image's package list, and a future runner
+        # image could drop a dependency this no longer installs.
+        run: timeout 600 npx playwright install chromium
 
       - name: Run Playwright Postgres smoke
         if: env.RUN_E2E != 'false' && env.RUN_HEAVY == 'true'
@@ -1059,49 +1023,33 @@ jobs:
 
       - name: Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        # `playwright install --with-deps` is an apt front end, and apt hangs on an
-        # unresponsive mirror rather than failing. Unbounded, that hang runs until
-        # the JOB timeout — 45 minutes — and GitHub reports a timed-out job as
-        # `cancelled`, not `failed`, so a required check goes red with no failed
-        # step to look at. It happened twice inside 24 hours: run 32070919012 on
-        # 2026-08-17 (45 min, took the README badge red) and run 32085785273 on
-        # 2026-08-18, both on this same step.
+        # NO `--with-deps`: this downloads the browser binary and touches apt not
+        # at all. The apt half used to live here and in a second step below, and
+        # it was the single least reliable thing in CI — three hangs in 24 hours
+        # on an unresponsive Azure mirror (runs 32070919012, 32085785273 and,
+        # after the timeout bound landed, 32090266798 failing honestly at 905 s).
         #
-        # Bounded, and NOT retried. Both halves are measured, and the first
-        # attempt at this fix got both of them wrong (run 32087754303):
+        # What it was buying, read off the install log of run 32081716803:
+        # `0 upgraded, 9 newly installed, 0 to remove and 12 not upgraded`. Every
+        # real Playwright dependency is already on the ubuntu-latest image; the
+        # nine were all FONTS — fonts-ipafont-gothic (Japanese), fonts-wqy-zenhei
+        # (Chinese), fonts-tlwg-loma-otf (Thai), fonts-unifont, fonts-freefont-ttf
+        # and the xfonts-* set. This application ships six locales — de en es fr
+        # it ru — so no CJK or Thai text exists to render, no spec contains a CJK
+        # or Thai character, and Cyrillic is served by DejaVu, which the image
+        # already carries.
         #
-        #   - the bound cannot be tight. The 11-50 s this step usually takes is
-        #     the path where the packages are already present; a cold run pulls
-        #     21.1 MB from the Azure mirror and legitimately ran past 300 s. The
-        #     bound exists to beat the 45-minute job timeout, nothing finer.
-        #   - a retry cannot work. `timeout` kills apt mid-transaction and the
-        #     orphan keeps /var/lib/dpkg/lock-frontend, so the next attempt dies
-        #     at once on `Could not get lock` — observed, exit 100. A bounded
-        #     single attempt fails honestly; a retry only fails twice.
-        run: timeout 1500 npx playwright install --with-deps chromium firefox webkit
-
-      - name: Install Playwright OS dependencies (cache hit)
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
-        # `playwright install-deps` is an apt front end, and apt hangs on an
-        # unresponsive mirror rather than failing. Unbounded, that hang runs until
-        # the JOB timeout — 45 minutes — and GitHub reports a timed-out job as
-        # `cancelled`, not `failed`, so a required check goes red with no failed
-        # step to look at. It happened twice inside 24 hours: run 32070919012 on
-        # 2026-08-17 (45 min, took the README badge red) and run 32085785273 on
-        # 2026-08-18, both on this same step.
+        # Playwright asserts the DOM, not pixels: a missing glyph cannot fail
+        # `toHaveText`, and the suite makes no screenshot comparison at all
+        # (`toHaveScreenshot`/`toMatchSnapshot`: zero occurrences). It does make
+        # geometry assertions, which is the one way a font could matter — so this
+        # is a change the browser suite itself judges, and its verdict on this
+        # pull request is the evidence for it.
         #
-        # Bounded, and NOT retried. Both halves are measured, and the first
-        # attempt at this fix got both of them wrong (run 32087754303):
-        #
-        #   - the bound cannot be tight. The 11-50 s this step usually takes is
-        #     the path where the packages are already present; a cold run pulls
-        #     21.1 MB from the Azure mirror and legitimately ran past 300 s. The
-        #     bound exists to beat the 45-minute job timeout, nothing finer.
-        #   - a retry cannot work. `timeout` kills apt mid-transaction and the
-        #     orphan keeps /var/lib/dpkg/lock-frontend, so the next attempt dies
-        #     at once on `Could not get lock` — observed, exit 100. A bounded
-        #     single attempt fails honestly; a retry only fails twice.
-        run: timeout 1200 npx playwright install-deps chromium firefox webkit
+        # If Chromium ever fails to LAUNCH rather than to render, look here first:
+        # the claim above rests on one image's package list, and a future runner
+        # image could drop a dependency this no longer installs.
+        run: timeout 600 npx playwright install chromium firefox webkit
 
       - name: Run Playwright cross-browser smoke
         run: npm run e2e:cross-browser

--- a/changelog.d/ci-drop-the-apt-step-from-browser-lanes.md
+++ b/changelog.d/ci-drop-the-apt-step-from-browser-lanes.md
@@ -1,0 +1,6 @@
+none
+
+CI reliability change with no user-visible effect: the browser lanes no longer
+install system packages through apt. Every real Playwright dependency is
+already present on the runner image, and the only packages the step added were
+fonts for scripts this application does not ship.

--- a/changelog.d/ci-drop-the-apt-step-from-browser-lanes.md
+++ b/changelog.d/ci-drop-the-apt-step-from-browser-lanes.md
@@ -1,6 +1,8 @@
 none
 
-CI reliability change with no user-visible effect: the browser lanes no longer
-install system packages through apt. Every real Playwright dependency is
-already present on the runner image, and the only packages the step added were
-fonts for scripts this application does not ship.
+CI reliability change with no user-visible effect: the two Chromium-only
+browser lanes no longer install system packages through apt. Every real
+Playwright dependency for Chromium is already present on the runner image, and
+the only packages the step added were fonts for scripts this application does
+not ship. The cross-browser lane keeps its apt steps: Firefox and WebKit need
+real system libraries there, not fonts.


### PR DESCRIPTION
> **This PR is its own probe.** The claim is that the two Chromium-only browser lanes do not need the fonts apt was installing. The e2e run on this pull request is what decides that.

## Why now

apt is the least reliable thing in this pipeline. Three hangs in 24 hours, all on the same step, all on an unresponsive `azure.archive.ubuntu.com`:

| run | outcome |
| --- | --- |
| [`32070919012`](https://github.com/ovumcy/ovumcy-web/actions/runs/32070919012) | 45 min, job timeout → `cancelled`; this is what took the README badge red |
| [`32085785273`](https://github.com/ovumcy/ovumcy-web/actions/runs/32085785273) | 28 min, cancelled by hand |
| [`32090266798`](https://github.com/ovumcy/ovumcy-web/actions/runs/32090266798) | failed honestly at **905 s** — the bound from #513 doing its job |

#513 turned a silent 45-minute hang into a 15-minute red. Better, and still red: while the mirror is degraded no browser lane passes and **nothing merges**. #512 was ejected from the queue for exactly this.

## What the step buys, per lane — and this is the whole point

Measured on push run `32081716803`, one commit, one runner image:

| lane | browsers | `newly installed` |
| --- | --- | --- |
| `e2e-shard` | chromium | **9** |
| `e2e-postgres-smoke` | chromium | **9** |
| `e2e-cross-browser` | chromium, firefox, webkit | **181** |

The nine are all fonts. Of the 181, **165 are real libraries** — `gstreamer1.0-*`, `libav*`, `libcairo-*`, WebKit's media stack — which Firefox and WebKit need to start at all.

**So the removal applies only to the two Chromium-only lanes.** `e2e-cross-browser` keeps its apt steps, restored verbatim from `main`, timeout bounds and all.

The first push of this branch got that wrong: it removed apt from all three lanes on evidence gathered from one. Worth naming, because the pull-request run could not have caught it — `e2e-cross-browser` runs only on push, release and `workflow_dispatch`, so a green PR would have proved Chromium and nothing else, and the breakage would have landed on `main`.

## Why the nine are unnecessary for Chromium

From the same log: `0 upgraded, 9 newly installed, 0 to remove and 12 not upgraded` — every real Chromium dependency is already on the image. The nine:

| package | script | shipped by this app? |
| --- | --- | --- |
| `fonts-ipafont-gothic` | Japanese | no |
| `fonts-wqy-zenhei` | Chinese | no |
| `fonts-tlwg-loma-otf` | Thai | no |
| `fonts-unifont`, `fonts-freefont-ttf` | fallback glyphs | — |
| `xfonts-cyrillic`, `xfonts-encodings`, `xfonts-scalable`, `xfonts-utils` | legacy X11 bitmaps | not consumed by Chromium |

Checked by content, not by filename: the six locales (`de en es fr it ru`) contain **zero** CJK or Thai characters; `web/` contains zero; the only such character in the tracked tree is `U+4F60` in `internal/services/calendar_feed_ics_mutkill_test.go:40`, used as a three-octet rune for a byte-count assertion in a **Go** test that renders nothing. Cyrillic is served by DejaVu, already on the image.

## Why a missing font is unlikely to fail a spec

Playwright asserts the **DOM**, not pixels. A missing glyph cannot fail `toHaveText`, and the suite makes no visual comparison at all — `toHaveScreenshot` and `toMatchSnapshot` appear **zero** times across its 33 spec files.

It does make **geometry** assertions — `boundingBox` / `getBoundingClientRect`, more than a dozen — and that is the one channel through which a font could matter. Which is why this is a probe and not a conclusion.

## The change

`e2e-shard` and `e2e-postgres-smoke`:

- the apt-only step, `Install Playwright OS dependencies (cache hit)`, is deleted;
- the cache-miss step drops `--with-deps`, leaving `npx playwright install chromium`, which touches apt nowhere;
- on a cache hit, nothing installs at all;
- the download keeps a 600 s bound, because a CDN can hang too.

`e2e-cross-browser`: unchanged from `main`.

## The limit of the reasoning, recorded in the file

This rests on **one** runner image's package list. A future image could drop a dependency this no longer installs, and the failure would be Chromium refusing to **launch** rather than to render. The step comment says so, along with both figures and the reason a pull request cannot see the cross-browser difference.

## Merge order

Based on `main`. Wants to go in **before** #509 and #512 are re-enqueued — while the mirror is degraded they cannot pass, and this is what unblocks them.
