### PR TITLE
test(api): compare register parity bodies by content, not length

### DIFF
--- a/changelog.d/fix-register-parity-body-comparison.md
+++ b/changelog.d/fix-register-parity-body-comparison.md
@@ -1,0 +1,10 @@
+none
+
+Test-only change with no user-visible effect: the register enumeration-parity
+regression compared the two response bodies by length, so `0 == 0` on a pair of
+empty 303 redirects passed whatever the branches actually returned. It now
+compares them byte for byte, requires both to be explicitly empty, and drives
+the same endpoint once more with `Accept: application/json` so the branch that
+does carry a payload is decoded and pinned field by field. A duplicate-email
+answer of `next_step=register_welcomf` — the same width as `register_welcome`,
+which is exactly what a length comparison cannot see — now fails the guard.

--- a/internal/api/auth_register_regressions_test.go
+++ b/internal/api/auth_register_regressions_test.go
@@ -1,12 +1,15 @@
 package api
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"sort"
 	"strings"
 	"testing"
+
+	"github.com/gofiber/fiber/v3"
 )
 
 func TestRegisterValidationErrorRedirectDoesNotLeakEmailOrErrorInQuery(t *testing.T) {
@@ -91,10 +94,20 @@ func TestRegisterResponseParityBetweenNewAndDuplicateEmail(t *testing.T) {
 		t.Fatalf("Location header mismatch: new=%q duplicate=%q", newLoc, dupLoc)
 	}
 
+	// Byte-for-byte, not by length: a body that carries a per-branch token of
+	// the same width ("register_welcome" vs "register_welcomf") is an oracle
+	// that any length comparison reads as parity. Both bodies must also be
+	// explicitly empty, so equal-but-populated redirect bodies cannot pass.
 	newBody := mustReadBodyString(t, newResponse.Body)
 	dupBody := mustReadBodyString(t, dupResponse.Body)
-	if len(newBody) != len(dupBody) {
-		t.Fatalf("body length mismatch: new=%d duplicate=%d", len(newBody), len(dupBody))
+	if newBody != dupBody {
+		t.Fatalf("body mismatch: new=%q duplicate=%q", newBody, dupBody)
+	}
+	if newBody != "" {
+		t.Fatalf("expected an empty redirect body on the new-email branch, got %q", newBody)
+	}
+	if dupBody != "" {
+		t.Fatalf("expected an empty redirect body on the duplicate-email branch, got %q", dupBody)
 	}
 
 	newCookies := indexSetCookies(newResponse)
@@ -122,6 +135,54 @@ func TestRegisterResponseParityBetweenNewAndDuplicateEmail(t *testing.T) {
 		}
 		if cookies[recoveryCodeCookieName] != nil {
 			t.Fatalf("%s response unexpectedly issued recovery cookie", label)
+		}
+	}
+
+	assertRegisterJSONPayloadParity(t, app, "parity-fresh-json@example.com", primaryEmail)
+}
+
+// assertRegisterJSONPayloadParity re-drives both branches with a JSON-negotiated
+// request. The HTML branch answers with an empty 303 body, so comparing bodies
+// there — however strictly — cannot observe a payload-carried oracle at all; the
+// JSON representation of the same endpoint is where the register response has
+// fields to diverge in. Both payloads are decoded and pinned to their expected
+// values, so a divergence that keeps every body the same width still fails, and
+// so does a token that drifts on both branches at once.
+func assertRegisterJSONPayloadParity(t *testing.T, app *fiber.App, freshEmail, duplicateEmail string) {
+	t.Helper()
+
+	newResponse := mustAppResponse(t, app, jsonRegisterRequest(freshEmail))
+	dupResponse := mustAppResponse(t, app, jsonRegisterRequest(duplicateEmail))
+
+	assertStatusCode(t, newResponse, http.StatusCreated)
+	assertStatusCode(t, dupResponse, http.StatusCreated)
+
+	newBody := mustReadBodyString(t, newResponse.Body)
+	dupBody := mustReadBodyString(t, dupResponse.Body)
+	if newBody != dupBody {
+		t.Fatalf("JSON body mismatch: new=%q duplicate=%q", newBody, dupBody)
+	}
+
+	for _, branch := range []struct {
+		label string
+		body  string
+	}{{label: "new", body: newBody}, {label: "duplicate", body: dupBody}} {
+		payload := struct {
+			OK       bool   `json:"ok"`
+			NextStep string `json:"next_step"`
+			NextPath string `json:"next_path"`
+		}{}
+		if err := json.Unmarshal([]byte(branch.body), &payload); err != nil {
+			t.Fatalf("decode %s register payload %q: %v", branch.label, branch.body, err)
+		}
+		if !payload.OK {
+			t.Fatalf("%s register payload reported ok=false: %q", branch.label, branch.body)
+		}
+		if payload.NextStep != "register_welcome" {
+			t.Fatalf("%s register payload next_step = %q, want %q", branch.label, payload.NextStep, "register_welcome")
+		}
+		if payload.NextPath != "/register/welcome" {
+			t.Fatalf("%s register payload next_path = %q, want %q", branch.label, payload.NextPath, "/register/welcome")
 		}
 	}
 }
