### PR TITLE
fix(services): withhold the first-cycle fertile save message, and make day-service settings writes name their owner

### DIFF
--- a/changelog.d/fix-g06-first-cycle-fertile-save-message-owner-scoped-day-stubs.md
+++ b/changelog.d/fix-g06-first-cycle-fertile-save-message-owner-scoped-day-stubs.md
@@ -1,0 +1,21 @@
+### Fixed
+
+- **Saving a day during a first tracked cycle no longer announces a fertile
+  window.** With a single logged period start no cycle has closed yet, so there
+  are no observed cycle lengths and the fertility window is the default cycle
+  length projected forward with the default luteal phase — configuration, not
+  anything the account recorded. The save confirmation stated it as fact ("You
+  are in your fertile window right now"), which is the estimate-presented-as-fact
+  the medical-safety rule forbids: where the only source is configuration
+  defaults, the surface is withheld rather than qualified. The day save now falls
+  back to its neutral confirmation until the first cycle closes; from the first
+  completed cycle on, the fertile message is unchanged, as are the self-care,
+  pregnancy-paused and unpredictable-cycle messages.
+
+### Internal
+
+- The day-service test doubles for the user repository now record the owner id of
+  every settings read and write, and the day tests assert that every such call
+  targets the acting owner. The id used to be discarded, so a settings write
+  aimed at another account — the luteal phase, the period tip, the long-period
+  warning — passed the whole day suite unnoticed.

--- a/internal/services/day_feedback_policy.go
+++ b/internal/services/day_feedback_policy.go
@@ -110,6 +110,15 @@ func resolveDaySaveMessageKey(user *models.User, day time.Time, stats CycleStats
 	// configuration defaults, suppression is the floor and a qualifier is not
 	// enough (docs/SECURITY_INVARIANTS.md -> medical safety), so the save falls
 	// back to the neutral message rather than softening the fertile one.
+	//
+	// FOLLOW-UP: this is the fifth surface carrying that same zero-completed-cycle
+	// floor, and the only one still spelling it out for itself — the calendar day
+	// states, the .ics feed, the webhook reminder and the dashboard reminder
+	// banner are being collapsed behind one shared suppression predicate in this
+	// package. Fold this call into that predicate once it exists: a floor stated
+	// at N of N+1 sites diverges the moment the shared one gains a disjunct or is
+	// narrowed to let a recorded observation through, and this site would keep the
+	// old rule silently.
 	if !DashboardAwaitingFirstCycle(stats) &&
 		!stats.FertilityWindowStart.IsZero() &&
 		!day.Before(stats.FertilityWindowStart) &&

--- a/internal/services/day_feedback_policy.go
+++ b/internal/services/day_feedback_policy.go
@@ -100,7 +100,20 @@ func resolveDaySaveMessageKey(user *models.User, day time.Time, stats CycleStats
 			return daySaveMessageSelfCare
 		}
 	}
-	if !stats.FertilityWindowStart.IsZero() && !day.Before(stats.FertilityWindowStart) && !day.After(stats.FertilityWindowEnd) {
+	// The fertile line is a claim about right now, so it may only be made from
+	// something the account recorded. Until the first cycle closes
+	// (DashboardAwaitingFirstCycle, the same tier the dashboard withholds its
+	// fertility surfaces at) there are no observed cycle lengths, so
+	// predictedCycleLength falls through to models.DefaultCycleLength and the
+	// window is that default projected forward with the default luteal phase.
+	// Display confidence follows data confidence: where the only source is
+	// configuration defaults, suppression is the floor and a qualifier is not
+	// enough (docs/SECURITY_INVARIANTS.md -> medical safety), so the save falls
+	// back to the neutral message rather than softening the fertile one.
+	if !DashboardAwaitingFirstCycle(stats) &&
+		!stats.FertilityWindowStart.IsZero() &&
+		!day.Before(stats.FertilityWindowStart) &&
+		!day.After(stats.FertilityWindowEnd) {
 		return daySaveMessageFertile
 	}
 	return daySaveMessageNeutral

--- a/internal/services/day_feedback_policy_test.go
+++ b/internal/services/day_feedback_policy_test.go
@@ -26,6 +26,9 @@ func TestResolveDayFeedbackUsesSelfCareMessageForEarlyPeriodDays(t *testing.T) {
 	}
 }
 
+// The positive anchor for the suppression below: one COMPLETED cycle (two
+// observed starts) makes the fertility window an observation of this account,
+// and the fertile save message renders.
 func TestResolveDayFeedbackUsesFertileMessageDuringFertilityWindow(t *testing.T) {
 	logs := newDayLogRepositoryStub()
 	users := &dayUserRepositoryStub{}
@@ -40,6 +43,57 @@ func TestResolveDayFeedbackUsesFertileMessageDuringFertilityWindow(t *testing.T)
 	}
 	if state.MessageKey != daySaveMessageFertile {
 		t.Fatalf("expected fertile message, got %q", state.MessageKey)
+	}
+}
+
+// TestResolveDayFeedbackWithholdsTheFertileMessageBeforeTheFirstCompletedCycle
+// pins the medical-safety floor for the day-save message: with a single logged
+// period start the account has completed no cycle, so cycleLengths returns
+// nothing, the median and the average stay 0, and predictedCycleLength falls
+// through to models.DefaultCycleLength. The fertility window that comes out is
+// that default projected forward with the default luteal phase — configuration,
+// not observation. Display confidence follows data confidence there:
+// suppression is the floor and a qualifier is not enough
+// (docs/SECURITY_INVARIANTS.md → medical safety), so the save message drops
+// back to the neutral one.
+func TestResolveDayFeedbackWithholdsTheFertileMessageBeforeTheFirstCompletedCycle(t *testing.T) {
+	logs := newDayLogRepositoryStub()
+	users := &dayUserRepositoryStub{}
+	service := NewDayService(logs, users)
+
+	firstStart := mustParseDayFeedbackDate(t, "2026-03-01")
+	seeded := make([]models.DailyLog, 0, 4)
+	for offset := range 4 {
+		day := firstStart.AddDate(0, 0, offset)
+		entry := models.DailyLog{UserID: 10, Date: day, IsPeriod: true}
+		logs.entries[day.Format("2006-01-02")] = entry
+		seeded = append(seeded, entry)
+	}
+
+	// The precondition this guard rests on, asserted rather than assumed: no
+	// completed cycle, and the requested day genuinely inside the projected
+	// window — otherwise the test could go green on a window that moved.
+	day := mustParseDayFeedbackDate(t, "2026-03-12")
+	stats := BuildCycleStats(seeded, day)
+	if stats.CompletedCycleCount != 0 {
+		t.Fatalf("expected zero completed cycles from one logged period start, got %d", stats.CompletedCycleCount)
+	}
+	if stats.FertilityWindowStart.IsZero() || day.Before(stats.FertilityWindowStart) || day.After(stats.FertilityWindowEnd) {
+		t.Fatalf("expected %s inside the projected fertility window %s..%s",
+			day.Format("2006-01-02"),
+			stats.FertilityWindowStart.Format("2006-01-02"),
+			stats.FertilityWindowEnd.Format("2006-01-02"))
+	}
+
+	state, err := service.ResolveDayFeedback(context.Background(), &models.User{ID: 10}, day, day, time.UTC)
+	if err != nil {
+		t.Fatalf("ResolveDayFeedback() unexpected error: %v", err)
+	}
+	if state.MessageKey == daySaveMessageFertile {
+		t.Fatal("expected no fertile claim on a window derived only from configuration defaults")
+	}
+	if state.MessageKey != daySaveMessageNeutral {
+		t.Fatalf("expected the neutral save message before the first completed cycle, got %q", state.MessageKey)
 	}
 }
 

