### PR TITLE
test: pin all five settings-view owner reads to the authenticated owner

### DIFF
--- a/changelog.d/test-settings-view-owner-identity.md
+++ b/changelog.d/test-settings-view-owner-identity.md
@@ -1,9 +1,11 @@
 none
 
-Test-only guard: the settings-page view builder's three owner reads — the
-persisted settings row, the export summary and the custom symptom catalogue —
-are now observed to receive the authenticated owner's id. The collaborator
-doubles previously discarded that argument, so replacing all three reads with a
-constant owner left the focused service suite green; the doubles now record it
-and a single case pins every operand against an owner id that is neither zero
-nor the first row's. No production change: the forwarding was already correct.
+Test-only guard: the settings-page view builder's five owner reads — the
+persisted settings row, the export summary, the custom symptom catalogue, the
+webhook URL projection and the .ics feed status — are now observed to receive
+the authenticated owner's id. The collaborator doubles previously discarded that
+argument, and the two status builders were not even supplied, so substituting a
+constant owner at any one of the five reads left the focused service suite
+green; the doubles now record it and a single case pins every operand against a
+non-zero owner id that no fixture supplies by default. No production change: the
+forwarding was already correct at all five sites.

--- a/changelog.d/test-settings-view-owner-identity.md
+++ b/changelog.d/test-settings-view-owner-identity.md
@@ -1,0 +1,9 @@
+none
+
+Test-only guard: the settings-page view builder's three owner reads — the
+persisted settings row, the export summary and the custom symptom catalogue —
+are now observed to receive the authenticated owner's id. The collaborator
+doubles previously discarded that argument, so replacing all three reads with a
+constant owner left the focused service suite green; the doubles now record it
+and a single case pins every operand against an owner id that is neither zero
+nor the first row's. No production change: the forwarding was already correct.