@@ -158,6 +219,12 @@ func registerRequest(email string) *http.Request {
 	request := httptest.NewRequest(http.MethodPost, "/api/v1/users", strings.NewReader(form.Encode()))
 	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	request.Header.Set("Accept-Language", "en")
+	return request
+}
+
+func jsonRegisterRequest(email string) *http.Request {
+	request := registerRequest(email)
+	request.Header.Set("Accept", fiber.MIMEApplicationJSON)
 	return request
 }
 


### PR DESCRIPTION
`TestRegisterResponseParityBetweenNewAndDuplicateEmail` guards the enumeration-safety property on `POST /api/v1/users`: the response must not reveal whether an account already exists. Its body check was `len(newBody) != len(dupBody)`. Both branches answer with an empty 303 body, so the comparison evaluated `0 == 0` and stayed green for any divergence that kept the two widths equal.

The bodies are now compared byte for byte, and each is required to be explicitly empty — an equal-but-populated pair of redirect bodies no longer passes either.

The redirect body has no payload to inspect, so the same pair is driven once more with `Accept: application/json`, the representation where this endpoint does answer with fields. Both payloads are compared byte for byte and then decoded and pinned to `ok`, `next_step` and `next_path`. Pinning the values rather than only comparing them also fails a token that drifts on **both** branches at once, which a pure parity check cannot see.

Test-only: the register handler and the shared `respondRegisterPickup` are unchanged. The sibling length-only comparison in `assertCookieParity` has its own finding and is untouched.

## Verification

The mutant returns `next_step: "register_welcomf"` on the decoy branch — the same width as `register_welcome`, so both JSON bodies stay 74 bytes and every length comparison reads them as identical.

1. Old assertions, mutant in place — still passes:

```
--- PASS: TestRegisterResponseParityBetweenNewAndDuplicateEmail (3.42s)
```

With the new JSON pair in place but its comparison downgraded back to `len(...)` and the decode skipped, the mutant is still invisible:

```
--- PASS: TestRegisterResponseParityBetweenNewAndDuplicateEmail (6.14s)
```

That isolates the blind spot to the length comparison itself rather than to the absence of a JSON leg.

2. Fixed assertions, mutant in place — fails and names the divergence:

```
auth_register_regressions_test.go:141: JSON body mismatch:
  new="{...\"next_step\":\"register_welcome\",\"ok\":true}"
  duplicate="{...\"next_step\":\"register_welcomf\",\"ok\":true}"
--- FAIL: TestRegisterResponseParityBetweenNewAndDuplicateEmail (4.75s)
```

3. Mutant reverted, fixed assertions — green:

```
--- PASS: TestRegisterResponseParityBetweenNewAndDuplicateEmail (5.58s)
```

`gofmt -l` clean, `go vet ./internal/api/...` clean, `golangci-lint run ./internal/api/...` → `0 issues.`, `go test ./internal/api/... -count=1 -timeout 20m` → `ok 549.778s`.

Rollback: single-commit revert; nothing persisted, no public contract touched.