--- a/internal/services/day_feedback_policy_test.go
+++ b/internal/services/day_feedback_policy_test.go
@@ -232,6 +232,9 @@ func TestAcknowledgeLongPeriodWarningPersistsCycleStart(t *testing.T) {
 	if got := users.settings.LongPeriodWarnedAt.Format("2006-01-02"); got != "2026-03-01" {
 		t.Fatalf("expected persisted warning date 2026-03-01, got %s", got)
 	}
+	// The written map is only half of the claim: the acknowledgement must land
+	// on the acting owner's row, never on another account's.
+	users.assertUserRepositoryCallsTargetOwner(t, 10)
 }
 
 func mustParseDayFeedbackDate(t *testing.T, raw string) time.Time {

--- a/internal/services/day_service_coverage_test.go
+++ b/internal/services/day_service_coverage_test.go
@@ -33,16 +33,38 @@ type dayserviceCovUserStub struct {
 	// AcknowledgePeriodTip persistence capture.
 	shownPeriodTipPersisted bool
 	shownPeriodTipValue     bool
+
+	// userIDs records the owner id of every user-repository call in arrival
+	// order. Without it, updateCalls counts that a write happened but says
+	// nothing about which account it landed on, and owner scoping
+	// (docs/SECURITY_INVARIANTS.md, privacy boundary) stays unfalsifiable here.
+	userIDs []uint
 }
 
-func (s *dayserviceCovUserStub) LoadSettingsByID(context.Context, uint) (models.User, error) {
+// assertUserRepositoryCallsTargetOwner mirrors the workflow stub's guard: at
+// least one call, and every recorded id is the acting owner.
+func (s *dayserviceCovUserStub) assertUserRepositoryCallsTargetOwner(t *testing.T, want uint) {
+	t.Helper()
+	if len(s.userIDs) == 0 {
+		t.Fatalf("expected at least one user-repository call for owner %d, saw none", want)
+	}
+	for index, got := range s.userIDs {
+		if got != want {
+			t.Fatalf("user-repository call %d targeted owner %d, want the acting owner %d", index+1, got, want)
+		}
+	}
+}
+
+func (s *dayserviceCovUserStub) LoadSettingsByID(_ context.Context, userID uint) (models.User, error) {
+	s.userIDs = append(s.userIDs, userID)
 	if s.loadErr != nil {
 		return models.User{}, s.loadErr
 	}
 	return s.settings, nil
 }
 
-func (s *dayserviceCovUserStub) UpdateByID(ctx context.Context, _ uint, updates map[string]any) error {
+func (s *dayserviceCovUserStub) UpdateByID(ctx context.Context, userID uint, updates map[string]any) error {
+	s.userIDs = append(s.userIDs, userID)
 	s.updateCalls++
 	if s.updateErr != nil {
 		return s.updateErr
@@ -642,6 +664,7 @@ func TestDayService_RefreshDerivedCycleSettings_EmptyLogSetPersistsDefaultLuteal
 	if users.settings.LutealPhase != defaultLutealPhaseDays {
 		t.Fatalf("expected the default luteal phase %d to be persisted when inference has no data, got %d", defaultLutealPhaseDays, users.settings.LutealPhase)
 	}
+	users.assertUserRepositoryCallsTargetOwner(t, 10)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/services/day_service_mutation_round3_test.go
+++ b/internal/services/day_service_mutation_round3_test.go
@@ -161,16 +161,37 @@ type mr3dayUserStub struct {
 	settings    models.User
 	loadErr     error
 	lastUpdates map[string]any
+	// userIDs records the owner id of every user-repository call, so a mutant
+	// that swaps the acting owner for another account is observable here rather
+	// than only in the written map (docs/SECURITY_INVARIANTS.md, privacy
+	// boundary).
+	userIDs []uint
 }
 
-func (s *mr3dayUserStub) LoadSettingsByID(context.Context, uint) (models.User, error) {
+// assertUserRepositoryCallsTargetOwner mirrors the workflow stub's guard: at
+// least one call, and every recorded id is the acting owner.
+func (s *mr3dayUserStub) assertUserRepositoryCallsTargetOwner(t *testing.T, want uint) {
+	t.Helper()
+	if len(s.userIDs) == 0 {
+		t.Fatalf("expected at least one user-repository call for owner %d, saw none", want)
+	}
+	for index, got := range s.userIDs {
+		if got != want {
+			t.Fatalf("user-repository call %d targeted owner %d, want the acting owner %d", index+1, got, want)
+		}
+	}
+}
+
+func (s *mr3dayUserStub) LoadSettingsByID(_ context.Context, userID uint) (models.User, error) {
+	s.userIDs = append(s.userIDs, userID)
 	if s.loadErr != nil {
 		return models.User{}, s.loadErr
 	}
 	return s.settings, nil
 }
 
-func (s *mr3dayUserStub) UpdateByID(ctx context.Context, _ uint, updates map[string]any) error {
+func (s *mr3dayUserStub) UpdateByID(ctx context.Context, userID uint, updates map[string]any) error {
+	s.userIDs = append(s.userIDs, userID)
 	s.lastUpdates = updates
 	return nil
 }
@@ -228,6 +249,7 @@ func TestMR3Day_ClearAutoFilledPeriodNeighbors_NonUTCCoverage(t *testing.T) {
 	if !logs.entries["2026-02-11"].IsPeriod {
 		t.Fatal("the anchor day 2026-02-11 must not be cleared")
 	}
+	users.assertUserRepositoryCallsTargetOwner(t, 10)
 }
 
 // NOTE: day_feedback_policy.go:62 NEGATION (`if location != nil { cycleStart =
@@ -264,6 +286,7 @@ func TestMR3Day_UpsertDayEntryWithAutoFillAt_ReturnsPopulatedEntry(t *testing.T)
 	if entry.Flow != models.FlowMedium {
 		t.Fatalf("returned entry Flow = %q, want %q", entry.Flow, models.FlowMedium)
 	}
+	users.assertUserRepositoryCallsTargetOwner(t, 10)
 }
 
 // --- day_service.go:448 NEGATION — MarkCycleStartManually tx-close propagates error ---
@@ -288,6 +311,7 @@ func TestMR3Day_MarkCycleStartManually_PropagatesTxError(t *testing.T) {
 	if !errors.Is(err, ErrManualCycleStartFailed) {
 		t.Fatalf("expected ErrManualCycleStartFailed wrap, got %v", err)
 	}
+	users.assertUserRepositoryCallsTargetOwner(t, 10)
 }
 
 func mr3dayKeys(stub *mr3dayLogStub) []string {

--- a/internal/services/day_service_workflow_test.go
+++ b/internal/services/day_service_workflow_test.go
@@ -177,9 +177,31 @@ type dayUserRepositoryStub struct {
 	// later read in the same write — the counterpart of saveErrFromCall above.
 	loadErrFromCall int
 	loadCalls       int
+	// userIDs records the owner id of every LoadSettingsByID and UpdateByID
+	// call in arrival order. Discarding it left owner scoping unfalsifiable at
+	// this layer: any mutation of the id argument passed the whole day suite,
+	// so a settings write aimed at another account read as a clean run.
+	userIDs []uint
 }
 
-func (stub *dayUserRepositoryStub) LoadSettingsByID(context.Context, uint) (models.User, error) {
+// assertUserRepositoryCallsTargetOwner fails unless the stub saw at least one
+// call and every one of them carried want. The "at least one" half matters as
+// much as the comparison: a seam that was never reached is unobservable, not
+// proven, and a loop over an empty slice would report success about nothing.
+func (stub *dayUserRepositoryStub) assertUserRepositoryCallsTargetOwner(t *testing.T, want uint) {
+	t.Helper()
+	if len(stub.userIDs) == 0 {
+		t.Fatalf("expected at least one user-repository call for owner %d, saw none", want)
+	}
+	for index, got := range stub.userIDs {
+		if got != want {
+			t.Fatalf("user-repository call %d targeted owner %d, want the acting owner %d", index+1, got, want)
+		}
+	}
+}
+
+func (stub *dayUserRepositoryStub) LoadSettingsByID(_ context.Context, userID uint) (models.User, error) {
+	stub.userIDs = append(stub.userIDs, userID)
 	stub.loadCalls++
 	if stub.loadErr != nil && stub.loadCalls >= stub.loadErrFromCall {
 		return models.User{}, stub.loadErr
@@ -187,7 +209,8 @@ func (stub *dayUserRepositoryStub) LoadSettingsByID(context.Context, uint) (mode
 	return stub.settings, nil
 }
 
-func (stub *dayUserRepositoryStub) UpdateByID(ctx context.Context, _ uint, updates map[string]any) error {
+func (stub *dayUserRepositoryStub) UpdateByID(ctx context.Context, userID uint, updates map[string]any) error {
+	stub.userIDs = append(stub.userIDs, userID)
 	if updates == nil {
 		return nil
 	}
@@ -743,5 +766,94 @@ func TestMarkCycleStartManuallyWrapsPersistenceFailure(t *testing.T) {
 	}
 	if logs.entries["2026-02-08"].CycleStart {
 		t.Fatalf("failed persistence must not leave the cycle-start flag set in the read model")
+	}
+}
+
+// TestDayServiceUserRepositoryCallsTargetTheActingOwner is the owner-scope
+// guard for every seam where DayService reaches the user repository: the
+// autofill settings read, the inline cycle-start confirmation, the manual
+// cycle-start policy read, the derived-settings refresh and both
+// acknowledgements. The privacy boundary scopes a per-user read or write to the
+// acting account and to no other (docs/SECURITY_INVARIANTS.md), and until the
+// stub recorded the id nothing at this layer could tell a correctly scoped call
+// from one aimed at a different row: replacing every id with a literal 1 left
+// the whole day suite — and the API suite — green.
+func TestDayServiceUserRepositoryCallsTargetTheActingOwner(t *testing.T) {
+	const actingOwner uint = 10
+
+	testCases := []struct {
+		name    string
+		arrange func(logs *dayLogRepositoryStub)
+		act     func(t *testing.T, service *DayService)
+	}{
+		{
+			name: "the day save reads the autofill settings, confirms the cycle start and refreshes the derived ones",
+			arrange: func(logs *dayLogRepositoryStub) {
+				logs.entries["2026-02-01"] = models.DailyLog{
+					ID: 1, UserID: actingOwner,
+					Date:     time.Date(2026, time.February, 1, 0, 0, 0, 0, time.UTC),
+					IsPeriod: true, CycleStart: true,
+				}
+			},
+			act: func(t *testing.T, service *DayService) {
+				t.Helper()
+				day := time.Date(2026, time.March, 1, 0, 0, 0, 0, time.UTC)
+				if _, err := service.UpsertDayEntryWithAutoFillAt(context.Background(), actingOwner, day,
+					DayEntryInput{IsPeriod: true, Flow: models.FlowMedium, ConfirmCycleStart: true}, day, time.UTC); err != nil {
+					t.Fatalf("UpsertDayEntryWithAutoFillAt() unexpected error: %v", err)
+				}
+			},
+		},
+		{
+			name: "the manual cycle start reads the policy settings and refreshes the derived ones",
+			arrange: func(logs *dayLogRepositoryStub) {
+				logs.entries["2026-02-08"] = models.DailyLog{
+					ID: 2, UserID: actingOwner,
+					Date:     time.Date(2026, time.February, 8, 0, 0, 0, 0, time.UTC),
+					IsPeriod: true, Flow: models.FlowLight,
+				}
+			},
+			act: func(t *testing.T, service *DayService) {
+				t.Helper()
+				targetDay := time.Date(2026, time.February, 8, 0, 0, 0, 0, time.UTC)
+				if err := service.MarkCycleStartManually(context.Background(), actingOwner, targetDay, targetDay, time.UTC, ManualCycleStartOptions{}); err != nil {
+					t.Fatalf("MarkCycleStartManually() unexpected error: %v", err)
+				}
+			},
+		},
+		{
+			name:    "the period tip acknowledgement",
+			arrange: func(*dayLogRepositoryStub) {},
+			act: func(t *testing.T, service *DayService) {
+				t.Helper()
+				if err := service.AcknowledgePeriodTip(context.Background(), actingOwner); err != nil {
+					t.Fatalf("AcknowledgePeriodTip() unexpected error: %v", err)
+				}
+			},
+		},
+		{
+			name:    "the long-period warning acknowledgement",
+			arrange: func(*dayLogRepositoryStub) {},
+			act: func(t *testing.T, service *DayService) {
+				t.Helper()
+				cycleStart := time.Date(2026, time.March, 1, 0, 0, 0, 0, time.UTC)
+				if err := service.AcknowledgeLongPeriodWarning(context.Background(), actingOwner, cycleStart, time.UTC); err != nil {
+					t.Fatalf("AcknowledgeLongPeriodWarning() unexpected error: %v", err)
+				}
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			logs := newDayLogRepositoryStub()
+			users := &dayUserRepositoryStub{settings: models.User{PeriodLength: 4}}
+			service := NewDayService(logs, users)
+			testCase.arrange(logs)
+
+			testCase.act(t, service)
+
+			users.assertUserRepositoryCallsTargetOwner(t, actingOwner)
+		})
 	}
 }


### PR DESCRIPTION
Two P1 records from the technical-debt board, group G06, wave 3: a fertility claim made from configuration defaults, and a pair of test doubles that made owner scoping unfalsifiable at the day-service layer.

## R2-0113 — the day-save fertile message is stated as fact when its window is a first-cycle default projection

With exactly one logged period start no cycle has closed yet: `cycleLengths` returns nil for a single start (`internal/services/cycles.go:518-521`), so `CompletedCycleCount` stays 0 and the median and average stay 0 (`:302-306`). `applyPredictedCycleStats` then calls `predictedCycleLength(0, 0)`, which falls through to `models.DefaultCycleLength` (`:373`), and with `stats.LutealPhase` already at `defaultLutealPhaseDays` (`:71`) the fertility window written at `:356-357` is derived entirely from configuration. `resolveDaySaveMessageKey` returned `daySaveMessageFertile` for any day inside that window with no completed-cycle check, and the copy states it as fact — "Saved. You are in your fertile window right now." It is reached on every day save, via `internal/api/handlers_days_write.go:121`, with no gating caller anywhere.

**The fix is suppression, not a qualifier.** The medical-safety invariant says display confidence follows data confidence, and where the only source is configuration defaults, suppression is the floor — a qualifier is not enough. `internal/services/day_feedback_policy.go:122` now guards the fertile branch with `!DashboardAwaitingFirstCycle(stats)`, and the save falls back to the neutral message until the first cycle closes. Two consequences worth stating explicitly:

- **No wording change and no new message key**, so no locale file is touched and locale parity is untouched. A qualifier would have been the wrong instrument here anyway: nothing observation-derived routes through this branch at zero completed cycles, so there is no honest estimate to qualify.
- **The existing exported predicate is reused rather than re-counted.** `DashboardAwaitingFirstCycle(stats)` is already the tier at which the dashboard withholds its fertility surfaces; a second count of the same thing is a second answer waiting to disagree.

The other four message keys — self-care, pregnancy-paused, unpredictable-cycle, neutral — are untouched, and the fertile message is unchanged from the first completed cycle on.

### Red, then green

Guard: `TestResolveDayFeedbackWithholdsTheFertileMessageBeforeTheFirstCompletedCycle` (`internal/services/day_feedback_policy_test.go:49-98`). It asserts its own preconditions before the claim — `CompletedCycleCount == 0`, and the requested day genuinely inside `FertilityWindowStart..FertilityWindowEnd` — so it cannot go green on a window that moved rather than on the rule it names.

Against the unfixed code:

```
=== RUN   TestResolveDayFeedbackWithholdsTheFertileMessageBeforeTheFirstCompletedCycle
    day_feedback_policy_test.go:93: expected no fertile claim on a window derived only from configuration defaults
--- FAIL: TestResolveDayFeedbackWithholdsTheFertileMessageBeforeTheFirstCompletedCycle (0.00s)
```

With the branch guarded, green — and `TestResolveDayFeedbackUsesFertileMessageDuringFertilityWindow` (`internal/services/day_feedback_policy_test.go:32`) stays green as the positive anchor: one completed cycle still renders the fertile message, so the suppression cannot quietly widen into "never fertile".

## R2-0491 — both day-service user-repository stubs discarded the owner id

`dayUserRepositoryStub.LoadSettingsByID` left both parameters unnamed and `UpdateByID(ctx, _ uint, updates)` discarded the id outright; `dayserviceCovUserStub.UpdateByID` and `mr3dayUserStub` did the same. `TestAcknowledgeLongPeriodWarningPersistsCycleStart` passed owner id 10 and asserted only the written map, never the target row. The privacy boundary scopes every per-user read and write to the acting account; here nothing at this layer could tell a correctly scoped call from one aimed at a different account's row.

All three doubles now record the owner id of every `LoadSettingsByID` and `UpdateByID` call in arrival order and expose `assertUserRepositoryCallsTargetOwner(t, want)`, which requires **at least one** call and then that every recorded id is the acting owner. The "at least one" half carries its own weight: a seam that was never reached is unobservable rather than proven, and a loop over an empty slice would report success about nothing.

The new table guard `TestDayServiceUserRepositoryCallsTargetTheActingOwner` (`internal/services/day_service_workflow_test.go:781-859`) covers every seam where `DayService` reaches the user repository — the autofill settings read, the inline cycle-start confirmation, the manual cycle-start policy read, the derived-settings refresh, and both acknowledgements. Assertions were also added to `TestAcknowledgeLongPeriodWarningPersistsCycleStart` (`internal/services/day_feedback_policy_test.go:237`), `TestDayService_RefreshDerivedCycleSettings_EmptyLogSetPersistsDefaultLutealPhase` (`internal/services/day_service_coverage_test.go:667`) and the three `TestMR3Day_*` tests.

### Three-step evidence: break, guard, restore

**1. Break the production behaviour — the suite stays green.** All six day-service user-repository call sites (`internal/services/day_service.go:326, 458, 505, 589, 733` and `internal/services/day_feedback_policy.go:77`) had their `userID` argument replaced with the literal `1`:

```
ok  	github.com/ovumcy/ovumcy-web/internal/services	103.975s
ok  	github.com/ovumcy/ovumcy-web/internal/api	468.342s
```

Both suites green with every day-service settings read and write aimed at account 1. The gap is wider than the record claimed: the API layer does not catch it either.

**2. Add the recording and the assertions — the same defect goes red, naming the culprit.**

```
--- FAIL: TestAcknowledgeLongPeriodWarningPersistsCycleStart
    day_feedback_policy_test.go:237: user-repository call 1 targeted owner 1, want the acting owner 10
--- FAIL: TestDayService_RefreshDerivedCycleSettings_EmptyLogSetPersistsDefaultLutealPhase
    day_service_coverage_test.go:667: user-repository call 1 targeted owner 1, want the acting owner 10
--- FAIL: TestMR3Day_ClearAutoFilledPeriodNeighbors_NonUTCCoverage
--- FAIL: TestMR3Day_UpsertDayEntryWithAutoFillAt_ReturnsPopulatedEntry
--- FAIL: TestMR3Day_MarkCycleStartManually_PropagatesTxError
--- FAIL: TestDayServiceUserRepositoryCallsTargetTheActingOwner
    --- FAIL: .../the_day_save_reads_the_autofill_settings,_confirms_the_cycle_start_and_refreshes_the_derived_ones
    --- FAIL: .../the_manual_cycle_start_reads_the_policy_settings_and_refreshes_the_derived_ones
    --- FAIL: .../the_period_tip_acknowledgement
    --- FAIL: .../the_long-period_warning_acknowledgement
```

**3. Restore `userID` — green.** The production diff against `main` is empty for both files; the change for this record is tests only.

### Per-seam sensitivity, not just all-seams-at-once

Review re-derived this independently by breaking **one** seam on its own — `AcknowledgeLongPeriodWarning`'s `UpdateByID(ctx, userID, …)` → `UpdateByID(ctx, 1, …)`. Both `TestAcknowledgeLongPeriodWarningPersistsCycleStart` and the table guard went red naming the culprit, so the guard localises a single misrouted write rather than only a wholesale substitution. Tree restored, `git status` clean.

## Review

Review re-derived both fixes rather than taking them on trust: reverting the `!DashboardAwaitingFirstCycle(stats) &&` term returned the R2-0113 guard to red at `day_feedback_policy_test.go:93`, and the single-seam break above confirmed per-seam sensitivity for R2-0491. One finding came back, and it is fixed in `dd32ddfc`:

**The day-save fertile branch is the fifth surface carrying the same zero-completed-cycle floor, and the only one that will not route through the shared predicate.** A sibling PR on this same wave is collapsing that identical floor on four surfaces — calendar day states, the `.ics` feed, the webhook reminder, the dashboard reminder banner — behind one shared suppression predicate in this package. This site calls `DashboardAwaitingFirstCycle(stats)` directly. Once both land, a later correction to the shared floor — a new disjunct, or a narrowing so that a recorded observation still permits the claim — would update four surfaces and silently leave the day-save confirmation on the old rule. That is the N-of-N+1 divergence this repository treats as a new defect rather than a partial fix.

The two changes cannot depend on each other, so nothing is imported here. The coupling is made findable instead: a `FOLLOW-UP` note at the call site (`internal/services/day_feedback_policy.go:114-121`) names the other four surfaces and says this site is to be folded into the shared predicate once it exists.

**Follow-up, explicitly outliving this PR:** fold `resolveDaySaveMessageKey`'s fertile branch into the shared suppression predicate as soon as that predicate lands, and delete the note. Until that happens the floor is stated in two places with one meaning, which is the state the note exists to make visible.

## Verification

- `gofmt -l` on the touched files: clean.
- `go build ./...`: clean.
- `go test -count=1 ./internal/services/... ./internal/i18n/...`: ok.
- `golangci-lint run ./internal/services/...`: 0 issues.
- `go run ./scripts/changelogd check`: OK.
- `internal/api` was exercised during the defect-injection run above with the R2-0113 suppression already in place, and stayed green — the fertile suppression breaks no transport-layer expectation.

**Pre-existing, not from this PR:** `gofmt -l internal/services/` also lists `day_service.go`, `settings_view_service.go` and `webhook_reminder.go`. Those three are unmodified here (`git diff origin/main...HEAD` does not include them) and are already divergent on `main` — struct-field alignment and list-item comment reformatting from a newer gofmt. `ptrDayFeedbackTime`, which a linter may flag near the touched test code, is likewise pre-existing on `main`.

## Scope

`internal/i18n/locales/*`, `internal/services/cycles.go` and `internal/services/day_service.go` were in the group's permitted file list but needed no change and are untouched. No file outside the list was modified; the changelog fragment is `changelog.d/fix-g06-first-cycle-fertile-save-message-owner-scoped-day-stubs.md`.

Rollback: single-commit revert per record; nothing here alters persisted data or a public contract.
