### PR TITLE
test(api): pin the auth page query exclusion where it can fail

### DIFF
--- a/changelog.d/fix-auth-page-view-query-vacuity.md
+++ b/changelog.d/fix-auth-page-view-query-vacuity.md
@@ -1,0 +1,15 @@
+none
+
+Test-only change with no user-visible effect: the auth page-view builder harness
+encoded a query string into its request URL, but `buildLoginPageData`,
+`buildRegisterPageData` and `buildForgotPasswordPageData` take no `fiber.Ctx`,
+so no assertion standing on that harness could ever observe a query read. The
+`query` parameter is gone, and the two cases named for a query fallback are
+renamed after the flash-absence contract they actually pin.
+
+The exclusion itself now sits where it can fail: `/login`, `/register` and
+`/forgot-password` are each requested through the real app with
+`?email=…&error=…`, and the rendered page must carry neither the query email in
+its own email field nor a server-error block raised by the query. Both halves
+were red-checked on their own against a page handler temporarily taught to read
+the query; with the handlers as they ship, the package is green.

--- a/internal/api/auth_page_view_builder_helpers_test.go
+++ b/internal/api/auth_page_view_builder_helpers_test.go
@@ -8,24 +8,21 @@ import (
 	"testing"
 
 	"github.com/gofiber/fiber/v3"
+	"golang.org/x/net/html"
 )
 
