### PR TITLE
test(services): prove owner scoping on the export read path

### DIFF
--- a/changelog.d/test-export-service-owner-identity.md
+++ b/changelog.d/test-export-service-owner-identity.md
@@ -1,0 +1,14 @@
+none
+
+Test-only guard: the export service's owner scoping is now observable. Both export
+stubs used to declare an unnamed `uint` and record nothing, and every integration
+fixture held a single owner, so an export that fetched a constant account's days or
+symptom catalog passed the whole suite. The stubs now record the owner operand of
+every read and the unit test asserts it across all four entry points — LoadDataForRange,
+BuildSummary, BuildJSONEntries, BuildCSVRows — with a positive anchor per collaborator,
+so a run that reached one of them fewer times than expected fails instead of reporting
+"no mismatch found". Alongside it, an integration case seeds two independent owners on
+one database, exports as the later-created owner and asserts that neither the other
+owner's day rows nor the other owner's symptom names appear, while each owner still
+exports their own data. No behaviour changes; the read path already carried the owner
+correctly.

--- a/changelog.d/test-export-service-owner-identity.md
+++ b/changelog.d/test-export-service-owner-identity.md
@@ -10,5 +10,7 @@ so a run that reached one of them fewer times than expected fails instead of rep
 "no mismatch found". Alongside it, an integration case seeds two independent owners on
 one database, exports as the later-created owner and asserts that neither the other
 owner's day rows nor the other owner's symptom names appear, while each owner still
-exports their own data. No behaviour changes; the read path already carried the owner
+exports their own data; like the range-boundary assertions beside it, it runs on both
+SQLite and Postgres, since the owner predicate reaches SQL through a separate migration
+set per dialect. No behaviour changes; the read path already carried the owner
 correctly.

--- a/internal/services/export_service_integration_test.go
+++ b/internal/services/export_service_integration_test.go
@@ -80,25 +80,29 @@ func TestExportServiceLoadDataForRangeFiltersInclusiveBoundariesPostgres(t *test
 	assertExportServiceLoadDataForRangeFiltersInclusiveBoundaries(t, newDayServicePostgresIntegration, "export-range-data-service-postgres@example.com")
 }
 
-// TestExportServiceScopesRangeExportToRequestingOwner pins the owner-isolation
+// assertExportServiceScopesRangeExportToRequestingOwner pins the owner-isolation
 // invariant on the export read path against a database that holds two independent
 // owners (household self-hosting). Owner B is created first, so B holds the lowest
 // user id: an export that read a constant owner instead of the requesting one
 // returns B's days and B's symptom catalog here, and every assertion below fails.
 // The boundary itself is docs/SECURITY_INVARIANTS.md — no surface may expose
