### PR TITLE
docs(api): say what the feed's bare 404 actually sends

### DIFF
--- a/changelog.d/fix-calendar-feed-404-comment-accuracy.md
+++ b/changelog.d/fix-calendar-feed-404-comment-accuracy.md
@@ -1,0 +1,9 @@
+none
+
+Comment-only correction in the calendar feed handler: the security envelope and
+the two inline notes claimed the uniform bad-token 404 carries "no body". It
+carries Fiber's fixed status text under `text/plain` — `c.SendStatus` fills an
+empty body — so the promise as written was false in its detail while true in its
+substance, and a reader checking the route against it would have looked for
+something the handler never does. The wording now says what `SendStatus` sends
+and why it is still no oracle: the same bytes whatever the cause was.

--- a/internal/api/handlers_calendar_feed.go
+++ b/internal/api/handlers_calendar_feed.go
@@ -26,9 +26,11 @@ import (
 //     resolves the owner by non-secret selector, constant-time-verifies the
 //     secret verifier, and scopes every read to the resolved user id.
 //   - 404-no-oracle: a malformed token, unknown selector, wrong verifier, and
-//     disabled feed ALL return an identical bare 404 with no body and no
-//     Set-Cookie, and are timing-equalized (a dummy bcrypt runs on the
-//     selector-miss path inside the service).
+//     disabled feed ALL return an identical bare 404 and no Set-Cookie, and are
+//     timing-equalized (a dummy bcrypt runs on the selector-miss path inside the
+//     service). Bare here means what c.SendStatus actually sends: Fiber's fixed
+//     status text under text/plain, the same bytes whatever the cause was — not
+//     an empty body.
 //   - Rate-limited per-IP by the edge /api-style limiter wired in main.go for
 //     this exact path; a 429 returns the limiter's own response (no UI needed).
 //   - Response headers pin text/calendar, a private 1-hour cache, and
@@ -50,7 +52,8 @@ const (
 // ServeCalendarFeed serves an owner's read-only .ics feed, authenticated by the
 // path token alone. It never sets a cookie and never renders an HTML error: the
 // only outcomes are 200 + calendar body, a bare 404 (every not-found/invalid
-// case, no oracle), or a generic 500 on an infrastructure failure.
+// case, answered with the same status text, so no oracle), or a generic 500 on
+// an infrastructure failure.
 func (handler *Handler) ServeCalendarFeed(c fiber.Ctx) error {
 	token := c.Params("token")
 	location := handler.requestLocation(c)
@@ -68,8 +71,9 @@ func (handler *Handler) ServeCalendarFeed(c fiber.Ctx) error {
 	}
 	if !ok {
 		// Uniform bare 404 for malformed token / unknown selector / wrong
-		// verifier / disabled feed. No body, no Set-Cookie, timing-equalized in
-		// the service.
+		// verifier / disabled feed: SendStatus answers with Fiber's fixed status
+		// text, identical in every case. No Set-Cookie, timing-equalized in the
+		// service.
 		return c.SendStatus(fiber.StatusNotFound)
 	}
 


### PR DESCRIPTION
Three comments in the calendar feed handler promised a bad-token 404 with **no body**: the security envelope at the top of the file, the `ServeCalendarFeed` doc comment, and the inline note beside the `SendStatus` call.

The handler answers with `c.SendStatus`, which fills an empty body with Fiber's fixed status text — so every bad-token case sends nine bytes of `Not Found` under `text/plain`. The property the route actually needs is intact: the bytes are identical whatever the cause was, which is what makes the response carry no oracle. But "no body" is not what happens, and a reader auditing the route against that promise would have gone looking for an absence the handler never produces.

The wording now states what `SendStatus` sends and why it is still no oracle. Comment-only: `git diff main -- internal/api/handlers_calendar_feed.go` touches no statement, and `go vet ./internal/api/` is clean.

This was surfaced while tightening the matching regression in #530, which pins the same nine bytes as measured rather than asserting an empty body. That PR is test-only and does not touch this file; the two are independent and can land in either order.

Rollback: single-commit revert; comments only, no behaviour and no contract.
