### PR TITLE
test: pin every dashboard provider read to the session owner

### DIFF
--- a/changelog.d/test-dashboard-view-owner-identity.md
+++ b/changelog.d/test-dashboard-view-owner-identity.md
@@ -1,0 +1,9 @@
+none
+
+Test-only guard: the dashboard and day-editor view builders now have their
+provider calls pinned to the acting session owner. The stub providers record
+the user they are handed and the owner ids the two day-state reads carry, and
+the test asserts each one is the session account — with a nontrivial id, so a
+hard-coded or unscoped read cannot agree with the fixture by accident, and with
+a positive anchor per provider, so a run that reached none of them fails rather
+than passing as "no mismatch found". No behaviour changes.

--- a/changelog.d/test-dashboard-view-owner-identity.md
+++ b/changelog.d/test-dashboard-view-owner-identity.md
@@ -1,9 +1,14 @@
 none
 
 Test-only guard: the dashboard and day-editor view builders now have their
-provider calls pinned to the acting session owner. The stub providers record
-the user they are handed and the owner ids the two day-state reads carry, and
-the test asserts each one is the session account — with a nontrivial id, so a
-hard-coded or unscoped read cannot agree with the fixture by accident, and with
-a positive anchor per provider, so a run that reached none of them fails rather
-than passing as "no mismatch found". No behaviour changes.
+provider calls pinned to the acting session owner — all three collaborators,
+including the cycle-stats provider whose output decides what the dashboard
+predicts. The stubs record the user they are handed and the owner ids the two
+day-state reads carry, and the test asserts each one is the session account —
+with a nontrivial id, so a hard-coded or unscoped read cannot agree with the
+fixture by accident, and with a positive anchor per provider, so a run that
+reached none of them fails rather than passing as "no mismatch found". The two
+cycle-stats entry points sit on mutually exclusive paths — an owner view derives
+its stats from the entry-context logs, any other session takes the ranged read —
+so each is driven by its own session rather than left unobserved. No behaviour
+changes.