--- a/internal/services/settings_view_service_test.go
+++ b/internal/services/settings_view_service_test.go
@@ -12,9 +12,13 @@ import (
 type stubSettingsViewLoader struct {
 	user models.User
 	err  error
+
+	// Captured userID argument — used to prove the read is owner-scoped.
+	settingsUserID uint
 }
 
-func (stub *stubSettingsViewLoader) LoadSettings(ctx context.Context, _ uint) (models.User, error) {
+func (stub *stubSettingsViewLoader) LoadSettings(ctx context.Context, userID uint) (models.User, error) {
+	stub.settingsUserID = userID
 	if stub.err != nil {
 		return models.User{}, stub.err
 	}
@@ -28,10 +32,15 @@ type stubSettingsViewExportBuilder struct {
 	called    bool
 	callIndex int
 	calls     []settingsViewSummaryCall
+
+	// Captured userID arguments, one per call — used to prove every summary
+	// read is owner-scoped, not just the first.
+	summaryUserIDs []uint
 }
 
-func (stub *stubSettingsViewExportBuilder) BuildSummary(ctx context.Context, _ uint, from *time.Time, to *time.Time, location *time.Location) (ExportSummary, error) {
+func (stub *stubSettingsViewExportBuilder) BuildSummary(ctx context.Context, userID uint, from *time.Time, to *time.Time, location *time.Location) (ExportSummary, error) {
 	stub.called = true
+	stub.summaryUserIDs = append(stub.summaryUserIDs, userID)
 	stub.calls = append(stub.calls, newSettingsViewSummaryCall(from, to, location))
 	if stub.err != nil {
 		return ExportSummary{}, stub.err
@@ -69,10 +78,14 @@ type stubSettingsViewSymptomProvider struct {
 	symptoms []models.SymptomType
 	err      error
 	called   bool
+
+	// Captured userID argument — used to prove the read is owner-scoped.
+	symptomsUserID uint
 }
 
-func (stub *stubSettingsViewSymptomProvider) FetchSymptoms(ctx context.Context, _ uint) ([]models.SymptomType, error) {
+func (stub *stubSettingsViewSymptomProvider) FetchSymptoms(ctx context.Context, userID uint) ([]models.SymptomType, error) {
 	stub.called = true
+	stub.symptomsUserID = userID
 	if stub.err != nil {
 		return nil, stub.err
 	}
@@ -156,6 +169,52 @@ func TestBuildSettingsPageViewDataOwnerLoadsExportSummary(t *testing.T) {
 		summaryFromDisplay: "01.02.2026",
 		summaryToDisplay:   "21.02.2026",
 	})
+}
+
+// The settings page reads three separate stores for the acting owner: the
+// persisted settings row, the export summary and the custom symptom catalogue.
+// Each read must carry the authenticated owner's id, so this pins all three
+// operands against an owner id that is neither zero nor the first row's id —
+// a hard-coded owner would otherwise render one owner's health settings,
+// symptom catalogue or export summary to another.
+func TestBuildSettingsPageViewDataScopesEveryOwnerReadToTheAuthenticatedOwner(t *testing.T) {
+	settingsLoader := &stubSettingsViewLoader{
+		user: models.User{
+			CycleLength:    28,
+			PeriodLength:   5,
+			AutoPeriodFill: true,
+		},
+	}
+	exportBuilder := &stubSettingsViewExportBuilder{
+		responses: []ExportSummary{
+			{TotalEntries: 2, HasData: true, DateFrom: "2026-02-01", DateTo: "2026-02-21"},
+			{TotalEntries: 2, HasData: true, DateFrom: "2026-02-01", DateTo: "2026-02-21"},
+		},
+	}
+	symptomProvider := &stubSettingsViewSymptomProvider{
+		symptoms: []models.SymptomType{{ID: 2, Name: "Joint stiffness"}},
+	}
+	service := NewSettingsViewService(settingsLoader, exportBuilder, symptomProvider, nil, nil)
+
+	owner := &models.User{ID: 4242, Role: models.RoleOwner}
+	if _, err := service.BuildSettingsPageViewData(context.Background(), owner, "en", SettingsViewInput{}, mustParseSettingsViewDay(t, "2026-02-21"), time.UTC); err != nil {
+		t.Fatalf("BuildSettingsPageViewData() unexpected error: %v", err)
+	}
+
+	if settingsLoader.settingsUserID != owner.ID {
+		t.Fatalf("expected settings read scoped to owner id %d, got %d", owner.ID, settingsLoader.settingsUserID)
+	}
+	if len(exportBuilder.summaryUserIDs) == 0 {
+		t.Fatalf("expected at least one export summary read for the owner")
+	}
+	for index, summaryUserID := range exportBuilder.summaryUserIDs {
+		if summaryUserID != owner.ID {
+			t.Fatalf("expected export summary read %d scoped to owner id %d, got %d", index, owner.ID, summaryUserID)
+		}
+	}
+	if symptomProvider.symptomsUserID != owner.ID {
+		t.Fatalf("expected symptom read scoped to owner id %d, got %d", owner.ID, symptomProvider.symptomsUserID)
+	}
 }
 
 func TestBuildSettingsPageViewDataOwnerClampsExportDefaultToRequestLocalToday(t *testing.T) {

--- a/internal/services/settings_view_service_test.go
+++ b/internal/services/settings_view_service_test.go
@@ -94,6 +94,35 @@ func (stub *stubSettingsViewSymptomProvider) FetchSymptoms(ctx context.Context, 
 	return result, nil
 }
 
+// stubSettingsViewWebhookStatusBuilder records the owner id the view forwards
+// into the webhook projection. The id is the AAD the ciphertext is bound to, so
+// a hard-coded one would silently report every owner's webhook unconfigured.
+type stubSettingsViewWebhookStatusBuilder struct {
+	display WebhookURLDisplay
+
+	// Captured userID argument — used to prove the read is owner-scoped.
+	webhookUserID uint
+}
+
+func (stub *stubSettingsViewWebhookStatusBuilder) BuildWebhookURLDisplay(userID uint, _ string) WebhookURLDisplay {
+	stub.webhookUserID = userID
+	return stub.display
+}
+
+// stubSettingsViewCalendarFeedStatusBuilder records the owner id the view
+// forwards into the .ics feed status, which reports whether a feed is armed.
+type stubSettingsViewCalendarFeedStatusBuilder struct {
+	status CalendarFeedStatus
+
+	// Captured userID argument — used to prove the read is owner-scoped.
+	feedUserID uint
+}
+
+func (stub *stubSettingsViewCalendarFeedStatusBuilder) BuildFeedStatus(ctx context.Context, userID uint) CalendarFeedStatus {
+	stub.feedUserID = userID
+	return stub.status
+}
+
 func TestBuildSettingsPageViewDataClassifiesChangePasswordError(t *testing.T) {
 	settingsLoader := &stubSettingsViewLoader{
 		user: models.User{
@@ -171,12 +200,14 @@ func TestBuildSettingsPageViewDataOwnerLoadsExportSummary(t *testing.T) {
 	})
 }
 
-// The settings page reads three separate stores for the acting owner: the
-// persisted settings row, the export summary and the custom symptom catalogue.
-// Each read must carry the authenticated owner's id, so this pins all three
-// operands against an owner id that is neither zero nor the first row's id —
-// a hard-coded owner would otherwise render one owner's health settings,
-// symptom catalogue or export summary to another.
+// The settings page reads five separate stores for the acting owner: the
+// persisted settings row, the export summary, the custom symptom catalogue, the
+// webhook URL projection and the .ics feed status. Each read must carry the
+// authenticated owner's id, so this pins every operand against a non-zero owner
+// id no fixture supplies by default — a hard-coded owner would otherwise render
+// one owner's health settings, symptom catalogue, export summary or feed state
+// to another. The two status builders are covered here rather than left nil
+// precisely because a nil collaborator returns early and observes nothing.
 func TestBuildSettingsPageViewDataScopesEveryOwnerReadToTheAuthenticatedOwner(t *testing.T) {
 	settingsLoader := &stubSettingsViewLoader{
 		user: models.User{
@@ -194,7 +225,13 @@ func TestBuildSettingsPageViewDataScopesEveryOwnerReadToTheAuthenticatedOwner(t 
 	symptomProvider := &stubSettingsViewSymptomProvider{
 		symptoms: []models.SymptomType{{ID: 2, Name: "Joint stiffness"}},
 	}
-	service := NewSettingsViewService(settingsLoader, exportBuilder, symptomProvider, nil, nil)
+	webhookStatus := &stubSettingsViewWebhookStatusBuilder{
+		display: WebhookURLDisplay{Configured: true, Host: "hooks.example.test"},
+	}
+	calendarFeedStatus := &stubSettingsViewCalendarFeedStatusBuilder{
+		status: CalendarFeedStatus{Configured: true},
+	}
+	service := NewSettingsViewService(settingsLoader, exportBuilder, symptomProvider, webhookStatus, calendarFeedStatus)
 
 	owner := &models.User{ID: 4242, Role: models.RoleOwner}
 	if _, err := service.BuildSettingsPageViewData(context.Background(), owner, "en", SettingsViewInput{}, mustParseSettingsViewDay(t, "2026-02-21"), time.UTC); err != nil {
@@ -214,6 +251,12 @@ func TestBuildSettingsPageViewDataScopesEveryOwnerReadToTheAuthenticatedOwner(t 
 	}
 	if symptomProvider.symptomsUserID != owner.ID {
 		t.Fatalf("expected symptom read scoped to owner id %d, got %d", owner.ID, symptomProvider.symptomsUserID)
+	}
+	if webhookStatus.webhookUserID != owner.ID {
+		t.Fatalf("expected webhook projection scoped to owner id %d, got %d", owner.ID, webhookStatus.webhookUserID)
+	}
+	if calendarFeedStatus.feedUserID != owner.ID {
+		t.Fatalf("expected calendar feed status scoped to owner id %d, got %d", owner.ID, calendarFeedStatus.feedUserID)
 	}
 }
 


### PR DESCRIPTION
Board group **G19**, master record **R2-0959** — the settings-view suite accepted every owner read under a single fixture id, so none of them was pinned to the authenticated account.

## What was wrong

The settings page builds from five owner-scoped reads. Three had doubles that discarded the id (`LoadSettings`, `BuildSummary`, `FetchSymptoms`); the other two — the webhook URL projection and the `.ics` feed status — were passed as **nil collaborators**, so the service returned early on its nil guard and those seams were not merely unobserved but never entered.

That second half is the review's finding on the first commit, and it is folded in here rather than deferred: closing three of five would leave the converted and unconverted seams to diverge.

## What changed

All five doubles now record the id the view forwards, following the capturing pattern already present unapplied at `internal/services/viewer_service_test.go:31,:93`. Two new doubles supply the webhook and feed status builders instead of `nil`.

`TestBuildSettingsPageViewDataScopesEveryOwnerReadToTheAuthenticatedOwner` pins every operand against one authenticated owner at id **4242** — non-zero, and not an id any fixture supplies by default, so a hard-coded read cannot agree by accident. The export read is asserted per call, since the owner export path calls `BuildSummary` twice.

Production is untouched: `internal/services/settings_view_service.go` is absent from the diff.

## Three-step evidence

Each of the five sites was mutated on its own, so no assertion masks another.

| mutation in `settings_view_service.go` | rest of the settings-view suite | this guard |
| --- | --- | --- |
| `:147` `LoadSettings(ctx, user.ID)` → `(ctx, 1)` | `ok` | **FAIL** — `expected settings read scoped to owner id 4242, got 1` |
| `:272` `buildOwnerExportViewData(ctx, CurrentUser.ID, …)` → `(ctx, 1, …)` | `ok` | **FAIL** — `expected export summary read 0 scoped to owner id 4242, got 1` |
| `:404` `FetchSymptoms(ctx, user.ID)` → `(ctx, 1)` | `ok` | **FAIL** — `expected symptom read scoped to owner id 4242, got 1` |
| `:294` `BuildWebhookURLDisplay(CurrentUser.ID, …)` → `(1, …)` | `ok` | **FAIL** — `expected webhook projection scoped to owner id 4242, got 1` |
| `:309` `BuildFeedStatus(ctx, CurrentUser.ID)` → `(ctx, 1)` | `ok` | **FAIL** — `expected calendar feed status scoped to owner id 4242, got 1` |
| production restored verbatim | `ok` | `ok` |

Why the last two matter beyond symmetry: the owner id is the AAD the webhook ciphertext is bound to, so a constant there reports every owner's webhook unconfigured; the feed status reports whether an owner's calendar feed is armed, so a constant there renders another account's feed state on this owner's settings page.

## Checks

`gofmt -l` clean on the changed file · `go vet ./...` · `staticcheck ./...` · `golangci-lint run --max-issues-per-linter=0 --max-same-issues=0 …` → `0 issues.` · `go test ./... -timeout 20m` no failures · `go run ./scripts/changelogd check` OK.

`internal/services/settings_view_service.go` is one of the files a repository-wide `gofmt -l` lists under the local toolchain; it is unchanged here and lists identically on `main`.

## Rollback

Revert both commits. Test-only: no persisted data, no public contract, no migration.
