### PR TITLE
test: pin the calendar render path to the authenticated owner

### DIFF
--- a/changelog.d/test-calendar-view-owner-identity.md
+++ b/changelog.d/test-calendar-view-owner-identity.md
@@ -1,0 +1,7 @@
+none
+
+Test-only guard: the calendar-view doubles now capture the owner argument they
+used to discard, and the render test asserts that the day read and the cycle-stats
+build each receive the same nonzero authenticated owner id. No user-visible change
+— the render path already passed the owner correctly; until now nothing could
+observe it, so a regression that swapped the owner for a constant stayed green.

--- a/internal/services/calendar_view_service_test.go
+++ b/internal/services/calendar_view_service_test.go
@@ -12,9 +12,13 @@ import (
 type stubCalendarViewDayReader struct {
 	logs []models.DailyLog
 	err  error
+
+	// Captured userID argument — used to prove the day read is owner-scoped.
+	logsUserID uint
 }
 
-func (stub *stubCalendarViewDayReader) FetchLogsForUser(ctx context.Context, _ uint, _ time.Time, _ time.Time, _ *time.Location) ([]models.DailyLog, error) {
+func (stub *stubCalendarViewDayReader) FetchLogsForUser(ctx context.Context, userID uint, _ time.Time, _ time.Time, _ *time.Location) ([]models.DailyLog, error) {
+	stub.logsUserID = userID
 	if stub.err != nil {
 		return nil, stub.err
 	}
@@ -27,9 +31,15 @@ type stubCalendarViewStatsProvider struct {
 	stats CycleStats
 	logs  []models.DailyLog
 	err   error
+
+	// Captured owner argument — used to prove the stats build is owner-scoped.
+	statsUserID uint
 }
 
-func (stub *stubCalendarViewStatsProvider) BuildCycleStatsForRange(ctx context.Context, _ *models.User, _ time.Time, _ time.Time, _ time.Time, _ *time.Location) (CycleStats, []models.DailyLog, error) {
+func (stub *stubCalendarViewStatsProvider) BuildCycleStatsForRange(ctx context.Context, user *models.User, _ time.Time, _ time.Time, _ time.Time, _ *time.Location) (CycleStats, []models.DailyLog, error) {
+	if user != nil {
+		stub.statsUserID = user.ID
+	}
 	if stub.err != nil {
 		return CycleStats{}, nil, stub.err
 	}
@@ -39,12 +49,13 @@ func (stub *stubCalendarViewStatsProvider) BuildCycleStatsForRange(ctx context.C
 }
 
 func TestBuildCalendarPageViewData(t *testing.T) {
-	service := NewCalendarViewService(
-		&stubCalendarViewDayReader{},
-		&stubCalendarViewStatsProvider{stats: CycleStats{MedianCycleLength: 28}},
-	)
+	dayReader := &stubCalendarViewDayReader{}
+	statsProvider := &stubCalendarViewStatsProvider{stats: CycleStats{MedianCycleLength: 28}}
+	service := NewCalendarViewService(dayReader, statsProvider)
 
-	user := &models.User{ID: 1, Role: models.RoleOwner}
+	// The id is deliberately not 1: an owner argument replaced by a constant must not
+	// coincide with the authenticated owner's id, or the guard below cannot go red.
+	user := &models.User{ID: 4242, Role: models.RoleOwner}
 	now := mustParseCalendarViewDay(t, "2026-02-21")
 	monthStart := mustParseCalendarViewDay(t, "2026-02-01")
 
@@ -70,6 +81,25 @@ func TestBuildCalendarPageViewData(t *testing.T) {
 	}
 	if len(viewData.DayStates) == 0 {
 		t.Fatalf("expected non-empty day states")
+	}
+
+	// Privacy boundary: both collaborators must be handed the authenticated owner, and the
+	// same one. A zero id is invalid input, never a reason to treat the read as unscoped.
+	if dayReader.logsUserID == 0 {
+		t.Fatalf("day read received no owner id")
+	}
+	if dayReader.logsUserID != user.ID {
+		t.Fatalf("expected day read scoped to owner id %d, got %d", user.ID, dayReader.logsUserID)
+	}
+	if statsProvider.statsUserID != user.ID {
+		t.Fatalf("expected stats build scoped to owner id %d, got %d", user.ID, statsProvider.statsUserID)
+	}
+	if statsProvider.statsUserID != dayReader.logsUserID {
+		t.Fatalf(
+			"day read and stats build disagree on the owner: day=%d stats=%d",
+			dayReader.logsUserID,
+			statsProvider.statsUserID,
+		)
 	}
 }
 


### PR DESCRIPTION
Board group **G16**, master record **R2-0924** — a protection gap, not a product bug: the calendar render path is a per-owner health-data read whose test doubles could not observe the owner argument at any layer.

## What was wrong

`stubCalendarViewDayReader.FetchLogsForUser` and `stubCalendarViewStatsProvider.BuildCycleStatsForRange` both declared their owner parameter unnamed and stored nothing, so no assertion in the file could see which id reached the collaborator. Every assertion in `TestBuildCalendarPageViewData` compared month strings, `TodayISO`, `IsOwner` and `len(DayStates)` — all derived from `monthStart`, `now` and `user.Role`, none from the id. Replacing the production owner with a constant therefore changed no compared value.

The fixture's own id made this worse: it was `1`, exactly the constant a hard-coded regression would use, so even a capturing double would have agreed by accident. The id is now `4242`, with a comment saying why.

## What changed

Both doubles name and store their owner argument (`logsUserID`, `statsUserID`, the latter nil-safe), following the capturing pattern that already existed unapplied in the same package at `internal/services/viewer_service_test.go:31,:93`. `TestBuildCalendarPageViewData` now asserts the day read got a nonzero id, that it equals `user.ID`, that the stats build equals `user.ID`, and that the two agree with each other.

Production is untouched — `internal/services/calendar_view_service.go` is absent from the diff. The record states the forwarding was already correct and it is.

## Three-step evidence

`CalendarViewService` has exactly two owner-carrying seams and both are covered; each was mutated on its own, so neither assertion masks the other.

| mutation in `calendar_view_service.go` | rest of the calendar-view suite | this guard |
| --- | --- | --- |
| `:56` `FetchLogsForUser(ctx, user.ID, …)` → `(ctx, 1, …)` | `ok` | **FAIL** — `expected day read scoped to owner id 4242, got 1` |
| `:61` `BuildCycleStatsForRange(ctx, user, …)` → `(ctx, &models.User{ID: 1}, …)` | `ok` | **FAIL** — `expected stats build scoped to owner id 4242, got 1` |
| production restored verbatim | `ok` | `ok` |

Before the guard existed, the same mutation left `go test -count=1 -run '^TestBuildCalendarPageViewData' ./internal/services` at exit 0 — reproducing the lane's scratch result that the R2 note recorded as never reproduced.

## Medical-safety check — §10.6

The calendar render path feeds a prediction surface (it builds `CycleStats` for the rendered month), so §10.6 is checked rather than waved past: display confidence follows data confidence, and where a window or fertility claim has no data behind it, suppression is the floor and a qualifier is not sufficient.

This diff is test-only and moves nothing §10.6 governs — no qualifier, no disclaimer, no suppression rule, no confidence value. `internal/services/calendar_view_service.go` is absent from the diff, so the rendered month is byte-for-byte what `main` renders. The invariant the guard does serve is §10.1 (owner scoping).

## Checks

`gofmt -l` clean on the changed file · `go vet ./...` · `staticcheck ./...` · `golangci-lint run --max-issues-per-linter=0 --max-same-issues=0 …` → `0 issues.` · `go test ./... -timeout 20m` no failures · `go run ./scripts/changelogd check` OK.

Six files are listed by a repository-wide `gofmt -l`; all six are pre-existing on `main` and none is touched here.

## Rollback

Single-commit revert. Test-only: no persisted data, no public contract, no migration.