-func evaluateAuthPageBuilder(t *testing.T, query url.Values, handler fiber.Handler) map[string]any {
+func evaluateAuthPageBuilder(t *testing.T, handler fiber.Handler) map[string]any {
 	t.Helper()
-	return evaluateAuthPageBuilderWithCookie(t, query, "", handler)
+	return evaluateAuthPageBuilderWithCookie(t, "", handler)
 }
 
-func evaluateAuthPageBuilderWithCookie(t *testing.T, query url.Values, cookieHeader string, handler fiber.Handler) map[string]any {
+func evaluateAuthPageBuilderWithCookie(t *testing.T, cookieHeader string, handler fiber.Handler) map[string]any {
 	t.Helper()
 
 	app := fiber.New()
 	app.Get("/", handler)
 
-	requestPath := "/"
-	if encoded := query.Encode(); encoded != "" {
-		requestPath += "?" + encoded
-	}
-	request := httptest.NewRequest(http.MethodGet, requestPath, nil)
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
 	if cookieHeader != "" {
 		request.Header.Set("Cookie", cookieHeader)
 	}
@@ -42,4 +39,57 @@ func evaluateAuthPageBuilderWithCookie(t *testing.T, query url.Values, cookieHea
 		t.Fatalf("decode payload failed: %v", err)
 	}
 	return payload
+}
+
+// hostileAuthPageQuery is what an attacker-supplied link carries into a public
+// auth page: an email to prefill and an error state to fake. Neither may be
+// read — PII and error codes travel in the sealed flash cookie, never in a URL.
+var hostileAuthPageQuery = url.Values{
+	"email": {"query-source@example.com"},
+	"error": {"invalid credentials"},
+}
+
+// requestAuthPageWithHostileQuery drives the REAL route through the real app so
+// the assertion observes the markup a browser would receive. The builders take
+// no fiber.Ctx today, which is exactly why the exclusion has to be pinned here
+// rather than at the builder: a query read reintroduced into a page handler is
+// invisible to any test that calls the builder directly.
+func requestAuthPageWithHostileQuery(t *testing.T, app *fiber.App, path string) string {
+	t.Helper()
+
+	request := httptest.NewRequest(http.MethodGet, path+"?"+hostileAuthPageQuery.Encode(), nil)
+	request.Header.Set("Accept-Language", "en")
+
+	response := mustAppResponse(t, app, request)
+	assertStatusCode(t, response, http.StatusOK)
+	return mustReadBodyString(t, response.Body)
+}
+
+// assertAuthPageIgnoredTheQuery pins both halves of the exclusion on a rendered
+// auth page: the query email reaches neither the markup nor the form field that
+// would round-trip it, and the query error raises no server-error block. The
+// email input is looked up by id first, so a page that stopped rendering its
+// form fails here instead of passing on absence.
+func assertAuthPageIgnoredTheQuery(t *testing.T, body string, emailInputID string) {
+	t.Helper()
+
+	assertBodyNotContainsAll(t, body, bodyStringMatch{
+		fragment: hostileAuthPageQuery.Get("email"),
+		message:  "did not expect the query email to reach the rendered auth page",
+	})
+
+	root := mustParseHTMLDocument(t, body)
+	emailInput := htmlElementByID(root, emailInputID)
+	if emailInput == nil {
+		t.Fatalf("expected the auth page to render its %q field", emailInputID)
+	}
+	if value := htmlAttr(emailInput, "value"); value != "" {
+		t.Fatalf("expected an empty prefilled email, got %q", value)
+	}
+	serverError := htmlFindElement(root, func(node *html.Node) bool {
+		return node.Type == html.ElementNode && htmlHasAttr(node, "data-auth-server-error")
+	})
+	if serverError != nil {
+		t.Fatalf("did not expect the query error to raise the server-error block, got key %q", htmlAttr(serverError, "data-error-key"))
+	}
 }

--- a/internal/api/auth_page_view_builder_helpers_test.go
+++ b/internal/api/auth_page_view_builder_helpers_test.go
@@ -65,17 +65,30 @@ func requestAuthPageWithHostileQuery(t *testing.T, app *fiber.App, path string) 
 	return mustReadBodyString(t, response.Body)
 }
 
-// assertAuthPageIgnoredTheQuery pins both halves of the exclusion on a rendered
-// auth page: the query email reaches neither the markup nor the form field that
-// would round-trip it, and the query error raises no server-error block. The
-// email input is looked up by id first, so a page that stopped rendering its
-// form fails here instead of passing on absence.
-func assertAuthPageIgnoredTheQuery(t *testing.T, body string, emailInputID string) {
+// assertAuthPageDidNotPrefillFromQuery pins both halves of what the page-data
+// builders decide: the query email does not prefill the page's own email field,
+// and the query error raises no server-error block. The email input is looked up
+// by id first, so a page that stopped rendering its form fails here instead of
+// passing on absence.
+//
+// The scope is deliberate and narrower than "this page carries no query-sourced
+// PII", which is FALSE today and must not be inferred from this file. The raw
+// request URI — query string included — does reach the markup through
+// CurrentPath (internal/api/i18n_helpers.go:93), rendered into the language
+// switch's hidden next field (internal/templates/base.html:53) and into the
+// privacy link's back parameter (internal/templates/base.html:161). So
+// /login?email=someone@example.com renders that address percent-encoded in both
+// places, and the back parameter carries it into a further outbound URL. That is
+// a separate finding against the shared layout with its own change; it is named
+// here so this guard's silence about it is a stated limit rather than an
+// accidental gap. Widening the assertion to the whole body belongs with that fix,
+// not before it.
+func assertAuthPageDidNotPrefillFromQuery(t *testing.T, body string, emailInputID string) {
 	t.Helper()
 
 	assertBodyNotContainsAll(t, body, bodyStringMatch{
 		fragment: hostileAuthPageQuery.Get("email"),
-		message:  "did not expect the query email to reach the rendered auth page",
+		message:  "did not expect the query email in raw form to reach the rendered auth page",
 	})
 
 	root := mustParseHTMLDocument(t, body)

--- a/internal/api/auth_page_view_forgot_password_helpers_test.go
+++ b/internal/api/auth_page_view_forgot_password_helpers_test.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"net/url"
 	"testing"
 
 	"github.com/gofiber/fiber/v3"
@@ -10,16 +9,12 @@ import (
 func TestBuildForgotPasswordPageDataUsesFlashEmailForRecoveryStep(t *testing.T) {
 	t.Parallel()
 
-	query := url.Values{
-		"error": {"invalid input"},
-		"email": {"query@example.com"},
-	}
 	flash := FlashPayload{
 		AuthError:   "invalid recovery code",
 		ForgotEmail: " Owner@Example.com ",
 	}
 
-	payload := evaluateAuthPageBuilder(t, query, func(c fiber.Ctx) error {
+	payload := evaluateAuthPageBuilder(t, func(c fiber.Ctx) error {
 		return c.JSON(buildForgotPasswordPageData(map[string]string{}, flash))
 	})
 
@@ -34,14 +29,10 @@ func TestBuildForgotPasswordPageDataUsesFlashEmailForRecoveryStep(t *testing.T) 
 	}
 }
 
-func TestBuildForgotPasswordPageDataDoesNotUseQueryEmail(t *testing.T) {
+func TestBuildForgotPasswordPageDataWithoutFlashHasNoEmail(t *testing.T) {
 	t.Parallel()
 
-	query := url.Values{
-		"email": {"query@example.com"},
-	}
-
-	payload := evaluateAuthPageBuilder(t, query, func(c fiber.Ctx) error {
+	payload := evaluateAuthPageBuilder(t, func(c fiber.Ctx) error {
 		return c.JSON(buildForgotPasswordPageData(map[string]string{}, FlashPayload{}))
 	})
 
@@ -51,4 +42,17 @@ func TestBuildForgotPasswordPageDataDoesNotUseQueryEmail(t *testing.T) {
 	if payload["ShowRecoveryCodeStep"] != false {
 		t.Fatalf("expected ShowRecoveryCodeStep=false, got %#v", payload["ShowRecoveryCodeStep"])
 	}
+}
+
+// The query exclusion is pinned on the real route, not on the builder:
+// buildForgotPasswordPageData takes no fiber.Ctx, so nothing calling it
+// directly can observe a query read added to ShowForgotPasswordPage. The
+// email-field anchor also proves the page stayed on its first step — a
+// query-sourced email would have advanced it to the recovery-code step.
+func TestForgotPasswordPageIgnoresAQueryOfferedPIIAndErrorState(t *testing.T) {
+	app, _ := newOnboardingTestApp(t)
+
+	body := requestAuthPageWithHostileQuery(t, app, "/forgot-password")
+
+	assertAuthPageIgnoredTheQuery(t, body, "forgot-email")
 }

--- a/internal/api/auth_page_view_forgot_password_helpers_test.go
+++ b/internal/api/auth_page_view_forgot_password_helpers_test.go
@@ -44,15 +44,16 @@ func TestBuildForgotPasswordPageDataWithoutFlashHasNoEmail(t *testing.T) {
 	}
 }
 
-// The query exclusion is pinned on the real route, not on the builder:
-// buildForgotPasswordPageData takes no fiber.Ctx, so nothing calling it
-// directly can observe a query read added to ShowForgotPasswordPage. The
-// email-field anchor also proves the page stayed on its first step — a
-// query-sourced email would have advanced it to the recovery-code step.
-func TestForgotPasswordPageIgnoresAQueryOfferedPIIAndErrorState(t *testing.T) {
+// Pinned on the real route, not on the builder: buildForgotPasswordPageData
+// takes no fiber.Ctx, so nothing calling it directly can observe a query read
+// added to ShowForgotPasswordPage. The email-field anchor also proves the page
+// stayed on its first step — a query-sourced email would have advanced it to
+// the recovery-code step. The claim is exactly the field and the error block —
+// see assertAuthPageDidNotPrefillFromQuery for what this page does still carry.
+func TestForgotPasswordPageDoesNotPrefillEmailOrErrorFromQuery(t *testing.T) {
 	app, _ := newOnboardingTestApp(t)
 
 	body := requestAuthPageWithHostileQuery(t, app, "/forgot-password")
 
-	assertAuthPageIgnoredTheQuery(t, body, "forgot-email")
+	assertAuthPageDidNotPrefillFromQuery(t, body, "forgot-email")
 }

--- a/internal/api/auth_page_view_login_helpers_test.go
+++ b/internal/api/auth_page_view_login_helpers_test.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"net/url"
 	"testing"
 
 	"github.com/gofiber/fiber/v3"
@@ -10,15 +9,11 @@ import (
 func TestBuildLoginPageDataUsesFlashPriorityAndSetupFlag(t *testing.T) {
 	t.Parallel()
 
-	query := url.Values{
-		"error": {"weak password"},
-		"email": {"query@example.com"},
-	}
 	flash := FlashPayload{
 		AuthError: "invalid credentials",
 	}
 
-	payload := evaluateAuthPageBuilder(t, query, func(c fiber.Ctx) error {
+	payload := evaluateAuthPageBuilder(t, func(c fiber.Ctx) error {
 		return c.JSON(buildLoginPageData(map[string]string{}, flash, true, false, false, true))
 	})
 
@@ -40,4 +35,15 @@ func TestBuildLoginPageDataUsesFlashPriorityAndSetupFlag(t *testing.T) {
 	if payload["LocalPublicAuthEnabled"] != true {
 		t.Fatalf("expected LocalPublicAuthEnabled=true, got %#v", payload["LocalPublicAuthEnabled"])
 	}
+}
+
+// The query exclusion is pinned on the real route, not on the builder:
+// buildLoginPageData takes no fiber.Ctx, so nothing calling it directly can
+// observe a query read added to ShowLoginPage.
+func TestLoginPageIgnoresAQueryOfferedPIIAndErrorState(t *testing.T) {
+	app, _ := newOnboardingTestApp(t)
+
+	body := requestAuthPageWithHostileQuery(t, app, "/login")
+
+	assertAuthPageIgnoredTheQuery(t, body, "login-email")
 }

--- a/internal/api/auth_page_view_login_helpers_test.go
+++ b/internal/api/auth_page_view_login_helpers_test.go
@@ -37,13 +37,14 @@ func TestBuildLoginPageDataUsesFlashPriorityAndSetupFlag(t *testing.T) {
 	}
 }
 
-// The query exclusion is pinned on the real route, not on the builder:
-// buildLoginPageData takes no fiber.Ctx, so nothing calling it directly can
-// observe a query read added to ShowLoginPage.
-func TestLoginPageIgnoresAQueryOfferedPIIAndErrorState(t *testing.T) {
+// Pinned on the real route, not on the builder: buildLoginPageData takes no
+// fiber.Ctx, so nothing calling it directly can observe a query read added to
+// ShowLoginPage. The claim is exactly the field and the error block — see
+// assertAuthPageDidNotPrefillFromQuery for what this page does still carry.
+func TestLoginPageDoesNotPrefillEmailOrErrorFromQuery(t *testing.T) {
 	app, _ := newOnboardingTestApp(t)
 
 	body := requestAuthPageWithHostileQuery(t, app, "/login")
 
-	assertAuthPageIgnoredTheQuery(t, body, "login-email")
+	assertAuthPageDidNotPrefillFromQuery(t, body, "login-email")
 }

--- a/internal/api/auth_page_view_register_helpers_test.go
+++ b/internal/api/auth_page_view_register_helpers_test.go
@@ -64,13 +64,14 @@ func TestBuildRegisterPageDataDefaultsToRegistrationDisabledWhenClosed(t *testin
 	}
 }
 
-// The query exclusion is pinned on the real route, not on the builder:
-// buildRegisterPageData takes no fiber.Ctx, so nothing calling it directly can
-// observe a query read added to ShowRegisterPage.
-func TestRegisterPageIgnoresAQueryOfferedPIIAndErrorState(t *testing.T) {
+// Pinned on the real route, not on the builder: buildRegisterPageData takes no
+// fiber.Ctx, so nothing calling it directly can observe a query read added to
+// ShowRegisterPage. The claim is exactly the field and the error block — see
+// assertAuthPageDidNotPrefillFromQuery for what this page does still carry.
+func TestRegisterPageDoesNotPrefillEmailOrErrorFromQuery(t *testing.T) {
 	app, _ := newOnboardingTestApp(t)
 
 	body := requestAuthPageWithHostileQuery(t, app, "/register")
 
-	assertAuthPageIgnoredTheQuery(t, body, "register-email")
+	assertAuthPageDidNotPrefillFromQuery(t, body, "register-email")
 }

--- a/internal/api/auth_page_view_register_helpers_test.go
+++ b/internal/api/auth_page_view_register_helpers_test.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"net/url"
 	"testing"
 
 	"github.com/gofiber/fiber/v3"
@@ -10,15 +9,11 @@ import (
 func TestBuildRegisterPageDataUsesOnlyFlashSources(t *testing.T) {
 	t.Parallel()
 
-	query := url.Values{
-		"error": {"weak password"},
-		"email": {"query@example.com"},
-	}
 	flash := FlashPayload{
 		AuthError: "email already exists",
 	}
 
-	payload := evaluateAuthPageBuilder(t, query, func(c fiber.Ctx) error {
+	payload := evaluateAuthPageBuilder(t, func(c fiber.Ctx) error {
 		return c.JSON(buildRegisterPageData(map[string]string{}, flash, true, true))
 	})
 
@@ -36,15 +31,10 @@ func TestBuildRegisterPageDataUsesOnlyFlashSources(t *testing.T) {
 	}
 }
 
-func TestBuildRegisterPageDataIgnoresRegisterQueryFallback(t *testing.T) {
+func TestBuildRegisterPageDataWithoutFlashHasNoErrorOrEmail(t *testing.T) {
 	t.Parallel()
 
-	query := url.Values{
-		"error": {"weak password"},
-		"email": {"query@example.com"},
-	}
-
-	payload := evaluateAuthPageBuilder(t, query, func(c fiber.Ctx) error {
+	payload := evaluateAuthPageBuilder(t, func(c fiber.Ctx) error {
 		return c.JSON(buildRegisterPageData(map[string]string{}, FlashPayload{}, false, true))
 	})
 
@@ -62,7 +52,7 @@ func TestBuildRegisterPageDataIgnoresRegisterQueryFallback(t *testing.T) {
 func TestBuildRegisterPageDataDefaultsToRegistrationDisabledWhenClosed(t *testing.T) {
 	t.Parallel()
 
-	payload := evaluateAuthPageBuilder(t, url.Values{}, func(c fiber.Ctx) error {
+	payload := evaluateAuthPageBuilder(t, func(c fiber.Ctx) error {
 		return c.JSON(buildRegisterPageData(map[string]string{}, FlashPayload{}, false, false))
 	})
 
@@ -72,4 +62,15 @@ func TestBuildRegisterPageDataDefaultsToRegistrationDisabledWhenClosed(t *testin
 	if payload["RegistrationOpen"] != false {
 		t.Fatalf("expected RegistrationOpen=false, got %#v", payload["RegistrationOpen"])
 	}
+}
+
+// The query exclusion is pinned on the real route, not on the builder:
+// buildRegisterPageData takes no fiber.Ctx, so nothing calling it directly can
+// observe a query read added to ShowRegisterPage.
+func TestRegisterPageIgnoresAQueryOfferedPIIAndErrorState(t *testing.T) {
+	app, _ := newOnboardingTestApp(t)
+
+	body := requestAuthPageWithHostileQuery(t, app, "/register")
+
+	assertAuthPageIgnoredTheQuery(t, body, "register-email")
 }

--- a/internal/api/auth_page_view_reset_password_helpers_test.go
+++ b/internal/api/auth_page_view_reset_password_helpers_test.go
@@ -23,7 +23,7 @@ func TestBuildResetPasswordPageDataValidTokenAndForcedFlag(t *testing.T) {
 	})
 	flash := FlashPayload{AuthError: "invalid credentials"}
 
-	payload := evaluateAuthPageBuilderWithCookie(t, nil, cookieHeader, func(c fiber.Ctx) error {
+	payload := evaluateAuthPageBuilderWithCookie(t, cookieHeader, func(c fiber.Ctx) error {
 		return c.JSON(handler.buildResetPasswordPageData(c, map[string]string{}, flash))
 	})
 
@@ -46,7 +46,7 @@ func TestBuildResetPasswordPageDataMarksInvalidToken(t *testing.T) {
 		Token: "invalid-token",
 	})
 
-	payload := evaluateAuthPageBuilderWithCookie(t, nil, cookieHeader, func(c fiber.Ctx) error {
+	payload := evaluateAuthPageBuilderWithCookie(t, cookieHeader, func(c fiber.Ctx) error {
 		return c.JSON(handler.buildResetPasswordPageData(c, map[string]string{}, FlashPayload{}))
 	})
 


### PR DESCRIPTION
The auth page-view builder harness encoded a query string into its request URL, but `buildLoginPageData`, `buildRegisterPageData` and `buildForgotPasswordPageData` (`internal/api/auth_page_view_helpers.go:10,23,37`) take no `fiber.Ctx`. The query was structurally unreachable by every subject the harness drove, so four cases named for a query-source exclusion asserted a shape they could not observe. Adding `data["Email"] = c.Query("email")` to all three real page handlers left the whole `internal/api` package green.

The unused `query` parameter is gone from both harness entry points, and the two cases named after a query fallback are renamed after the flash-absence contract they actually pin.

The exclusion now runs against the real routes: `/login`, `/register` and `/forgot-password` are each requested through the real app with `?email=…&error=…`, and the rendered page must neither prefill its own email field from the query nor raise a server-error block because of it. The email input is looked up by id first, so a page that stopped rendering its form fails here instead of passing on absence — and on `/forgot-password` that lookup also proves the page stayed on its first step rather than advancing to the recovery-code step.

## What these tests do NOT claim

They are named for prefilling, not for ignoring, because the page does **not** ignore the query. The raw request URI — query string included — reaches the markup through `CurrentPath` (`internal/api/i18n_helpers.go:93`), rendered into the language switch's hidden `next` field (`internal/templates/base.html:53`) and into the privacy link's `back` parameter (`internal/templates/base.html:161`). `/login?email=someone@example.com` renders that address percent-encoded in both places, and `back` carries it into a further outbound URL.

That is a separate defect against the shared layout, fixed in its own change. It is named in the helper's doc comment so this guard's silence about it is a stated limit rather than an accidental gap: no reader should be able to conclude from this file that the page is clean of query-sourced PII. Widening the assertion to the whole body belongs with that fix, not before it — a test that asserts more than production delivers cannot be committed green.

## Verification

The mutation — `data["Email"] = c.Query("email")` plus a query-sourced `ErrorKey` in `ShowLoginPage`, `ShowRegisterPage` and `ShowForgotPasswordPage` — was applied in a scratch worktree and reverted before committing. The diff contains no production file.

1. Broken handlers, old assertions — the whole package stays green:

```
ok  	github.com/ovumcy/ovumcy-web/internal/api	524.132s
```

2. Broken handlers, new assertions — red, with each half checked separately. The email half:

```
--- FAIL: TestForgotPasswordPageDoesNotPrefillEmailOrErrorFromQuery (0.34s)
    auth_page_view_forgot_password_helpers_test.go:57: did not expect the query email in raw form to reach the rendered auth page
--- FAIL: TestLoginPageDoesNotPrefillEmailOrErrorFromQuery (0.28s)
--- FAIL: TestRegisterPageDoesNotPrefillEmailOrErrorFromQuery (0.22s)
```

And with only the error read left in the handlers, the other half fires instead:

```
auth_page_view_login_helpers_test.go:48: did not expect the query error to raise the server-error block, got key "auth.error.invalid_credentials"
```

3. Handlers restored — green:

```
ok  	github.com/ovumcy/ovumcy-web/internal/api	305.519s
```

`gofmt -l` clean on every touched file, `go vet ./internal/api/...` clean, `golangci-lint run ./internal/api/...` → `0 issues.`

`auth_page_view_reset_password_helpers_test.go` is in the diff for two mechanical lines: it calls the same harness, so dropping the parameter drops its `nil` argument too.

Rollback: single-commit revert; test-only, nothing persisted, no public contract touched.
