### PR TITLE
test(db): derive the account-erasure sweep from the live schema, on both dialects

### DIFF
--- a/changelog.d/test-derive-erasure-user-scoped-tables.md
+++ b/changelog.d/test-derive-erasure-user-scoped-tables.md
@@ -6,7 +6,9 @@ hand-written list of the five user-scoped tables — a list that mirrored
 derives the tables from the live schema through GORM's migrator (every table
 carrying a `user_id` column), requires the fixture to have seeded each of them
 before the erasure, and asserts each is empty for the deleted account
-afterwards. Production behaviour is unchanged: the five tables the code erases
+afterwards. Because the migration sets are per dialect, the scenario runs once
+per engine: SQLite always, Postgres behind the shared docker-gated container
+helper. Production behaviour is unchanged: the five tables the code erases
 today are exactly the five the derivation finds. What changes is that a later
 migration adding a user-scoped table without a matching delete now turns the
 test red instead of staying green.

--- a/changelog.d/test-derive-erasure-user-scoped-tables.md
+++ b/changelog.d/test-derive-erasure-user-scoped-tables.md
@@ -1,0 +1,12 @@
+none
+
+Test-only. The account-erasure completeness test no longer carries a
+hand-written list of the five user-scoped tables — a list that mirrored
+`DeleteAccountAndRelatedData` and so could only ever agree with it. It now
+derives the tables from the live schema through GORM's migrator (every table
+carrying a `user_id` column), requires the fixture to have seeded each of them
+before the erasure, and asserts each is empty for the deleted account
+afterwards. Production behaviour is unchanged: the five tables the code erases
+today are exactly the five the derivation finds. What changes is that a later
+migration adding a user-scoped table without a matching delete now turns the
+test red instead of staying green.

--- a/internal/db/delete_account_completeness_test.go
+++ b/internal/db/delete_account_completeness_test.go
@@ -3,12 +3,35 @@ package db
 import (
 	"context"
 	"path/filepath"
+	"sort"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/ovumcy/ovumcy-web/internal/models"
 	"gorm.io/gorm"
 )
+
+// userScopeColumn is the column that marks a table as holding one owner's rows.
+// Erasure completeness is defined against it: every table carrying it must be
+// empty for the deleted account.
+const userScopeColumn = "user_id"
+
+// erasureUserScopeExemptions lists tables that carry userScopeColumn yet are
+// deliberately NOT required to be empty for the deleted account afterwards,
+// each with the one-line reason that bounds the surviving rows.
+//
+// It is empty on purpose. Every user-scoped table in the schema today is erased
+// by DeleteAccountAndRelatedData, and an exemption-free sweep is what also
+// covers tables added later — an entry here is a hole punched in the GDPR
+// erasure guarantee, so it may only be added together with the reason those
+// rows are allowed to survive (a bounded TTL, a separate erasure path, rows
+// that belong to a different owner).
+//
+// Note that `users` is not a candidate: it is keyed by `id`, not by
+// userScopeColumn, so the derivation below never sees it and the account row
+// itself is asserted gone separately.
+var erasureUserScopeExemptions = map[string]string{}
 
 // countWhere returns the row count for model matching query, failing the test
 // on a query error — folding the repeated count-and-check-err blocks out of the
@@ -20,11 +43,65 @@ func countWhere(t *testing.T, database *gorm.DB, model any, query string, args .
 	return count
 }
 
