### PR TITLE
fix(services): suppress the stats cycle stack's fertility claims with predictions

### DIFF
--- a/changelog.d/fix-stats-ribbon-prediction-suppression.md
+++ b/changelog.d/fix-stats-ribbon-prediction-suppression.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- **The Insights cycle stack stops claiming a fertile window once predictions are suppressed.** With
+  "unpredictable cycle" switched on — or a pregnancy pause, or a cycle running past its own
+  reference length — every other surface withholds the fertile window, the peak day and the
+  ovulation phase, the calendar's past cycles included. The stack kept shading all three over its
+  completed cycles on the strength of the "show historical phases" preference alone, so an account
+  that had told the product its cycle math does not describe it still read an ovulation day off the
+  stats page. Those cells now render blank there, and the recorded half of the stack is untouched:
+  the rows, their observed lengths and their logged period days stay exactly as they were.

--- a/changelog.d/fix-stats-ribbon-prediction-suppression.md
+++ b/changelog.d/fix-stats-ribbon-prediction-suppression.md
@@ -6,5 +6,7 @@
   ovulation phase, the calendar's past cycles included. The stack kept shading all three over its
   completed cycles on the strength of the "show historical phases" preference alone, so an account
   that had told the product its cycle math does not describe it still read an ovulation day off the
-  stats page. Those cells now render blank there, and the recorded half of the stack is untouched:
-  the rows, their observed lengths and their logged period days stay exactly as they were.
+  stats page. The inferred phase axis now goes dark on the stack as a whole — follicular and luteal
+  with it, since both are placed only relative to that same estimated ovulation day — and the
+  recorded half is untouched: the rows, their observed lengths and their logged period days stay
+  exactly as they were, period days keeping their own colour.

--- a/internal/services/stats_cycle_ribbon.go
+++ b/internal/services/stats_cycle_ribbon.go
@@ -32,7 +32,8 @@ type StatsCycleRibbon struct {
 	AxisDays int
 	// ShowPhases follows the owner's ShowHistoricalPhases preference, the same
 	// switch that decides whether the calendar shades past cycles with inferred
-	// phases. Off, the stack draws only what was recorded.
+	// phases — and, above it, the medical-safety suppression gate every projected
+	// surface shares. Off, the stack draws only what was recorded.
 	ShowPhases bool
 	Rows       []StatsCycleRibbonRow
 }
@@ -77,7 +78,18 @@ func buildStatsCycleRibbon(user *models.User, stats CycleStats, logs []models.Da
 		return StatsCycleRibbon{}
 	}
 
-	showPhases := user != nil && user.ShowHistoricalPhases
+	// Inferred phases need BOTH the owner's preference and the medical-safety
+	// suppression gate open. Everything the phase axis adds to a row — the
+	// fertile window, the peak day, the ovulation cell and the luteal span that
+	// is only located relative to it — is PredictCycleWindow applied to a past
+	// cycle, i.e. the same cycle math the account has told the product not to
+	// trust. The calendar settles that reading: its historical-phase pass
+	// (appendHistoricalCycles) runs below buildCalendarPredictionMaps' early
+	// return on PredictionsSuppressed, so inferred history is not exempt there
+	// and must not be exempt here. The gate is the shared predicate, never a
+	// hand-picked disjunct, so a fourth suppression signal reaches this surface
+	// with the others.
+	showPhases := user != nil && user.ShowHistoricalPhases && !PredictionsSuppressed(user, stats)
 	luteal := ResolveLutealPhase(stats.LutealPhase)
 	loggedByDay := statsCycleRibbonLoggedDays(logs)
 

--- a/internal/services/stats_cycle_ribbon_test.go
+++ b/internal/services/stats_cycle_ribbon_test.go
@@ -330,3 +330,88 @@ func TestBuildStatsCycleRibbonMarksRecordedDays(t *testing.T) {
 		}
 	}
 }
