### PR TITLE
fix(security): stop the not-found page echoing its requested path

### DIFF
--- a/changelog.d/fix-not-found-path-echo.md
+++ b/changelog.d/fix-not-found-path-echo.md
@@ -1,0 +1,14 @@
+### Security
+
+- **A "page not found" no longer echoes the address it was opened at.** Every page renders the
+  address it was requested at back into its own markup — the language switcher carries it as the
+  `next` field, and the footer privacy link carries it into a new outgoing URL. On a page that is
+  not found there is no route behind that address, so all of it comes from whoever wrote the link:
+  opening `/someone@example.com/nowhere` showed that address in the page and, through the footer
+  link, carried it onward into browser history, the `Referer` header and the `/privacy` entry in
+  the server access log. Nothing stored was exposed and the value was never trusted for navigation
+  — it came from the visitor's own link — but a value nobody typed had no business being shown or
+  forwarded. The not-found page now renders a fixed address of its own, so nothing from the request
+  reaches the markup. Switching language there still returns you to the same page, and the footer
+  privacy link still appears; because that fixed address names no section, the navigation marks no
+  current section on a page that is not one, which is how it already behaved.

--- a/internal/api/current_path_query_leak_regression_test.go
+++ b/internal/api/current_path_query_leak_regression_test.go
@@ -229,3 +229,52 @@ func TestSignedInPageKeepsItsAllowlistedQueryParameters(t *testing.T) {
 		t.Fatalf("%s: expected the allowlisted step to survive, got %q", onboardingLabel, got)
 	}
 }
+
+// TestNotFoundPageDropsTheCallerSuppliedPathFromTheRenderedAddress closes the
+// same leak one level up. On a 404 the whole path is caller-chosen, not merely
+// its query, and the browser branch renders the full layout — so
+// /query-source@example.com/nowhere puts that address into the switcher field
+// and into the outgoing /privacy?back=… link exactly as ?email= did on a routed
+// page. The handler pins the rendered address itself, so nothing the caller
+// wrote survives into the markup.
+func TestNotFoundPageDropsTheCallerSuppliedPathFromTheRenderedAddress(t *testing.T) {
+	t.Parallel()
+
+	app, database := newOnboardingTestApp(t)
+	target := "/" + currentPathLeakAddress + "/nowhere"
+
+	// The two sessions render different halves of the layout — the switcher
+	// field is signed-out only, the primary navigation signed-in only — so they
+	// are separate subtests: a failure in one must not hide the other.
+	t.Run("signed out", func(t *testing.T) {
+		label := "signed-out not-found path"
+		body := smokeGET(t, app, "", target, http.StatusNotFound)
+
+		assertNoCurrentPathLeak(t, label, body)
+		if got := currentPathNextField(t, label, body); got != notFoundRenderedPath {
+			t.Fatalf("%s: expected the rendered path to be %q, got %q", label, notFoundRenderedPath, got)
+		}
+		if got := currentPathPrivacyBack(t, label, body); got != url.QueryEscape(notFoundRenderedPath) {
+			t.Fatalf("%s: expected the privacy link to carry %q, got %q", label, notFoundRenderedPath, got)
+		}
+	})
+
+	t.Run("signed in", func(t *testing.T) {
+		label := "signed-in not-found path"
+		owner := createOnboardingTestUser(t, database, "current-path-not-found@example.com", "StrongPass1", true)
+		ownerCookie := loginAndExtractAuthCookie(t, app, owner.Email, "StrongPass1")
+		body := smokeGET(t, app, ownerCookie, target, http.StatusNotFound)
+
+		assertNoCurrentPathLeak(t, label, body)
+		if got := currentPathPrivacyBack(t, label, body); got != url.QueryEscape(notFoundRenderedPath) {
+			t.Fatalf("%s: expected the privacy link to carry %q, got %q", label, notFoundRenderedPath, got)
+		}
+		// This session renders the primary navigation, and every active state in
+		// it derives from the same rendered address. A substitute naming a real
+		// section would light that section's tab and announce aria-current on a
+		// page that is not it, so the address must match no navigation route.
+		if strings.Contains(body, `aria-current="page"`) {
+			t.Fatalf("%s: the rendered address lit a navigation tab on a page that is not it", label)
+		}
+	})
+}

--- a/internal/api/current_path_query_leak_regression_test.go
+++ b/internal/api/current_path_query_leak_regression_test.go
@@ -53,7 +53,7 @@ func assertNoCurrentPathLeak(t *testing.T, label string, body string) {
 
 	for _, form := range currentPathLeakForms() {
 		if strings.Contains(body, form) {
-			t.Fatalf("%s: rendered page carries the caller-supplied query value %q", label, form)
+			t.Fatalf("%s: rendered page carries the caller-supplied value %q", label, form)
 		}
 	}
 }

