### PR TITLE
test(api): pin the current-user key set by equality, across account states

### DIFF
--- a/changelog.d/test-pin-current-user-key-set.md
+++ b/changelog.d/test-pin-current-user-key-set.md
@@ -1,0 +1,8 @@
+none
+
+Test-only change: the current-user identity DTO regression
+(`TestGetCurrentUserReturnsMinimalIdentityShape`) now pins the decoded JSON key
+set by equality instead of by presence, so a field added to
+`GET /api/v1/users/current` fails the suite until it is deliberately
+classified. The response itself is unchanged, and the existing sensitive-field
+denylist and raw-body markers stay in place as defense in depth.

--- a/internal/api/handlers_basic_smoke_test.go
+++ b/internal/api/handlers_basic_smoke_test.go
@@ -9,7 +9,9 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/gofiber/fiber/v3"
 	"github.com/ovumcy/ovumcy-web/internal/models"
 	"gorm.io/gorm"
 )
@@ -129,6 +131,12 @@ func TestGetCurrentUserWithoutAuthCookieReturnsUnauthorized(t *testing.T) {
 // mutating calls it can make. The handler intentionally never includes
 // sensitive fields (password/recovery hashes, TOTP secret), so this test
 // also blocks accidental field leaks added by a future refactor.
+//
+// The shape is asserted over SEVERAL states of the same account, not just the
+// freshly onboarded one: a key added conditionally — `if user.OIDCSubject !=
+// "" { payload["oidc_subject"] = ... }` — is invisible to a guard that only
+// ever renders the state where the condition is false. The claim here is that
+// the key set does not depend on account state.
 func TestGetCurrentUserReturnsMinimalIdentityShape(t *testing.T) {
 	app, database := newOnboardingTestApp(t)
 	user := createOnboardingTestUser(t, database, "current-user-shape@example.com", "StrongPass1", true)
@@ -140,6 +148,70 @@ func TestGetCurrentUserReturnsMinimalIdentityShape(t *testing.T) {
 	}
 	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
 
+	assertCurrentUserIdentityShape(t, app, authCookie, "local password, display name set", user.Email)
+
+	// Local auth off and the display name cleared, so a key emitted only for
+	// one polarity of those two cannot hide behind the seeded state.
+	if err := database.Model(&user).Updates(map[string]any{
+		"display_name":       "",
+		"local_auth_enabled": false,
+	}).Error; err != nil {
+		t.Fatalf("clear display name and local auth: %v", err)
+	}
+	assertCurrentUserIdentityShape(t, app, authCookie, "local auth off, display name empty", user.Email)
+
+	// An account with a linked OIDC identity. The identity row is written
+	// directly because the DTO reads account state, not the login route that
+	// produced it; the issuer and the subject are passed as forbidden values
+	// so a subject reaching the wire under an existing key fails too.
+	const (
+		linkedIssuer  = "https://idp.example.com"
+		linkedSubject = "oidc-subject-must-not-ship"
+	)
+	if err := database.Create(&models.OIDCIdentity{
+		UserID:    user.ID,
+		Issuer:    linkedIssuer,
+		Subject:   linkedSubject,
+		CreatedAt: time.Now().UTC(),
+	}).Error; err != nil {
+		t.Fatalf("link oidc identity: %v", err)
+	}
+	assertCurrentUserIdentityShape(t, app, authCookie, "oidc identity linked", user.Email, linkedIssuer, linkedSubject)
+
+	// The DTO's other two flags have no reachable opposite polarity, so the
+	// shape above is deliberately narrower than the flag combinations the
+	// payload can spell: setting must_change_password revokes the live
+	// session (services.ResolveAuthSession), and an account that has not
+	// finished onboarding is answered by the middleware before the handler
+	// runs. Both are pinned as refusals so a change that makes either state
+	// reachable fails here, instead of leaving the key set unexercised for a
+	// state the handler newly serves.
+	for _, unreachable := range []struct {
+		state  string
+		update map[string]any
+	}{
+		{state: "must change password", update: map[string]any{"must_change_password": true}},
+		{state: "onboarding incomplete", update: map[string]any{"must_change_password": false, "onboarding_completed": false}},
+	} {
+		if err := database.Model(&user).Updates(unreachable.update).Error; err != nil {
+			t.Fatalf("apply %q state: %v", unreachable.state, err)
+		}
+		request := httptest.NewRequest(http.MethodGet, "/api/v1/users/current", nil)
+		request.Header.Set("Cookie", authCookie)
+		if response := mustAppResponse(t, app, request); response.StatusCode == http.StatusOK {
+			t.Fatalf("[%s] current-user answered 200: that state is now reachable, so the shape assertion above has to cover it too", unreachable.state)
+		}
+	}
+}
+
+// assertCurrentUserIdentityShape drives GET /api/v1/users/current with the
+// given session and asserts the whole shape contract against whatever account
+// state the caller has just written: the exact key set, the sensitive-field
+// denylist, the identity values, and the raw-body markers. state names the
+// account state under test so a failure says which one broke the contract.
+func assertCurrentUserIdentityShape(t *testing.T, app *fiber.App, authCookie string, state string, expectedEmail string, forbiddenValues ...string) {
+	t.Helper()
+
 	request := httptest.NewRequest(http.MethodGet, "/api/v1/users/current", nil)
 	request.Header.Set("Cookie", authCookie)
 	response := mustAppResponse(t, app, request)
@@ -147,11 +219,11 @@ func TestGetCurrentUserReturnsMinimalIdentityShape(t *testing.T) {
 
 	body, err := io.ReadAll(response.Body)
 	if err != nil {
-		t.Fatalf("read current-user body: %v", err)
+		t.Fatalf("[%s] read current-user body: %v", state, err)
 	}
 	payload := map[string]any{}
 	if err := json.Unmarshal(body, &payload); err != nil {
-		t.Fatalf("decode current-user JSON %q: %v", body, err)
+		t.Fatalf("[%s] decode current-user JSON %q: %v", state, body, err)
 	}
 
 	// The documented key set, in the order the handler writes it. It is
@@ -166,23 +238,23 @@ func TestGetCurrentUserReturnsMinimalIdentityShape(t *testing.T) {
 	expectedKeys := slices.Sorted(slices.Values(expectedFields))
 	actualKeys := slices.Sorted(maps.Keys(payload))
 	if !slices.Equal(actualKeys, expectedKeys) {
-		t.Fatalf("expected current-user payload to expose exactly the keys %v, got %v", expectedKeys, actualKeys)
+		t.Fatalf("[%s] expected current-user payload to expose exactly the keys %v, got %v", state, expectedKeys, actualKeys)
 	}
 	for _, leakedField := range []string{"password_hash", "password", "recovery_code_hash", "recovery_code", "totp_secret", "totp_secret_encrypted"} {
 		if _, ok := payload[leakedField]; ok {
-			t.Fatalf("did not expect current-user payload to expose %q (sensitive field leak): %v", leakedField, payload)
+			t.Fatalf("[%s] did not expect current-user payload to expose %q (sensitive field leak): %v", state, leakedField, payload)
 		}
 	}
-	if payload["email"] != user.Email {
-		t.Fatalf("expected email %q, got %v", user.Email, payload["email"])
+	if payload["email"] != expectedEmail {
+		t.Fatalf("[%s] expected email %q, got %v", state, expectedEmail, payload["email"])
 	}
 	if payload["role"] != string(models.RoleOwner) {
-		t.Fatalf("expected role %q, got %v", models.RoleOwner, payload["role"])
+		t.Fatalf("[%s] expected role %q, got %v", state, models.RoleOwner, payload["role"])
 	}
 	bodyString := string(body)
-	for _, leak := range []string{"$2a$", "$2b$", "totp_secret"} {
+	for _, leak := range append([]string{"$2a$", "$2b$", "totp_secret"}, forbiddenValues...) {
 		if strings.Contains(bodyString, leak) {
-			t.Fatalf("current-user response contained sensitive token %q: %q", leak, bodyString)
+			t.Fatalf("[%s] current-user response contained sensitive token %q: %q", state, leak, bodyString)
 		}
 	}
 }

--- a/internal/api/handlers_basic_smoke_test.go
+++ b/internal/api/handlers_basic_smoke_test.go
@@ -3,8 +3,10 @@ package api
 import (
 	"encoding/json"
 	"io"
+	"maps"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 
@@ -152,11 +154,19 @@ func TestGetCurrentUserReturnsMinimalIdentityShape(t *testing.T) {
 		t.Fatalf("decode current-user JSON %q: %v", body, err)
 	}
 
+	// The documented key set, in the order the handler writes it. It is
+	// pinned by EQUALITY rather than by presence on purpose: a presence
+	// loop accepts every key it was not told about, so a sensitive field
+	// added to the identity DTO later (an OIDC subject, a feed-token hash)
+	// would reach every wrapper client with this suite green. Any new key
+	// fails here until someone classifies it and extends this slice; the
+	// denylist and the raw-body markers below stay as defense in depth for
+	// a key that gets classified wrongly.
 	expectedFields := []string{"id", "email", "display_name", "role", "onboarding_completed", "local_auth_enabled", "must_change_password"}
-	for _, field := range expectedFields {
-		if _, ok := payload[field]; !ok {
-			t.Fatalf("expected current-user payload to expose %q, got %v", field, payload)
-		}
+	expectedKeys := slices.Sorted(slices.Values(expectedFields))
+	actualKeys := slices.Sorted(maps.Keys(payload))
+	if !slices.Equal(actualKeys, expectedKeys) {
+		t.Fatalf("expected current-user payload to expose exactly the keys %v, got %v", expectedKeys, actualKeys)
 	}
 	for _, leakedField := range []string{"password_hash", "password", "recovery_code_hash", "recovery_code", "totp_secret", "totp_secret_encrypted"} {
 		if _, ok := payload[leakedField]; ok {


### PR DESCRIPTION
## What was wrong

`TestGetCurrentUserReturnsMinimalIdentityShape` claims to lock the shape of the
identity DTO returned by `GET /api/v1/users/current`, but it could not fail on
an added key:

- The test listed seven documented fields and looped over them asserting
  **presence only** — never `len(payload)`, never a key-set comparison — so
  every key the list did not mention was accepted.
- The sensitive-field guard below it is a six-name denylist (`password_hash`,
  `password`, `recovery_code_hash`, `recovery_code`, `totp_secret`,
  `totp_secret_encrypted`), and the raw-body scan matches `$2a$`, `$2b$` and
  the literal string `totp_secret`. Both key off names and values that are
  already known.
- No other test in `internal/api` pins this response:
  `internal/api/openapi_contract_test.go:688-719` covers only
  `PATCH /api/v1/users/current/profile` and `.../cycle`, never the GET schema.

A future sensitive field on the identity DTO — an OIDC subject, a feed-token
hash — would therefore reach every wrapper client with the suite green.

## What changed

`internal/api/handlers_basic_smoke_test.go` only.

1. The decoded key set is compared for **equality** against the documented
   slice (`slices.Sorted(maps.Keys(payload))` against the expected keys), so
   any key added to the DTO fails until someone classifies it and extends the
   list. The denylist and the raw-body markers stay as defense in depth.
2. The whole shape check (decode, key-set equality, denylist, identity values,
   raw-body markers) moved into `assertCurrentUserIdentityShape` and now runs
   over **several states of the same account**, so the guard asserts that the
   key set does not depend on account state rather than pinning the one state
   the fixture happened to produce. States exercised:
   - local password, display name set (the seeded state);
   - local auth off, display name empty;
   - an account with a linked `oidc_identities` row — the issuer and the
     subject are also passed as forbidden raw-body values, so a subject
     reaching the wire under an *existing* key fails too.

   Without this, a conditional key (`if user.OIDCSubject != "" { … }`) stays
   invisible: the fixture never satisfies the condition. See the red-check
   below, which is exactly that mutation.
3. The two flags whose opposite polarity is **unreachable** from an
   authenticated request are pinned as refusals rather than silently skipped:
   `must_change_password = true` revokes the live session in
   `services.ResolveAuthSession`, and an account with
   `onboarding_completed = false` is answered by the onboarding middleware
   before the handler runs. If either state ever starts answering 200, the test
   fails and says the shape assertion has to cover it.

The handler and its response are untouched; rollback is a single-commit revert.

## Proof the guard can fail

The mutations below live only in the working tree while the evidence is taken
and are **not committed** — the handler is unmodified in this branch.

### 1. An added key, unconditional — the OLD assertion stayed green

Scratch mutation in `internal/api/handlers_users_current.go`:

```diff
 		"must_change_password": user.MustChangePassword,
+		"reset_token":          "scratch-not-committed",
 	})
```

`go test ./internal/api/ -run TestGetCurrentUserReturnsMinimalIdentityShape -count=1 -v`
against the presence-only assertion:

```
=== RUN   TestGetCurrentUserReturnsMinimalIdentityShape
--- PASS: TestGetCurrentUserReturnsMinimalIdentityShape (0.60s)
PASS
ok  	github.com/ovumcy/ovumcy-web/internal/api	6.126s
```

A leaked `reset_token` in the identity DTO: green.

### 2. Same mutation, this PR's assertion — fails, naming the key

```
=== RUN   TestGetCurrentUserReturnsMinimalIdentityShape
    handlers_basic_smoke_test.go:151: [local password, display name set] expected current-user payload to expose exactly the keys [display_name email id local_auth_enabled must_change_password onboarding_completed role], got [display_name email id local_auth_enabled must_change_password onboarding_completed reset_token role]
--- FAIL: TestGetCurrentUserReturnsMinimalIdentityShape (3.67s)
FAIL
FAIL	github.com/ovumcy/ovumcy-web/internal/api	12.488s
FAIL
```

### 3. An added key, CONDITIONAL — only the extra states catch it

The realistic shape of the leak this change is about: a key emitted for one
account state only.

```diff
-	return c.JSON(fiber.Map{
+	payload := fiber.Map{
 		…
-	})
+	}
+	if !user.LocalAuthEnabled {
+		payload["oidc_subject"] = "scratch-not-committed"
+	}
+	return c.JSON(payload)
```

```
=== RUN   TestGetCurrentUserReturnsMinimalIdentityShape
    handlers_basic_smoke_test.go:161: [local auth off, display name empty] expected current-user payload to expose exactly the keys [display_name email id local_auth_enabled must_change_password onboarding_completed role], got [display_name email id local_auth_enabled must_change_password oidc_subject onboarding_completed role]
--- FAIL: TestGetCurrentUserReturnsMinimalIdentityShape (0.59s)
FAIL
FAIL	github.com/ovumcy/ovumcy-web/internal/api	4.498s
FAIL
```

The failure names the second state, and the seeded state directly above it
passed — which is precisely why a single-state key-set equality would have
stayed green on this mutation.

### 4. Mutations reverted — the test is green

```
=== RUN   TestGetCurrentUserWithoutAuthCookieReturnsUnauthorized
--- PASS: TestGetCurrentUserWithoutAuthCookieReturnsUnauthorized (0.32s)
=== RUN   TestGetCurrentUserReturnsMinimalIdentityShape
--- PASS: TestGetCurrentUserReturnsMinimalIdentityShape (1.35s)
PASS
ok  	github.com/ovumcy/ovumcy-web/internal/api	8.904s
```

## Known limit

The OIDC-linked state is exercised by writing the `oidc_identities` row
directly, which is what that account state amounts to for the DTO today. It
cannot be red-checked the way step 3 red-checks the flag states:
`GetCurrentUser` has no identity lookup to key a scratch conditional on, and
adding one would be a production change this test-only PR does not make. If the
handler ever grows that lookup, the state is already in place to catch a key
derived from it.

## Checks run

- `go test ./internal/api/... -count=1 -timeout 20m` — `ok  github.com/ovumcy/ovumcy-web/internal/api 361.336s`
- `golangci-lint run ./internal/api/...` — `0 issues.`
- `gofmt -l internal/api/handlers_basic_smoke_test.go` — no output
- `go run ./scripts/changelogd check` — `changelog fragment check OK.`