-// another account's data.
-func TestExportServiceScopesRangeExportToRequestingOwner(t *testing.T) {
-	dayService, database := newDayServiceIntegration(t)
+// another account's data. Both dialects run it: the daily-log read carries the
+// owner predicate into SQL, and this repository maintains a separate Postgres
+// migration set, so a divergence there is exactly the leak this case exists for.
+func assertExportServiceScopesRangeExportToRequestingOwner(t *testing.T, setup func(*testing.T) (*DayService, *gorm.DB), emailA string, emailB string) {
+	t.Helper()
+
+	dayService, database := setup(t)
 	repositories := db.NewRepositories(database)
 	symptomService := NewSymptomService(repositories.Symptoms)
 	exportService := NewExportService(dayService, symptomService)
 
-	ownerB := createDayServiceTestUser(t, database, "export-idor-b@example.com")
+	ownerB := createDayServiceTestUser(t, database, emailB)
 	bSymptom, err := symptomService.CreateSymptomForUser(context.Background(), ownerB.ID, "Owner B Only", "", "")
 	if err != nil {
 		t.Fatalf("seed owner B symptom: %v", err)
 	}
-	ownerA := createDayServiceTestUser(t, database, "export-idor-a@example.com")
+	ownerA := createDayServiceTestUser(t, database, emailA)
 	aSymptom, err := symptomService.CreateSymptomForUser(context.Background(), ownerA.ID, "Owner A Only", "", "")
 	if err != nil {
 		t.Fatalf("seed owner A symptom: %v", err)
@@ -187,6 +191,24 @@ func TestExportServiceScopesRangeExportToRequestingOwner(t *testing.T) {
 	if symptomNamesB[bSymptom.ID] != "Owner B Only" {
 		t.Fatalf("expected owner B's own symptom name in B's export, got %q", symptomNamesB[bSymptom.ID])
 	}
+}
+
+func TestExportServiceScopesRangeExportToRequestingOwner(t *testing.T) {
+	assertExportServiceScopesRangeExportToRequestingOwner(
+		t,
+		newDayServiceIntegration,
+		"export-idor-a@example.com",
+		"export-idor-b@example.com",
+	)
+}
+
+func TestExportServiceScopesRangeExportToRequestingOwnerPostgres(t *testing.T) {
+	assertExportServiceScopesRangeExportToRequestingOwner(
+		t,
+		newDayServicePostgresIntegration,
+		"export-idor-a-postgres@example.com",
+		"export-idor-b-postgres@example.com",
+	)
 }
 
 func TestExportServiceBuildSummaryForRangeFiltersInclusiveBoundaries(t *testing.T) {

--- a/internal/services/export_service_integration_test.go
+++ b/internal/services/export_service_integration_test.go
@@ -80,6 +80,115 @@ func TestExportServiceLoadDataForRangeFiltersInclusiveBoundariesPostgres(t *test
 	assertExportServiceLoadDataForRangeFiltersInclusiveBoundaries(t, newDayServicePostgresIntegration, "export-range-data-service-postgres@example.com")
 }
 
+// TestExportServiceScopesRangeExportToRequestingOwner pins the owner-isolation
+// invariant on the export read path against a database that holds two independent
+// owners (household self-hosting). Owner B is created first, so B holds the lowest
+// user id: an export that read a constant owner instead of the requesting one
+// returns B's days and B's symptom catalog here, and every assertion below fails.
+// The boundary itself is docs/SECURITY_INVARIANTS.md — no surface may expose
+// another account's data.
+func TestExportServiceScopesRangeExportToRequestingOwner(t *testing.T) {
+	dayService, database := newDayServiceIntegration(t)
+	repositories := db.NewRepositories(database)
+	symptomService := NewSymptomService(repositories.Symptoms)
+	exportService := NewExportService(dayService, symptomService)
+
+	ownerB := createDayServiceTestUser(t, database, "export-idor-b@example.com")
+	bSymptom, err := symptomService.CreateSymptomForUser(context.Background(), ownerB.ID, "Owner B Only", "", "")
+	if err != nil {
+		t.Fatalf("seed owner B symptom: %v", err)
+	}
+	ownerA := createDayServiceTestUser(t, database, "export-idor-a@example.com")
+	aSymptom, err := symptomService.CreateSymptomForUser(context.Background(), ownerA.ID, "Owner A Only", "", "")
+	if err != nil {
+		t.Fatalf("seed owner A symptom: %v", err)
+	}
+
+	logs := []models.DailyLog{
+		{
+			UserID:     ownerB.ID,
+			Date:       time.Date(2026, time.February, 10, 0, 0, 0, 0, time.UTC),
+			Flow:       models.FlowHeavy,
+			SymptomIDs: []uint{bSymptom.ID},
+			Notes:      "owner B note",
+		},
+		{
+			UserID:     ownerA.ID,
+			Date:       time.Date(2026, time.February, 12, 0, 0, 0, 0, time.UTC),
+			Flow:       models.FlowLight,
+			SymptomIDs: []uint{aSymptom.ID},
+			Notes:      "owner A note",
+		},
+	}
+	if err := database.Create(&logs).Error; err != nil {
+		t.Fatalf("create logs: %v", err)
+	}
+
+	from := time.Date(2026, time.February, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, time.February, 28, 0, 0, 0, 0, time.UTC)
+
+	exported, symptomNames, err := exportService.LoadDataForRange(context.Background(), ownerA.ID, &from, &to, time.UTC)
+	if err != nil {
+		t.Fatalf("LoadDataForRange for owner A: %v", err)
+	}
+	// Positive anchor first: A's own day must be in the export, so an export that
+	// returned nothing at all cannot pass the isolation assertions vacuously.
+	if len(exported) != 1 {
+		t.Fatalf("expected owner A's single day, got %d rows", len(exported))
+	}
+	if exported[0].UserID != ownerA.ID {
+		t.Fatalf("cross-owner leak: exported day belongs to owner %d, not requesting owner A (%d)", exported[0].UserID, ownerA.ID)
+	}
+	if exported[0].Notes != "owner A note" {
+		t.Fatalf("expected owner A's own day, got notes %q", exported[0].Notes)
+	}
+
+	// And no trace of owner B: neither B's rows nor B's symptom names.
+	for _, logEntry := range exported {
+		if logEntry.UserID == ownerB.ID || logEntry.Notes == "owner B note" {
+			t.Fatalf("cross-owner leak: owner B's day %s reached owner A's export", CalendarDayKey(logEntry.Date))
+		}
+	}
+	if _, leaked := symptomNames[bSymptom.ID]; leaked {
+		t.Fatalf("cross-owner leak: owner B's symptom id %d reached owner A's export", bSymptom.ID)
+	}
+	for symptomID, name := range symptomNames {
+		if name == "Owner B Only" {
+			t.Fatalf("cross-owner leak: owner B's symptom name reached owner A's export as id %d", symptomID)
+		}
+	}
+	if symptomNames[aSymptom.ID] != "Owner A Only" {
+		t.Fatalf("expected owner A's own symptom name in the export, got %q", symptomNames[aSymptom.ID])
+	}
+
+	// The summary is a separate read of the day repository, so it carries the owner
+	// on its own: B's earlier day would widen the range even where the row list is
+	// scoped correctly.
+	summary, err := exportService.BuildSummary(context.Background(), ownerA.ID, &from, &to, time.UTC)
+	if err != nil {
+		t.Fatalf("BuildSummary for owner A: %v", err)
+	}
+	if summary.TotalEntries != 1 {
+		t.Fatalf("expected owner A's single entry in the summary, got %d", summary.TotalEntries)
+	}
+	if summary.DateFrom != "2026-02-12" || summary.DateTo != "2026-02-12" {
+		t.Fatalf("expected summary range 2026-02-12..2026-02-12, got %s..%s", summary.DateFrom, summary.DateTo)
+	}
+
+	// Owner B still exports B's own day: the scoping is a filter on the requesting
+	// owner, not an export path that dropped the second account's data entirely.
+	exportedB, symptomNamesB, err := exportService.LoadDataForRange(context.Background(), ownerB.ID, &from, &to, time.UTC)
+	if err != nil {
+		t.Fatalf("LoadDataForRange for owner B: %v", err)
+	}
+	if len(exportedB) != 1 || exportedB[0].UserID != ownerB.ID {
+		t.Fatalf("expected owner B's own single day, got %#v", exportedB)
+	}
+	if symptomNamesB[bSymptom.ID] != "Owner B Only" {
+		t.Fatalf("expected owner B's own symptom name in B's export, got %q", symptomNamesB[bSymptom.ID])
+	}
+}
+
 func TestExportServiceBuildSummaryForRangeFiltersInclusiveBoundaries(t *testing.T) {
 	dayService, database := newDayServiceIntegration(t)
 	user := createDayServiceTestUser(t, database, "export-range-summary-service@example.com")

--- a/internal/services/export_service_test.go
+++ b/internal/services/export_service_test.go
@@ -12,9 +12,13 @@ import (
 type stubExportDayReader struct {
 	logs []models.DailyLog
 	err  error
+	// ownerIDs records the owner operand of every read, so a build that exported
+	// under some other account's id can be observed instead of merely assumed.
+	ownerIDs []uint
 }
 
-func (stub *stubExportDayReader) FetchLogsForOptionalRange(context.Context, uint, *time.Time, *time.Time, *time.Location) ([]models.DailyLog, error) {
+func (stub *stubExportDayReader) FetchLogsForOptionalRange(_ context.Context, userID uint, _ *time.Time, _ *time.Time, _ *time.Location) ([]models.DailyLog, error) {
+	stub.ownerIDs = append(stub.ownerIDs, userID)
 	if stub.err != nil {
 		return nil, stub.err
 	}
@@ -26,15 +30,69 @@ func (stub *stubExportDayReader) FetchLogsForOptionalRange(context.Context, uint
 type stubExportSymptomReader struct {
 	symptoms []models.SymptomType
 	err      error
+	// ownerIDs records the owner operand of every catalog read; symptom names are
+	// per-owner rows, so an unscoped read here leaks another account's labels.
+	ownerIDs []uint
 }
 
-func (stub *stubExportSymptomReader) FetchSymptoms(context.Context, uint) ([]models.SymptomType, error) {
+func (stub *stubExportSymptomReader) FetchSymptoms(_ context.Context, userID uint) ([]models.SymptomType, error) {
+	stub.ownerIDs = append(stub.ownerIDs, userID)
 	if stub.err != nil {
 		return nil, stub.err
 	}
 	result := make([]models.SymptomType, len(stub.symptoms))
 	copy(result, stub.symptoms)
 	return result, nil
+}
+
+// TestExportServiceReadsEveryEntryPointUnderTheActingOwner pins the owner operand
+// of the export read path on both collaborators. Until the stubs above recorded
+// it, every export test asserted shapes and counts only, so a read that fetched a
+// constant owner's days or symptom catalog stayed green — the privacy boundary in
+// docs/SECURITY_INVARIANTS.md forbids exactly that. Each of the four entry points
+// is driven separately: they are independent call sites, and one of them losing
+// the owner must not be masked by the other three.
+func TestExportServiceReadsEveryEntryPointUnderTheActingOwner(t *testing.T) {
+	const actingOwnerID uint = 8137
+
+	days := &stubExportDayReader{logs: []models.DailyLog{
+		{Date: mustParseExportDay(t, "2026-02-18"), SymptomIDs: []uint{1}},
+	}}
+	symptoms := &stubExportSymptomReader{symptoms: []models.SymptomType{{ID: 1, Name: "Cramps"}}}
+	service := NewExportService(days, symptoms)
+
+	ctx := context.Background()
+	if _, _, err := service.LoadDataForRange(ctx, actingOwnerID, nil, nil, time.UTC); err != nil {
+		t.Fatalf("LoadDataForRange() unexpected error: %v", err)
+	}
+	if _, err := service.BuildSummary(ctx, actingOwnerID, nil, nil, time.UTC); err != nil {
+		t.Fatalf("BuildSummary() unexpected error: %v", err)
+	}
+	if _, err := service.BuildJSONEntries(ctx, actingOwnerID, nil, nil, time.UTC); err != nil {
+		t.Fatalf("BuildJSONEntries() unexpected error: %v", err)
+	}
+	if _, err := service.BuildCSVRows(ctx, actingOwnerID, nil, nil, time.UTC); err != nil {
+		t.Fatalf("BuildCSVRows() unexpected error: %v", err)
+	}
+
+	// Positive anchors: all four entry points read days, and the three that resolve
+	// symptom names read the catalog. A run that reached a collaborator fewer times
+	// than that fails here rather than passing as "no mismatched owner found".
+	assertExportOwnerObserved(t, "day reader", days.ownerIDs, 4, actingOwnerID)
+	assertExportOwnerObserved(t, "symptom reader", symptoms.ownerIDs, 3, actingOwnerID)
+}
+
+func assertExportOwnerObserved(t *testing.T, collaborator string, observed []uint, wantCalls int, wantOwnerID uint) {
+	t.Helper()
+
+	if len(observed) != wantCalls {
+		t.Fatalf("expected %d %s reads, got %d", wantCalls, collaborator, len(observed))
+	}
+	for index, ownerID := range observed {
+		if ownerID != wantOwnerID {
+			t.Fatalf("%s read #%d ran for owner %d, want acting owner %d", collaborator, index+1, ownerID, wantOwnerID)
+		}
+	}
 }
 
 func TestExportBuildSummaryUsesDateBounds(t *testing.T) {


### PR DESCRIPTION
## What this fixes

Audit record **R2-0507** (P1, `authz-scope` / `test-coverage-gap`): the export-service tests never
proved owner scoping.

- `internal/services/export_service_test.go:17,:31` — both export stubs declared an **unnamed**
  `uint` and recorded nothing, so no unit test could observe which account was queried.
- `internal/services/export_service_integration_test.go` seeded exactly **one** user per database,
  and its assertions compared row counts and dates only — which cannot distinguish owners whatever
  id is forwarded.

Production was, and is, correct: `export_service.go:199` forwards
`FetchLogsForOptionalRange(ctx, userID, …)`, `:204` `FetchSymptoms(ctx, userID)` and `:218` the
summary's own day read. This is a missing guard, not a live leak — but an export that read another
account's days or symptom catalog would have shipped green through this layer, and the privacy
boundary in `docs/SECURITY_INVARIANTS.md` is exactly that no surface may expose another account's
data.

`internal/services/export_service.go` is **byte-identical to `origin/main`**: this change is tests
only.

## The guard

**Unit** — `internal/services/export_service_test.go`
- Both stubs name the owner operand and append it to an `ownerIDs` slice (`:12-48`).
- `TestExportServiceReadsEveryEntryPointUnderTheActingOwner` drives all four entry points —
  `LoadDataForRange`, `BuildSummary`, `BuildJSONEntries`, `BuildCSVRows` — under owner `8137` and
  asserts every recorded read carries it. The expected call counts (4 day reads, 3 catalog reads,
  matching the production call sites) are the positive anchor: a run that reached a collaborator
  fewer times than that fails instead of passing as "no mismatch found".

**Integration** — `internal/services/export_service_integration_test.go`
- `assertExportServiceScopesRangeExportToRequestingOwner` seeds two independent owners on one
  database (household self-hosting), owner B **first** so B holds the lowest user id — the constant
  a regression would fetch. Each owner gets a custom symptom and one day row.
- Exporting as owner A asserts: exactly one row, owned by A (positive anchor, so the isolation
  assertions cannot pass vacuously); zero B rows; B's symptom id and name absent from the resolved
  names; A's own symptom name present; and a summary range of `2026-02-12..2026-02-12`, since B's
  earlier day would widen it even where the row list is scoped. A closing read as owner B proves
  the scoping is a filter, not an export path that dropped the second account entirely.
- Both dialects run it, via the `…` / `…Postgres` wrapper pair the neighbouring assertions in this
  file already use.

## Evidence

### Three steps: defect in, guard red, defect out

**1. Break production, run the *original* suite — green, i.e. blind.** All three repository calls in
`export_service.go` changed to fetch owner `1`:

```
$ go test -count=1 -run 'Export' ./internal/services/
ok  	github.com/ovumcy/ovumcy-web/internal/services	15.152s

$ go test -count=1 -timeout 20m -run 'Export' ./internal/api/
ok  	github.com/ovumcy/ovumcy-web/internal/api	11.307s
```

The api layer is included because the record's open counter-claim was whether the invariant is
covered one layer down. It is not.

**2. Add the guard, defect still in — red, naming the culprit.**

```
$ go test -count=1 -run 'TestExportServiceReadsEveryEntryPointUnderTheActingOwner|TestExportServiceScopesRangeExportToRequestingOwner' ./internal/services/
--- FAIL: TestExportServiceScopesRangeExportToRequestingOwner (0.25s)
    export_service_integration_test.go:140: cross-owner leak: exported day belongs to owner 1, not requesting owner A (2)
--- FAIL: TestExportServiceReadsEveryEntryPointUnderTheActingOwner (0.00s)
    export_service_test.go:81: day reader read #1 ran for owner 1, want acting owner 8137
FAIL
FAIL	github.com/ovumcy/ovumcy-web/internal/services	8.894s
```

**3. Restore production — green.**

```
$ gofmt -l internal/services/export_service.go internal/services/export_service_test.go internal/services/export_service_integration_test.go
$ go build ./... && go vet ./internal/services/
$ go test -count=1 -timeout 20m ./internal/services/...
ok  	github.com/ovumcy/ovumcy-web/internal/services	169.233s

$ golangci-lint run ./internal/services/...
0 issues.

$ go run ./scripts/changelogd check
changelog fragment check OK.
```

### One red check per seam

A mutant per change proves the set, not the member, so each owner-carrying call site was broken on
its own — both lanes react to each:

**Symptom catalog alone** (`export_service.go:204` → `FetchSymptoms(ctx, 1)`):

```
--- FAIL: TestExportServiceScopesRangeExportToRequestingOwner (0.15s)
    export_service_integration_test.go:153: cross-owner leak: owner B's symptom id 1 reached owner A's export
--- FAIL: TestExportServiceReadsEveryEntryPointUnderTheActingOwner (0.00s)
    export_service_test.go:82: symptom reader read #1 ran for owner 1, want acting owner 8137
```

**Summary's own day read alone** (`export_service.go:218`):

```
--- FAIL: TestExportServiceScopesRangeExportToRequestingOwner (0.48s)
    export_service_integration_test.go:175: expected summary range 2026-02-12..2026-02-12, got 2026-02-10..2026-02-10
--- FAIL: TestExportServiceReadsEveryEntryPointUnderTheActingOwner (0.00s)
    export_service_test.go:81: day reader read #2 ran for owner 1, want acting owner 8137
```

**Day read alone** (`export_service.go:199`) is the step-2 output above; the same mutation was also
re-run against the Postgres wrapper on its own, see below.

### Postgres lane

The twin executes against a real container here rather than skipping — the wall-time gap is the
tell:

```
$ go test -count=1 -v -run 'TestExportServiceScopesRangeExportToRequestingOwner' ./internal/services/
--- PASS: TestExportServiceScopesRangeExportToRequestingOwner (1.92s)
--- PASS: TestExportServiceScopesRangeExportToRequestingOwnerPostgres (12.55s)
```

Red check on the Postgres lane alone, with `export_service.go:199` fetching owner `1`:

```
$ go test -count=1 -run 'TestExportServiceScopesRangeExportToRequestingOwnerPostgres' ./internal/services/
--- FAIL: TestExportServiceScopesRangeExportToRequestingOwnerPostgres (11.91s)
    export_service_integration_test.go:206: cross-owner leak: exported day belongs to owner 1, not requesting owner A (2)
```

After every mutation the file was restored from `origin/main` and the empty diff re-confirmed.

## Review

One finding came out of review and is closed here.

- **The owner-isolation case had no Postgres twin.** It first landed calling `newDayServiceIntegration`
  directly, while every other integration assertion in this file is a shared `assertX(t, setup, email)`
  helper with a SQLite and a Postgres wrapper. That convention exists because this repository keeps a
  separate Postgres migration set: a divergence there that weakened the `user_id` predicate on the
  daily-log read — precisely the leak this case exists to catch — would have left a SQLite-only test
  green.
- **Closed in `414c9426`** by extracting
  `assertExportServiceScopesRangeExportToRequestingOwner(t, setup, emailA, emailB)` and adding both
  wrappers with distinct emails per dialect, following the neighbours. Adding them needs nothing
  started: `internal/testdb/postgres.go:34` skips when the `docker` binary is absent, and
  `:141-149` turns any docker failure into a skip, so an unreachable daemon skips rather than fails.
  The Postgres lane was then red-checked on its own, above.

## Scope and rollback

Three files: the two export test files plus `changelog.d/test-export-service-owner-identity.md`
(`none` — test-only, no user-visible change). No production file is touched, so a revert is a single
commit and restores nothing but the blind spot.