+
+// statscycleribbonInferredFertility counts, across the whole stack, the cells
+// that make a fertility claim: a shaded fertile day, the peak band, and an
+// ovulation phase cell. It is the quantity the medical-safety suppression has
+// to drive to zero — three encodings of one claim, so a guard reading only one
+// of them would go green while the other two still paint.
+func statscycleribbonInferredFertility(ribbon StatsCycleRibbon) (fertile int, peak int, ovulation int) {
+	for _, row := range ribbon.Rows {
+		for _, day := range row.Days {
+			if day.IsFertile {
+				fertile++
+			}
+			if day.IsFertilePeak {
+				peak++
+			}
+			if day.Phase == "ovulation" {
+				ovulation++
+			}
+		}
+	}
+	return fertile, peak, ovulation
+}
+
+// TestBuildStatsCycleRibbonSuppressesInferredFertilityInUnpredictableMode is the
+// medical-safety gate on this surface. An owner in unpredictable-cycle mode has
+// said the cycle math does not describe her, and every other projected surface
+// answers by withholding the fertile window, the peak band and the ovulation
+// day — the calendar included, whose historical-phase pass sits BELOW the same
+// suppression return, so inferred history is not exempt there. The stack shaded
+// all three anyway, on the strength of the ShowHistoricalPhases preference
+// alone: a fertility claim at a confidence the data no longer carries.
+//
+// The case is named for unpredictable mode, which is the disjunct it drives; the
+// gate itself is the shared PredictionsSuppressed predicate, so a pregnancy
+// pause and an overdue cycle reach this surface through the same line and are
+// pinned on the predicate rather than re-pinned per surface here.
+//
+// The suppressed half is a negative assertion, so the same history renders once
+// with prediction enabled first: that anchor proves the three claims can appear
+// here at all, and that the guard is not green against an empty stack. What must
+// SURVIVE the gate is asserted too — the rows, their observed lengths and the
+// recorded period days are facts, not projections.
+func TestBuildStatsCycleRibbonSuppressesInferredFertilityInUnpredictableMode(t *testing.T) {
+	logs := statscycleribbonHistory(t)
+	spans := buildCompletedCycleSpans(logs, time.UTC)
+
+	predicting := buildStatsCycleRibbon(
+		statscycleribbonOwner(true),
+		CycleStats{LutealPhase: 14},
+		logs,
+		spans,
+	)
+	fertile, peak, ovulation := statscycleribbonInferredFertility(predicting)
+	if fertile == 0 || peak == 0 || ovulation == 0 {
+		t.Fatalf("anchor: with prediction on, the stack shades a fertile window, a peak and an ovulation day; got fertile=%d peak=%d ovulation=%d", fertile, peak, ovulation)
+	}
+
+	owner := statscycleribbonOwner(true)
+	owner.UnpredictableCycle = true
+	ribbon := buildStatsCycleRibbon(
+		owner,
+		CycleStats{LutealPhase: 14},
+		logs,
+		spans,
+	)
+
+	if !ribbon.Visible || len(ribbon.Rows) != len(predicting.Rows) {
+		t.Fatalf("recorded cycles are facts and keep rendering: visible=%v rows=%d", ribbon.Visible, len(ribbon.Rows))
+	}
+	fertile, peak, ovulation = statscycleribbonInferredFertility(ribbon)
+	if fertile != 0 || peak != 0 || ovulation != 0 {
+		t.Fatalf("unpredictable mode suppresses every fertility claim on the stack; got fertile=%d peak=%d ovulation=%d", fertile, peak, ovulation)
+	}
+
+	// Row 0 is the 2026-01-01 cycle: five recorded period days, which stay.
+	row := ribbon.Rows[0]
+	if row.CycleLength != 30 || row.PeriodLength != 5 {
+		t.Fatalf("expected the observed 30-day cycle with five period days, got %d/%d", row.CycleLength, row.PeriodLength)
+	}
+	for _, day := range row.Days {
+		if day.Day <= row.PeriodLength && (!day.IsPeriod || day.Phase != "menstrual") {
+			t.Fatalf("day %d is a recorded period day: period=%v phase=%q", day.Day, day.IsPeriod, day.Phase)
+		}
+	}
+}


### PR DESCRIPTION
## What was wrong

`buildStatsCycleRibbon` gated the Insights cycle stack's inferred phases on the owner's preference
alone — `showPhases := user != nil && user.ShowHistoricalPhases` (`internal/services/stats_cycle_ribbon.go:80`
before this change) — and then painted, per cell,
`IsFertile`, `IsFertilePeak` and `Phase == "ovulation"` (`stats_cycle_ribbon.go:145-150`,
`statsCycleRibbonPhase`). No prediction-suppression predicate appeared anywhere on that path, and
its only caller is gated by `IsOwnerUser` (`stats_page_view_service.go:238,258`).

So an account with **unpredictable cycle** switched on — the setting whose whole meaning is "this
cycle math does not describe me" — still read a fertile window, a peak day and an ovulation cell off
the stats page, while the dashboard, the calendar, the `.ics` feed and the webhook pass were all
withholding exactly those three.

"Inferred history is exempt from suppression" is not this product's rule: the calendar is the
tiebreaker and says the opposite. `appendHistoricalCycles` (`internal/services/calendar_days.go:330`),
itself gated on `ShowHistoricalPhases`, is invoked at `calendar_days.go:169` — **below**
`buildCalendarPredictionMaps`' early return on `PredictionsSuppressed` (`calendar_days.go:150`), and
**outside** the `if !fertilitySuppressed` blocks that carry the extra first-cycle floor
(`calendar_days.go:159`). So for exactly this content — completed past cycles — the calendar gates on
`PredictionsSuppressed` and does not apply the first-cycle floor to history at all. Past cycles on
the grid are already withheld; the stack was the one surface that was not.

## The change

One conjunct in `internal/services/stats_cycle_ribbon.go`:

```go
showPhases := user != nil && user.ShowHistoricalPhases && !PredictionsSuppressed(user, stats)
```

