### PR TITLE
fix(docs): pin example env templates to the current release image

### DIFF
--- a/changelog.d/fix-example-env-image-pin.md
+++ b/changelog.d/fix-example-env-image-pin.md
@@ -1,0 +1,21 @@
+### Fixed
+
+- **The two public Postgres example env templates no longer downgrade the stack they ship with.**
+  `docs/examples/reverse-proxy/caddy-postgres/.env.example` and its nginx twin pinned
+  `OVUMCY_IMAGE=ghcr.io/ovumcy/ovumcy-web:v0.8.4`, while the `docker-compose.yml` beside each one
+  defaults to `${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.9.2}`. The runbook links both files as
+  the env template and instructs an operator to copy them to `.env` before the first start, and an
+  assignment in `.env` wins over the compose default — so the documented setup path deployed a
+  pre-1.0 image on a stack written for the current release, skipping every intervening fix and
+  migration. Both now pin `v1.9.2`; the three other examples carry no override and already floated
+  to the compose default.
+
+### Internal
+
+- **`scripts/readmeversion` now also guards the example env templates against release-tag drift.**
+  Nothing re-checked those pins when the release tag moved, which is why they were six minors
+  behind. `TestExampleEnvImagePinsMatchReleaseTag` walks every `.env.example` under
+  `docs/examples/`, and requires an active `OVUMCY_IMAGE` assignment to name the published image at
+  the exact release tag README.md asserts. It fails closed the way the neighbouring guards do: no
+  templates, no pin in any of them, or a pin that is not an exact release tag (`:latest`, a digest)
+  each fail rather than pass quietly.

--- a/docs/examples/reverse-proxy/caddy-postgres/.env.example
+++ b/docs/examples/reverse-proxy/caddy-postgres/.env.example
@@ -1,4 +1,4 @@
-OVUMCY_IMAGE=ghcr.io/ovumcy/ovumcy-web:v0.8.4
+OVUMCY_IMAGE=ghcr.io/ovumcy/ovumcy-web:v1.9.2
 TZ=UTC
 DEFAULT_LANGUAGE=en
 # Set exactly one secret source before first start. SECRET_KEY takes precedence if both are set.

--- a/docs/examples/reverse-proxy/nginx-postgres/.env.example
+++ b/docs/examples/reverse-proxy/nginx-postgres/.env.example
@@ -1,4 +1,4 @@
-OVUMCY_IMAGE=ghcr.io/ovumcy/ovumcy-web:v0.8.4
+OVUMCY_IMAGE=ghcr.io/ovumcy/ovumcy-web:v1.9.2
 TZ=UTC
 DEFAULT_LANGUAGE=en
 # Set exactly one secret source before first start. SECRET_KEY takes precedence if both are set.

--- a/scripts/readmeversion/main_test.go
+++ b/scripts/readmeversion/main_test.go
@@ -4,12 +4,19 @@
 // verification examples, and the Releases section) with no single source of
 // truth, so a release bump that updates one occurrence and misses another
 // goes unnoticed. This test asserts every occurrence agrees.
+//
+// The same drift reaches the shipped example stacks: an `.env.example` under
+// docs/examples/ that pins OVUMCY_IMAGE overrides its own compose file's
+// default, and the runbook tells an operator to copy that template verbatim.
+// So the release tag README.md asserts is also the tag every example env
+// template must pin.
 package readmeversion
 
 import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"testing"
 )
 
@@ -19,12 +26,167 @@ var releaseTagPatterns = []*regexp.Regexp{
 	regexp.MustCompile("Latest tagged release: `v(\\d+\\.\\d+\\.\\d+)`"),
 }
 
