### PR TITLE
test(api): scope each egress disclaimer check to its own hook

### DIFF
--- a/changelog.d/fix-prediction-disclaimer-hook-scoping.md
+++ b/changelog.d/fix-prediction-disclaimer-hook-scoping.md
@@ -1,0 +1,12 @@
+none
+
+Test-only tightening: the settings egress regression now binds the medical
+disclaimer to each surface that ships predicted dates off the instance, instead
+of counting the wording across the whole page. Both hooks — the webhook reminder
+and the calendar feed — are located in the parsed document, and each one's own
+subtree must contain «not medical advice or a method of contraception». The old
+assertion paired hook presence with a page-wide occurrence count, so emptying
+the calendar-feed disclaimer while the webhook disclaimer stated the sentence
+twice held the page total at two and kept the test green with one egress surface
+carrying no qualifier at all. No production change: both templates already
+render the shared key.

--- a/internal/api/dashboard_prediction_disclaimer_test.go
+++ b/internal/api/dashboard_prediction_disclaimer_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"golang.org/x/net/html"
 )
 
 // TestDashboardRendersPredictionDisclaimer pins the medical-safety labeling
@@ -54,20 +56,32 @@ func TestCalendarRendersPredictionDisclaimer(t *testing.T) {
 // the calendar feed. Both used to spell the qualifier out in their own
 // catalogue entry; they now reference the single medical.disclaimer key, so
 // this pins that the consolidation of the TEXT did not silently drop either
-// SURFACE — the count of surfaces showing the disclaimer is the invariant.
+// SURFACE. The binding is made PER SURFACE: each hook's own subtree must carry
+// the mandatory wording. A page-wide occurrence count cannot do that — an empty
+// calendar-feed disclaimer beside a webhook disclaimer stating the sentence
+// twice keeps the page total at two and passes while one egress surface ships
+// predicted dates with no qualifier at all.
 func TestSettingsEgressSurfacesRenderPredictionDisclaimer(t *testing.T) {
 	app, database := newOnboardingTestApp(t)
 	user := createOnboardingTestUser(t, database, "settings-disclaimer@example.com", "StrongPass1", true)
 	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
 
 	body := fetchPageBody(t, app, "/settings", authCookie)
+	document := mustParseHTMLDocument(t, body)
 	for _, hook := range []string{`data-webhook-disclaimer`, `data-calendar-feed-disclaimer`} {
-		if !strings.Contains(body, hook) {
+		elements := htmlFindElements(document, func(node *html.Node) bool {
+			return node.Type == html.ElementNode && htmlHasAttr(node, hook)
+		})
+		if len(elements) == 0 {
 			t.Fatalf("settings must render the disclaimer hook %q", hook)
 		}
-	}
-	if occurrences := strings.Count(body, "not medical advice or a method of contraception"); occurrences < 2 {
-		t.Fatalf("expected the safety copy on both settings egress surfaces, found %d occurrence(s)", occurrences)
+		for index, element := range elements {
+			text := normalizeHTMLText(htmlNodeText(element))
+			if !strings.Contains(text, "not medical advice or a method of contraception") {
+				t.Fatalf("disclaimer hook %q (occurrence %d of %d) must carry the safety copy in its own subtree, got %q",
+					hook, index+1, len(elements), text)
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
The settings egress regression asserted hook presence and the medical-disclaimer wording independently: both `data-webhook-disclaimer` and `data-calendar-feed-disclaimer` had to be present in the body, and the sentence "not medical advice or a method of contraception" had to appear at least twice *anywhere* on the page. Nothing tied a hook to the text inside it, so the guard held by the current absence of a third occurrence rather than by construction.

Emptying the calendar-feed disclaimer while the webhook disclaimer states the sentence twice keeps the page-wide total at two: the old assertions stay green with one surface that ships predicted dates off the instance carrying no qualifier at all. That is the half of the medical-safety invariant this test exists to hold — a persistent disclaimer **per surface**.

Both hooks are now located in the parsed document and each one's own subtree must contain the mandatory wording, so an empty hook beside a doubled sibling fails and the failure names the hook and the occurrence. Test-only: the templates already render the shared `medical.disclaimer` key and nothing about suppression behaviour changed.

## Verification

The mutation was applied in a scratch worktree and reverted before committing; the committed branch touches no template — `git diff main --stat -- internal/templates/ web/` is empty.

1. Broken templates (`components/settings_calendar_feed.html:17` emptied, `components/settings_webhook.html:14` doubled, page-wide count held at 2), old assertions — still passes:

```
--- PASS: TestSettingsEgressSurfacesRenderPredictionDisclaimer (0.69s)
ok  	github.com/ovumcy/ovumcy-web/internal/api	6.232s
```

2. Broken templates, fixed assertions — fails, naming the culprit:

```
dashboard_prediction_disclaimer_test.go:81: disclaimer hook "data-calendar-feed-disclaimer" (occurrence 1 of 1) must carry the safety copy in its own subtree, got ""
--- FAIL: TestSettingsEgressSurfacesRenderPredictionDisclaimer (1.38s)
```

3. Templates restored, fixed assertions — green across all four disclaimer surfaces:

```
--- PASS: TestDashboardRendersPredictionDisclaimer (0.61s)
--- PASS: TestStatsRendersPredictionDisclaimer (0.58s)
--- PASS: TestCalendarRendersPredictionDisclaimer (0.58s)
--- PASS: TestSettingsEgressSurfacesRenderPredictionDisclaimer (0.59s)
ok  	github.com/ovumcy/ovumcy-web/internal/api	7.484s
```

Full package: `go test ./internal/api/... -count=1 -timeout 20m` → `ok 540.709s`; `go vet` and `golangci-lint run ./internal/api/...` (`0 issues.`) clean.

## Scope

The hooks sit on leaf `<p>` elements, so a subtree check reads the disclaimer itself and cannot be satisfied by neighbouring copy.

`data-calendar-feed-disclaimer` renders on a third surface as well — the one-time reveal page, `calendar_feed_reveal.html:29`. That page is a different route and outside this test's fixture, and it is already guarded: `e2e/settings-calendar-feed.spec.ts` asserts the hook on `/settings/calendar-feed` inside `readRevealedFeed`. That assertion pins visibility rather than the wording, which is the weaker form of the same binding this change tightens on the server side; tightening it is its own change on the browser side and is not folded in here.

Rollback: single-commit revert; nothing persisted, no public contract touched.