--- a/internal/api/handlers_not_found.go
+++ b/internal/api/handlers_not_found.go
@@ -6,6 +6,24 @@ import (
 	"github.com/gofiber/fiber/v3"
 )
 
+// notFoundRenderedPath is the address the shared layout renders back into the
+// 404 page — the language switcher's `next` field and the outgoing
+// `/privacy?back=…` link — in place of the request's own path. On a 404 that
+// path is entirely caller-chosen, and the browser branch below renders the full
+// layout, so `/victim@example.com/nowhere` would put the address into the markup
+// and carry it into a further outgoing URL: browser history, `Referer`, and the
+// `/privacy` access log. Every other page's path is its own route, which is why
+// this substitution is owed here alone.
+//
+// It is deliberately not the primary action's target. The primary navigation
+// renders on a signed-in 404, and every active state in it is derived from this
+// same address, so `/dashboard` would light the "Today" tab and announce
+// `aria-current="page"` on a page that is not it. A path matching no navigation
+// route highlights nothing, keeps the footer privacy link visible, and — since
+// nothing serves it — sends the language switcher back to a 404 in the newly
+// chosen language, which is where the visitor actually is.
+const notFoundRenderedPath = "/404"
+
 func (handler *Handler) NotFound(c fiber.Ctx) error {
 	if strings.HasPrefix(c.Path(), "/api/") || acceptsJSON(c) || isHTMX(c) {
 		return respondNotFoundMappedError(c)
@@ -26,6 +44,7 @@ func (handler *Handler) NotFound(c fiber.Ctx) error {
 	c.Status(fiber.StatusNotFound)
 	return handler.render(c, "not_found", fiber.Map{
 		"Title":           localizedPageTitle(currentMessages(c), "meta.title.not_found", "Ovumcy | Page Not Found"),
+		"CurrentPath":     notFoundRenderedPath,
 		"CurrentUser":     currentUser,
 		"PrimaryPath":     primaryPath,
 		"PrimaryLabelKey": primaryLabelKey,


### PR DESCRIPTION
Every page renders the address it was requested at back into the shared layout twice: the language switcher's hidden `next` field (`internal/templates/base.html:53`) and the outgoing `/privacy?back=…` link (`internal/templates/base.html:161`). On a 404 there is no route behind that address, so the whole of it is caller-chosen, and the browser branch renders the full layout — `GET /victim@example.com/nowhere` put that address into the markup and carried it onward into browser history, the `Referer` header and the `/privacy` access log.

This is the only surface where the path half can carry anything: every other page's path is its own route, and `/calendar/day/:date` renders a partial and rejects a malformed parameter first. The query half of the same address is filtered by the allowlist that landed just before this change; this closes the path half on the one route where it is not fixed by the router.

`NotFound` now pins the rendered address itself (`internal/api/handlers_not_found.go`); `withTemplateDefaults` only fills `CurrentPath` when the caller left it blank, so the request's path never reaches the layout.

## Why the substitute is `/404` and not the primary action's target

The primary navigation renders on a signed-in 404, and every active state in it derives from this same address. `/dashboard` would light the "Today" tab and announce `aria-current="page"` on a page that is not it — a change of behaviour, not a cosmetic one, since the attacker-chosen path lights nothing today. `/404` matches no navigation route, keeps the footer privacy link visible, and sends the language switcher back to a 404 in the newly chosen language, which is where the visitor actually is.

The value is supplied by whoever wrote the link, so this is neither an open redirect nor a disclosure of stored data. It is the "no addresses or error codes in the app's own URLs" rule, one level up from the query filter this builds on.

## Verification

`TestNotFoundPageDropsTheCallerSuppliedPathFromTheRenderedAddress` drives the real app for both sessions and asserts the address is absent in every encoding, reusing the helper the query filter introduced. The signed-in half additionally asserts that no navigation tab is marked current, so the substitute cannot be swapped for one that names a real section.

Both subtests fail on the parent commit and pass here — the unfixed state is the base, so no mutation is needed:

```
current_path_query_leak_regression_test.go:253: signed-out not-found path: rendered page carries the caller-supplied value "query-source@example.com"
current_path_query_leak_regression_test.go:268: signed-in not-found path: rendered page carries the caller-supplied value "query-source%40example.com"
--- FAIL: TestNotFoundPageDropsTheCallerSuppliedPathFromTheRenderedAddress (1.08s)
```

The two halves fail independently and name different encodings because they exercise different parts of the layout: the switcher field is signed-out only and carries the address raw, the privacy link is on both and carries it percent-encoded.

The shared leak helper's failure message was reworded in the same branch: it said "caller-supplied **query** value", and this case feeds it a path from a request with no query string at all, so on a real regression it would have sent the reader looking for a parameter that does not exist.

`go test ./internal/api/...` green, `gofmt -l` clean, `go vet` clean, `golangci-lint run ./internal/api/...` → `0 issues`.

Rollback: single-commit revert; no persisted state, no public contract.