`PredictionsSuppressed` is the existing shared predicate (unpredictable · pregnancy-paused ·
overdue), not a hand-picked disjunct: a fourth signal added there reaches this surface with the rest,
which is the reason that predicate exists. It is also neither the wider nor the narrower predicate
by accident: it is the one the calendar puts on the same content. The first-cycle floor above it
would be inert here anyway — the stack needs two completed cycles to render at all — and all three
disjuncts are live on this surface, since the page builds its `CycleStats` through
`BuildCycleStatsForRange` (`stats_page_view_service.go:191`) and hands the same struct to
`BuildDashboardCycleContext` (`:139`), so a pregnancy pause and an overdue cycle reach the ribbon
exactly as unpredictable mode does.

There is one flag, so with the gate closed the whole inferred phase axis goes dark, not only its
fertile part: the row falls back to the same shape the preference-off path already produces —
observed period days keep `menstrual`, and every other cell carries no phase at all, no fertile
shading and no peak. Follicular and luteal go with the fertile three deliberately rather than by
omission: both are placed only relative to the projected ovulation day, so keeping them would leave
the same projection on the page under another name.

## How this satisfies medical safety (§10.6)

The invariant is that display confidence follows data confidence, and that where a window or
fertility claim has no support left, **suppression is the floor and a qualifier is not sufficient**.
This lands on the suppression side: with predictions suppressed the ribbon renders **no** fertile
cell, **no** peak cell and **no** ovulation phase cell — nor any other inferred phase — so the
attributes the template would emit as `data-fertile`, `data-fertile-peak` and `data-phase`
(`internal/templates/stats.html:351-354`) are simply absent, and nothing is softened, hedged or
relabelled. What stays is recorded fact only:
the rows, their observed cycle lengths, their observed period days and the logged marks.

## Evidence — failing first, then green

The guard was written and run against the unmodified builder:

```
=== RUN   TestBuildStatsCycleRibbonSuppressesInferredFertilityInUnpredictableMode
    stats_cycle_ribbon_test.go:404: unpredictable mode suppresses every fertility claim on the stack; got fertile=24 peak=4 ovulation=4
--- FAIL: TestBuildStatsCycleRibbonSuppressesInferredFertilityInUnpredictableMode (0.00s)
FAIL
FAIL	github.com/ovumcy/ovumcy-web/internal/services	4.603s
```

24 fertile cells, 4 peak days and 4 ovulation cells across a four-cycle stack, for an owner who had
asked for none of them. With the gate wired in:

```
--- PASS: TestBuildStatsCycleRibbonSuppressesInferredFertilityInUnpredictableMode (0.00s)
```

The pre-existing ribbon cases confirm the gate suppresses nothing it should render — the
prediction-on case still asserts ovulation on day 16 of a 30-day cycle and 14 luteal days:

```
--- PASS: TestBuildStatsCycleRibbonWaitsForTwoCompletedCycles (0.00s)
--- PASS: TestBuildStatsCycleRibbonSharesOneAxisAcrossRows (0.00s)
--- PASS: TestBuildStatsCycleRibbonKeepsOnlyTheMostRecentCycles (0.00s)
--- PASS: TestBuildStatsCycleRibbonDrawsObservedPeriodDaysWithoutInferredPhases (0.00s)
--- PASS: TestBuildStatsCycleRibbonInfersPhasesOnlyWhenTheOwnerAsked (0.00s)
--- PASS: TestStatsCycleRibbonAxisDaysClampsAWildCycle (0.00s)
--- PASS: TestBuildStatsCycleRibbonRefusesAnEmptyAxis (0.00s)
--- PASS: TestStatsCycleRibbonPhaseFallsBackWhenNoWindowIsCalculable (0.00s)
--- PASS: TestBuildStatsCycleRibbonMarksRecordedDays (0.00s)
--- PASS: TestStatsCycleRibbonFertileWindowIsCalendarBound (0.00s)
```

Whole package, plus the stats render path and the linter:

```
$ go test ./internal/services/...
ok  	github.com/ovumcy/ovumcy-web/internal/services	116.508s

$ go test ./internal/api/ -run TestStats -timeout 20m
ok  	github.com/ovumcy/ovumcy-web/internal/api	18.587s

$ gofmt -l internal/services/stats_cycle_ribbon.go internal/services/stats_cycle_ribbon_test.go
$ golangci-lint run internal/services/...
0 issues.

$ go run ./scripts/changelogd check
changelog fragment check OK.
```

## Notes on the guard

The suppressed half is a negative assertion, so the test renders the same history **with** prediction
enabled first and requires all three claims to be present. That anchor is what keeps the case from
passing against an empty stack or a renamed field, and the assertion on the surviving rows, lengths
and period days pins that the gate withholds the projection and nothing else.

## Rollback

Reverting the one production commit is enough (the second only rewords the changelog fragment).
Service-local; no persisted data, no migration, no public contract.
