### PR TITLE
ci: give every non-PR run its own concurrency group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,15 @@ permissions:
 # string of fixup pushes doesn't queue every intermediate run to completion.
 # Only cancels pull_request runs — push (main), release, and workflow_dispatch
 # always run to completion, since each may gate a deploy.
+#
+# Those non-PR events therefore take one group PER COMMIT. Sharing a group per
+# ref made them queue behind each other instead, and GitHub holds at most one
+# pending run per group: on 2026-08-18 the push run for 6ad13ff5 sat queued and
+# never started, while the run for the commit after it completed. A commit on
+# main is a state to test, not a draft to supersede, and the lanes only this
+# event runs go with it — e2e-cross-browser, image-smoke, e2e-postgres-smoke.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'pull_request' && 'pr' || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:

--- a/changelog.d/ci-one-concurrency-group-per-commit.md
+++ b/changelog.d/ci-one-concurrency-group-per-commit.md
@@ -1,0 +1,5 @@
+none
+
+Continuous integration only, with no effect on the application: a run for a
+commit on `main` no longer shares a concurrency group with the runs for the
+commits around it, so it cannot sit queued behind them and never start.


### PR DESCRIPTION
The comment above `concurrency:` already states the intent: only a pull request cancels a
superseded run, while push, release and `workflow_dispatch` "always run to completion, since
each may gate a deploy". `cancel-in-progress` implements that half. The group did not.

Every push to `main` shared one group, `CI-refs/heads/main`. GitHub holds at most one pending
run per group, so those runs queued behind each other rather than running to completion.

## The case

| run | event | created | state |
|---|---|---|---|
| `32095933083` | `merge_group` | 03:35 | success |
| `32096093339` | `push` (6ad13ff5) | 03:36:30 | **queued, no jobs, never started** |
| — | `push` (51c7a21c) | 03:48:21 | success |

Nothing merged untested: all 35 check runs on 6ad13ff5 are success or skipped, and the
`merge_group` run — the one the badge reads and the queue gates on — passed. What was lost is
the set of lanes that run *only* on push: `e2e-cross-browser`, `image-smoke` and
`e2e-postgres-smoke`. A commit that skips those is exactly the gap recorded when the apt step
was measured on a Chromium-only lane: a green pull request proves Chromium and nothing more.

## The change

```yaml
group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'pull_request' && 'pr' || github.sha }}
```

- **pull_request** — one group per ref, cancellation unchanged: a new push still cancels the
  superseded run, because there only the newest commit matters.
- **push, merge_group, release, workflow_dispatch** — one group per commit, so no run waits on
  another. A commit on `main` is a state to test, not a draft to supersede.

`cancel-in-progress` is untouched. `actionlint` is clean on the file.