+// envImageAssignment matches any uncommented line in an example env template
+// whose assignment target is OVUMCY_IMAGE, optionally exported, and captures
+// everything to the right of the `=`. Keying on the KEY rather than on a
+// well-formed value is the point: a pattern anchored to the value shape it
+// expects SKIPS every other shape, and a skipped template is precisely the one
+// that drifts unnoticed: a pattern running the value to end of line passes
+// over `OVUMCY_IMAGE=...:v0.8.4 # keep in sync with README` and over an
+// `export` prefix, and the walk below still reports success, because the
+// remaining templates keep its pin count non-zero.
+var envImageAssignment = regexp.MustCompile(`(?m)^[ \t]*(?:export[ \t]+)?OVUMCY_IMAGE[ \t]*=(.*)$`)
+
+// ovumcyImageRef matches the published runtime image at an exact release tag.
+var ovumcyImageRef = regexp.MustCompile(`^ghcr\.io/ovumcy/ovumcy-web:v(\d+\.\d+\.\d+)$`)
+
 // TestReadmeReleaseTagsAgree asserts every occurrence of the current release
 // tag in README.md is the same version. It fails closed: finding zero
 // occurrences is itself a failure, so a rewording that stops matching the
 // patterns above cannot silently stop being checked.
 func TestReadmeReleaseTagsAgree(t *testing.T) {
+	found := readmeReleaseTags(t, repoRoot(t))
+
+	want := found[0]
+	for _, got := range found[1:] {
+		if got != want {
+			t.Errorf("README.md release tags disagree: found both v%s and v%s; update every occurrence to the same released version", want, got)
+		}
+	}
+}
+
+// TestExampleEnvImagePinsMatchReleaseTag asserts that every `.env.example`
+// under docs/examples/ which pins OVUMCY_IMAGE names the same release tag
+// README.md asserts. An example env template is copied to `.env` as the first
+// setup step, and the assignment wins over the `${OVUMCY_IMAGE:-...}` default
+// in the compose file beside it, so a template left behind at an older tag
+// silently downgrades the stack it ships with.
+//
+// It fails closed twice over: no `.env.example` files at all, or no
+// OVUMCY_IMAGE pin in any of them, is a failure rather than a pass, so neither
+// a moved example stack nor a dropped pin can leave the guard checking
+// nothing. A value that is not the published image at an exact release tag is
+// reported too — an unparsable pin is a pin nobody is comparing.
+func TestExampleEnvImagePinsMatchReleaseTag(t *testing.T) {
 	root := repoRoot(t)
+	want := readmeReleaseTags(t, root)[0]
+	examplesDir := filepath.Join(root, "docs", "examples")
+
+	var templates, pins int
+	err := filepath.WalkDir(examplesDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || d.Name() != ".env.example" {
+			return nil
+		}
+		templates++
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+
+		rel, _ := filepath.Rel(root, path)
+		rel = filepath.ToSlash(rel)
+		for _, m := range envImageAssignment.FindAllSubmatch(content, -1) {
+			pins++
+			value := envImageValue(string(m[1]))
+			ref := ovumcyImageRef.FindStringSubmatch(value)
+			if ref == nil {
+				t.Errorf("%s: OVUMCY_IMAGE=%q is not ghcr.io/ovumcy/ovumcy-web at an exact release tag, so nothing can tell which image an operator copying this template would run", rel, value)
+				continue
+			}
+			if ref[1] != want {
+				t.Errorf("%s: OVUMCY_IMAGE pins v%s while the release tag asserted in README.md is v%s; copying this template overrides the compose default and deploys the older image", rel, ref[1], want)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", examplesDir, err)
+	}
+	if templates == 0 {
+		t.Fatalf("no .env.example files found under %s: the drift guard has nothing to check", examplesDir)
+	}
+	if pins == 0 {
+		t.Fatalf("no OVUMCY_IMAGE assignment found in any .env.example under %s: the drift guard has nothing to check", examplesDir)
+	}
+}
+
+// TestEnvImageAssignmentMatchesEveryPinShape proves the matcher keys on the
+// assignment target rather than on one value shape, using inline fixtures
+// rather than the real templates. The trailing-comment and `export` cases are
+// the regression: a value-anchored pattern skipped both, so a template written
+// either way contributed no pin at all — it could carry a stale tag while the
+// walk above passed, since the other templates kept the pin count non-zero.
+func TestEnvImageAssignmentMatchesEveryPinShape(t *testing.T) {
+	const image = "ghcr.io/ovumcy/ovumcy-web:v1.9.2"
+
+	pinned := []struct {
+		name string
+		line string
+		want string
+	}{
+		{"bare assignment", "OVUMCY_IMAGE=" + image, image},
+		{"trailing comment", "OVUMCY_IMAGE=" + image + " # keep in sync with README", image},
+		{"export prefix", "export OVUMCY_IMAGE=" + image, image},
+		{"double quoted", `OVUMCY_IMAGE="` + image + `"`, image},
+		{"single quoted with comment", "OVUMCY_IMAGE='" + image + "'  # note", image},
+		{"indented and padded", "  OVUMCY_IMAGE =  " + image + "  ", image},
+		{"empty value", "OVUMCY_IMAGE=", ""},
+		{"stale tag with comment", "OVUMCY_IMAGE=ghcr.io/ovumcy/ovumcy-web:v0.8.4 # pinned", "ghcr.io/ovumcy/ovumcy-web:v0.8.4"},
+	}
+	for _, tc := range pinned {
+		t.Run(tc.name, func(t *testing.T) {
+			matches := envImageAssignment.FindAllStringSubmatch(tc.line+"\nTZ=UTC\n", -1)
+			if len(matches) != 1 {
+				t.Fatalf("%q: expected exactly one OVUMCY_IMAGE assignment, got %d", tc.line, len(matches))
+			}
+			if got := envImageValue(matches[0][1]); got != tc.want {
+				t.Fatalf("%q: got value %q, want %q", tc.line, got, tc.want)
+			}
+		})
+	}
+
+	ignored := []struct {
+		name string
+		line string
+	}{
+		{"commented out", "# OVUMCY_IMAGE=" + image},
+		{"different variable", "OVUMCY_IMAGE_TAG=v1.9.2"},
+		{"key as a suffix", "EXTRA_OVUMCY_IMAGE=" + image},
+	}
+	for _, tc := range ignored {
+		t.Run(tc.name, func(t *testing.T) {
+			if matches := envImageAssignment.FindAllStringSubmatch(tc.line+"\nTZ=UTC\n", -1); len(matches) != 0 {
+				t.Fatalf("%q: expected no OVUMCY_IMAGE assignment, got %d", tc.line, len(matches))
+			}
+		})
+	}
+}
+
+// envImageValue reduces the captured right-hand side of an OVUMCY_IMAGE line
+// to the image reference it sets: surrounding whitespace, one pair of matching
+// quotes and a trailing `#` comment are removed. Whatever remains is compared
+// against the release tag and, when it does not parse as an image reference,
+// reported verbatim — never dropped.
+func envImageValue(raw string) string {
+	value := strings.TrimSpace(raw)
+	if i := strings.Index(value, "#"); i >= 0 {
+		value = strings.TrimSpace(value[:i])
+	}
+	if len(value) >= 2 && (value[0] == '"' || value[0] == '\'') && value[len(value)-1] == value[0] {
+		value = value[1 : len(value)-1]
+	}
+	return value
+}
+
+// readmeReleaseTags returns every release-tag occurrence in README.md, in the
+// order releaseTagPatterns finds them. It fails closed for its callers: zero
+// occurrences aborts the test, so a rewording that stops matching the patterns
+// cannot silently turn a guard built on this tag into a no-op.
+func readmeReleaseTags(t *testing.T, root string) []string {
+	t.Helper()
 	content, err := os.ReadFile(filepath.Join(root, "README.md"))
 	if err != nil {
 		t.Fatalf("read README.md: %v", err)
@@ -36,17 +198,10 @@ func TestReadmeReleaseTagsAgree(t *testing.T) {
 			found = append(found, string(m[1]))
 		}
 	}
-
 	if len(found) == 0 {
 		t.Fatal("no release-tag occurrences found in README.md: the drift guard has nothing to check")
 	}
-
-	want := found[0]
-	for _, got := range found[1:] {
-		if got != want {
-			t.Errorf("README.md release tags disagree: found both v%s and v%s; update every occurrence to the same released version", want, got)
-		}
-	}
+	return found
 }
 
 func repoRoot(t *testing.T) string {


### PR DESCRIPTION
## What this fixes

Record **R2-0819** (P1, config-ops, confirmed): both public Postgres reverse-proxy example
templates pinned the runtime image to a pre-1.0 tag while the compose file beside each one
defaults to the current release.

- `docs/examples/reverse-proxy/caddy-postgres/.env.example:1` and
  `docs/examples/reverse-proxy/nginx-postgres/.env.example:1` set
  `OVUMCY_IMAGE=ghcr.io/ovumcy/ovumcy-web:v0.8.4`.
- Their own `docker-compose.yml:22` defaults `image: ${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.9.2}`.
- `docs/self-hosted.md:176,:180` link both files as the "Env template" for those stacks, and
  `:211-212` instruct copying the example `docker-compose.yml` and `.env.example` and renaming the
  latter to `.env`. An assignment in `.env` wins over the compose default, so the documented setup
  path deployed **v0.8.4** on a stack written for **v1.9.2** — skipping every intervening fix and
  migration, silently, with a green healthcheck.

The other three examples (`docs/examples/postgres/`, `reverse-proxy/caddy/`, `reverse-proxy/nginx/`)
carry no `OVUMCY_IMAGE` override at all and already floated to the compose default. Nothing
re-checked these two pins when the release tag moved, which is how they fell six minors behind.

## The tag, and where it comes from

`v1.9.2`, derived from this repository at the time of the change rather than copied from the
record:

- `git tag --list` → `v1.9.2` is the newest tag; `gh release list` → `v1.9.2  Latest  2026-07-24`.
- `README.md` asserts it in six places, which is exactly the set `TestReadmeReleaseTagsAgree`
  already holds together — so the guard added here reuses that value instead of introducing a
  second source of truth.
- All five example `docker-compose.yml` defaults and the root `docker-compose.yml` name it.

`SECURITY.md:28,:36` shows `ghcr.io/ovumcy/ovumcy-web:v1.1.0` in the cosign and attestation
examples. That is deliberate and out of scope here: the line above them reads "replace `v1.1.0`
with the tag you are pulling", so it illustrates a command rather than asserting the current
release. It is not a missed site.

## The guard

`scripts/readmeversion` is the home: it already owns "the current release tag" as a concept and
computes it from `README.md`. The sibling `scripts/examplecompose` guards compose *semantics*
(the postgres 18+ `PGDATA` mount), not versions.

`TestExampleEnvImagePinsMatchReleaseTag` walks every `.env.example` under `docs/examples/`, and for
each active `OVUMCY_IMAGE` assignment requires the published image at exactly the release tag
`README.md` asserts. `readmeReleaseTags` was extracted from the existing test so both guards read
that tag the same way, including its fail-closed behaviour.

The matcher keys on the assignment **target**, not on a value shape:

```go
var envImageAssignment = regexp.MustCompile(`(?m)^[ \t]*(?:export[ \t]+)?OVUMCY_IMAGE[ \t]*=(.*)$`)
```

`envImageValue` then reduces the captured right-hand side — trims whitespace, cuts a trailing `#`
comment, strips one matching quote pair — and whatever remains is either compared to the release
tag or reported verbatim. Nothing is dropped. As a side effect `(.*)$` absorbs a `\r`, so the guard
does not depend on the checkout's line endings.

## Red, then green — the pin drift

With the pins as they were (`v0.8.4`), against the new guard:

```
=== RUN   TestExampleEnvImagePinsMatchReleaseTag
    main_test.go:99: docs/examples/reverse-proxy/caddy-postgres/.env.example: OVUMCY_IMAGE pins v0.8.4 while the release tag asserted in README.md is v1.9.2; copying this template overrides the compose default and deploys the older image
    main_test.go:99: docs/examples/reverse-proxy/nginx-postgres/.env.example: OVUMCY_IMAGE pins v0.8.4 while the release tag asserted in README.md is v1.9.2; copying this template overrides the compose default and deploys the older image
--- FAIL: TestExampleEnvImagePinsMatchReleaseTag (0.00s)
exit=1
```

With both pins corrected to `v1.9.2`:

```
=== RUN   TestExampleEnvImagePinsMatchReleaseTag
--- PASS: TestExampleEnvImagePinsMatchReleaseTag (0.00s)
ok  	github.com/ovumcy/ovumcy-web/scripts/readmeversion	1.152s
exit=0
```

## Red, then green — the matcher hole

The first draft of the matcher ran the value to end of line (`(\S*)[ \t]*$`), which **skips** any
other shape instead of reporting it. Demonstrated end-to-end through the walk, with a temporary
third template `docs/examples/_probe/.env.example` holding
`OVUMCY_IMAGE=ghcr.io/ovumcy/ovumcy-web:v0.8.4 # keep in sync with README` — a stale pin that a
release bump would leave behind:

```
# value-anchored draft: the stale pin is invisible
=== RUN   TestExampleEnvImagePinsMatchReleaseTag
--- PASS: TestExampleEnvImagePinsMatchReleaseTag (0.00s)
exit=0

# keyed on the assignment target: the same file is named
=== RUN   TestExampleEnvImagePinsMatchReleaseTag
    main_test.go:99: docs/examples/_probe/.env.example: OVUMCY_IMAGE pins v0.8.4 while the release tag asserted in README.md is v1.9.2; copying this template overrides the compose default and deploys the older image
--- FAIL: TestExampleEnvImagePinsMatchReleaseTag (0.00s)
exit=1
```

The probe template was removed afterwards; it is not part of this change. `pins == 0` did not fire
in the first run because the two real templates kept the count non-zero — which is precisely why a
skipped file is worse than a missing one.

`TestEnvImageAssignmentMatchesEveryPinShape` pins that permanently, on inline fixtures rather than
the real templates: eight shapes that must be recognised (bare, trailing comment, `export` prefix,
quoted, quoted with comment, indented and padded, empty value, stale tag with comment) and three
that must not (`# OVUMCY_IMAGE=`, `OVUMCY_IMAGE_TAG=`, `EXTRA_OVUMCY_IMAGE=`). Reverting the
regex to the value-anchored draft turns four of them red, so the test is sensitive by
construction:

```
--- FAIL: TestEnvImageAssignmentMatchesEveryPinShape/trailing_comment
        "OVUMCY_IMAGE=ghcr.io/ovumcy/ovumcy-web:v1.9.2 # keep in sync with README": expected exactly one OVUMCY_IMAGE assignment, got 0
--- FAIL: TestEnvImageAssignmentMatchesEveryPinShape/export_prefix
--- FAIL: TestEnvImageAssignmentMatchesEveryPinShape/single_quoted_with_comment
--- FAIL: TestEnvImageAssignmentMatchesEveryPinShape/stale_tag_with_comment
```

## Fail-closed, both branches exercised

Neither is dead code; both were reached by running them:

- Every `.env.example` under `docs/examples/` moved aside →
  `no .env.example files found under …\docs\examples: the drift guard has nothing to check` (Fatal).
- All `OVUMCY_IMAGE` lines commented out →
  `no OVUMCY_IMAGE assignment found in any .env.example under …\docs\examples: the drift guard has nothing to check` (Fatal).

So neither a moved example stack nor a dropped pin can leave the guard passing over nothing. A pin
that is not the published image at an exact release tag (`:latest`, a digest, an empty value) is
reported rather than skipped.

## Review

Two findings from review of this branch, both closed here:

1. **The matcher was anchored to a value shape, so a differently written pin was silently skipped**
   — `OVUMCY_IMAGE=…:v0.8.4 # keep in sync with README` or `export OVUMCY_IMAGE=…` matched nothing,
   contributed no pin, and could not trip `pins == 0` while the other templates kept the count
   non-zero. A third template written that way would have carried a stale tag past a green guard —
   the exact drift this exists to prevent — and the doc comment claimed the opposite. Closed by
   keying on the assignment target and reporting an unparsable value verbatim (`envImageValue`),
   with the comment brought back into agreement and `TestEnvImageAssignmentMatchesEveryPinShape`
   added as the standing proof.
2. **The fail-closed branches were asserted but not exercised** — both are now shown failing above.

## Known neighbouring gap, deliberately not fixed here

The `${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v1.9.2}` defaults in the five example compose files
and in the root `docker-compose.yml` are checked against nothing: if a release bump misses one, no
test notices. Same drift class, different sites, outside R2-0819 — its own finding and its own
pull request, not widened into this one.

## Verification

- `go build ./...` — exit 0
- `go test -count=1 ./scripts/readmeversion/` — ok (3 tests)
- `gofmt -l scripts/readmeversion/main_test.go` — no output
- `golangci-lint run ./scripts/readmeversion/...` — 0 issues
- `go run ./scripts/changelogd check` — OK

## Rollback

Single-commit revert. No persisted data, schema or public contract is touched.
