### PR TITLE
fix(prediction): hold the first-cycle fertility floor on every surface

### DIFF
--- a/changelog.d/fix-first-cycle-prediction-floor.md
+++ b/changelog.d/fix-first-cycle-prediction-floor.md
@@ -1,0 +1,34 @@
+### Fixed
+
+- **No fertile window, peak band or ovulation day before the first cycle is complete — on any
+  surface.** Until one cycle has been observed, that window is nothing but the onboarding
+  cycle-length slider projected forward, and the dashboard header has always withheld it. Four other
+  surfaces did not: the calendar grid painted a fertile window, a peak band and an ovulation day; the
+  `.ics` feed pushed three ovulation events into subscribed calendar clients, where they outlive any
+  correction made in the app; the webhook pass sent an ovulation reminder to the configured endpoint;
+  and the dashboard's own reminder banner counted down to a date the header beside it was declining
+  to name. All four now stay quiet until a cycle closes, and resume with the first completed one. The
+  next-period estimate is unchanged everywhere — it is anchored on a day that was actually recorded
+  and carries its own estimate qualifier — and so are recorded observations such as logged period
+  days and the BBT signal.
+- **One stats page, one cycle history.** A cycle start marked uncertain was honoured by the insights
+  ribbon and ignored by the phase cards on the same page, so the page reported one merged 56-day
+  cycle in one panel and two 28-day cycles in the other — and the merged length then fed the
+  cycle-factor comparison, which labelled that fabricated cycle "longer" and attributed the logged
+  factors to it. Both halves now read the same detector, the one that honours an explicit start and
+  withholds a cluster whose only explicit start is uncertain.
+- **The stats current-phase card states its phase where it can be read.** On a stale cycle the card
+  withheld the phase in words only; it now carries the unknown phase and fertility status in the
+  same attributes the rest of the page exposes, so the withholding is visible to assistive
+  technology and pinnable by a test.
+
+### Internal
+
+- The three suppression signals every projected surface shares (`PredictionsSuppressed`) and the
+  first-cycle fertility floor on top of them (`FertilityProjectionSuppressed`) live in one place
+  each, instead of being written out once per surface — which is how the floor came to be missing
+  from four of them without a failing test.
+- The stats service doubles now record the owner id of all four owner-scoped reads (ranged logs, all
+  logs, frequency calculation, symptom catalogue) and can serve different data per owner. A
+  two-owner stats render pins each seam: every one of the four could previously have been re-pointed
+  at a constant owner with the whole stats selection still green.

--- a/changelog.d/fix-first-cycle-prediction-floor.md
+++ b/changelog.d/fix-first-cycle-prediction-floor.md
@@ -27,7 +27,9 @@
 - The three suppression signals every projected surface shares (`PredictionsSuppressed`) and the
   first-cycle fertility floor on top of them (`FertilityProjectionSuppressed`) live in one place
   each, instead of being written out once per surface — which is how the floor came to be missing
-  from four of them without a failing test.
+  from four of them without a failing test. Surfaces built from the dashboard cycle context read the
+  decision that context already resolved rather than recombining the signals for themselves, so a
+  future disjunct reaches all of them at once.
 - The stats service doubles now record the owner id of all four owner-scoped reads (ranged logs, all
   logs, frequency calculation, symptom catalogue) and can serve different data per owner. A
   two-owner stats render pins each seam: every one of the four could previously have been re-pointed

