### PR TITLE
test(e2e): keep the interface-save wait in one place

### DIFF
--- a/changelog.d/test-one-interface-save-wait.md
+++ b/changelog.d/test-one-interface-save-wait.md
@@ -1,0 +1,12 @@
+none
+
+Test-only cleanup: the wait that proves a settings-interface save reached the
+server existed twice — once in the language helper, once inline in the theme
+scenario that had just gained it. Both were the same request-bound wait on the
+same endpoint, and two copies drift: a fix applied to either would have missed
+the other. They now call one `saveInterfaceSettingsForm`, with the
+success-flash readback opt-in, because the callers that only need the save not
+to be raced leave `/settings` before that notice is rendered.
+
+`saveSettingsLanguage` keeps its signature and its behaviour, so the four specs
+importing it are unchanged.

--- a/e2e/support/language-helpers.ts
+++ b/e2e/support/language-helpers.ts
@@ -1,5 +1,7 @@
 import { expect, type Page } from '@playwright/test';
 
+import { saveInterfaceSettingsForm } from './settings-interface-helpers';
+
 export async function switchPublicLanguage(page: Page, code: string): Promise<void> {
   const form = page.locator('[data-language-switch-form]');
   const button = form.locator(`[data-language-switch-option="${code}"]`);
@@ -26,19 +28,12 @@ export async function saveSettingsLanguage(page: Page, code: string): Promise<vo
     await option.locator('.chip-stack').click();
     // The radio change flips data-selected optimistically on the client, so the
     // assertion below can pass before the htmx PATCH persists the preference.
-    // Bind to the save click's own request and await its response so callers
-    // that navigate away next (e.g. straight to /calendar) don't race an
-    // in-flight save that would otherwise drop the just-chosen language.
-    const [saveRequest] = await Promise.all([
-      page.waitForRequest(
-        (request) =>
-          request.method() === 'PATCH' &&
-          request.url().includes('/api/v1/users/current/interface'),
-      ),
-      form.locator('[data-settings-interface-save]').click(),
-    ]);
-    const saveResponse = await saveRequest.response();
-    expect(saveResponse?.ok()).toBeTruthy();
+    // The shared helper waits on the save click's own request and its response,
+    // so callers that navigate away next (e.g. straight to /calendar) don't race
+    // an in-flight save that would otherwise drop the just-chosen language.
+    // The success flash is not asserted here: those callers leave /settings
+    // immediately and never land on the page that renders it.
+    await saveInterfaceSettingsForm(page);
   }
 
   await expect(option).toHaveAttribute('data-selected', 'true');

--- a/e2e/support/settings-interface-helpers.ts
+++ b/e2e/support/settings-interface-helpers.ts
@@ -1,0 +1,56 @@
+import { expect, type Page } from '@playwright/test';
+
+/** The endpoint every settings interface save goes through. */
+export const INTERFACE_SETTINGS_ENDPOINT = '/api/v1/users/current/interface';
+
+/**
+ * Presses the settings interface form's save button and returns only once the
+ * server has answered that click's own PATCH.
+ *
+ * Waiting on the save button's state does not prove that. The shared htmx busy
+ * handler only touches `form[data-save-feedback] [data-save-button]`, and the
+ * interface form is neither, so nothing disables this button while its PATCH is
+ * outstanding — what re-disables it is the reload the endpoint's `HX-Redirect`
+ * triggers. That makes "disabled again" a proxy for "some page loaded", not for
+ * "the account took the save". Nor do the form's own attributes help: the radio
+ * change flips `data-selected` optimistically, and the theme is written to
+ * `localStorage` synchronously in the submit listener, both before any network
+ * I/O.
+ *
+ * So the wait binds to the click's OWN request and to that request's response,
+ * which is the only wait that outlives the PATCH and cannot be satisfied by a
+ * navigation the caller did not ask for.
+ *
+ * `expectSuccessFlash` adds the server-backed half: the handler puts the notice
+ * in a flash cookie and answers with a redirect, so the notice is rendered by
+ * `/settings` itself and no client state can fabricate it. It is opt-in because
+ * a caller that only needs the save not to be raced — one that navigates
+ * elsewhere straight after — never lands on the page that renders it.
+ */
+export async function saveInterfaceSettingsForm(
+  page: Page,
+  options: { expectSuccessFlash?: boolean } = {},
+): Promise<void> {
+  const form = page.locator('[data-settings-interface-form]');
+  const [saveRequest] = await Promise.all([
+    page.waitForRequest(
+      (request) =>
+        request.method() === 'PATCH' && request.url().includes(INTERFACE_SETTINGS_ENDPOINT),
+    ),
+    form.locator('[data-settings-interface-save]').click(),
+  ]);
+
+  const saveResponse = await saveRequest.response();
+  expect(
+    saveResponse?.ok(),
+    `the interface PATCH answered ${String(saveResponse?.status())}, so nothing was saved`,
+  ).toBe(true);
+
+  if (options.expectSuccessFlash) {
+    await expect(
+      page.locator(
+        '[data-flash-key="settings.success.interface_updated"][data-flash-status="success"]',
+      ),
+    ).toBeVisible();
+  }
+}

--- a/e2e/theme-dark-mode.spec.ts
+++ b/e2e/theme-dark-mode.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test, type Frame, type Page } from '@playwright/test';
 import { expectDashboardStatusHeader } from './support/dashboard-helpers';
 import { cancelConfirmDialog } from './support/confirm-dialog-helpers';
+import { saveInterfaceSettingsForm } from './support/settings-interface-helpers';
 import {
   WCAG_AA_GRAPHIC_CONTRAST,
   applyTheme,
@@ -89,53 +90,6 @@ async function awaitSystemColorSchemeFlip(page: Page, scheme: 'light' | 'dark'):
   );
 }
 