--- a/internal/services/dashboard_view_service_test.go
+++ b/internal/services/dashboard_view_service_test.go
@@ -12,16 +12,23 @@ import (
 type stubDashboardStatsProvider struct {
 	stats CycleStats
 	err   error
+
+	// Captured user arguments — used to prove the cycle-stats reads, which
+	// derive the predictions the dashboard renders, carry the session owner.
+	rangeUsers   []*models.User
+	fromLogUsers []*models.User
 }
 
-func (stub *stubDashboardStatsProvider) BuildCycleStatsForRange(ctx context.Context, _ *models.User, _ time.Time, _ time.Time, _ time.Time, _ *time.Location) (CycleStats, []models.DailyLog, error) {
+func (stub *stubDashboardStatsProvider) BuildCycleStatsForRange(ctx context.Context, user *models.User, _ time.Time, _ time.Time, _ time.Time, _ *time.Location) (CycleStats, []models.DailyLog, error) {
+	stub.rangeUsers = append(stub.rangeUsers, user)
 	if stub.err != nil {
 		return CycleStats{}, nil, stub.err
 	}
 	return stub.stats, nil, nil
 }
 
-func (stub *stubDashboardStatsProvider) BuildCycleStatsFromLogs(_ *models.User, _ []models.DailyLog, _ time.Time, _ *time.Location) CycleStats {
+func (stub *stubDashboardStatsProvider) BuildCycleStatsFromLogs(user *models.User, _ []models.DailyLog, _ time.Time, _ *time.Location) CycleStats {
+	stub.fromLogUsers = append(stub.fromLogUsers, user)
 	return stub.stats
 }
 
@@ -378,7 +385,8 @@ func TestDashboardViewProvidersReadOnlyTheSessionOwner(t *testing.T) {
 			{Date: now, IsPeriod: true},
 		},
 	}
-	service := NewDashboardViewService(&stubDashboardStatsProvider{}, viewer, days)
+	stats := &stubDashboardStatsProvider{stats: CycleStats{MedianCycleLength: 28}}
+	service := NewDashboardViewService(stats, viewer, days)
 
 	if _, err := service.BuildDashboardViewData(context.Background(), user, "en", now, time.UTC); err != nil {
 		t.Fatalf("BuildDashboardViewData() unexpected error: %v", err)
@@ -414,6 +422,46 @@ func TestDashboardViewProvidersReadOnlyTheSessionOwner(t *testing.T) {
 	for index, capturedID := range days.allLogsUserIDs {
 		if capturedID != sessionOwnerID {
 			t.Fatalf("FetchAllLogsForUser call %d read owner id %d, want the session owner %d", index, capturedID, sessionOwnerID)
+		}
+	}
+
+	// The cycle-stats reads decide what the dashboard predicts, so a session
+	// mixed up here shows one account's phase and fertile window on another's
+	// dashboard — the same boundary, one layer further in. An owner view
+	// derives its stats from the entry-context logs, so this path reaches
+	// BuildCycleStatsFromLogs and never BuildCycleStatsForRange.
+	if len(stats.fromLogUsers) == 0 {
+		t.Fatal("expected the stats provider to be reached; it recorded no BuildCycleStatsFromLogs call")
+	}
+	for index, captured := range stats.fromLogUsers {
+		if captured == nil {
+			t.Fatalf("BuildCycleStatsFromLogs call %d received no user at all", index)
+		}
+		if captured.ID != sessionOwnerID {
+			t.Fatalf("BuildCycleStatsFromLogs call %d read owner id %d, want the session owner %d", index, captured.ID, sessionOwnerID)
+		}
+	}
+
+	// The ranged stats read is the other half of the same seam and is reached
+	// only by a session that needs no entry-context logs, so it gets its own
+	// session user rather than being left unobserved.
+	const rangeSessionID uint = 7373
+
+	rangeStats := &stubDashboardStatsProvider{stats: CycleStats{MedianCycleLength: 28}}
+	rangeSession := &models.User{ID: rangeSessionID, Role: "viewer", CycleLength: 28}
+	rangeService := NewDashboardViewService(rangeStats, &stubDashboardViewerProvider{}, &stubDashboardDayStateProvider{})
+	if _, err := rangeService.BuildDashboardViewData(context.Background(), rangeSession, "en", now, time.UTC); err != nil {
+		t.Fatalf("BuildDashboardViewData() unexpected error on the ranged stats path: %v", err)
+	}
+	if len(rangeStats.rangeUsers) == 0 {
+		t.Fatal("expected the stats provider to be reached; it recorded no BuildCycleStatsForRange call")
+	}
+	for index, captured := range rangeStats.rangeUsers {
+		if captured == nil {
+			t.Fatalf("BuildCycleStatsForRange call %d received no user at all", index)
+		}
+		if captured.ID != rangeSessionID {
+			t.Fatalf("BuildCycleStatsForRange call %d read session id %d, want %d", index, captured.ID, rangeSessionID)
 		}
 	}
 }

--- a/internal/services/dashboard_view_service_test.go
+++ b/internal/services/dashboard_view_service_test.go
@@ -29,9 +29,13 @@ type stubDashboardViewerProvider struct {
 	logEntry models.DailyLog
 	symptoms []models.SymptomType
 	err      error
+
+	// Captured user arguments — used to prove reads carry the session owner.
+	viewerUsers []*models.User
 }
 
-func (stub *stubDashboardViewerProvider) FetchDayLogForViewer(ctx context.Context, _ *models.User, _ time.Time, _ *time.Location) (models.DailyLog, []models.SymptomType, error) {
+func (stub *stubDashboardViewerProvider) FetchDayLogForViewer(ctx context.Context, user *models.User, _ time.Time, _ *time.Location) (models.DailyLog, []models.SymptomType, error) {
+	stub.viewerUsers = append(stub.viewerUsers, user)
 	if stub.err != nil {
 		return models.DailyLog{}, nil, stub.err
 	}
@@ -44,16 +48,22 @@ type stubDashboardDayStateProvider struct {
 	hasData bool
 	err     error
 	logs    []models.DailyLog
+
+	// Captured userID arguments — used to prove reads are owner-scoped.
+	dayStateUserIDs []uint
+	allLogsUserIDs  []uint
 }
 
-func (stub *stubDashboardDayStateProvider) DayHasDataForDate(ctx context.Context, _ uint, _ time.Time, _ *time.Location) (bool, error) {
+func (stub *stubDashboardDayStateProvider) DayHasDataForDate(ctx context.Context, userID uint, _ time.Time, _ *time.Location) (bool, error) {
+	stub.dayStateUserIDs = append(stub.dayStateUserIDs, userID)
 	if stub.err != nil {
 		return false, stub.err
 	}
 	return stub.hasData, nil
 }
 
-func (stub *stubDashboardDayStateProvider) FetchAllLogsForUser(ctx context.Context, _ uint) ([]models.DailyLog, error) {
+func (stub *stubDashboardDayStateProvider) FetchAllLogsForUser(ctx context.Context, userID uint) ([]models.DailyLog, error) {
+	stub.allLogsUserIDs = append(stub.allLogsUserIDs, userID)
 	if stub.err != nil {
 		return nil, stub.err
 	}
@@ -338,6 +348,73 @@ func TestBuildDayEditorViewDataReturnsTypedErrors(t *testing.T) {
 	)
 	if _, err := dayLogErrService.BuildDayEditorViewData(context.Background(), user, "en", day, now, time.UTC); !errors.Is(err, ErrDashboardViewLoadDayLog) {
 		t.Fatalf("expected ErrDashboardViewLoadDayLog, got %v", err)
+	}
+}
+
+// TestDashboardViewProvidersReadOnlyTheSessionOwner pins owner propagation on
+// the dashboard's whole read path. Every provider call these two builders make
+// reads special-category health data, so each must carry the acting session
+// owner and nothing else: the viewer fetch takes the user itself, the day-state
+// reads take its id. The stubs record what they were handed, and the account id
+// is deliberately not 1 — an unscoped or hard-coded read would otherwise agree
+// with the fixture by accident. Each provider is asserted to have been reached
+// at least once, so a run that recorded nothing fails here instead of passing
+// as "no mismatch found".
+func TestDashboardViewProvidersReadOnlyTheSessionOwner(t *testing.T) {
+	const sessionOwnerID uint = 4242
+
+	user := &models.User{ID: sessionOwnerID, Role: models.RoleOwner, CycleLength: 28}
+	now := mustParseDashboardServiceDay(t, "2026-02-21")
+	day := mustParseDashboardServiceDay(t, "2026-02-20")
+
+	viewer := &stubDashboardViewerProvider{
+		logEntry: models.DailyLog{Date: now, Notes: "owner-note"},
+		symptoms: []models.SymptomType{{ID: 3, Name: "Headache"}},
+	}
+	days := &stubDashboardDayStateProvider{
+		hasData: true,
+		logs: []models.DailyLog{
+			{Date: mustParseDashboardServiceDay(t, "2026-02-01"), IsPeriod: true, CycleStart: true},
+			{Date: now, IsPeriod: true},
+		},
+	}
+	service := NewDashboardViewService(&stubDashboardStatsProvider{}, viewer, days)
+
+	if _, err := service.BuildDashboardViewData(context.Background(), user, "en", now, time.UTC); err != nil {
+		t.Fatalf("BuildDashboardViewData() unexpected error: %v", err)
+	}
+	if _, err := service.BuildDayEditorViewData(context.Background(), user, "en", day, now, time.UTC); err != nil {
+		t.Fatalf("BuildDayEditorViewData() unexpected error: %v", err)
+	}
+
+	if len(viewer.viewerUsers) == 0 {
+		t.Fatal("expected the viewer provider to be reached; it recorded no call")
+	}
+	for index, captured := range viewer.viewerUsers {
+		if captured == nil {
+			t.Fatalf("viewer call %d received no user at all", index)
+		}
+		if captured.ID != sessionOwnerID {
+			t.Fatalf("viewer call %d read owner id %d, want the session owner %d", index, captured.ID, sessionOwnerID)
+		}
+	}
+
+	if len(days.dayStateUserIDs) == 0 {
+		t.Fatal("expected the day-state provider to be reached; it recorded no DayHasDataForDate call")
+	}
+	for index, capturedID := range days.dayStateUserIDs {
+		if capturedID != sessionOwnerID {
+			t.Fatalf("DayHasDataForDate call %d read owner id %d, want the session owner %d", index, capturedID, sessionOwnerID)
+		}
+	}
+
+	if len(days.allLogsUserIDs) == 0 {
+		t.Fatal("expected the day-state provider to be reached; it recorded no FetchAllLogsForUser call")
+	}
+	for index, capturedID := range days.allLogsUserIDs {
+		if capturedID != sessionOwnerID {
+			t.Fatalf("FetchAllLogsForUser call %d read owner id %d, want the session owner %d", index, capturedID, sessionOwnerID)
+		}
 	}
 }
 


### PR DESCRIPTION
Board group **G17**, master record **R2-0932** — the dashboard's provider doubles discarded the owner identity the whole read path exists to protect.

## What was wrong

`stubDashboardViewerProvider.FetchDayLogForViewer`, `stubDashboardDayStateProvider.DayHasDataForDate` and `.FetchAllLogsForUser` all declared their owner parameter unnamed. Every call these two builders make reads special-category health data, and nothing in the suite could observe which account it was read for.

The review of the first commit found the same hole one collaborator further in: `stubDashboardStatsProvider` discarded the user on **both** its entry points, and those decide what the dashboard predicts. Fixing three of five sites and leaving two would have left the converted and unconverted seams to diverge, so this PR closes all five.

## What changed

Every stub records what it was handed — `viewerUsers`, `dayStateUserIDs`, `allLogsUserIDs`, `rangeUsers`, `fromLogUsers` — following the capturing pattern already present unapplied at `internal/services/viewer_service_test.go:31,:93`.

`TestDashboardViewProvidersReadOnlyTheSessionOwner` drives `BuildDashboardViewData` and `BuildDayEditorViewData` with one session at id **4242** and asserts every recorded user and id is that account, with a positive anchor per provider so a run that reached none of them fails instead of passing as "no mismatch found". The id is deliberately not `1`: an unscoped read must not agree with the fixture by accident.

The two cycle-stats entry points sit on mutually exclusive branches — an owner view derives its stats from the entry-context logs and reaches `BuildCycleStatsFromLogs`, while a session that needs no such logs takes the ranged `BuildCycleStatsForRange` — so the ranged half is driven by its own session (id 7373) rather than left unobserved.

Production is untouched: `internal/services/dashboard_view_service.go` is absent from the diff.

## Three-step evidence

Before the guard existed, all five forwarding sites mutated to owner `1` left the targeted dashboard tests at `ok` and the whole package at `ok` — the record's claim, reproduced independently.

| mutation in `dashboard_view_service.go` | rest of the dashboard suite | this guard |
| --- | --- | --- |
| viewer sites `:130`/`:334` | `ok` | **FAIL** — `viewer call 0 read owner id 1, want the session owner 4242` |
| day-state sites `:155`/`:329` | `ok` | **FAIL** — `DayHasDataForDate call 0 read owner id 1, …` |
| `:392` `FetchAllLogsForUser` | `ok` | **FAIL** — `FetchAllLogsForUser call 0 read owner id 1, …` |
| `:408` `BuildCycleStatsForRange` → `&models.User{ID: 1}` | `ok` | **FAIL** — `BuildCycleStatsForRange call 0 read session id 1, want 7373` |
| `:420` `BuildCycleStatsFromLogs` → `&models.User{ID: 1}` | `ok` | **FAIL** — `BuildCycleStatsFromLogs call 0 read owner id 1, want the session owner 4242` |
| production restored verbatim | `ok` | `ok` |

Each capture point goes red on its own and names the culprit method.

## Medical-safety check — §10.6

Checked against §10.6 of the audit protocol (MEDICAL SAFETY): display confidence follows data confidence, and where a window or fertility claim has no data behind it, suppression is the floor rather than a qualifier.

The dashboard is a prediction surface, so the check is not vacuous — but this diff is test-only and moves nothing §10.6 governs. No qualifier text, no disclaimer, no suppression rule and no confidence value is added, removed or re-derived, and `internal/services/dashboard_view_service.go` is absent from the diff, so every value the templates render is byte-for-byte what `main` renders. What the new guard does touch is §10.1 (owner scoping): it pins the reads the prediction surface is built from to the acting session, both cycle-stats entry points included.

## Checks

`gofmt -l` clean on the changed file · `go vet ./...` · `staticcheck ./...` · `golangci-lint run --max-issues-per-linter=0 --max-same-issues=0 …` → `0 issues.` · `go test ./... -timeout 20m` no failures · `go run ./scripts/changelogd check` OK.

## Rollback

Revert both commits. Test-only: no persisted data, no public contract, no migration.