+// countUserRowsInTable counts the rows a live table holds for userID, addressing
+// the table by the name the schema reports rather than through a model — the
+// point of the derivation is to reach tables no model in this test knows about.
+func countUserRowsInTable(t *testing.T, database *gorm.DB, table string, userID uint) int64 {
+	t.Helper()
+	var count int64
+	requireNoErr(t, database.Table(table).Where(userScopeColumn+" = ?", userID).Count(&count).Error, "count "+table)
+	return count
+}
+
+// userScopedTablesFromSchema derives from the LIVE schema every table carrying
+// a userScopeColumn column, minus erasureUserScopeExemptions, sorted for a
+// stable failure message.
+//
+// It reads the schema through GORM's migrator (GetTables/ColumnTypes) rather
+// than a dialect-specific sqlite_master or information_schema query, so the
+// same derivation holds on both supported engines. Deriving instead of listing
+// is the whole point: a hand-written list mirrors the implementation it is
+// meant to check, and a table added by a later migration but forgotten in
+// DeleteAccountAndRelatedData would never enter it.
+func userScopedTablesFromSchema(t *testing.T, database *gorm.DB) []string {
+	t.Helper()
+	migrator := database.Migrator()
+	tables, err := migrator.GetTables()
+	requireNoErr(t, err, "list tables")
+
+	scoped := make([]string, 0, len(tables))
+	for _, table := range tables {
+		columns, err := migrator.ColumnTypes(table)
+		requireNoErr(t, err, "column types of "+table)
+		for _, column := range columns {
+			if !strings.EqualFold(column.Name(), userScopeColumn) {
+				continue
+			}
+			if reason, exempt := erasureUserScopeExemptions[table]; exempt {
+				t.Logf("skipping user-scoped table %s: %s", table, reason)
+				break
+			}
+			scoped = append(scoped, table)
+			break
+		}
+	}
+	sort.Strings(scoped)
+	return scoped
+}
+
 // TestDeleteAccountAndRelatedDataRemovesAllUserRows proves account erasure is
 // complete across every user-scoped table — including register_pickup_tokens
 // (which has no foreign key) and oidc_identities — so no orphaned auth-linkage
 // rows survive a delete. This guards the GDPR right-to-erasure contract
 // independently of whether ON DELETE CASCADE is enforced.