--- a/e2e/a11y-wcag-audit.spec.ts
+++ b/e2e/a11y-wcag-audit.spec.ts
@@ -59,8 +59,13 @@ test.describe('WCAG AA audit regressions', () => {
     await page.setViewportSize({ width: 1280, height: 900 });
 
     // A recorded cycle start paints period cells and the fertile window that
-    // follows it, so both phase fills are on the page.
+    // follows it, so both phase fills are on the page. The window itself is
+    // withheld until one cycle has been observed, so the previous cycle's start
+    // is seeded too, exactly one 28-day cycle earlier: that is the length the
+    // account settings already carry, so the fertile days land where they always
+    // did and this case keeps measuring contrast rather than the data tier.
     const today = await todayISOFromDashboard(page);
+    await markCycleStart(page, shiftISODate(today, -34));
     await markCycleStart(page, shiftISODate(today, -6));
 
     await page.goto('/calendar');

--- a/e2e/bugs.spec.ts
+++ b/e2e/bugs.spec.ts
@@ -292,7 +292,7 @@ test.describe('Bug regressions', () => {
 
     });
 
-    test('calendar marks the current baseline period window before manual day logs exist', async ({
+    test('calendar marks the current baseline period window, and withholds the fertile half of it, before manual day logs exist', async ({
       page,
     }) => {
       const creds = await registerOwnerAndReachDashboard(page, 'bug01-baseline-period');
@@ -328,7 +328,13 @@ test.describe('Bug regressions', () => {
 
       await page.goto(`/calendar?month=${currentDay.slice(0, 7)}&day=${currentDay}`);
       await expect(page.locator(`button[data-day="${currentDay}"]`)).toHaveClass(/calendar-cell-predicted/);
-      await expect(page.locator(`button[data-day="${preFertileDay}"]`)).toHaveAttribute('data-calendar-state', 'pre-fertile');
+      // The account has recorded no cycle, so the fertile half of the projection
+      // is withheld: the day after the baseline period window would be shaded
+      // from the cycle-length slider alone, and a fertility claim with only a
+      // configuration default behind it is suppressed rather than qualified. The
+      // predicted period days asserted above stay — their anchor is the last
+      // period start the owner entered, and only the length falls back.
+      await expect(page.locator(`button[data-day="${preFertileDay}"]`)).toHaveAttribute('data-calendar-state', 'default');
     });
 
     test('onboarding with auto period fill disabled does not create logged-entry markers', async ({

--- a/e2e/calendar.spec.ts
+++ b/e2e/calendar.spec.ts
@@ -12,7 +12,7 @@ import { applyTheme } from './support/contrast-helpers';
 import { saveSettingsLanguage } from './support/language-helpers';
 import { expectElementAboveMobileTabbar } from './support/mobile-layout-helpers';
 import { ensureNotesFieldVisible } from './support/note-helpers';
-import { openCalendarDayEditor, saveDayEditorForm } from './support/stats-helpers';
+import { markCycleStart, openCalendarDayEditor, saveDayEditorForm } from './support/stats-helpers';
 import { setRequestTimezoneFromBrowser } from './support/timezone-helpers';
 import { checkStyledControl } from './support/form-helpers';
 import { selectOnboardingStartDate } from './support/onboarding-helpers';
@@ -563,6 +563,14 @@ test.describe('Calendar page', () => {
     ]);
     await setRequestTimezoneFromBrowser(page);
 
+    // The demotion acts on the PREDICTED ovulation day, and that projection is
+    // withheld until one cycle has been observed. Log this cycle's start and the
+    // previous one exactly 28 days before it — the length the account settings
+    // already carry — so the observed cycle changes nothing about where the
+    // predicted ovulation lands, and the latest logged start is still today-13.
+    await markCycleStart(page, shiftISODate(startISO, -28));
+    await markCycleStart(page, startISO);
+
     // Enable TrackBBT via the tracking settings endpoint. Send the full
     // default snapshot — the JSON body parser does not treat missing fields
     // as no-op, so a single-field patch would wipe the other tracking flags.
@@ -678,6 +686,16 @@ test.describe('Calendar page', () => {
       stepTwoForm.locator('[data-onboarding-step2-submit]').click(),
     ]);
     await setRequestTimezoneFromBrowser(page);
+
+    // The fertile window is withheld until one cycle has been observed, so the
+    // two cycles before this one are logged as well, 28 days apart — the length
+    // the account settings already carry, so the window stays mid-month exactly
+    // as described above. Two of them, not one: on a run date that IS the 1st,
+    // the anchor itself has not closed a cycle yet, and the pair before it has.
+    const anchorISO = `${monthISO}-01`;
+    await markCycleStart(page, shiftISODate(anchorISO, -56));
+    await markCycleStart(page, shiftISODate(anchorISO, -28));
+    await markCycleStart(page, anchorISO);
 
     await page.goto(`/calendar?month=${monthISO}`);
     await expect(page.locator('[data-calendar-view]')).toHaveAttribute('data-usage-goal', 'health');

--- a/internal/api/calendar_ovulation_tag_regression_test.go
+++ b/internal/api/calendar_ovulation_tag_regression_test.go
@@ -34,14 +34,21 @@ func TestCalendarRendersOvulationTagWithoutFertileOverride(t *testing.T) {
 		t.Fatalf("update user cycle settings: %v", err)
 	}
 
-	for offset := range 5 {
-		if err := database.Create(&models.DailyLog{
-			UserID:   user.ID,
-			Date:     periodStart.AddDate(0, 0, offset),
-			IsPeriod: true,
-			Flow:     models.FlowMedium,
-		}).Error; err != nil {
-			t.Fatalf("create period log day %d: %v", offset, err)
+	// The ovulation markers ride the first-cycle floor: the grid withholds a
+	// window whose only source is the cycle-length slider until one cycle has
+	// been observed. So the fixture carries the previous cycle as well, exactly
+	// one 28-day cycle back — the same length the account settings already carry,
+	// which leaves every projected date where this test pins it.
+	for _, cycleStart := range []time.Time{periodStart.AddDate(0, 0, -28), periodStart} {
+		for offset := range 5 {
+			if err := database.Create(&models.DailyLog{
+				UserID:   user.ID,
+				Date:     cycleStart.AddDate(0, 0, offset),
+				IsPeriod: true,
+				Flow:     models.FlowMedium,
+			}).Error; err != nil {
+				t.Fatalf("create period log %s day %d: %v", cycleStart.Format("2006-01-02"), offset, err)
+			}
 		}
 	}
 

--- a/internal/api/stats_stale_cycle_ui_regression_test.go
+++ b/internal/api/stats_stale_cycle_ui_regression_test.go
@@ -3,34 +3,71 @@ package api
 import (
 	"net/http"
 	"net/http/httptest"
-	"strconv"
 	"testing"
 	"time"
 
+	"github.com/gofiber/fiber/v3"
 	"github.com/ovumcy/ovumcy-web/internal/models"
 	"github.com/ovumcy/ovumcy-web/internal/services"
 	"golang.org/x/net/html"
 )
 
+// TestStatsPageShowsUnknownPhaseWhenCycleDataIsStale reads the phase the page
+// actually renders. The account has two completed cycles, so the insights grid
+// (and with it the current-phase card) is on screen and the only reason left to
+// withhold a phase is the stale anchor — the condition under test. Seeding no
+// cycles at all would replace the whole grid with the empty state, and the card
+// this test is named for would never be reached.
 func TestStatsPageShowsUnknownPhaseWhenCycleDataIsStale(t *testing.T) {
 	document := renderStatsPageWithStaleCycleData(t)
+
+	phaseValue := htmlFindElement(document, func(node *html.Node) bool {
+		return node.Type == html.ElementNode && htmlHasAttr(node, "data-stats-current-phase")
+	})
+	if phaseValue == nil {
+		t.Fatalf("expected the current-phase card to render with a data-stats-current-phase hook")
+	}
+	if got := htmlAttr(phaseValue, "data-stats-current-phase"); got != "unknown" {
+		t.Fatalf("expected the rendered phase to be unknown on a 60-day-stale cycle, got %q", got)
+	}
+	if got := htmlAttr(phaseValue, "data-fertility-status"); got != "unknown" {
+		t.Fatalf("expected the rendered fertility status to be unknown on a 60-day-stale cycle, got %q", got)
+	}
+
+	staleNote := htmlFindElement(document, func(node *html.Node) bool {
+		return node.Type == html.ElementNode && htmlHasAttr(node, "data-stats-phase-estimated")
+	})
+	if staleNote == nil {
+		t.Fatalf("expected the phase-estimated note beside the withheld phase")
+	}
+}
+
+// TestStatsPageRendersTheDetectedPhaseWhileTheAnchorIsCurrent is the positive
+// anchor for the case above: same fixture shape, a current anchor, so a change
+// that hard-coded the unknown phase would be caught here rather than read as a
+// pass.
+func TestStatsPageRendersTheDetectedPhaseWhileTheAnchorIsCurrent(t *testing.T) {
+	document := renderStatsPageForCycleAnchorAge(t, "stats-fresh-ui@example.com", 3)
+
+	phaseValue := htmlFindElement(document, func(node *html.Node) bool {
+		return node.Type == html.ElementNode && htmlHasAttr(node, "data-stats-current-phase")
+	})
+	if phaseValue == nil {
+		t.Fatalf("expected the current-phase card to render with a data-stats-current-phase hook")
+	}
+	if got := htmlAttr(phaseValue, "data-stats-current-phase"); got == "unknown" {
+		t.Fatalf("expected a detected phase while the cycle anchor is current, got %q", got)
+	}
+}
+
+func TestStatsPageEmptyStateUsesDedicatedProgressMeterWithoutInlineStyle(t *testing.T) {
+	document := renderStatsPageWithoutCompletedCycles(t)
 	emptyState := htmlFindElement(document, func(node *html.Node) bool {
 		return node.Type == html.ElementNode && htmlHasAttr(node, "data-stats-empty-state")
 	})
 	if emptyState == nil {
 		t.Fatalf("expected stats empty-state element with data-stats-empty-state attribute")
 	}
-	completedCycles, err := strconv.Atoi(htmlAttr(emptyState, "data-stats-completed-cycles"))
-	if err != nil {
-		t.Fatalf("expected data-stats-completed-cycles to be numeric, got %q", htmlAttr(emptyState, "data-stats-completed-cycles"))
-	}
-	if completedCycles >= 2 {
-		t.Fatalf("expected data-stats-completed-cycles < 2 (gating reason), got %d", completedCycles)
-	}
-}
-
-func TestStatsPageEmptyStateUsesDedicatedProgressMeterWithoutInlineStyle(t *testing.T) {
-	document := renderStatsPageWithStaleCycleData(t)
 	progressMeter := htmlElementByTagAndClass(document, "progress", "stats-progress-meter")
 	if progressMeter == nil {
 		t.Fatalf("expected stats empty state to render a dedicated progress meter")
@@ -42,9 +79,50 @@ func TestStatsPageEmptyStateUsesDedicatedProgressMeterWithoutInlineStyle(t *test
 
 func renderStatsPageWithStaleCycleData(t *testing.T) *html.Node {
 	t.Helper()
+	return renderStatsPageForCycleAnchorAge(t, "stats-stale-ui@example.com", 60)
+}
+
+// renderStatsPageForCycleAnchorAge seeds three period starts 30 days apart, the
+// most recent of them startedDaysAgo back, and renders /stats. Three starts are
+// two completed cycles, which is what unlocks the insights grid; with both
+// cycles the same length the reference length is that length, so the caller
+// controls staleness purely through the age of the latest anchor.
+func renderStatsPageForCycleAnchorAge(t *testing.T, email string, startedDaysAgo int) *html.Node {
+	t.Helper()
 
 	app, database := newOnboardingTestApp(t)
-	user := createOnboardingTestUser(t, database, "stats-stale-ui@example.com", "StrongPass1", true)
+	user := createOnboardingTestUser(t, database, email, "StrongPass1", true)
+	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
+
+	const cycleLength = 30
+	lastPeriodStart := services.DateAtLocation(time.Now().UTC(), time.UTC).AddDate(0, 0, -startedDaysAgo)
+	logs := []models.DailyLog{
+		{UserID: user.ID, Date: lastPeriodStart.AddDate(0, 0, -2*cycleLength), IsPeriod: true},
+		{UserID: user.ID, Date: lastPeriodStart.AddDate(0, 0, -cycleLength), IsPeriod: true},
+		{UserID: user.ID, Date: lastPeriodStart, IsPeriod: true},
+	}
+	if err := database.Create(&logs).Error; err != nil {
+		t.Fatalf("seed period logs: %v", err)
+	}
+	if err := database.Model(&models.User{}).Where("id = ?", user.ID).Updates(map[string]any{
+		"cycle_length":      28,
+		"period_length":     5,
+		"last_period_start": lastPeriodStart,
+	}).Error; err != nil {
+		t.Fatalf("update user cycle context: %v", err)
+	}
+
+	return renderStatsPageDocument(t, app, authCookie)
+}
+
+// renderStatsPageWithoutCompletedCycles keeps the empty-state fixture the
+// progress-meter case needs: an onboarded account with a cycle anchor and no
+// logged cycles at all.
+func renderStatsPageWithoutCompletedCycles(t *testing.T) *html.Node {
+	t.Helper()
+
+	app, database := newOnboardingTestApp(t)
+	user := createOnboardingTestUser(t, database, "stats-empty-ui@example.com", "StrongPass1", true)
 	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
 
 	lastPeriodStart := services.DateAtLocation(time.Now().UTC(), time.UTC).AddDate(0, 0, -60)
@@ -55,6 +133,12 @@ func renderStatsPageWithStaleCycleData(t *testing.T) *html.Node {
 	}).Error; err != nil {
 		t.Fatalf("update user cycle context: %v", err)
 	}
+
+	return renderStatsPageDocument(t, app, authCookie)
+}
+
+func renderStatsPageDocument(t *testing.T, app *fiber.App, authCookie string) *html.Node {
+	t.Helper()
 
 	request := httptest.NewRequest(http.MethodGet, "/stats", nil)
 	request.Header.Set("Accept-Language", "en")

--- a/internal/services/calendar_days.go
+++ b/internal/services/calendar_days.go
@@ -137,27 +137,42 @@ func buildCalendarPredictionMaps(user *models.User, logs []models.DailyLog, stat
 	ovulationMap := maps.ovulation
 	tentativeOvulationMap := maps.tentativeOvulation
 
-	// Medical-safety suppression gate, the same three signals every projected
-	// surface gates on: unpredictable-cycle mode, a pregnancy pause, or a cycle
-	// running past the account's reference length by more than a week
-	// (DashboardCycleOverdue). Past that point stats.NextPeriodStart is a date the
-	// account's own data no longer supports: appendPredictedCycles chains from it,
-	// so the grid painted a predicted period in the PAST — one that never happened
-	// — and then a phantom window every cycle length after it. Every prediction map
-	// stays empty here; the recorded facts (logged period days, has-data, sex
-	// activity) are read elsewhere and are untouched.
-	if DashboardPredictionDisabled(user) || stats.PregnancyPaused || DashboardCycleOverdue(user, stats) {
+	// Medical-safety suppression gate, the shared predicate every projected
+	// surface gates on (PredictionsSuppressed): unpredictable-cycle mode, a
+	// pregnancy pause, or a cycle running past the account's reference length by
+	// more than a week (DashboardCycleOverdue). Past that point
+	// stats.NextPeriodStart is a date the account's own data no longer supports:
+	// appendPredictedCycles chains from it, so the grid painted a predicted period
+	// in the PAST — one that never happened — and then a phantom window every
+	// cycle length after it. Every prediction map stays empty here; the recorded
+	// facts (logged period days, has-data, sex activity) are read elsewhere and
+	// are untouched.
+	if PredictionsSuppressed(user, stats) {
 		return maps
 	}
 
+	// The fertility half of the projection carries the extra first-cycle floor:
+	// until one cycle has been observed, the fertile window, the peak band and the
+	// ovulation day are the onboarding slider projected forward, so the grid
+	// paints none of them (FertilityProjectionSuppressed). The predicted period
+	// days keep their anchor in a recorded cycle start and stay.
+	fertilitySuppressed := FertilityProjectionSuppressed(user, stats)
+
 	appendCurrentBaselinePeriod(predictedPeriodMap, stats, location)
-	appendCurrentBaselinePreFertile(preFertileMap, stats, location)
-	appendFertilityWindow(fertilityEdgeMap, fertilityPeakMap, stats.FertilityWindowStart, stats.FertilityWindowEnd, stats.OvulationDate)
-	appendCalendarSingleDate(ovulationMap, stats.OvulationDate)
-	appendPredictedCycles(predictedPeriodMap, preFertileMap, fertilityEdgeMap, fertilityPeakMap, ovulationMap, stats, gridEnd, location)
+	if !fertilitySuppressed {
+		appendCurrentBaselinePreFertile(preFertileMap, stats, location)
+		appendFertilityWindow(fertilityEdgeMap, fertilityPeakMap, stats.FertilityWindowStart, stats.FertilityWindowEnd, stats.OvulationDate)
+		appendCalendarSingleDate(ovulationMap, stats.OvulationDate)
+	}
+	appendPredictedCycles(predictedPeriodMap, preFertileMap, fertilityEdgeMap, fertilityPeakMap, ovulationMap, stats, gridEnd, location, !fertilitySuppressed)
 	appendPredictedStartRange(maps.predictedStartRange, user, stats, location)
 	appendHistoricalCycles(preFertileMap, fertilityEdgeMap, fertilityPeakMap, ovulationMap, logs, stats, user, location)
-	appendCurrentCycleBBTSignal(user, logs, stats, now, ovulationMap, tentativeOvulationMap, location)
+	if !fertilitySuppressed {
+		// The BBT pass only ever downgrades the projected ovulation day to
+		// "tentative", so with the fertility maps withheld it would reintroduce
+		// the very day the floor just removed, one shade lighter.
+		appendCurrentCycleBBTSignal(user, logs, stats, now, ovulationMap, tentativeOvulationMap, location)
+	}
 
 	return maps
 }
@@ -280,7 +295,11 @@ func appendFertilityWindow(fertilityEdgeMap map[string]bool, fertilityPeakMap ma
 	})
 }
 
-func appendPredictedCycles(predictedPeriodMap map[string]bool, preFertileMap map[string]bool, fertilityEdgeMap map[string]bool, fertilityPeakMap map[string]bool, ovulationMap map[string]bool, stats CycleStats, gridEnd time.Time, location *time.Location) {
+// appendPredictedCycles chains the projected cycles across the visible grid.
+// includeFertility is false in the first-cycle tier: the chained period days
+// still descend from a recorded anchor, while the window inside each of them
+// would be the onboarding slider projected forward one cycle at a time.
+func appendPredictedCycles(predictedPeriodMap map[string]bool, preFertileMap map[string]bool, fertilityEdgeMap map[string]bool, fertilityPeakMap map[string]bool, ovulationMap map[string]bool, stats CycleStats, gridEnd time.Time, location *time.Location, includeFertility bool) {
 	if stats.NextPeriodStart.IsZero() {
 		return
 	}
@@ -295,7 +314,9 @@ func appendPredictedCycles(predictedPeriodMap map[string]bool, preFertileMap map
 	// markers are never painted.
 	for cycleStart := CalendarDay(stats.NextPeriodStart, location); CalendarDaysBetween(cycleStart, gridEnd) >= 0; cycleStart = cycleStart.AddDate(0, 0, predictedCycleLength) {
 		appendPredictedPeriod(predictedPeriodMap, cycleStart, predictedPeriodLength)
-		appendPredictedWindow(preFertileMap, fertilityEdgeMap, fertilityPeakMap, ovulationMap, cycleStart, predictedCycleLength, predictedPeriodLength, stats.LutealPhase)
+		if includeFertility {
+			appendPredictedWindow(preFertileMap, fertilityEdgeMap, fertilityPeakMap, ovulationMap, cycleStart, predictedCycleLength, predictedPeriodLength, stats.LutealPhase)
+		}
 	}
 }
 

--- a/internal/services/calendar_days_coverage_test.go
+++ b/internal/services/calendar_days_coverage_test.go
@@ -266,6 +266,10 @@ func TestCalendarDaysPreFertileEndIsOneDayBeforeFertilityStart(t *testing.T) {
 	now := time.Date(2026, time.March, 10, 0, 0, 0, 0, time.UTC)
 
 	stats := CycleStats{
+		// CompletedCycleCount lifts the fixture above the first-cycle floor
+		// (FertilityProjectionSuppressed): these cases pin the window math, not
+		// the tier that withholds a window with only the slider behind it.
+		CompletedCycleCount:  1,
 		AveragePeriodLength:  5,
 		LastPeriodStart:      time.Date(2026, time.March, 1, 0, 0, 0, 0, time.UTC),
 		FertilityWindowStart: time.Date(2026, time.March, 16, 0, 0, 0, 0, time.UTC),
@@ -309,6 +313,7 @@ func TestCalendarDaysFertilityWindowPeakThreshold(t *testing.T) {
 	now := time.Date(2026, time.March, 10, 0, 0, 0, 0, time.UTC)
 
 	stats := CycleStats{
+		CompletedCycleCount:  1,
 		LastPeriodStart:      time.Date(2026, time.March, 1, 0, 0, 0, 0, time.UTC),
 		NextPeriodStart:      time.Date(2026, time.March, 29, 0, 0, 0, 0, time.UTC),
 		OvulationDate:        time.Date(2026, time.March, 15, 0, 0, 0, 0, time.UTC),
@@ -438,6 +443,7 @@ func TestCalendarDaysPredictedWindowPreFertileEndBoundary(t *testing.T) {
 	now := time.Date(2026, time.April, 1, 0, 0, 0, 0, time.UTC)
 
 	stats := CycleStats{
+		CompletedCycleCount: 1,
 		MedianCycleLength:   28,
 		AveragePeriodLength: 5,
 		LutealPhase:         14,

--- a/internal/services/calendar_days_test.go
+++ b/internal/services/calendar_days_test.go
@@ -70,6 +70,10 @@ func TestBuildCalendarDayStatesProjectsOvulationIntoFutureCycles(t *testing.T) {
 	now := time.Date(2026, time.February, 23, 0, 0, 0, 0, time.UTC)
 
 	stats := CycleStats{
+		// CompletedCycleCount lifts the fixture above the first-cycle floor
+		// (FertilityProjectionSuppressed): these cases pin the window math, not
+		// the tier that withholds a window with only the slider behind it.
+		CompletedCycleCount:  1,
 		MedianCycleLength:    28,
 		AveragePeriodLength:  5,
 		LastPeriodStart:      time.Date(2026, time.February, 10, 0, 0, 0, 0, time.UTC),
@@ -363,6 +367,7 @@ func TestBuildCalendarDayStatesIncludesCurrentBaselinePeriodWindow(t *testing.T)
 	now := time.Date(2026, time.March, 12, 0, 0, 0, 0, time.UTC)
 
 	stats := CycleStats{
+		CompletedCycleCount: 1,
 		AveragePeriodLength: 5,
 		LastPeriodStart:     time.Date(2026, time.March, 8, 0, 0, 0, 0, time.UTC),
 	}
@@ -647,6 +652,7 @@ func TestBuildCalendarDayStatesMarksTentativeOvulationWhenBBTHasNoShift(t *testi
 	}
 
 	stats := CycleStats{
+		CompletedCycleCount:  1,
 		LastPeriodStart:      time.Date(2026, time.March, 1, 0, 0, 0, 0, time.UTC),
 		NextPeriodStart:      time.Date(2026, time.March, 29, 0, 0, 0, 0, time.UTC),
 		OvulationDate:        time.Date(2026, time.March, 15, 0, 0, 0, 0, time.UTC),
@@ -685,9 +691,10 @@ func TestBuildCalendarDayStatesKeepsBBTDemotedDashInGridOnEveryRunDate(t *testin
 		todayKey := today.Format("2006-01-02")
 		cycleStart := today.AddDate(0, 0, -13)
 		stats := CycleStats{
-			LastPeriodStart: cycleStart,
-			OvulationDate:   today,
-			NextPeriodStart: cycleStart.AddDate(0, 0, 28),
+			CompletedCycleCount: 1,
+			LastPeriodStart:     cycleStart,
+			OvulationDate:       today,
+			NextPeriodStart:     cycleStart.AddDate(0, 0, 28),
 		}
 		monthStart := time.Date(today.Year(), today.Month(), 1, 0, 0, 0, 0, location)
 
@@ -726,6 +733,7 @@ func TestBuildCalendarDayStatesSeparatesFertilityEdgeAndPeak(t *testing.T) {
 	now := time.Date(2026, time.March, 12, 0, 0, 0, 0, time.UTC)
 
 	stats := CycleStats{
+		CompletedCycleCount:  1,
 		LastPeriodStart:      time.Date(2026, time.March, 1, 0, 0, 0, 0, time.UTC),
 		NextPeriodStart:      time.Date(2026, time.March, 29, 0, 0, 0, 0, time.UTC),
 		OvulationDate:        time.Date(2026, time.March, 15, 0, 0, 0, 0, time.UTC),
@@ -769,6 +777,7 @@ func TestBuildCalendarDayStatesKeepsConfirmedOvulationWhenBBTHasShift(t *testing
 	}
 
 	stats := CycleStats{
+		CompletedCycleCount:  1,
 		LastPeriodStart:      time.Date(2026, time.March, 10, 0, 0, 0, 0, time.UTC),
 		NextPeriodStart:      time.Date(2026, time.April, 7, 0, 0, 0, 0, time.UTC),
 		OvulationDate:        time.Date(2026, time.March, 15, 0, 0, 0, 0, time.UTC),

--- a/internal/services/calendar_feed_ics.go
+++ b/internal/services/calendar_feed_ics.go
@@ -125,11 +125,18 @@ func calendarFeedEvents(input CalendarFeedICSInput) []calendarFeedEvent {
 	// nothing. Unpredictable-cycle mode, a pregnancy pause, OR an overdue cycle
 	// (DashboardCycleOverdue — past the account's reference length by more than a
 	// week, where the projection can only roll a whole cycle forward) each
-	// suppress on their own. The feed carries prediction events only, so this is
+	// suppress on their own, and they are read here through the one predicate
+	// every surface shares. The feed carries prediction events only, so this is
 	// the empty-but-well-formed VCALENDAR path.
-	if DashboardPredictionDisabled(user) || stats.PregnancyPaused || DashboardCycleOverdue(user, stats) {
+	if PredictionsSuppressed(user, stats) {
 		return nil
 	}
+
+	// The ovulation events carry the extra first-cycle floor: with no completed
+	// cycle behind it, the projected ovulation day is the onboarding slider, and
+	// this feed sends it off the instance into a calendar client that keeps it
+	// long after the app would correct it (FertilityProjectionSuppressed).
+	includeOvulation := !FertilityProjectionSuppressed(user, stats)
 
 	today := DateAtLocation(input.Now, input.Location)
 	cycleLength := DashboardProjectionCycleLength(user, stats)
@@ -174,7 +181,7 @@ func calendarFeedEvents(input CalendarFeedICSInput) []calendarFeedEvent {
 		// needs a calendar-day comparison, or the ovulation event disappears from
 		// the feed on the ovulation day itself in every UTC-minus zone (issue #48
 		// class).
-		if window.Calculable && CalendarDaysBetween(window.OvulationDate, today) <= 0 {
+		if includeOvulation && window.Calculable && CalendarDaysBetween(window.OvulationDate, today) <= 0 {
 			appendEvent("ovulation", CalendarDay(window.OvulationDate, input.Location))
 		}
 	}

--- a/internal/services/dashboard_cycle.go
+++ b/internal/services/dashboard_cycle.go
@@ -121,10 +121,37 @@ func DashboardProjectionCycleLength(user *models.User, stats CycleStats) int {
 // so every date it yields is manufactured rather than estimated, and presenting
 // one as a window is the estimate-presented-as-fact the medical-safety invariant
 // forbids. Every surface that shows a projected window gates on all three —
-// dashboard display and reminder banner here; the calendar grid, the webhook
-// reminder and the .ics feed are the remaining callers of that pair.
+// through PredictionsSuppressed, which is where the three now live together.
 func DashboardCycleOverdue(user *models.User, stats CycleStats) bool {
 	return DashboardCycleDayLooksLong(stats.CurrentCycleDay, DashboardCycleReferenceLength(user, stats))
+}
+
+// PredictionsSuppressed is the whole-projection suppression gate: unpredictable-
+// cycle mode, a pregnancy pause, or a cycle overdue past its own reference
+// length. Any one of them withholds every projected date, on every surface.
+//
+// It exists as one predicate because the three disjuncts had been written out
+// once per surface — the calendar grid, the .ics feed and the webhook pass each
+// carried their own copy — so a fourth suppression signal had to be found at
+// four sites, and the one that was missed (the completed-cycle floor below)
+// stayed missing silently. A new signal belongs here, never in a caller.
+func PredictionsSuppressed(user *models.User, stats CycleStats) bool {
+	return DashboardPredictionDisabled(user) || stats.PregnancyPaused || DashboardCycleOverdue(user, stats)
+}
+
+// FertilityProjectionSuppressed adds the zero-completed-cycle floor to the three
+// signals above, and is the gate for the fertility half of the projection: the
+// fertile window, the peak band and the ovulation date, wherever they are shown
+// or sent — calendar grid, .ics feed, webhook reminder, dashboard banner.
+//
+// The two predicates are deliberately not one. PredictionsSuppressed withholds
+// everything; the first-cycle floor withholds only what has nothing but the
+// onboarding slider behind it, which is exactly the fertility half (see
+// DashboardAwaitingFirstCycle). The next-period estimate keeps its own path: it
+// is anchored on a day the owner recorded and already carries an estimate
+// qualifier, and the dashboard header shows it in this tier too.
+func FertilityProjectionSuppressed(user *models.User, stats CycleStats) bool {
+	return PredictionsSuppressed(user, stats) || DashboardAwaitingFirstCycle(stats)
 }
 
 // DashboardAwaitingFirstCycle reports that the account has not completed a

--- a/internal/services/dashboard_cycle.go
+++ b/internal/services/dashboard_cycle.go
@@ -18,6 +18,14 @@ import (
 //
 // AwaitingFirstCycle reports the earliest data tier — no completed cycle yet —
 // which decides how much detail the header may show (DashboardAwaitingFirstCycle).
+//
+// FertilitySuppressed is that policy already applied, resolved once here from
+// FertilityProjectionSuppressed(user, stats) — the same predicate the calendar
+// grid, the .ics feed and the webhook pass call. Surfaces built from this
+// context read the field rather than recombining AwaitingFirstCycle with the
+// suppression signals themselves: a floor re-derived per surface diverges the
+// moment the shared predicate gains a disjunct or is narrowed to let a recorded
+// observation through.
 type DashboardCycleContext struct {
 	CycleDayReference           int
 	CycleDayWarning             bool
@@ -41,6 +49,7 @@ type DashboardCycleContext struct {
 	DisplayOvulationImpossible  bool
 	NextPeriodEstimatePaused    bool
 	AwaitingFirstCycle          bool
+	FertilitySuppressed         bool
 	NextPeriodInPast            bool
 	OvulationInPast             bool
 }
@@ -319,21 +328,27 @@ func BuildDashboardCycleContext(user *models.User, stats CycleStats, today time.
 	// reported "not awaiting" merely because predictions are off would disable
 	// the gate for exactly the accounts with the least data.
 	awaitingFirstCycle := DashboardAwaitingFirstCycle(stats)
+	// Resolved beside the tier and carried by every branch below, for the same
+	// reason: a context that answered "not suppressed" on a suppression branch
+	// would hand the banner the very rule it is meant to be gated by.
+	fertilitySuppressed := FertilityProjectionSuppressed(user, stats)
 	if stats.PregnancyPaused {
 		return DashboardCycleContext{
-			CycleDayReference:  DashboardCycleReferenceLength(user, stats),
-			PredictionDisabled: true,
-			PregnancyPaused:    true,
-			AwaitingFirstCycle: awaitingFirstCycle,
+			CycleDayReference:   DashboardCycleReferenceLength(user, stats),
+			PredictionDisabled:  true,
+			PregnancyPaused:     true,
+			AwaitingFirstCycle:  awaitingFirstCycle,
+			FertilitySuppressed: fertilitySuppressed,
 		}
 	}
 	if DashboardPredictionDisabled(user) {
 		return DashboardCycleContext{
-			CycleDayReference:  DashboardCycleReferenceLength(user, stats),
-			CycleDayWarning:    false,
-			CycleDataStale:     false,
-			PredictionDisabled: true,
-			AwaitingFirstCycle: awaitingFirstCycle,
+			CycleDayReference:   DashboardCycleReferenceLength(user, stats),
+			CycleDayWarning:     false,
+			CycleDataStale:      false,
+			PredictionDisabled:  true,
+			AwaitingFirstCycle:  awaitingFirstCycle,
+			FertilitySuppressed: fertilitySuppressed,
 		}
 	}
 
@@ -365,6 +380,7 @@ func BuildDashboardCycleContext(user *models.User, stats CycleStats, today time.
 		DisplayOvulationImpossible:  display.ovulationImpossible,
 		NextPeriodEstimatePaused:    display.estimatePaused,
 		AwaitingFirstCycle:          awaitingFirstCycle,
+		FertilitySuppressed:         fertilitySuppressed,
 		NextPeriodInPast:            dashboardNextPeriodInPast(display, today),
 		OvulationInPast:             dashboardOvulationInPast(display, today),
 	}

--- a/internal/services/dashboard_reminder_banner.go
+++ b/internal/services/dashboard_reminder_banner.go
@@ -164,7 +164,12 @@ func dashboardReminderBannerForPeriod(cycleContext DashboardCycleContext, today 
 }
 
 func dashboardReminderBannerForOvulation(cycleContext DashboardCycleContext, today time.Time, windowDays int) (DashboardReminderBanner, bool) {
-	if cycleContext.DisplayOvulationUseRange || cycleContext.DisplayOvulationNeedsData || cycleContext.DisplayOvulationImpossible {
+	// AwaitingFirstCycle is the same first-cycle floor the header applies to the
+	// ovulation estimate (ShowOvulationEstimate): with no completed cycle the
+	// date counted down to here would be the onboarding slider projected forward,
+	// and the banner is the one place that date still spoke while the header
+	// beside it stayed quiet.
+	if cycleContext.AwaitingFirstCycle || cycleContext.DisplayOvulationUseRange || cycleContext.DisplayOvulationNeedsData || cycleContext.DisplayOvulationImpossible {
 		return DashboardReminderBanner{}, false
 	}
 	daysUntil, ok := dashboardReminderBannerDaysUntil(cycleContext.DisplayOvulationDate, today, windowDays)

--- a/internal/services/dashboard_reminder_banner.go
+++ b/internal/services/dashboard_reminder_banner.go
@@ -164,12 +164,15 @@ func dashboardReminderBannerForPeriod(cycleContext DashboardCycleContext, today 
 }
 
 func dashboardReminderBannerForOvulation(cycleContext DashboardCycleContext, today time.Time, windowDays int) (DashboardReminderBanner, bool) {
-	// AwaitingFirstCycle is the same first-cycle floor the header applies to the
-	// ovulation estimate (ShowOvulationEstimate): with no completed cycle the
-	// date counted down to here would be the onboarding slider projected forward,
-	// and the banner is the one place that date still spoke while the header
-	// beside it stayed quiet.
-	if cycleContext.AwaitingFirstCycle || cycleContext.DisplayOvulationUseRange || cycleContext.DisplayOvulationNeedsData || cycleContext.DisplayOvulationImpossible {
+	// FertilitySuppressed is the shared fertility floor as the context resolved
+	// it (FertilityProjectionSuppressed) — read, never re-derived here: with no
+	// completed cycle the date counted down to would be the onboarding slider
+	// projected forward, and the banner was the one place that date still spoke
+	// while the header beside it stayed quiet. Reading the carried decision is
+	// what keeps this surface moving with the calendar, the feed and the webhook
+	// when the predicate changes. The three disjuncts after it are the banner's
+	// own display conditions, not policy.
+	if cycleContext.FertilitySuppressed || cycleContext.DisplayOvulationUseRange || cycleContext.DisplayOvulationNeedsData || cycleContext.DisplayOvulationImpossible {
 		return DashboardReminderBanner{}, false
 	}
 	daysUntil, ok := dashboardReminderBannerDaysUntil(cycleContext.DisplayOvulationDate, today, windowDays)

--- a/internal/services/prediction_first_cycle_floor_test.go
+++ b/internal/services/prediction_first_cycle_floor_test.go
@@ -1,0 +1,175 @@
+package services
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+)
+
+// The zero-completed-cycle floor is one policy with four consumers: the
+// calendar grid, the .ics feed, the webhook reminder pass and the dashboard
+// reminder banner. Until the first cycle closes, the fertile window and the
+// ovulation date are the onboarding cycle-length slider projected forward, so
+// every one of them must withhold the fertility half of the projection — two of
+// the four carry it off the instance. The same table drives a one-completed-
+// cycle history as the positive anchor: the surfaces must resume there, or a
+// guard that simply emptied every projection would read as green.
+
+// firstCycleFloorLogs seeds a five-day period per start, the first day of each
+// flagged as an explicit cycle start.
+func firstCycleFloorLogs(starts []time.Time) []models.DailyLog {
+	logs := make([]models.DailyLog, 0, len(starts)*5)
+	for _, start := range starts {
+		for offset := range 5 {
+			logs = append(logs, models.DailyLog{
+				Date:       start.AddDate(0, 0, offset),
+				IsPeriod:   true,
+				CycleStart: offset == 0,
+			})
+		}
+	}
+	return logs
+}
+
+// firstCycleFloorUser is a regular owner on the onboarding defaults: nothing but
+// the slider stands behind a fertility claim until a cycle completes.
+func firstCycleFloorUser() *models.User {
+	return &models.User{
+		ID:           7,
+		Role:         models.RoleOwner,
+		CycleLength:  28,
+		PeriodLength: 5,
+		LutealPhase:  14,
+	}
+}
+
+// firstCycleFloorCase is one cycle history plus the completed-cycle count it is
+// asserted to produce, so a fixture that stopped meaning what its name says
+// fails on the count rather than silently changing what the surfaces are asked.
+type firstCycleFloorCase struct {
+	name            string
+	startsDaysAgo   []int
+	wantCompleted   int
+	wantOvulation   bool
+	wantFertileDays bool
+}
+
+func firstCycleFloorCases() []firstCycleFloorCase {
+	return []firstCycleFloorCase{
+		{
+			name:          "zero completed cycles: only the slider stands behind the window",
+			startsDaysAgo: []int{12},
+			wantCompleted: 0,
+		},
+		{
+			name:            "one completed cycle: the window has an observed length behind it",
+			startsDaysAgo:   []int{40, 12},
+			wantCompleted:   1,
+			wantOvulation:   true,
+			wantFertileDays: true,
+		},
+	}
+}
+
+func TestFirstCycleFloorSuppressesFertilityOnEverySurface(t *testing.T) {
+	location := time.UTC
+	now := time.Date(2026, 4, 20, 9, 0, 0, 0, location)
+	today := DateAtLocation(now, location)
+
+	for _, testCase := range firstCycleFloorCases() {
+		t.Run(testCase.name, func(t *testing.T) {
+			user := firstCycleFloorUser()
+			starts := make([]time.Time, 0, len(testCase.startsDaysAgo))
+			for _, daysAgo := range testCase.startsDaysAgo {
+				starts = append(starts, today.AddDate(0, 0, -daysAgo))
+			}
+			logs := firstCycleFloorLogs(starts)
+			stats := NewStatsService(nil, nil).BuildCycleStatsFromLogs(user, logs, now, location)
+
+			if stats.CompletedCycleCount != testCase.wantCompleted {
+				t.Fatalf("fixture: expected %d completed cycles, got %d", testCase.wantCompleted, stats.CompletedCycleCount)
+			}
+			if stats.OvulationDate.IsZero() {
+				t.Fatalf("fixture: expected the baseline to project an ovulation date, got none")
+			}
+
+			assertCalendarFertilityMaps(t, user, logs, stats, now, location, testCase)
+			assertFeedOvulationEvents(t, user, logs, now, location, testCase)
+			assertWebhookOvulationReminder(t, user, logs, now, location, testCase)
+			assertDashboardOvulationBanner(t, user, stats, today, location, testCase)
+		})
+	}
+}
+
+// assertCalendarFertilityMaps reads the grid's own prediction maps. The
+// predicted-period map is asserted non-empty in both histories: the floor
+// withholds the fertility half of the projection, not the next-period estimate
+// the dashboard header keeps showing with its qualifier.
+func assertCalendarFertilityMaps(t *testing.T, user *models.User, logs []models.DailyLog, stats CycleStats, now time.Time, location *time.Location, testCase firstCycleFloorCase) {
+	t.Helper()
+
+	gridEnd := DateAtLocation(now, location).AddDate(0, 0, 45)
+	maps := buildCalendarPredictionMaps(user, logs, stats, gridEnd, now, location)
+
+	if len(maps.predictedPeriod) == 0 {
+		t.Errorf("calendar: expected the predicted-period days to survive the fertility floor")
+	}
+	if got := len(maps.ovulation) > 0; got != testCase.wantOvulation {
+		t.Errorf("calendar: ovulation days present = %v, want %v (%d days)", got, testCase.wantOvulation, len(maps.ovulation))
+	}
+	fertileDays := len(maps.fertilityPeak) + len(maps.fertilityEdge) + len(maps.preFertile)
+	if got := fertileDays > 0; got != testCase.wantFertileDays {
+		t.Errorf("calendar: fertility days present = %v, want %v (%d days)", got, testCase.wantFertileDays, fertileDays)
+	}
+}
+
+func assertFeedOvulationEvents(t *testing.T, user *models.User, logs []models.DailyLog, now time.Time, location *time.Location, testCase firstCycleFloorCase) {
+	t.Helper()
+
+	events := calendarFeedEvents(CalendarFeedICSInput{
+		User:     user,
+		Logs:     logs,
+		Now:      now,
+		Location: location,
+	})
+
+	ovulationEvents := 0
+	periodEvents := 0
+	for _, event := range events {
+		switch event.kind {
+		case "ovulation":
+			ovulationEvents++
+		case "period":
+			periodEvents++
+		}
+	}
+
+	if periodEvents == 0 {
+		t.Errorf("feed: expected the projected period events to survive the fertility floor")
+	}
+	if got := ovulationEvents > 0; got != testCase.wantOvulation {
+		t.Errorf("feed: ovulation VEVENTs present = %v, want %v (%d events)", got, testCase.wantOvulation, ovulationEvents)
+	}
+}
+
+func assertWebhookOvulationReminder(t *testing.T, user *models.User, logs []models.DailyLog, now time.Time, location *time.Location, testCase firstCycleFloorCase) {
+	t.Helper()
+
+	reminders := DecideDueReminders(user, enabledWebhookSettings(3), logs, now, location)
+	_, hasOvulation := findDueReminder(reminders, DueReminderTypeOvulation)
+	if hasOvulation != testCase.wantOvulation {
+		t.Errorf("webhook: ovulation reminder due = %v, want %v", hasOvulation, testCase.wantOvulation)
+	}
+}
+
+func assertDashboardOvulationBanner(t *testing.T, user *models.User, stats CycleStats, today time.Time, location *time.Location, testCase firstCycleFloorCase) {
+	t.Helper()
+
+	cycleContext := BuildDashboardCycleContext(user, stats, today, location)
+	banner := BuildDashboardReminderBanner(cycleContext, today, 3)
+	isOvulationBanner := banner.Show && banner.Kind == DashboardReminderBannerKindOvulation
+	if isOvulationBanner != testCase.wantOvulation {
+		t.Errorf("banner: ovulation banner shown = %v, want %v (kind %q, show %v)", isOvulationBanner, testCase.wantOvulation, banner.Kind, banner.Show)
+	}
+}

--- a/internal/services/prediction_first_cycle_floor_test.go
+++ b/internal/services/prediction_first_cycle_floor_test.go
@@ -163,10 +163,23 @@ func assertWebhookOvulationReminder(t *testing.T, user *models.User, logs []mode
 	}
 }
 
+// assertDashboardOvulationBanner also pins the banner to the SHARED predicate,
+// not merely to the tier: the banner reads a decision the cycle context
+// resolved, so the case asserts that the carried decision is the predicate's
+// own answer. Without that link the banner row would keep passing if the floor
+// were dropped from FertilityProjectionSuppressed — the banner would go on
+// reading AwaitingFirstCycle while the calendar, the feed and the webhook moved.
 func assertDashboardOvulationBanner(t *testing.T, user *models.User, stats CycleStats, today time.Time, location *time.Location, testCase firstCycleFloorCase) {
 	t.Helper()
 
 	cycleContext := BuildDashboardCycleContext(user, stats, today, location)
+	if got, want := cycleContext.FertilitySuppressed, FertilityProjectionSuppressed(user, stats); got != want {
+		t.Errorf("banner: cycle context carries FertilitySuppressed = %v, want the shared predicate's %v", got, want)
+	}
+	if got, want := cycleContext.FertilitySuppressed, !testCase.wantOvulation; got != want {
+		t.Errorf("banner: cycle context carries FertilitySuppressed = %v, want %v", got, want)
+	}
+
 	banner := BuildDashboardReminderBanner(cycleContext, today, 3)
 	isOvulationBanner := banner.Show && banner.Kind == DashboardReminderBannerKindOvulation
 	if isOvulationBanner != testCase.wantOvulation {

--- a/internal/services/stats_completed_cycle_agreement_test.go
+++ b/internal/services/stats_completed_cycle_agreement_test.go
@@ -1,0 +1,150 @@
+package services
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+)
+
+// One stats render builds its cycle history twice: the ribbon and the cycle
+// factor context read buildCompletedCycleSpans, the phase cards and the history
+// statements read buildCompletedCyclePhaseContexts. Both answer "where does a
+// cycle begin" over the same logs, so they must answer it the same way — a page
+// whose two halves count different cycles reports a merged 56-day cycle in one
+// panel and two 28-day cycles in the other, and the longer of the two then
+// carries the owner's logged factors as if it were measured.
+
+type completedCycleAgreementCase struct {
+	name string
+	logs []models.DailyLog
+	// wantCycles is what BOTH builders must report, so the table pins the shared
+	// answer rather than merely pinning the two to each other.
+	wantCycles  []int
+	wantStarts  []string
+	description string
+}
+
+func agreementPeriodDays(t *testing.T, start string, days int, cycleStart bool, uncertain bool) []models.DailyLog {
+	t.Helper()
+	startDay, err := time.Parse("2006-01-02", start)
+	if err != nil {
+		t.Fatalf("parse day %q: %v", start, err)
+	}
+	logs := make([]models.DailyLog, 0, days)
+	for offset := range days {
+		logs = append(logs, models.DailyLog{
+			Date:        startDay.AddDate(0, 0, offset),
+			IsPeriod:    true,
+			CycleStart:  cycleStart && offset == 0,
+			IsUncertain: uncertain && offset == 0,
+		})
+	}
+	return logs
+}
+
+func completedCycleAgreementCases(t *testing.T) []completedCycleAgreementCase {
+	t.Helper()
+
+	plain := append(agreementPeriodDays(t, "2026-01-01", 4, false, false), agreementPeriodDays(t, "2026-01-29", 4, false, false)...)
+	plain = append(plain, agreementPeriodDays(t, "2026-02-26", 4, false, false)...)
+
+	explicit := append(agreementPeriodDays(t, "2026-01-01", 4, true, false), agreementPeriodDays(t, "2026-01-29", 4, true, false)...)
+	explicit = append(explicit, agreementPeriodDays(t, "2026-02-26", 4, true, false)...)
+
+	uncertainMiddle := append(agreementPeriodDays(t, "2026-01-01", 4, true, false), agreementPeriodDays(t, "2026-01-29", 4, true, true)...)
+	uncertainMiddle = append(uncertainMiddle, agreementPeriodDays(t, "2026-02-26", 4, true, false)...)
+
+	uncertainLast := append(agreementPeriodDays(t, "2026-01-01", 4, true, false), agreementPeriodDays(t, "2026-01-29", 4, true, false)...)
+	uncertainLast = append(uncertainLast, agreementPeriodDays(t, "2026-02-26", 4, true, true)...)
+
+	return []completedCycleAgreementCase{
+		{
+			name:        "three period clusters, no explicit starts",
+			logs:        plain,
+			wantCycles:  []int{28, 28},
+			wantStarts:  []string{"2026-01-01", "2026-01-29"},
+			description: "the cluster's first day is the start",
+		},
+		{
+			name:        "three explicit starts",
+			logs:        explicit,
+			wantCycles:  []int{28, 28},
+			wantStarts:  []string{"2026-01-01", "2026-01-29"},
+			description: "the explicit start is the start",
+		},
+		{
+			name:        "middle start marked uncertain",
+			logs:        uncertainMiddle,
+			wantCycles:  []int{56},
+			wantStarts:  []string{"2026-01-01"},
+			description: "an uncertain-only cluster yields no start, so the two cycles read as one",
+		},
+		{
+			name:        "latest start marked uncertain",
+			logs:        uncertainLast,
+			wantCycles:  []int{28},
+			wantStarts:  []string{"2026-01-01"},
+			description: "the uncertain cluster closes no cycle",
+		},
+	}
+}
+
+func TestCompletedCycleSpansAndPhaseContextsAgree(t *testing.T) {
+	for _, testCase := range completedCycleAgreementCases(t) {
+		t.Run(testCase.name, func(t *testing.T) {
+			spans := buildCompletedCycleSpans(testCase.logs, time.UTC)
+			contexts := buildCompletedCyclePhaseContexts(testCase.logs, time.UTC)
+
+			if len(spans) != len(contexts) {
+				t.Errorf("cycle count disagrees: %d span(s) against %d phase context(s) — %s", len(spans), len(contexts), testCase.description)
+			}
+
+			spanLengths := make([]int, 0, len(spans))
+			spanStarts := make([]string, 0, len(spans))
+			for _, span := range spans {
+				spanLengths = append(spanLengths, span.CycleLength)
+				spanStarts = append(spanStarts, span.Start.Format("2006-01-02"))
+			}
+			contextLengths := make([]int, 0, len(contexts))
+			contextStarts := make([]string, 0, len(contexts))
+			for _, context := range contexts {
+				contextLengths = append(contextLengths, context.CycleLength)
+				contextStarts = append(contextStarts, context.Start.Format("2006-01-02"))
+			}
+
+			assertIntSliceEquals(t, "span cycle lengths", spanLengths, testCase.wantCycles)
+			assertIntSliceEquals(t, "phase-context cycle lengths", contextLengths, testCase.wantCycles)
+			assertStringSliceEquals(t, "span starts", spanStarts, testCase.wantStarts)
+			assertStringSliceEquals(t, "phase-context starts", contextStarts, testCase.wantStarts)
+		})
+	}
+}
+
+func assertIntSliceEquals(t *testing.T, label string, got []int, want []int) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Errorf("%s = %v, want %v", label, got, want)
+		return
+	}
+	for index := range want {
+		if got[index] != want[index] {
+			t.Errorf("%s = %v, want %v", label, got, want)
+			return
+		}
+	}
+}
+
+func assertStringSliceEquals(t *testing.T, label string, got []string, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Errorf("%s = %v, want %v", label, got, want)
+		return
+	}
+	for index := range want {
+		if got[index] != want[index] {
+			t.Errorf("%s = %v, want %v", label, got, want)
+			return
+		}
+	}
+}

--- a/internal/services/stats_page_view_service_owner_scope_test.go
+++ b/internal/services/stats_page_view_service_owner_scope_test.go
@@ -1,0 +1,113 @@
+package services
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+)
+
+// The stats page is the richest health-data read in the product — cycle
+// history, BBT, symptoms and every insight inferred from them — and it reaches
+// the repositories through four owner-scoped seams: the ranged logs, all logs,
+// the frequency calculation and the symptom catalogue. An instance may host
+// more than one independent owner, so each of those four must carry the
+// authenticated owner's id and no other. Two owners are rendered here with
+// deliberately different cycle lengths and symptom names, so a seam that
+// stopped forwarding the id fails on what the page reports, not only on what
+// the double recorded.
+
+type statsOwnerScopeCase struct {
+	name         string
+	userID       uint
+	cycleLength  int
+	symptomID    uint
+	symptomName  string
+	wantMedian   int
+	wantSymptoms string
+}
+
+func statsOwnerScopeCases() []statsOwnerScopeCase {
+	return []statsOwnerScopeCase{
+		{name: "first owner", userID: 11, cycleLength: 28, symptomID: 101, symptomName: "owner-a-cramps", wantMedian: 28, wantSymptoms: "owner-a-cramps"},
+		{name: "second owner", userID: 22, cycleLength: 35, symptomID: 202, symptomName: "owner-b-headache", wantMedian: 35, wantSymptoms: "owner-b-headache"},
+	}
+}
+
+// statsOwnerScopeLogs seeds three cycle starts of the owner's own length, the
+// last of them still running, plus one symptom day inside the last completed
+// cycle so the symptom-derived sections have something owner-specific to show.
+func statsOwnerScopeLogs(t *testing.T, testCase statsOwnerScopeCase, anchor time.Time) []models.DailyLog {
+	t.Helper()
+
+	firstStart := anchor.AddDate(0, 0, -2*testCase.cycleLength)
+	secondStart := anchor.AddDate(0, 0, -testCase.cycleLength)
+	return []models.DailyLog{
+		{UserID: testCase.userID, Date: firstStart, IsPeriod: true, CycleStart: true},
+		{UserID: testCase.userID, Date: secondStart, IsPeriod: true, CycleStart: true},
+		{UserID: testCase.userID, Date: secondStart.AddDate(0, 0, 8), SymptomIDs: []uint{testCase.symptomID}},
+		{UserID: testCase.userID, Date: anchor, IsPeriod: true, CycleStart: true},
+	}
+}
+
+func TestBuildStatsPageViewDataScopesEveryReadToTheSessionOwner(t *testing.T) {
+	now := mustParseStatsServiceDay(t, "2026-06-01")
+	anchor := now.AddDate(0, 0, -5)
+
+	logsByOwner := make(map[uint][]models.DailyLog, len(statsOwnerScopeCases()))
+	symptomsByOwner := make(map[uint][]models.SymptomType, len(statsOwnerScopeCases()))
+	frequenciesByOwner := make(map[uint][]SymptomFrequency, len(statsOwnerScopeCases()))
+	for _, testCase := range statsOwnerScopeCases() {
+		logsByOwner[testCase.userID] = statsOwnerScopeLogs(t, testCase, anchor)
+		symptomsByOwner[testCase.userID] = []models.SymptomType{{ID: testCase.symptomID, UserID: testCase.userID, Name: testCase.symptomName, Icon: "S"}}
+		frequenciesByOwner[testCase.userID] = []SymptomFrequency{{Name: testCase.symptomName, Icon: "S", Count: 1, TotalDays: 1}}
+	}
+
+	for _, testCase := range statsOwnerScopeCases() {
+		t.Run(testCase.name, func(t *testing.T) {
+			dayReader := &stubStatsDayReader{logsByOwner: logsByOwner}
+			symptomReader := &stubStatsSymptomReader{symptomsByOwner: symptomsByOwner, frequenciesByOwner: frequenciesByOwner}
+			service := NewStatsService(dayReader, symptomReader)
+			user := &models.User{ID: testCase.userID, Role: models.RoleOwner, CycleLength: 30, PeriodLength: 5}
+
+			viewData, err := service.BuildStatsPageViewData(context.Background(), user, "en", "Cycle %d", now, time.UTC, 12)
+			if err != nil {
+				t.Fatalf("BuildStatsPageViewData: %v", err)
+			}
+
+			assertStatsReadOwner(t, "ranged logs", dayReader.gotRangeOwner, testCase.userID)
+			assertStatsReadOwner(t, "all logs", dayReader.gotAllOwner, testCase.userID)
+			assertStatsReadOwner(t, "frequency calculation", symptomReader.gotFrequencyOwner, testCase.userID)
+			assertStatsReadOwner(t, "symptom catalogue", symptomReader.gotSymptomOwner, testCase.userID)
+
+			if viewData.Stats.MedianCycleLength != testCase.wantMedian {
+				t.Errorf("median cycle length = %d, want %d — the page reports another owner's cycle history", viewData.Stats.MedianCycleLength, testCase.wantMedian)
+			}
+			assertOnlySymptomName(t, "symptom counts", statsSymptomCountNames(viewData.SymptomCounts), testCase.wantSymptoms)
+			assertOnlySymptomName(t, "last cycle symptoms", statsSymptomCountNames(viewData.LastCycleSymptoms), testCase.wantSymptoms)
+		})
+	}
+}
+
+func assertStatsReadOwner(t *testing.T, seam string, got uint, want uint) {
+	t.Helper()
+	if got != want {
+		t.Errorf("%s read owner id = %d, want %d", seam, got, want)
+	}
+}
+
+func statsSymptomCountNames(items []StatsSymptomCountViewData) []string {
+	names := make([]string, 0, len(items))
+	for _, item := range items {
+		names = append(names, item.Name)
+	}
+	return names
+}
+
+func assertOnlySymptomName(t *testing.T, section string, names []string, want string) {
+	t.Helper()
+	if len(names) != 1 || names[0] != want {
+		t.Errorf("%s = %v, want exactly [%s]", section, names, want)
+	}
+}

--- a/internal/services/stats_phase_insights.go
+++ b/internal/services/stats_phase_insights.go
@@ -49,7 +49,13 @@ type completedCyclePhaseContext struct {
 }
 
 func buildCompletedCyclePhaseContexts(logs []models.DailyLog, location *time.Location) []completedCyclePhaseContext {
-	starts := DetectCycleStarts(logs)
+	// ObservedCycleStarts, the same detector buildCompletedCycleSpans reads, and
+	// for the same reason: it is the one that honours an explicit cycle start and
+	// withholds a cluster whose only explicit start the owner marked uncertain.
+	// The raw gap walk (DetectCycleStarts) keeps that start, and the two used to
+	// run side by side in a single render — the ribbon reporting one merged cycle
+	// where the phase cards counted two.
+	starts := ObservedCycleStarts(logs)
 	if len(starts) < 2 {
 		return nil
 	}

--- a/internal/services/stats_service_test.go
+++ b/internal/services/stats_service_test.go
@@ -9,58 +9,93 @@ import (
 	"github.com/ovumcy/ovumcy-web/internal/models"
 )
 
+// The stats doubles observe the owner operand of every read they serve. All
+// four reads are owner-scoped in production — the ranged logs, all logs, the
+// frequency calculation and the symptom catalogue — and while the doubles
+// discarded the id, each of those call sites could be re-pointed at a constant
+// owner with the whole stats selection still green. The *ByOwner maps let a
+// test serve different data per owner so the rendered page, not just the
+// recorded id, tells the two apart.
 type stubStatsDayReader struct {
 	logsForRange   []models.DailyLog
 	logsForAll     []models.DailyLog
+	logsByOwner    map[uint][]models.DailyLog
 	rangeErr       error
 	allErr         error
 	fetchAllCalled bool
 	gotFrom        time.Time
 	gotTo          time.Time
+	gotRangeOwner  uint
+	gotAllOwner    uint
 }
 
-func (stub *stubStatsDayReader) FetchLogsForUser(ctx context.Context, _ uint, from time.Time, to time.Time, _ *time.Location) ([]models.DailyLog, error) {
+func (stub *stubStatsDayReader) FetchLogsForUser(ctx context.Context, userID uint, from time.Time, to time.Time, _ *time.Location) ([]models.DailyLog, error) {
+	stub.gotRangeOwner = userID
 	stub.gotFrom = from
 	stub.gotTo = to
 	if stub.rangeErr != nil {
 		return nil, stub.rangeErr
 	}
-	result := make([]models.DailyLog, len(stub.logsForRange))
-	copy(result, stub.logsForRange)
-	return result, nil
+	return copyDailyLogsForOwner(stub.logsByOwner, userID, stub.logsForRange), nil
 }
 
-func (stub *stubStatsDayReader) FetchAllLogsForUser(context.Context, uint) ([]models.DailyLog, error) {
+func (stub *stubStatsDayReader) FetchAllLogsForUser(_ context.Context, userID uint) ([]models.DailyLog, error) {
+	stub.gotAllOwner = userID
 	stub.fetchAllCalled = true
 	if stub.allErr != nil {
 		return nil, stub.allErr
 	}
-	result := make([]models.DailyLog, len(stub.logsForAll))
-	copy(result, stub.logsForAll)
-	return result, nil
+	return copyDailyLogsForOwner(stub.logsByOwner, userID, stub.logsForAll), nil
+}
+
+// copyDailyLogsForOwner serves the owner's own rows when the test supplied a
+// per-owner map, and the flat slice otherwise. It always copies: a double that
+// hands out its own backing array lets the subject mutate the fixture.
+func copyDailyLogsForOwner(byOwner map[uint][]models.DailyLog, userID uint, fallback []models.DailyLog) []models.DailyLog {
+	source := fallback
+	if byOwner != nil {
+		source = byOwner[userID]
+	}
+	result := make([]models.DailyLog, len(source))
+	copy(result, source)
+	return result
 }
 
 type stubStatsSymptomReader struct {
-	frequencies []SymptomFrequency
-	symptoms    []models.SymptomType
-	err         error
+	frequencies        []SymptomFrequency
+	frequenciesByOwner map[uint][]SymptomFrequency
+	symptoms           []models.SymptomType
+	symptomsByOwner    map[uint][]models.SymptomType
+	err                error
+	gotFrequencyOwner  uint
+	gotSymptomOwner    uint
 }
 
-func (stub *stubStatsSymptomReader) CalculateFrequencies(context.Context, uint, []models.DailyLog) ([]SymptomFrequency, error) {
+func (stub *stubStatsSymptomReader) CalculateFrequencies(_ context.Context, userID uint, _ []models.DailyLog) ([]SymptomFrequency, error) {
+	stub.gotFrequencyOwner = userID
 	if stub.err != nil {
 		return nil, stub.err
 	}
-	result := make([]SymptomFrequency, len(stub.frequencies))
-	copy(result, stub.frequencies)
+	source := stub.frequencies
+	if stub.frequenciesByOwner != nil {
+		source = stub.frequenciesByOwner[userID]
+	}
+	result := make([]SymptomFrequency, len(source))
+	copy(result, source)
 	return result, nil
 }
 
-func (stub *stubStatsSymptomReader) FetchSymptoms(context.Context, uint) ([]models.SymptomType, error) {
+func (stub *stubStatsSymptomReader) FetchSymptoms(_ context.Context, userID uint) ([]models.SymptomType, error) {
+	stub.gotSymptomOwner = userID
 	if stub.err != nil {
 		return nil, stub.err
 	}
-	result := make([]models.SymptomType, len(stub.symptoms))
-	copy(result, stub.symptoms)
+	source := stub.symptoms
+	if stub.symptomsByOwner != nil {
+		source = stub.symptomsByOwner[userID]
+	}
+	result := make([]models.SymptomType, len(source))
+	copy(result, source)
 	return result, nil
 }
 

--- a/internal/services/webhook_notify_service_test.go
+++ b/internal/services/webhook_notify_service_test.go
@@ -176,6 +176,18 @@ func periodStartLog(userID uint, day time.Time) models.DailyLog {
 	}
 }
 
+// completedCycleStartLogs returns the owner's current cycle start plus the
+// previous start exactly one 28-day cycle earlier. The ovulation reminder is
+// withheld until one cycle has been observed (FertilityProjectionSuppressed),
+// and a previous start one full cycle back observes the same 28 days the record
+// carries, so every projected date stays where the case pins it.
+func completedCycleStartLogs(userID uint, day time.Time) []models.DailyLog {
+	return []models.DailyLog{
+		periodStartLog(userID, day.AddDate(0, 0, -28)),
+		periodStartLog(userID, day),
+	}
+}
+
 // dueRecord returns a notify record for a regular 28-day owner whose last period
 // started lastPeriodDaysAgo before now, with webhook delivery on and the given
 // ciphertext-of-record URL token. With a 28-day cycle and lastPeriodDaysAgo=26,
@@ -917,7 +929,7 @@ func TestNotifyDeliversOvulationReminderCopy(t *testing.T) {
 	now := time.Date(2026, 3, 12, 9, 0, 0, 0, time.UTC)
 	record := ovulationDueRecord(1, "https://a.example/hook", now)
 	repo := &stubNotifyRepo{records: []models.WebhookNotifyRecord{record}}
-	logs := stubLogReader{byUser: map[uint][]models.DailyLog{1: {periodStartLog(1, *record.LastPeriodStart)}}}
+	logs := stubLogReader{byUser: map[uint][]models.DailyLog{1: completedCycleStartLogs(1, *record.LastPeriodStart)}}
 	deliverer := &stubDeliverer{}
 	service := newTestNotifyService(repo, logs, stubDecryptor{}, deliverer)
 

--- a/internal/services/webhook_reminder.go
+++ b/internal/services/webhook_reminder.go
@@ -162,8 +162,9 @@ func DecideDueReminders(user *models.User, settings WebhookReminderSettings, log
 	// stats derivation (baseline + pregnancy-pause resolution) without a store.
 	stats := NewStatsService(nil, nil).BuildCycleStatsFromLogs(user, logs, now, location)
 
-	// Medical-safety gate: if the app suppresses predictions, emit nothing.
-	if DashboardPredictionDisabled(user) || stats.PregnancyPaused || DashboardCycleOverdue(user, stats) {
+	// Medical-safety gate: if the app suppresses predictions, emit nothing. The
+	// three signals are read through the predicate every surface shares.
+	if PredictionsSuppressed(user, stats) {
 		return nil
 	}
 
@@ -177,8 +178,15 @@ func DecideDueReminders(user *models.User, settings WebhookReminderSettings, log
 	if due, ok := decidePeriodReminder(settings, prediction, today, leadDays); ok {
 		reminders = append(reminders, due)
 	}
-	if due, ok := decideOvulationReminder(stats, settings, prediction, today, cycleLength, leadDays); ok {
-		reminders = append(reminders, due)
+	// The ovulation reminder carries the extra first-cycle floor: before one
+	// cycle has been observed its date comes from the onboarding slider alone,
+	// and this pass sends it to an endpoint outside the instance
+	// (FertilityProjectionSuppressed). The period reminder keeps its own path —
+	// it is anchored on a recorded cycle start and rides the estimate flag.
+	if !FertilityProjectionSuppressed(user, stats) {
+		if due, ok := decideOvulationReminder(stats, settings, prediction, today, cycleLength, leadDays); ok {
+			reminders = append(reminders, due)
+		}
 	}
 
 	if len(reminders) == 0 {

--- a/internal/services/webhook_reminder_test.go
+++ b/internal/services/webhook_reminder_test.go
@@ -41,6 +41,21 @@ func enabledWebhookSettings(leadDays int) WebhookReminderSettings {
 	}
 }
 
+// webhookReminderCycleLogs seeds the cycle start under test plus the previous
+// start exactly one 28-day cycle earlier. The ovulation reminder rides the
+// first-cycle floor (FertilityProjectionSuppressed), so the decision path needs
+// one completed cycle behind it; a previous start one full cycle back is the
+// same 28 days the account settings carry, which leaves every projected date
+// exactly where these cases pin it.
+func webhookReminderCycleLogs(t *testing.T, start string) []models.DailyLog {
+	t.Helper()
+	startDay := mustParseWebhookReminderDay(t, start, time.UTC)
+	return []models.DailyLog{
+		{Date: startDay.AddDate(0, 0, -28), IsPeriod: true, CycleStart: true},
+		{Date: startDay, IsPeriod: true, CycleStart: true},
+	}
+}
+
 // findDueReminder returns the reminder of the given type, or false when absent.
 func findDueReminder(reminders []DueReminder, reminderType string) (DueReminder, bool) {
 	for _, reminder := range reminders {
@@ -116,9 +131,7 @@ func TestReminderWithinWindowZeroLeadOnlyToday(t *testing.T) {
 func TestDecideDueRemindersOvulationWindowBoundaries(t *testing.T) {
 	const leadDays = 3
 	user := regularWebhookUser()
-	logs := []models.DailyLog{
-		{Date: mustParseWebhookReminderDay(t, "2026-03-01", time.UTC), IsPeriod: true, CycleStart: true},
-	}
+	logs := webhookReminderCycleLogs(t, "2026-03-01")
 
 	cases := []struct {
 		name       string
@@ -219,9 +232,7 @@ func TestDecideDueRemindersPeriodWindow(t *testing.T) {
 func TestDecideDueRemindersIdempotencyByWatermark(t *testing.T) {
 	const leadDays = 14
 	user := regularWebhookUser()
-	logs := []models.DailyLog{
-		{Date: mustParseWebhookReminderDay(t, "2026-03-01", time.UTC), IsPeriod: true, CycleStart: true},
-	}
+	logs := webhookReminderCycleLogs(t, "2026-03-01")
 	now := mustParseWebhookReminderDay(t, "2026-03-28", time.UTC)
 
 	// Baseline (no watermarks): both kinds fire. Capture their anchors.
@@ -405,9 +416,7 @@ func TestDecideDueRemindersSuppressesOverdueCycle(t *testing.T) {
 func TestDecideDueRemindersToggles(t *testing.T) {
 	const leadDays = 14
 	user := regularWebhookUser()
-	logs := []models.DailyLog{
-		{Date: mustParseWebhookReminderDay(t, "2026-03-01", time.UTC), IsPeriod: true, CycleStart: true},
-	}
+	logs := webhookReminderCycleLogs(t, "2026-03-01")
 	now := mustParseWebhookReminderDay(t, "2026-03-28", time.UTC)
 
 	t.Run("webhook disabled emits nothing", func(t *testing.T) {
@@ -466,9 +475,7 @@ func TestDecideDueRemindersTimezoneResolvesOnOwnerLocalDay(t *testing.T) {
 	user := regularWebhookUser()
 	// Period log built as a plain calendar day (UTC-midnight), matching how
 	// stored date-only values persist.
-	logs := []models.DailyLog{
-		{Date: mustParseWebhookReminderDay(t, "2026-03-01", time.UTC), IsPeriod: true, CycleStart: true},
-	}
+	logs := webhookReminderCycleLogs(t, "2026-03-01")
 	// 2026-03-14 02:00 UTC → 03-14 11:00 in Tokyo, 03-13 in Los Angeles.
 	nowInstant := time.Date(2026, time.March, 14, 2, 0, 0, 0, time.UTC)
 

--- a/internal/templates/stats.html
+++ b/internal/templates/stats.html
@@ -103,7 +103,7 @@
         {{else}}
         <p class="stat-label">{{t .Messages "dashboard.current_phase"}}</p>
           {{if .CycleDataStale}}
-          <p class="stat-value mt-2"><span class="mr-2" aria-hidden="true">{{template "icon" (phaseIcon "unknown")}}</span>{{phaseLabel .Messages "unknown"}}</p>
+          <p class="stat-value mt-2" data-stats-current-phase="unknown" data-fertility-status="unknown"><span class="mr-2" aria-hidden="true">{{template "icon" (phaseIcon "unknown")}}</span>{{phaseLabel .Messages "unknown"}}</p>
           <p class="warning-amber mt-2 text-xs" data-stats-phase-estimated data-notice-key="dashboard.phase_estimated">{{t .Messages "dashboard.phase_estimated"}}</p>
           {{else}}
           <p class="stat-value mt-2" data-stats-current-phase="{{.Stats.CurrentPhase}}" data-fertility-status="{{.Stats.CurrentFertility}}"><span class="mr-2" aria-hidden="true">{{template "icon" (phaseIcon .Stats.CurrentPhase)}}</span>{{phaseLabel .Messages .Stats.CurrentPhase}}</p>


### PR DESCRIPTION
One medical-safety policy — no fertility claim before a cycle has been observed — was written out
once per surface, and four of the five copies were missing the floor. This collapses the repeated
disjunction into one predicate, gives it the completed-cycle floor, and points every surface at it.
Alongside it: the two halves of the stats page stop counting different cycles, and two tests that
were green about nothing now assert what their names claim.

Seven records from the P1 board, wave 3: R2-0040, R2-0085, R2-0107, R2-0424, R2-0838, R2-0855,
R2-0960.

## What each record claimed, and what changed

### R2-0040 / R2-0107 / R2-0838 / R2-0855 — one defect, four surfaces

The zero-completed-cycle floor (`DashboardAwaitingFirstCycle`, `stats.CompletedCycleCount < 1`) ran
on the dashboard header alone. The calendar day states, the `.ics` feed, the webhook reminder pass
and the dashboard's own reminder banner each carried only the three disjuncts
`DashboardPredictionDisabled(user) || stats.PregnancyPaused || DashboardCycleOverdue(user, stats)`.
With zero logged cycles the baseline is slider-derived (`cycle_baseline.go:51-58,:70-101`), so those
four went on projecting a fertile window, a peak band and an ovulation day — two of them *off the
instance*, into a subscribed calendar client and to a configured webhook endpoint.

- `dashboard_cycle.go` now holds both predicates: `PredictionsSuppressed` (the three signals,
  verbatim, so no surface changes behaviour by adopting it) and `FertilityProjectionSuppressed`
  (those plus the completed-cycle floor). Their doc comments state the rule the group exists to
  enforce: a new suppression signal belongs in the predicate, never in a caller.
- `calendar_days.go` — whole-grid gate via `PredictionsSuppressed`; the fertility maps
  (pre-fertile, edge, peak, ovulation) and the fertility half of each chained projected cycle now
  ride `FertilityProjectionSuppressed`, through a new `includeFertility` argument on
  `appendPredictedCycles`.
- `calendar_feed_ics.go` — same gate; the ovulation VEVENT rides the floor.
- `webhook_reminder.go` — same gate; the ovulation reminder rides the floor.
- `dashboard_reminder_banner.go` — the ovulation banner gates on the decision the cycle context
  resolved (see Review below).

The BBT pass (`calendar_days.go`) is skipped in the suppressed tier: it never surfaces a *detected*
ovulation date — when a shift is found it returns early — it only demotes the projected day to
"tentative", so running it there would reintroduce the day the floor just removed, one shade
lighter. Recorded data is untouched everywhere: logged period days, has-data, sex activity, the
historical fertile windows painted from the owner's own recorded starts, and the projected
next-period days.

Guard: `internal/services/prediction_first_cycle_floor_test.go` — one table, two cycle histories
(0 and 1 completed cycles) × four surfaces, with the fixture's completed-cycle count asserted so a
fixture that stopped meaning what its name says fails on the count rather than quietly changing
what the surfaces are asked.

**Red, against the unfixed code:**

```
calendar: ovulation days present = true, want false (3 days)
calendar: fertility days present = true, want false (27 days)
feed: ovulation VEVENTs present = true, want false (3 events)
webhook: ovulation reminder due = true, want false
banner: ovulation banner shown = true, want false (kind "ovulation", show true)
```

The one-completed-cycle row passed throughout — the guard is not green by emptying every
projection. **Green** after the wiring, and red again on all six assertions if the floor is dropped
from the predicate (the experiment is reproducible: delete `|| DashboardAwaitingFirstCycle(stats)`
from `FertilityProjectionSuppressed`).

### R2-0085 — two cycle-start detectors in one render

`buildCompletedCycleSpans` (ribbon, cycle-factor context) read `ObservedCycleStarts`, which drops a
cluster whose only explicit start the owner marked uncertain; `buildCompletedCyclePhaseContexts`
(phase cards, history statements) read `DetectCycleStarts`, a raw gap walk that keeps it. One
uncertain start made a single page report a merged 56-day cycle in one panel and two 28-day cycles
in the other — and the merged length then fed the cycle-factor comparison, which labelled the
fabricated cycle "longer" and attributed the owner's logged factors to it.

`stats_phase_insights.go` now reads `ObservedCycleStarts`, the detector that honours an explicit
start and an uncertainty flag. Guard:
`internal/services/stats_completed_cycle_agreement_test.go` — four rows (plain clusters, explicit
starts, uncertain middle start, uncertain latest start) asserting both builders' counts, cycle
lengths and start dates, and asserting the shared answer rather than merely pinning the two to each
other.

**Red, against the unfixed code:**

```
cycle count disagrees: 1 span(s) against 2 phase context(s) — an uncertain-only cluster yields no start, so the two cycles read as one
phase-context cycle lengths = [28 28], want [56]
phase-context starts = [2026-01-01 2026-01-29], want [2026-01-01]
```

**Green** after the detector change, with no fixture fallout in the package.

### R2-0424 — a stale-cycle test asserting a tautology

`TestStatsPageShowsUnknownPhaseWhenCycleDataIsStale` seeded no logs at all, found the empty state,
and then asserted `data-stats-completed-cycles < 2` — the gating condition its own fixture had just
established. It never read a phase. On the path it took the phase card is not rendered at all: the
empty state and the card are the two arms of one `if/else`.

Rewritten to seed three period starts (two completed cycles, so the insights grid and the card are
on screen) with a 60-day-stale anchor, and to assert the *rendered* phase and fertility status. That
needed one template line: the stale arm of the card carried no `data-*` hook at all, so the withheld
phase could not be read — `internal/templates/stats.html` now renders
`data-stats-current-phase="unknown" data-fertility-status="unknown"` there, the same shape
`dashboard.html` already uses. A positive anchor (`…RendersTheDetectedPhaseWhileTheAnchorIsCurrent`)
keeps a hard-coded "unknown" from passing, and the empty-state progress-meter case keeps its own
zero-cycle fixture.

**Three-step evidence.** Production broken so the stale arm renders the detected phase:

1. old test → `--- PASS` (it only re-read its own empty-state count);
2. new test → `--- FAIL … expected the rendered phase to be unknown on a 60-day-stale cycle, got "luteal"`;
3. suppression restored → green.

### R2-0960 — four owner-scoped reads, all discarded by the doubles

The shared stats doubles dropped the owner argument on the ranged logs, all logs, the frequency
calculation and the symptom catalogue, while production forwards `user.ID` at four call sites. The
stats page is the richest health-data read in the product, and an instance may host more than one
independent owner.

`stats_service_test.go` records all four owner operands and can serve different data per owner.
Guard: `internal/services/stats_page_view_service_owner_scope_test.go` — two owners with different
cycle lengths and different symptom names, asserting both the recorded ids and what the page
reports.

**Three-step evidence.** `user.ID` replaced by the constant `1` at `stats_service.go:50,:132,:138`
and `stats_page_view_service.go:253`:

1. the whole `internal/services` package → **only** the new guard failed, so the pre-existing
   selection was green about all four seams;
2. the new guard named each one — `ranged logs read owner id = 1, want 11`, `all logs …`,
   `frequency calculation …`, `symptom catalogue …` — plus the rendered divergence
   `median cycle length = 30, want 28 — the page reports another owner's cycle history`;
3. `user.ID` restored → green.

## Two deliberate scope decisions

**Projected next-period output is retained; only fertility/ovulation is suppressed.** R2-0855's
guard text asks for "a valid empty VCALENDAR with no period/ovulation VEVENTs". The area rule scopes
the zero-completed-cycle trigger to the slider-derived *fertility status and ovulation estimate*,
and the dashboard header keeps showing its next-period estimate in that tier, with its own
qualifier: the anchor is a day the owner recorded, and only the cycle *length* falls back to the
setting. Suppressing next-period on the feed would have made one predicate mean two different
policies on two surfaces — the disagreement this group exists to end. The remaining §10.6 question
is whether the feed states a period date *as fact*, and it does not: every VEVENT carries the single
neutral summary at `calendar_feed_ics.go:45` (`"Ovumcy: reminder (estimate)"`), which already
carries the estimate qualifier and no health specifics.

**No stats-page code was needed.** R2-0838 lists the stats fertility status among the leaking
surfaces. That value is real in `CycleStats`, but the card that renders it is behind `HasInsights`,
set at `stats_service.go:108` as `completedCycleCount >= statsMinimumInsightsCycles` (2) and pinned
false at one completed cycle by `stats_page_view_service_test.go:164` — strictly stricter than the
floor, so below two cycles the whole grid is replaced by the empty state and no fertility status is
rendered. A `ShowFertilityStatus` field there would have been an unreachable branch.

## Review

Two findings came out of review; both are closed in this branch.

1. **The banner was gated on the tier, not on the predicate.** It read `cycleContext
   .AwaitingFirstCycle` directly, so dropping the floor from `FertilityProjectionSuppressed` left
   the banner assertion green while the other three surfaces went red — exactly the divergence the
   group exists to end. `BuildDashboardCycleContext` now resolves the predicate once and carries it
   as `DashboardCycleContext.FertilitySuppressed`, set on **all three** branches (pregnancy-paused,
   predictions-disabled, normal): a context that answered "not suppressed" on a suppression branch
   would hand the banner the rule it is meant to be gated by. The banner reads that field; its other
   three disjuncts are display conditions, not policy. The guard now asserts the carried decision
   *equals* `FertilityProjectionSuppressed(user, stats)`, so the banner row can see a change in the
   predicate. Re-running the drop-the-floor experiment now fails six assertions, including
   `banner: cycle context carries FertilitySuppressed = false, want true` and
   `banner: ovulation banner shown = true, want false`.
2. **Both scope decisions above were re-derived independently** rather than taken on the report —
   the feed summary and the `HasInsights` gate are the two checks that settled them, and they are
   cited in place above.

## Fixture repairs outside the group's file list

Extending a suppression to four surfaces necessarily changes what those surfaces emit under existing
fixtures. Five files were repaired for that reason and no other; each repair lifts a fixture above
the floor honestly and says so in place, and each keeps every projected date exactly where its test
pins it:

- `internal/services/calendar_days_test.go`, `internal/services/calendar_days_coverage_test.go` —
  nine `CycleStats` literals gain `CompletedCycleCount: 1`. These cases pin window math, not the
  tier that withholds a window.
- `internal/services/webhook_reminder_test.go` — four fixtures seeding a single cycle start now use
  one helper that adds the previous start exactly one 28-day cycle back: the same 28 days the
  account settings already carry, so median, projection and every asserted date are unchanged.
- `internal/services/webhook_notify_service_test.go` — the ovulation-copy case gets the same
  two-start history.
- `internal/api/calendar_ovulation_tag_regression_test.go` — the ovulation-tag fixture seeds the
  previous cycle's period days as well.

## Follow-up (not in this PR)

- `internal/services/dashboard_view_service.go:273-274` still writes the floor longhand:
  `!predictionSuppressed && !cycleContext.AwaitingFirstCycle` is `!FertilityProjectionSuppressed`
  spelled out, and `:201` (`ShowFertilityStatus`) plus `dashboard_cycle_hero.go:197` ride the same
  tier by hand. The file is outside this group's scope; it is the one remaining longhand site and
  the natural next change.
- `internal/services/day_feedback_policy.go` carries the FOLLOW-UP note left by #526: "the fifth
  surface carrying that same zero-completed-cycle floor, and the only one still spelling it out for
  itself … fold this call into that predicate once it exists". The predicate it waits for is
  `FertilityProjectionSuppressed`, and surfaces holding a cycle context can read
  `DashboardCycleContext.FertilitySuppressed` instead.
- The completed-cycle *count* itself (`CompletedCycleTrendLengths`, `CycleLengths`) still walks
  `DetectCycleStarts`, so "where does a cycle begin" has one more answer than this PR unified. It
  has its own finding.

## Verification

`gofmt -l` clean on every file authored here; `go build ./...`; `go vet`; `golangci-lint run` over
the repository → 0 issues; `go test -count=1 ./...` with a 25m timeout → all packages ok (and
`./internal/services/...` + `./internal/api/...` re-run after the rebase onto current `main`);
`go run ./scripts/changelogd check` → OK; `scripts/patchcov` against a profile generated in the same
invocation → every modified coverable line covered.

## Browser specs: the same two classes, and one of them is the evidence

The e2e shard caught four cases the group's file list did not reach. They split into the two classes
this change produces, and the split is the point: a fixture that never meant to talk about the data
tier needs a completed cycle; an expectation that encoded the old policy has to change, and its
failure is the change working.

**Fixture debt — seeded no completed cycle, subject is something else entirely.** Each now logs the
previous cycle exactly one settings-length back, so the observed length equals the configured one and
every date the case pins stays where it was:

- `e2e/a11y-wcag-audit.spec.ts` (`calendar phase cells keep day numbers above WCAG AA in both
  themes`) — measures contrast on a fertile cell; the cell was correctly withheld.
- `e2e/calendar.spec.ts` (`BBT tracking without a confirmed signal demotes the predicted ovulation
  day to a tentative dash`) — the demotion acts on the projected ovulation day, and the floor
  withholds it; the case now logs this cycle's start and the one 28 days before it, so the latest
  logged start is still today-13 and the predicted ovulation still lands on today.
- `e2e/calendar.spec.ts` (`the two fertile tiers paint distinct fills for the default usage goal`) —
  needs the fertile window to paint at all. Two previous cycles, not one: on a run date that *is* the
  1st of the month the anchor itself has closed no cycle, and the pair before it has.

**An expectation that encoded the old policy — not to be rescued by widening the fixture.**
`e2e/bugs.spec.ts` (BUG-01, `calendar marks the current baseline period window … before manual day
logs exist`) asserted `data-calendar-state="pre-fertile"` on the day after the baseline period
window, on an account with no completed cycle: its whole subject is the tier this change withholds
the fertile half in. Seeding a second cycle there would have quietly changed what the case is about.
The assertion now pins `default`, the case is renamed to state the floor it pins, and BUG-01's own
subject is intact — the predicted-period assertion beside it is untouched and still green, which is
the projected-period half being deliberately retained.

Two specs that pass **unchanged** are worth naming as the other half of that evidence:
`e2e/dashboard-reminder-banner.spec.ts` renders period banners on accounts with zero completed cycles
and stays green (the floor is fertility-only), and `e2e/dashboard.spec.ts` (`the goal about timing
gets the first-cycle promise …`) already asserted the dashboard's own first-cycle behaviour — the
rule the other four surfaces have now joined.

The rest of `e2e/` was swept for both classes (`calendar-cell-fertile`, `-pre-fertile`,
`ovulation-dot`, `ovulation-dash`, `data-calendar-state`, `data-fertility-status`,
`data-dashboard-ovulation`, reminder-banner keys) rather than stopping at what the shard reported:
the calendar legend is static markup, the dark-theme ribbon and the stats specs seed two or more
cycles already, and `visual-a11y.spec.ts` sets its phase/fertility attributes in the page.

**Evidence.** Both calendar repairs were red-checked by removing the seeding again:
`element(s) not found` for `button[data-day]:has(.calendar-ovulation-dash)` and for
`.calendar-cell-fertile:not(...)`, so neither fixture was widened without cause. Full local suite
after the repairs: **196 passed, 5 skipped** (the opt-in OIDC lanes and closed-registration mode),
`npm run e2e`, 19.0m, exit 0. `npm run lint` (ESLint over `e2e/` plus `tsc --noEmit`) clean.