-/**
- * Saves the settings interface form and returns only once the server has
- * answered the save.
- *
- * Waiting on the save button's own state does not prove that. The shared htmx
- * busy handler only touches `form[data-save-feedback] [data-save-button]`, and
- * the interface form is neither, so nothing disables this button while its
- * PATCH is outstanding — what re-disables it is the reload that the endpoint's
- * `HX-Redirect` triggers. That makes "disabled again" a proxy for "some page
- * loaded", not for "the account took the save": with the endpoint persisting
- * nothing and confirming nothing while still redirecting, the scenario ran
- * green end to end. Every other signal in it is client-fed — the form writes
- * `ovumcy_theme` synchronously in its own submit listener, and both the
- * `data-theme` attribute and the next page's theme are read back out of that
- * same storage.
- *
- * So the wait binds to the click's OWN request and to that request's response,
- * which is the only wait that outlives the PATCH and cannot be satisfied by a
- * navigation the test did not ask for. The success flash is the server-backed
- * half: the handler puts it in a flash cookie and answers with a redirect, so
- * the notice is rendered by `/settings` itself and no client state can
- * fabricate it. The theme has no account column to read back — it is client
- * storage by design — so what the flash proves is that the endpoint accepted
- * this save rather than the page going on showing a preference it refused.
- */
-async function saveInterfaceForm(page: Page): Promise<void> {
-  const form = page.locator('[data-settings-interface-form]');
-  const [saveRequest] = await Promise.all([
-    page.waitForRequest(
-      (request) =>
-        request.method() === 'PATCH' && request.url().includes('/api/v1/users/current/interface')
-    ),
-    form.locator('[data-settings-interface-save]').click(),
-  ]);
-
-  const saveResponse = await saveRequest.response();
-  expect(
-    saveResponse?.ok(),
-    `the interface PATCH answered ${String(saveResponse?.status())}, so nothing was saved`
-  ).toBe(true);
-  await expect(
-    page.locator(
-      '[data-flash-key="settings.success.interface_updated"][data-flash-status="success"]'
-    )
-  ).toBeVisible();
-}
-
 test.describe('Theme mode', () => {
   test('theme toggle switches mode and persists between pages', async ({ page, context }) => {
     await registerAndReachDashboard(page, 'theme-mode');
@@ -212,7 +166,11 @@ test.describe('Theme mode', () => {
 
     await nextOption.locator('.chip-stack').click();
     await expect(saveButton).toBeEnabled();
-    await saveInterfaceForm(page);
+    // The success flash is the only server-backed readback this scenario has:
+    // the theme itself lives in client storage by design, so what the flash
+    // proves is that the endpoint accepted the save rather than the page going
+    // on showing a preference it refused.
+    await saveInterfaceSettingsForm(page, { expectSuccessFlash: true });
     // Kept as the draft's own end state, no longer as the wait for the save.
     await expect(saveButton).toBeDisabled();
     await expect(html).toHaveAttribute('data-theme', nextTheme);


### PR DESCRIPTION
Follow-up to #522, which landed before this could join it. Pure test-infrastructure cleanup: no product code, no Go.

## What was wrong

#522 gave the theme-persistence scenario a wait that binds to the save click's own PATCH and awaits its response. `e2e/support/language-helpers.ts` already carried the same wait, on the same endpoint, for the same form — written out a second time. Two copies of one wait drift, and a fix applied to either would have missed the other. That is the same N-of-N+1 shape the current campaign is busy closing inside the Go tests, so leaving it in the e2e layer would have been inconsistent.

## What changed

`e2e/support/settings-interface-helpers.ts` is new and holds `saveInterfaceSettingsForm(page, { expectSuccessFlash })`, with the reasoning that used to live in the theme spec's local copy: why the save button's state is not a valid wait (the shared htmx busy handler only touches `form[data-save-feedback] [data-save-button]`, and the interface form is neither, so what re-disables the button is the reload the endpoint's `HX-Redirect` triggers), and why the flash is the server-backed half.

- `saveSettingsLanguage` now calls it. The flash is **not** asserted there: its callers leave `/settings` immediately and never land on the page that renders the notice. Signature and behaviour unchanged, so `bugs`, `calendar`, `calendar-save-resilience` and `cross-browser-smoke` are untouched.
- `e2e/theme-dark-mode.spec.ts` drops its local copy and calls the shared helper with `expectSuccessFlash: true`.

## Evidence

The point of a shared helper is that it must still be able to go red, so the three-step check was re-run against the consolidated version rather than inherited from #522.

Defect injected in `UpdateInterfaceSettings`: drop `setFlashCookie`, keep the redirect — the endpoint confirms nothing while the page reloads exactly as on the happy path.

| step | result |
| --- | --- |
| consolidated spec, endpoint broken | **failed** on `[data-flash-key="settings.success.interface_updated"][data-flash-status="success"]` |
| endpoint restored verbatim | `theme-dark-mode` **4 passed** |
| whole surface, this branch | `theme-dark-mode` + `calendar.spec.ts` → **21 passed (2.0m)** |

Also measured rather than assumed: the theme spec's other two saves, in the prefers-color-scheme scenario, already assert the server-rendered flash and do go red under the same injected defect. They are left as they are — routing them through the helper would add only a `response.ok()` assertion to a wait that already outlives the PATCH.

## Checks

`npm run lint` (eslint + `tsc --noEmit`, which type-checks `e2e/**`) clean · `go run ./scripts/changelogd check` OK. No Go source is touched.

## Rollback

Single-commit revert. Test-only: no persisted data, no public contract, no migration.