+//
+// "Every user-scoped table" is derived from the live schema, not listed here:
+// the set under test is whatever carries a user_id column after the migrations
+// have run. That makes both halves of a forgotten table fail. A table with no
+// seed fails before the erasure ("the fixture covers nothing here"), and a
+// seeded table whose rows survive fails after it — so a later migration adding
+// a user-scoped table turns this test RED whether or not anyone remembers to
+// touch it.
 func TestDeleteAccountAndRelatedDataRemovesAllUserRows(t *testing.T) {
 	dir := t.TempDir()
 	database, err := OpenDatabase(Config{Driver: DriverSQLite, SQLitePath: filepath.Join(dir, "erasure.db")})
@@ -69,25 +146,34 @@ func TestDeleteAccountAndRelatedDataRemovesAllUserRows(t *testing.T) {
 		requireNoErr(t, database.Create(row).Error, "seed row")
 	}
 
+	// The set under test comes from the schema, so it cannot drift behind a
+	// migration the way a literal list does.
+	scopedTables := userScopedTablesFromSchema(t, database)
+	if len(scopedTables) == 0 {
+		t.Fatal("derived no user-scoped tables from the live schema — the derivation is broken, not the schema")
+	}
+	t.Logf("user-scoped tables derived from the live schema: %v", scopedTables)
+
+	// Positive anchor, and the fixture-coverage gate in one: every derived
+	// table must actually hold a row for this account before the erasure runs.
+	// Without it the post-erasure count of a table nothing seeded would be zero
+	// for the wrong reason, and the sweep would pass while proving nothing
+	// about it.
+	for _, table := range scopedTables {
+		if seeded := countUserRowsInTable(t, database, table, user.ID); seeded == 0 {
+			t.Fatalf("%s carries a %s column but this test seeds no row for the account under erasure — add a seed row above, and thread the table through DeleteAccountAndRelatedData, or record it in erasureUserScopeExemptions with the reason", table, userScopeColumn)
+		}
+	}
+
 	requireNoErr(t, repos.Users.DeleteAccountAndRelatedData(context.Background(), user.ID), "delete account")
 
 	if usersLeft := countWhere(t, database, &models.User{}, "id = ?", user.ID); usersLeft != 0 {
 		t.Fatalf("users still has %d row(s) for the deleted account", usersLeft)
 	}
 
-	type tableCheck struct {
-		label string
-		model any
-	}
-	for _, tc := range []tableCheck{
-		{"daily_logs", &models.DailyLog{}},
-		{"symptom_types", &models.SymptomType{}},
-		{"register_pickup_tokens", &models.RegisterPickupToken{}},
-		{"oidc_identities", &models.OIDCIdentity{}},
-		{"oidc_logout_states", &models.OIDCLogoutState{}},
-	} {
-		if remaining := countWhere(t, database, tc.model, "user_id = ?", user.ID); remaining != 0 {
-			t.Fatalf("%s still has %d row(s) for the deleted user — account erasure incomplete", tc.label, remaining)
+	for _, table := range scopedTables {
+		if remaining := countUserRowsInTable(t, database, table, user.ID); remaining != 0 {
+			t.Fatalf("%s still has %d row(s) for the deleted user — account erasure incomplete", table, remaining)
 		}
 	}
 

--- a/internal/db/delete_account_completeness_test.go
+++ b/internal/db/delete_account_completeness_test.go
@@ -102,15 +102,41 @@ func userScopedTablesFromSchema(t *testing.T, database *gorm.DB) []string {
 // seeded table whose rows survive fails after it — so a later migration adding
 // a user-scoped table turns this test RED whether or not anyone remembers to
 // touch it.
+//
+// The derivation is per DIALECT, because the migration sets are: OpenDatabase
+// applies the embedded migrations of the driver it opened, so a table created
+// only in migrations/postgres never exists in a SQLite schema and a SQLite-only
+// derivation could not see it. The scenario therefore runs once per supported
+// engine — SQLite unconditionally, Postgres behind the shared docker-gated
+// container helper, which skips when docker is absent. The SQLite arm is what
+// keeps the guard non-vacuous on a host without docker.
 func TestDeleteAccountAndRelatedDataRemovesAllUserRows(t *testing.T) {
-	dir := t.TempDir()
-	database, err := OpenDatabase(Config{Driver: DriverSQLite, SQLitePath: filepath.Join(dir, "erasure.db")})
-	requireNoErr(t, err, "open sqlite")
-	t.Cleanup(func() {
-		if sqlDB, err := database.DB(); err == nil {
-			_ = sqlDB.Close()
-		}
+	t.Run("sqlite", func(t *testing.T) {
+		dir := t.TempDir()
+		database, err := OpenDatabase(Config{Driver: DriverSQLite, SQLitePath: filepath.Join(dir, "erasure.db")})
+		requireNoErr(t, err, "open sqlite")
+		t.Cleanup(func() {
+			if sqlDB, err := database.DB(); err == nil {
+				_ = sqlDB.Close()
+			}
+		})
+		assertAccountErasureLeavesNoUserScopedRows(t, database)
 	})
+
+	t.Run("postgres", func(t *testing.T) {
+		// startPostgresTestConfig skips the subtest when docker is unavailable;
+		// the sqlite arm above still runs, so the guard never goes vacuous.
+		assertAccountErasureLeavesNoUserScopedRows(t, openPostgresForMigrationBootstrapTest(t, startPostgresTestConfig(t)))
+	})
+}
+
+// assertAccountErasureLeavesNoUserScopedRows runs the whole erasure scenario —
+// seed, derive the user-scoped set from the schema, gate that the fixture
+// covers it, erase, sweep — against an already-migrated database, so the same
+// assertions bind on every dialect the repository ships migrations for.
+// It is deliberately NOT a t.Helper: marking it one would report every failure
+// at the two call sites above, hiding which of the scenario's assertions broke.
+func assertAccountErasureLeavesNoUserScopedRows(t *testing.T, database *gorm.DB) {
 	repos := NewRepositories(database)
 
 	user := &models.User{


### PR DESCRIPTION
## What

`TestDeleteAccountAndRelatedDataRemovesAllUserRows` checked erasure completeness against a literal
slice of five table names — `daily_logs`, `symptom_types`, `register_pickup_tokens`,
`oidc_identities`, `oidc_logout_states` — in the same order as the five `Delete(...)` calls in
`DeleteAccountAndRelatedData` (`internal/db/user_repository.go:792-834`). That is a mirror of the
implementation, not an independent check of the schema: a migration adding a sixth user-scoped
table with no matching delete never entered the slice, so the loop never looked at it, and CI
stayed green over health data surviving a GDPR erasure request. Nothing else in the repository
derived the set of `user_id`-bearing tables from the schema either.

The set under test now comes from the **live schema**: every table carrying a `user_id` column,
read through GORM's migrator (`Migrator().GetTables()` + `ColumnTypes`) rather than
`sqlite_master` or `information_schema`, so one derivation serves both dialects. No dialect
special-casing was needed. Over that derived set the test asserts:

- **before** the erasure, each derived table holds at least one row for the account — the positive
  anchor, and the gate that a newly added user-scoped table is covered by the fixture at all;
- **after** the erasure, each derived table holds none.

Production behaviour is untouched. The five tables the code erases today are exactly the five the
derivation finds; what changes is that a sixth one, added later and forgotten in
`DeleteAccountAndRelatedData`, now turns this test red instead of staying green.

## Both dialects, because the migration sets are per dialect

`OpenDatabase` applies the embedded migrations **of the driver it opened**
(`internal/db/database.go:90` → `loadEmbeddedMigrations(driver)`, `internal/db/migrations.go:34`),
and `migrations/` and `migrations/postgres/` are separate trees. A schema-derived sweep that only
ever opens SQLite therefore inherits the same blind spot one level up: a user-scoped table living
only in the Postgres tree (or lost from the SQLite half when the two diverge) would not appear in
the derived set, the test would stay green, and its rows would survive account erasure on a
Postgres deployment — while the test doc comment and the `SECURITY.md` row promise "every
user-scoped table" with no dialect caveat.

The scenario is one function, `assertAccountErasureLeavesNoUserScopedRows`, driven once per
supported engine:

- **SQLite — unconditional.** This is what keeps the guard non-vacuous where docker is unavailable.
- **Postgres — behind the package's existing docker gate.** `startPostgresTestConfig` →
  `testdb.StartPostgresDSN`, the same idiom `postgres_bootstrap_test.go` already uses; it calls
  `t.Skip("docker is required for postgres tests")` when docker is absent. Nothing in
  `internal/testdb` was touched.

The shared body is deliberately **not** a `t.Helper`: marking it one would report every failure at
the two subtest call sites instead of at the assertion that broke.

Both arms were run for real on a host with docker, and both derive the same five tables. The skip
path was exercised too (docker off `PATH`): the Postgres arm reports `SKIP`, the SQLite arm still
passes — so the coverage is "always SQLite, plus Postgres wherever docker exists", never nothing.

## Allowlist

`erasureUserScopeExemptions` is declared and **empty**. An exemption-free sweep is what also covers
tables added later, so an entry may only be added together with the one-line reason those rows are
allowed to survive (a bounded TTL, a separate erasure path, rows owned by someone else). Two cases
that might look like candidates and are not:

- `users` — keyed by `id`, not `user_id`, so the derivation never sees it; the account row is
  asserted gone by its own check.
- `oidc_logout_states` rows with `user_id = 0` (belonging to no owner) — the sweep counts rows for
  the *erased account's* id, so they are outside it by construction; the existing
  `sess-expired` / `sess-live` assertions still pin the post-commit purge behaviour.

## Proof the guard can fail (uncommitted scratch table)

A sixth user-scoped table was created inside the fixture and seeded for the account under erasure,
and left out of `DeleteAccountAndRelatedData`. It is not committed.

**1. Old test, broken state — still PASSES.** Scratch DDL
`CREATE TABLE scratch_orphan_notes (id INTEGER PRIMARY KEY, user_id INTEGER NOT NULL, note TEXT)`
plus a seeded row; the extra `t.Logf` was scratch too, so the surviving row can be read next to the
green verdict:

```
=== RUN   TestDeleteAccountAndRelatedDataRemovesAllUserRows
    delete_account_completeness_test.go:113: SCRATCH: scratch_orphan_notes still holds 1 row(s) for the erased account
--- PASS: TestDeleteAccountAndRelatedDataRemovesAllUserRows (0.12s)
PASS
ok  	github.com/ovumcy/ovumcy-web/internal/db	4.014s
```

**2. Fixed test, same broken state — FAILS, naming the orphan table, on both dialects.** Same
scratch table, now with portable DDL (`id BIGINT PRIMARY KEY, user_id BIGINT NOT NULL, note TEXT`)
so it lands on SQLite and Postgres alike:

```
=== RUN   TestDeleteAccountAndRelatedDataRemovesAllUserRows
=== RUN   TestDeleteAccountAndRelatedDataRemovesAllUserRows/sqlite
    delete_account_completeness_test.go:187: user-scoped tables derived from the live schema: [daily_logs oidc_identities oidc_logout_states register_pickup_tokens scratch_orphan_notes symptom_types]
    delete_account_completeness_test.go:208: scratch_orphan_notes still has 1 row(s) for the deleted user — account erasure incomplete
=== RUN   TestDeleteAccountAndRelatedDataRemovesAllUserRows/postgres
    delete_account_completeness_test.go:187: user-scoped tables derived from the live schema: [daily_logs oidc_identities oidc_logout_states register_pickup_tokens scratch_orphan_notes symptom_types]
    delete_account_completeness_test.go:208: scratch_orphan_notes still has 1 row(s) for the deleted user — account erasure incomplete
--- FAIL: TestDeleteAccountAndRelatedDataRemovesAllUserRows (4.91s)
    --- FAIL: TestDeleteAccountAndRelatedDataRemovesAllUserRows/sqlite (0.13s)
    --- FAIL: TestDeleteAccountAndRelatedDataRemovesAllUserRows/postgres (4.78s)
FAIL
FAIL	github.com/ovumcy/ovumcy-web/internal/db	7.698s
```

The other half of the guard, for the likelier case where nobody touches this test at all — same
scratch table, **no** seed row:

```
=== RUN   TestDeleteAccountAndRelatedDataRemovesAllUserRows
    delete_account_completeness_test.go:169: scratch_orphan_notes carries a user_id column but this test seeds no row for the account under erasure — add a seed row above, and thread the table through DeleteAccountAndRelatedData, or record it in erasureUserScopeExemptions with the reason
--- FAIL: TestDeleteAccountAndRelatedDataRemovesAllUserRows (0.12s)
FAIL
FAIL	github.com/ovumcy/ovumcy-web/internal/db	3.634s
```

**3. Scratch table removed — GREEN on both arms**, and the log shows what each sweep covered:

```
=== RUN   TestDeleteAccountAndRelatedDataRemovesAllUserRows
=== RUN   TestDeleteAccountAndRelatedDataRemovesAllUserRows/sqlite
    delete_account_completeness_test.go:181: user-scoped tables derived from the live schema: [daily_logs oidc_identities oidc_logout_states register_pickup_tokens symptom_types]
=== RUN   TestDeleteAccountAndRelatedDataRemovesAllUserRows/postgres
    delete_account_completeness_test.go:181: user-scoped tables derived from the live schema: [daily_logs oidc_identities oidc_logout_states register_pickup_tokens symptom_types]
--- PASS: TestDeleteAccountAndRelatedDataRemovesAllUserRows (5.30s)
    --- PASS: TestDeleteAccountAndRelatedDataRemovesAllUserRows/sqlite (0.13s)
    --- PASS: TestDeleteAccountAndRelatedDataRemovesAllUserRows/postgres (5.17s)
PASS
ok  	github.com/ovumcy/ovumcy-web/internal/db	9.133s
```

And with docker off `PATH`, the skip path — the SQLite arm carries the guard alone:

```
--- PASS: TestDeleteAccountAndRelatedDataRemovesAllUserRows (0.15s)
    --- PASS: TestDeleteAccountAndRelatedDataRemovesAllUserRows/sqlite (0.14s)
    --- SKIP: TestDeleteAccountAndRelatedDataRemovesAllUserRows/postgres (0.00s)
PASS
ok  	github.com/ovumcy/ovumcy-web/internal/db	4.132s
```

## Verification

- `go test ./internal/db/... -count=1` — ok, 40.7 s (docker present, so the Postgres arm ran)
- `gofmt -l internal/db/` — clean; `go vet ./internal/db/` — clean
- `golangci-lint run ./internal/db/...` — 0 issues
- `go run ./scripts/changelogd check` — OK (fragment
  `changelog.d/test-derive-erasure-user-scoped-tables.md`, first line `none`)

## Scope / rollback

Test-only: one test file plus the changelog fragment. No production code, no migration, and
`internal/testdb` is called but not modified. `SECURITY.md:261` already claims "every user-scoped
table is empty afterwards" for this test — the change makes that claim true on both supported
engines rather than restating it, so no matrix edit is owed. Rollback: revert the two commits;
category is privacy-deletion, not migration-parity, so no dialect-parity or OpenAPI re-run.
