### PR TITLE
test: make the theme-persistence scenario able to fail

### DIFF
--- a/changelog.d/test-theme-persistence-await-patch.md
+++ b/changelog.d/test-theme-persistence-await-patch.md
@@ -1,0 +1,9 @@
+none
+
+Test-only fix: the theme-persistence scenario proved nothing about the save it
+was named for. Every signal it waited on after pressing save was written by the
+client before any network I/O, and the one that looked server-backed — the save
+button falling back to disabled — only meant that some page had loaded. With the
+interface endpoint persisting nothing and confirming nothing, the scenario still
+ran green. It now waits on the save click's own PATCH, asserts that response,
+and reads back the success notice the server renders. No product code involved.

--- a/e2e/theme-dark-mode.spec.ts
+++ b/e2e/theme-dark-mode.spec.ts
@@ -89,6 +89,53 @@ async function awaitSystemColorSchemeFlip(page: Page, scheme: 'light' | 'dark'):
   );
 }
 
+/**
+ * Saves the settings interface form and returns only once the server has
+ * answered the save.
+ *
+ * Waiting on the save button's own state does not prove that. The shared htmx
+ * busy handler only touches `form[data-save-feedback] [data-save-button]`, and
+ * the interface form is neither, so nothing disables this button while its
+ * PATCH is outstanding — what re-disables it is the reload that the endpoint's
+ * `HX-Redirect` triggers. That makes "disabled again" a proxy for "some page
+ * loaded", not for "the account took the save": with the endpoint persisting
+ * nothing and confirming nothing while still redirecting, the scenario ran
+ * green end to end. Every other signal in it is client-fed — the form writes
+ * `ovumcy_theme` synchronously in its own submit listener, and both the
+ * `data-theme` attribute and the next page's theme are read back out of that
+ * same storage.
+ *
+ * So the wait binds to the click's OWN request and to that request's response,
+ * which is the only wait that outlives the PATCH and cannot be satisfied by a
+ * navigation the test did not ask for. The success flash is the server-backed
+ * half: the handler puts it in a flash cookie and answers with a redirect, so
+ * the notice is rendered by `/settings` itself and no client state can
+ * fabricate it. The theme has no account column to read back — it is client
+ * storage by design — so what the flash proves is that the endpoint accepted
+ * this save rather than the page going on showing a preference it refused.
+ */
+async function saveInterfaceForm(page: Page): Promise<void> {
+  const form = page.locator('[data-settings-interface-form]');
+  const [saveRequest] = await Promise.all([
+    page.waitForRequest(
+      (request) =>
+        request.method() === 'PATCH' && request.url().includes('/api/v1/users/current/interface')
+    ),
+    form.locator('[data-settings-interface-save]').click(),
+  ]);
+
+  const saveResponse = await saveRequest.response();
+  expect(
+    saveResponse?.ok(),
+    `the interface PATCH answered ${String(saveResponse?.status())}, so nothing was saved`
+  ).toBe(true);
+  await expect(
+    page.locator(
+      '[data-flash-key="settings.success.interface_updated"][data-flash-status="success"]'
+    )
+  ).toBeVisible();
+}
+
 test.describe('Theme mode', () => {
   test('theme toggle switches mode and persists between pages', async ({ page, context }) => {
     await registerAndReachDashboard(page, 'theme-mode');
@@ -165,13 +212,16 @@ test.describe('Theme mode', () => {
 
     await nextOption.locator('.chip-stack').click();
     await expect(saveButton).toBeEnabled();
-    await saveButton.click();
+    await saveInterfaceForm(page);
+    // Kept as the draft's own end state, no longer as the wait for the save.
     await expect(saveButton).toBeDisabled();
     await expect(html).toHaveAttribute('data-theme', nextTheme);
     await expect
       .poll(async () => page.evaluate(() => window.localStorage.getItem('ovumcy_theme')))
       .toBe(nextTheme);
 
+    // The save is answered, so this navigation has nothing left to abort. What
+    // the two pages below check is the client half — where the theme lives.
     await page.goto('/dashboard');
     await expect(page).toHaveURL(/\/dashboard$/);
     await expect(html).toHaveAttribute('data-theme', nextTheme);


### PR DESCRIPTION
Board group **G21**, master record **R2-1006** — the theme-persistence scenario proved nothing about the save it was named for.

## The record's stated mechanism does not hold, and the PR says so

R2-1006 attributes the vacuity to an abort race: `await expect(saveButton).toBeDisabled()` being satisfied by `htmx:beforeRequest` while the PATCH is still outstanding, letting the following `page.goto` cancel it. That is not what happens. `setSaveButtonState` resolves its form through `target.closest("form[data-save-feedback]")` (`web/src/js/app/30-feedback-htmx.js:102`) and then needs `[data-save-button]` (`:109`); the interface form carries neither attribute. Nothing disables that button during its own request — what re-disables it is the reload the endpoint's `HX-Redirect` triggers.

Measured rather than argued: an injected 400 made the **old** spec go red at its `toBeDisabled()` line, which it could not do if the record's mechanism held. So the race as stated was not implemented, and no fix was written for it.

The **vacuity** half of the finding is real, and is what this PR closes.

## What was actually wrong

Every signal the scenario waited on after pressing save was written by the client before any network I/O: the form writes `ovumcy_theme` synchronously in its own submit listener, and both the `data-theme` attribute and the next page's theme are read back out of that same storage. The one signal that looked server-backed — the save button falling back to disabled — only meant *some page loaded*. With the interface endpoint persisting nothing and confirming nothing while still redirecting, the scenario ran green end to end.

## What changed

One helper, `saveInterfaceForm`, binds the wait to the click's **own** PATCH and to that request's response — the only wait that outlives the PATCH and cannot be satisfied by a navigation the test did not ask for — then asserts the success notice `/settings` renders from the flash cookie, which no client state can fabricate. The `toBeDisabled()` assertion stays, now as the draft's end state rather than as the wait for the save.

No product code changed. `internal/api/handlers_settings_interface.go` was edited for defect injection only and is absent from the diff; the two JS files on the board row are cited by the record as evidence, not as sites of the fix.

## Three-step evidence

Defect injected in `UpdateInterfaceSettings`: drop `SaveInterfaceLanguage` and the success flash, keep the redirect — the endpoint persists nothing and confirms nothing while the page reloads exactly as on the happy path. Command each time: `npm run e2e -- e2e/theme-dark-mode.spec.ts`.

| step | result |
| --- | --- |
| spec as on `main`, endpoint broken | **passed** (`1 passed (31.4s)`, exit 0) — it cannot go red |
| fixed spec, same break | **failed** at `theme-dark-mode.spec.ts:131`, naming the culprit: the `settings.success.interface_updated` flash was not found |
| endpoint restored verbatim, fixed spec | **4 passed (30.1s)**, whole file green |

## One wait, not two

The language helper already carried its own copy of the same request-bound wait on the same endpoint (`e2e/support/language-helpers.ts`). Two copies of one wait drift, and a fix applied to either would have missed the other — the exact shape this campaign is otherwise busy closing inside the Go tests, so leaving it would have been inconsistent.

Both now call `saveInterfaceSettingsForm` from the new `e2e/support/settings-interface-helpers.ts`. The success-flash readback is opt-in: it is the only server-backed half the theme scenario has, while the language callers leave `/settings` immediately and never land on the page that renders it. `saveSettingsLanguage` keeps its signature and its behaviour, so the four specs importing it are untouched.

Scope note: this reaches two files outside the board row for the group. Deliberate and owner-approved, not an oversight.

The three-step evidence above was re-run against the consolidated version, not only the inline one.

## Coverage the product bounds

The readback is partial and cannot currently be otherwise: the theme has no account-side column — it is client `localStorage` by design — so the strongest server-backed surface is the success flash. **A defect that drops persistence while still emitting the success flash is caught by neither spec.** Stated rather than papered over; giving the theme a server-side half is a product change with its own migration, tracked separately.

Also measured rather than assumed: the theme spec's other two saves, in the prefers-color-scheme scenario, already assert the server-rendered flash and do go red under the same injected defect. They were left as they are — routing them through the helper would only add a `response.ok()` assertion to a wait that already outlives the PATCH.

## Checks

`npm run lint` (eslint + `tsc --noEmit`, which type-checks `e2e/**`) · `npm run test:unit` 73/73 · `go vet ./...` · `staticcheck ./...` · `golangci-lint run --max-issues-per-linter=0 --max-same-issues=0 …` → `0 issues.` · `go test ./... -timeout 20m` no failures · `go run ./scripts/changelogd check` OK. No Go is touched, so the Go lanes are a formality here.

## Suite health

Run on this branch: `theme-dark-mode` 4 passed; `calendar.spec.ts` 17 passed; the combined run of `theme-dark-mode` + `calendar` + `calendar-save-resilience` + `bugs` gave 37 passed / 1 failed at `calendar.spec.ts:721`, a test that touches neither helper. That test passes alone (5.1s) and passes in a full `calendar.spec.ts` run (17/17), so it is a cross-file flake in the combined run and not a regression from this change. Recorded rather than re-run until green.

## Rollback

Revert both commits. Test-only: no persisted data, no public contract, no migration.
