### PR TITLE
test(deploy): execute the documented backup and restore, both engines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -955,9 +955,29 @@ jobs:
               printf '%s\n' "$files"
               # Anything NOT matching this docs/meta allowlist forces e2e to run.
               app_changes="$(printf '%s\n' "$files" | grep -vE '^(docs/|\.clusterfuzzlite/|LICENSE$|\.gitignore$|\.gitattributes$|.*\.md$)' || true)"
+              # One document is not inert text: scripts/backuprestoredoc reads
+              # the Postgres backup and restore commands out of the operator
+              # runbook and RUNS them against an ephemeral database, so an edit
+              # there breaks a test exactly as a Go edit does. It is caught by
+              # BOTH arms of the allowlist above (the `docs/` prefix and the
+              # `.md` suffix), so it is detected separately here — and consumed
+              # at `run_core` below, NOT here: the guard rides the Go lanes
+              # alone, and forcing it through `run_e2e` would buy a runbook
+              # typo a full browser battery that cannot look at it. Measured
+              # 2026-08-20: 10 of the 22 commits touching that file since June
+              # carried no other app-affecting file, so without the force
+              # nearly half of all runbook edits would land with the guard
+              # never having executed. The name is cross-checked from the
+              # guard's own package, so a rename cannot leave this filter
+              # pointing at nothing.
+              runbook_changes="$(printf '%s\n' "$files" | grep -E '^docs/self-hosted\.md$' || true)"
               if [ -z "$app_changes" ]; then
                 run_e2e=false
-                verdict="docs/meta-only change: the browser e2e jobs and the unit/race battery report success without running."
+                if [ -n "$runbook_changes" ]; then
+                  verdict="documentation-only change that touches the executed operator runbook: the browser e2e jobs and the race lanes report success without running, and the Go lanes run for it."
+                else
+                  verdict="docs/meta-only change: the browser e2e jobs and the unit/race battery report success without running."
+                fi
               else
                 verdict="app-affecting change detected: running e2e and the battery."
               fi
@@ -986,6 +1006,16 @@ jobs:
           # written only inside the `push` branch, so an unknown event, a
           # crashed job or an empty output all leave the core suite RUNNING.
           run_core="$run_e2e"
+          # The runbook force, and the only place it is applied: the Go lanes
+          # execute the operator runbook (see the detection above), so a diff
+          # that touches it needs them even when everything else about the
+          # diff is documentation. It sits BEFORE the `push` branch on purpose
+          # — there the merge queue has already run the core suite, and this
+          # guard with it, on this exact commit, so `push` still wins.
+          if [ -n "${runbook_changes:-}" ]; then
+            run_core=true
+            echo "the executed operator runbook changed: the Go lanes run for it, the browser lanes do not."
+          fi
           if [ "$EVENT_NAME" = "push" ]; then
             run_core=false
             echo "push to main: the merge queue already ran the core suite on this exact commit; running only the lanes it skips."
@@ -1011,7 +1041,12 @@ jobs:
             fi
             # Browser-spec-only: the e2e allowlist plus the docs/meta one.
             beyond_specs="$(printf '%s\n' "$files" | grep -vE '^(e2e/|docs/|\.clusterfuzzlite/|LICENSE$|\.gitignore$|\.gitattributes$|.*\.md$)' || true)"
-            if [ -z "$beyond_specs" ]; then
+            # The runbook force above reaches `run_core`, and this slice would
+            # take it straight back: `beyond_specs` excuses every `^docs/`
+            # path, so without the second half of this condition a
+            # runbook-only diff would clear the Go lanes again — the very
+            # lanes that run the guard reading it.
+            if [ -z "$beyond_specs" ] && [ -z "${runbook_changes:-}" ]; then
               run_unit=false
               echo "browser specs only: the Go suite reports success without running."
             fi

--- a/changelog.d/guard-documented-backup-restore.md
+++ b/changelog.d/guard-documented-backup-restore.md
@@ -1,0 +1,44 @@
+### Fixed
+
+- **The Postgres restore in `docs/self-hosted.md` no longer promises an export that the procedure
+  cannot produce, and its "changed nothing" case now says what it does change.** Running the
+  documented commands settled both. A dump taken after the documented restore is never
+  byte-identical to the one that was replayed: `pg_dump` 17.6+ wraps every dump in a fresh random
+  `\restrict` token, and dropping and recreating `public` leaves a schema `initdb` did not create,
+  so every later dump carries an `ALTER SCHEMA public OWNER` / `COMMENT ON SCHEMA public` /
+  `REVOKE USAGE ON SCHEMA public` block the earlier one did not. Neither is data, and an operator
+  who verified a restore with a byte-for-byte `diff` — which the old wording invited — would have
+  read a good restore as a failed one. The runbook now names both differences and says to compare
+  the `COPY` blocks and `setval` lines instead. The failure row of the same section is corrected
+  too: replaying a dump into a database that still holds its schema restores no row, but `setval`
+  is the one statement that still succeeds, so every sequence is rewound to the backup's value and
+  the next insert lands on an id that is already taken.
+
+### Internal
+
+- **The backup and restore runbook is now executed, not just written.** Both documented procedures —
+  the Postgres one (`pg_dump`, then a schema drop and a `psql -v ON_ERROR_STOP=1` replay) and the
+  SQLite named-volume one (`tar czf` through Alpine, then `docker volume rm`/`create` and `tar xzf`)
+  — existed only as prose: nothing in the repository ran a single one of those commands, so an
+  incident would have been the first time either ran end to end. `scripts/backuprestoredoc` reads
+  them out of `docs/self-hosted.md` and runs them verbatim against ephemeral resources, substituting
+  only what would otherwise reach a real deployment: the compose transport becomes a direct
+  `docker exec` against a throwaway container, and the data volume name becomes a throwaway volume.
+  That second substitution is safety, not convenience — the documented restore begins by deleting
+  the volume — so an executed command is refused outright if either literal survived it. The two
+  `docker compose` lifecycle lines are asserted present and then skipped: the guard never starts the
+  application, it writes the volume and reads it back itself.
+
+  Each half seeds a generation, backs it up, deliberately drifts the database — a row written, a row
+  changed, a row deleted — restores, and only then compares, so a restore that moved nothing cannot
+  pass; both then read the owner and the day logs back through the repositories. The Postgres half
+  closes with the runbook's own failure row as a counterfactual. The SQLite half writes its fixture
+  with the connection held open, which puts the rows in `ovumcy.db-wal` rather than in the database
+  file, and so checks the runbook's promise that the whole-volume archive captures `ovumcy.db`, its
+  `-wal` and its `-shm` together — an archive missing the sidecars restores the clean, empty instance
+  the Post-Restore Verification section warns about, and nothing checked that before.
+
+  CI's relevance filter learns the one consequence: a diff that touches only the runbook now forces
+  the Go lanes, which would otherwise be cleared as documentation — 10 of the 22 commits that touched
+  it since June carried nothing else. The browser lanes are deliberately not forced with them: the
+  guard does not ride there.

--- a/docs/self-hosted.md
+++ b/docs/self-hosted.md
@@ -345,7 +345,7 @@ The first command destroys everything currently in that database. Take a fresh r
 Both additions are load-bearing:
 
 - **Dropping the schema** is the Postgres equivalent of `docker volume rm ovumcy_data` + `docker volume create` on the SQLite path, and for the same reason: the restore has to start from an empty target. A plain `pg_dump` writes `CREATE TABLE` followed by `COPY` and carries no `DROP` of its own, so against a database that still holds its schema every `CREATE TABLE` fails — and `COPY`, one all-or-nothing statement per table, only lands in a table that is still empty.
-- **`-v ON_ERROR_STOP=1`** makes `psql` treat those failures as failures. Its default is to run past every error and exit `0` regardless, which is what lets a restore that moved nothing report success.
+- **`-v ON_ERROR_STOP=1`** makes `psql` treat those failures as failures. Its default is to run past every error and exit `0` regardless, which is what lets a restore that moved none of the data report success.
 
 Without both, the restore's outcome depends on the state of the target database, and the three cases are indistinguishable from outside — all of them exit `0` after printing roughly 40 `ERROR:  relation "…" already exists` lines to stderr:
 
@@ -353,9 +353,16 @@ Without both, the restore's outcome depends on the state of the target database,
 | --- | --- |
 | Tables empty (fresh volume, rehearsal stack) | Restored every row — the case that makes the procedure look correct |
 | Partial loss (some rows survived) | Restored **nothing**; the missing rows stayed missing |
-| Data intact, or drifted since the backup | Changed **nothing**; the operator is looking at the wrong generation of data |
+| Data intact, or drifted since the backup | Restored **no row**, and rewound every **sequence** to the value it held in the backup — `setval` is the one statement in a plain dump that succeeds against a populated schema. The operator is looking at the wrong generation of data on a database whose next insert lands on an id that is already taken |
 
-With the drop step and `ON_ERROR_STOP=1`, the same restore prints no `ERROR:` lines, exits `0`, and leaves an export byte-identical to the one taken when the dump was made.
+With the drop step and `ON_ERROR_STOP=1`, the same restore prints no `ERROR:` lines, exits `0`, and brings back every table, row and sequence the dump carried.
+
+Two differences to the dump you took survive it, and neither of them is your data, so do not read either as a failed restore:
+
+- `pg_dump` 17.6 and newer wrap every dump in a fresh random `\restrict …` / `\unrestrict …` pair, so no two dumps of the same database are ever byte-identical.
+- Dropping and recreating `public` leaves a schema that `initdb` did not create, so every dump taken *after* a restore carries an `ALTER SCHEMA public OWNER` / `COMMENT ON SCHEMA public` / `REVOKE USAGE ON SCHEMA public` block that the dump taken before it did not.
+
+Compare two dumps by their `COPY` blocks and their `setval` lines rather than with a byte-for-byte `diff`.
 
 A clean exit now means the two commands ran, not that the data came back: a truncated or empty dump replays into a freshly dropped schema without a single error and exits `0` just the same, leaving the stack healthy and blank. Finish through [Post-Restore Verification](#post-restore-verification) — `/readyz` and a normal page load stay green on an empty database, so neither closes out a Postgres restore either.
 

--- a/internal/testdb/postgres.go
+++ b/internal/testdb/postgres.go
@@ -31,6 +31,20 @@ const (
 func StartPostgresDSN(t *testing.T, databaseName string) string {
 	t.Helper()
 
+	dsn, _ := StartPostgres(t, databaseName)
+	return dsn
+}
+
+// StartPostgres is StartPostgresDSN plus the container id, for a test that must
+// also run a command INSIDE the container — the operator runbook reaches
+// pg_dump and psql through `docker compose exec -T postgres`, and a guard that
+// executes those commands needs the container the DSN points at, not only a
+// host connection to it. The container is started with POSTGRES_USER and
+// POSTGRES_DB set, so `$POSTGRES_USER`/`$POSTGRES_DB` resolve inside it exactly
+// as they do in the bundled compose stack.
+func StartPostgres(t *testing.T, databaseName string) (dsn string, containerID string) {
+	t.Helper()
+
 	if _, err := exec.LookPath("docker"); err != nil {
 		t.Skip("docker is required for postgres tests")
 	}
@@ -42,7 +56,7 @@ func StartPostgresDSN(t *testing.T, databaseName string) string {
 
 	ensurePostgresImageAvailable(t)
 
-	containerID := runDockerCommand(t, "run", "-d", "--rm", "-P",
+	containerID = runDockerCommand(t, "run", "-d", "--rm", "-P",
 		"-e", "POSTGRES_USER="+postgresTestUser,
 		"-e", "POSTGRES_PASSWORD="+postgresTestPassword,
 		"-e", "POSTGRES_DB="+databaseName,
@@ -55,7 +69,7 @@ func StartPostgresDSN(t *testing.T, databaseName string) string {
 
 	waitForPostgresReadiness(t, containerID, databaseName)
 	port := loadPostgresMappedPort(t, containerID)
-	dsn := fmt.Sprintf(
+	dsn = fmt.Sprintf(
 		"host=127.0.0.1 port=%s user=%s password=%s dbname=%s sslmode=disable TimeZone=UTC",
 		port,
 		postgresTestUser,
@@ -64,7 +78,7 @@ func StartPostgresDSN(t *testing.T, databaseName string) string {
 	)
 	waitForHostSQLReadiness(t, dsn)
 
-	return dsn
+	return dsn, containerID
 }
 
 func waitForPostgresReadiness(t *testing.T, containerID string, databaseName string) {

--- a/scripts/backuprestoredoc/export_compare_test.go
+++ b/scripts/backuprestoredoc/export_compare_test.go
@@ -1,0 +1,292 @@
+package backuprestoredoc
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// The runbook's claim is about what an export looks like after a restore, so
+// this file is where "the same export" is defined — and the definition is not
+// `bytes.Equal`, because two dumps of one unchanged database are not byte-equal
+// on any currently shipping pg_dump:
+//
+//   - `pg_dump` 17.6+ opens and closes every dump with `\restrict <token>` /
+//     `\unrestrict <token>`, and the token is fresh on every run. It is a psql
+//     meta-command guard, not data.
+//   - The documented restore drops and recreates `public`, so the schema is no
+//     longer the one initdb made. Every LATER dump therefore carries an
+//     explicit ownership/comment/ACL block for `public` that the dump taken
+//     before the restore did not — restoreResidue below, three statements, all
+//     about the schema object itself and none about a row.
+//
+// Both were measured, not assumed: they are the whole difference between a dump
+// taken before the documented restore and one taken after it, over this
+// application's schema. So a comparison drops the first class and accounts for
+// the second EXPLICITLY, and anything beyond them is a failure — a restore that
+// lost a row, a column or a sequence has nowhere to hide.
+
+// copyBlockStart and copyBlockEnd bracket the regions of a dump that are data
+// rather than SQL. Nothing inside them is ever normalised away: a day-log note
+// is free text and may begin with `--`, and stripping it as a comment would
+// make this guard blind to exactly the loss it exists to catch.
+var (
+	copyBlockStart = regexp.MustCompile(`^COPY .* FROM stdin;$`)
+	copyBlockEnd   = `\.`
+
+	// restrictGuard is pg_dump 17.6+'s per-dump random token.
+	restrictGuard = regexp.MustCompile(`^\\(un)?restrict \S+$`)
+
+	// restoreResidue is what the documented restore leaves behind in every
+	// later dump, because `CREATE SCHEMA public` produces a schema owned by
+	// the restoring role instead of the pinned one initdb created. Each
+	// pattern must actually appear (see assertExportMatchesApartFromRestoreResidue):
+	// if a pg_dump release stops emitting one, the runbook's wording about it
+	// is stale and this guard says so instead of quietly passing.
+	restoreResidue = []*regexp.Regexp{
+		regexp.MustCompile(`^ALTER SCHEMA public OWNER TO \S+;$`),
+		regexp.MustCompile(`^COMMENT ON SCHEMA public IS '.*';$`),
+		regexp.MustCompile(`^REVOKE USAGE ON SCHEMA public FROM PUBLIC;$`),
+	}
+)
+
+// reportedDifferenceLimit bounds how many differing lines a failed comparison
+// prints, so a wholesale mismatch cannot bury the log.
+const reportedDifferenceLimit = 8
+
+// canonicalExport reduces a dump to the lines that carry its schema and its
+// data: comments, blank lines and the per-dump restrict tokens go, everything
+// inside a COPY block stays exactly as it is.
+func canonicalExport(export []byte) []string {
+	var (
+		canonical []string
+		inData    bool
+	)
+	for _, line := range strings.Split(string(export), "\n") {
+		line = strings.TrimSuffix(line, "\r")
+		if inData {
+			canonical = append(canonical, line)
+			if line == copyBlockEnd {
+				inData = false
+			}
+			continue
+		}
+		switch {
+		case strings.TrimSpace(line) == "":
+		case strings.HasPrefix(line, "--"):
+		case restrictGuard.MatchString(line):
+		default:
+			canonical = append(canonical, line)
+			if copyBlockStart.MatchString(line) {
+				inData = true
+			}
+		}
+	}
+	return canonical
+}
+
+// sequenceSetting matches the `setval` calls a dump ends with. They are the
+// part of a dump that a failed replay still lands: `CREATE TABLE` and `COPY`
+// fail against a populated schema, `setval` does not, which is why the two
+// halves of an export are compared separately below.
+var sequenceSetting = regexp.MustCompile(`^SELECT pg_catalog\.setval\(.*\);$`)
+
+// copyData returns the rows of a dump: every line of every COPY block,
+// terminators included, and nothing else.
+func copyData(export []byte) []string {
+	var (
+		rows   []string
+		inData bool
+	)
+	for _, line := range canonicalExport(export) {
+		switch {
+		case inData:
+			rows = append(rows, line)
+			if line == copyBlockEnd {
+				inData = false
+			}
+		case copyBlockStart.MatchString(line):
+			rows = append(rows, line)
+			inData = true
+		}
+	}
+	return rows
+}
+
+// sequenceSettings returns the `setval` calls of a dump, in order.
+func sequenceSettings(export []byte) []string {
+	var settings []string
+	for _, line := range canonicalExport(export) {
+		if sequenceSetting.MatchString(line) {
+			settings = append(settings, line)
+		}
+	}
+	return settings
+}
+
+func sameLines(first, second []string) bool {
+	if len(first) != len(second) {
+		return false
+	}
+	for i := range first {
+		if first[i] != second[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// exportsMatch reports whether two dumps carry the same schema and the same
+// data.
+func exportsMatch(before, after []byte) bool {
+	return sameLines(canonicalExport(before), canonicalExport(after))
+}
+
+// assertExportMatchesApartFromRestoreResidue is the runbook's claim, stated as
+// precisely as the instrument allows: the dump taken after the restore carries
+// every line the dump taken before it carried, in order, and the only lines it
+// adds are the recreated-schema residue named above — each of which it must
+// actually add.
+func assertExportMatchesApartFromRestoreResidue(t *testing.T, before, after []byte) {
+	t.Helper()
+
+	beforeLines := canonicalExport(before)
+	afterLines := canonicalExport(after)
+
+	seen := make([]bool, len(restoreResidue))
+	var (
+		differences []string
+		i, j        int
+	)
+	for i < len(beforeLines) && j < len(afterLines) {
+		if beforeLines[i] == afterLines[j] {
+			i++
+			j++
+			continue
+		}
+		if index := matchesRestoreResidue(afterLines[j]); index >= 0 {
+			seen[index] = true
+			j++
+			continue
+		}
+		differences = append(differences, fmt.Sprintf("  before the dump:   %s\n  after the restore: %s", beforeLines[i], afterLines[j]))
+		if len(differences) == reportedDifferenceLimit {
+			differences = append(differences, "  …")
+			break
+		}
+		i++
+		j++
+	}
+	for ; j < len(afterLines) && len(differences) < reportedDifferenceLimit; j++ {
+		if index := matchesRestoreResidue(afterLines[j]); index >= 0 {
+			seen[index] = true
+			continue
+		}
+		differences = append(differences, "  only after the restore: "+afterLines[j])
+	}
+	for ; i < len(beforeLines) && len(differences) < reportedDifferenceLimit; i++ {
+		differences = append(differences, "  only before the dump: "+beforeLines[i])
+	}
+
+	if len(differences) > 0 {
+		t.Fatalf("the documented restore did not reproduce the dumped database — %s claims it does:\n%s", runbookPath, strings.Join(differences, "\n"))
+	}
+	for index, found := range seen {
+		if !found {
+			t.Fatalf("the dump taken after the restore no longer carries %q, which %s tells the operator to expect: the runbook's account of the restore is stale", restoreResidue[index], runbookPath)
+		}
+	}
+}
+
+func matchesRestoreResidue(line string) int {
+	for index, pattern := range restoreResidue {
+		if pattern.MatchString(line) {
+			return index
+		}
+	}
+	return -1
+}
+
+// differenceReport describes where two dumps diverge, for the assertions that
+// only need to say "these two are not the same".
+func differenceReport(before, after []byte) string {
+	beforeLines := canonicalExport(before)
+	afterLines := canonicalExport(after)
+
+	var report []string
+	for i := 0; i < len(beforeLines) && i < len(afterLines); i++ {
+		if beforeLines[i] == afterLines[i] {
+			continue
+		}
+		if len(report) == reportedDifferenceLimit {
+			report = append(report, "  …")
+			break
+		}
+		report = append(report, fmt.Sprintf("line %d:\n  first:  %s\n  second: %s", i+1, beforeLines[i], afterLines[i]))
+	}
+	if len(beforeLines) != len(afterLines) {
+		report = append(report, fmt.Sprintf("the dumps differ in length: %d lines against %d", len(beforeLines), len(afterLines)))
+	}
+	if len(report) == 0 {
+		return "  (no difference found)"
+	}
+	return strings.Join(report, "\n")
+}
+
+// TestCanonicalExportKeepsDataAndDropsOnlyPerDumpNoise proves the normalisation
+// above on fixtures: it must drop the random restrict token and the SQL
+// comments around a dump, and must NOT touch a row whose free-text field looks
+// like one.
+func TestCanonicalExportKeepsDataAndDropsOnlyPerDumpNoise(t *testing.T) {
+	dump := strings.Join([]string{
+		`\restrict AbCdEf123`,
+		"",
+		"--",
+		"-- Name: daily_logs; Type: TABLE; Schema: public; Owner: ovumcy",
+		"--",
+		"CREATE TABLE public.daily_logs (id bigint NOT NULL);",
+		"COPY public.daily_logs (id, notes) FROM stdin;",
+		"1\t-- not a comment, an owner's note",
+		"2\t",
+		`\.`,
+		"",
+		`\unrestrict AbCdEf123`,
+		"",
+	}, "\n")
+
+	want := []string{
+		"CREATE TABLE public.daily_logs (id bigint NOT NULL);",
+		"COPY public.daily_logs (id, notes) FROM stdin;",
+		"1\t-- not a comment, an owner's note",
+		"2\t",
+		`\.`,
+	}
+
+	got := canonicalExport([]byte(dump))
+	if len(got) != len(want) {
+		t.Fatalf("canonical dump has %d lines, want %d:\n%q", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("canonical line %d is %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestExportsMatchSeesALostRow is the positive control for the comparison: the
+// normalisation must not be so eager that a missing row survives it.
+func TestExportsMatchSeesALostRow(t *testing.T) {
+	with := []byte("COPY public.users (id) FROM stdin;\n1\n2\n\\.\n")
+	without := []byte("COPY public.users (id) FROM stdin;\n1\n\\.\n")
+
+	if !exportsMatch(with, with) {
+		t.Error("a dump does not compare equal to itself")
+	}
+	if exportsMatch(with, without) {
+		t.Error("a dump missing a row compares equal to one carrying it")
+	}
+	if !exportsMatch(with, []byte("\\restrict xyz\n"+string(with))) {
+		t.Error("the per-dump restrict token is not being normalised away")
+	}
+}

--- a/scripts/backuprestoredoc/main_test.go
+++ b/scripts/backuprestoredoc/main_test.go
@@ -1,0 +1,348 @@
+// Package backuprestoredoc EXECUTES the backup and restore runbook in
+// docs/self-hosted.md instead of trusting its prose.
+//
+// The runbook documents two procedures, one per storage engine, and makes a
+// specific claim about each: the Postgres restore, with the schema dropped
+// first and `psql` run under `-v ON_ERROR_STOP=1`, brings back every table,
+// row and sequence the dump carried; the SQLite named-volume archive captures
+// `ovumcy.db`, `ovumcy.db-wal` and `ovumcy.db-shm` together, and the restore
+// puts them back. Until this package, both claims and all four destructive
+// commands existed only as prose — a repository-wide search for `pg_dump`,
+// `ON_ERROR_STOP`, the schema drop, `docker volume rm` or `tar xzf` matched
+// documentation and the changelog, never a test, a script or a workflow — so a
+// real incident would have been the first end-to-end run of either.
+//
+// The commands are therefore READ OUT OF THE DOCUMENT and executed verbatim
+// against ephemeral resources. Nothing here restates a command as a Go string
+// literal. What each half substitutes, and why the substitution is the thing
+// that keeps a `go test ./...` on a self-hoster’s own machine away from a real
+// deployment, is stated where it happens: composeExecPrefix below for Postgres,
+// the volume name and the compose lifecycle bracket in volume_test.go, and
+// refusedInAnExecutedCommand in shell_test.go, which refuses to run whatever a
+// substitution missed. A drift between the prose an operator follows and a
+// procedure that works is what turns this red.
+//
+// What the two halves cover:
+//
+//   - the documented `pg_dump` backup command, and the documented restore in
+//     both its steps — dropping and recreating the `public` schema, then the
+//     `-v ON_ERROR_STOP=1` replay;
+//   - the claim about what that restore leaves behind, over the application’s
+//     own migrated schema and with a deliberately drifted intermediate
+//     generation, so a restore that moved nothing cannot pass. What "the same
+//     export" means, and the two differences that survive any restore, are
+//     export_compare_test.go’s subject;
+//   - the runbook’s own "data intact, or drifted since the backup" table row —
+//     the restore that exits 0 having restored no row — as the counterfactual
+//     that makes the drop step and ON_ERROR_STOP load-bearing rather than
+//     decorative, down to the sequences it rewinds and the collision that
+//     follows;
+//   - the documented named-volume archive and restore (`tar czf` / `docker
+//     volume rm` + `create` / `tar xzf`), against an ephemeral volume holding
+//     the application’s own SQLite database, drifted the same three ways and
+//     read back through the repositories;
+//   - the whole-WAL-set claim: the fixture is written with the connection held
+//     OPEN, so the rows are in `ovumcy.db-wal` rather than in the database
+//     file, and an archive that missed the sidecars restores the clean, empty
+//     instance the runbook’s Post-Restore Verification warns about.
+//
+// What stays outside, deliberately: `docker compose down` / `up -d` are
+// asserted present in the restore block and then removed rather than run —
+// this package never starts the application, it writes the volume and reads it
+// back itself — and the operator-side checklist in Post-Restore Verification,
+// which is performed against a running instance and cannot be seen from here.
+package backuprestoredoc
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+const (
+	// runbookPath is the operator document under test, and postgresSection the
+	// heading whose fenced blocks are the Postgres procedure — the named-volume
+	// sections are volume_test.go's. Reading a named section rather than the
+	// whole file keeps every extraction honest: a renamed or removed heading
+	// fails there instead of quietly matching some other `pg_dump` further down
+	// the page.
+	runbookPath     = "docs/self-hosted.md"
+	postgresSection = "## Backup and Restore Contract"
+
+	// composeExecPrefix is how the runbook reaches the database: the bundled
+	// compose stack's postgres service, without a TTY. It is the ONE part of a
+	// documented command this guard rewrites — `docker exec -i <container>` is
+	// the same call against a container named directly instead of resolved by
+	// service name — and everything to its right, redirections and pipes
+	// included, runs exactly as written. A runbook that switches transport
+	// (podman, a remote psql, a different service name) stops containing this
+	// prefix and fails the extraction rather than silently running something
+	// else.
+	composeExecPrefix = "docker compose exec -T postgres"
+
+	// The two additions the runbook declares load-bearing. They are asserted
+	// present, not supplied: the guard would otherwise pass on a document that
+	// had dropped them.
+	dropSchemaStatement = "DROP SCHEMA public CASCADE"
+	createSchemaClause  = "CREATE SCHEMA public"
+	onErrorStopFlag     = "-v ON_ERROR_STOP=1"
+)
+
+// bashBlock matches one fenced shell block of the runbook.
+var bashBlock = regexp.MustCompile("(?s)```bash\n(.*?)```")
+
+// dumpRedirect and replaySource read the dump file path off the two commands
+// that name it. They exist to cross-check the pair: a runbook whose backup
+// writes one path and whose restore replays another documents a restore that
+// cannot work, and no assertion about either command alone would see it.
+var (
+	dumpRedirect = regexp.MustCompile(`>\s*(\S+\.sql)\s*$`)
+	replaySource = regexp.MustCompile(`^cat\s+(\S+\.sql)\s*\|`)
+)
+
+// runbookCommands is the Postgres procedure as the document spells it.
+type runbookCommands struct {
+	// backup is the whole first fenced block — `mkdir -p backups` and the
+	// pg_dump redirect — kept together because the redirect depends on the
+	// mkdir.
+	backup string
+	// drop and replay are the two commands of the restore block, in order.
+	drop   string
+	replay string
+	// dumpFile is the path both of them agree on, relative to the working
+	// directory the operator runs in.
+	dumpFile string
+}
+
+// documentedPostgresCommands reads the Postgres backup and restore commands out
+// of the runbook. Every shape assertion here fails CLOSED: an extraction that
+// found nothing, or found something it did not recognise, is this guard's own
+// failure rather than a reason to test less.
+func documentedPostgresCommands(t *testing.T) runbookCommands {
+	t.Helper()
+
+	section := runbookSectionText(t, postgresSection)
+	blocks := bashBlock.FindAllStringSubmatch(section, -1)
+	if len(blocks) != 2 {
+		t.Fatalf("%s: expected exactly 2 shell blocks under %q (backup, then restore), found %d — the extraction no longer matches the document", runbookPath, postgresSection, len(blocks))
+	}
+
+	backup := strings.TrimSpace(blocks[0][1])
+	restore := strings.TrimSpace(blocks[1][1])
+
+	if !strings.Contains(backup, "pg_dump") {
+		t.Fatalf("%s: the first shell block under %q does not run pg_dump:\n%s", runbookPath, postgresSection, backup)
+	}
+
+	// The restore block is two commands separated by a blank line, and an
+	// operator runs them one after the other. Splitting keeps the failure
+	// legible — which of the two steps died — and gives the counterfactual
+	// below a replay command it can run on its own.
+	steps := splitBlankLineSeparated(restore)
+	if len(steps) != 2 {
+		t.Fatalf("%s: expected the restore block to be exactly 2 commands (drop the schema, then replay the dump), found %d:\n%s", runbookPath, len(steps), restore)
+	}
+	drop, replay := steps[0], steps[1]
+
+	for _, required := range []struct {
+		command string
+		name    string
+		substr  string
+	}{
+		{drop, "the schema-drop step", dropSchemaStatement},
+		{drop, "the schema-drop step", createSchemaClause},
+		{drop, "the schema-drop step", onErrorStopFlag},
+		{replay, "the dump replay", onErrorStopFlag},
+	} {
+		if !strings.Contains(required.command, required.substr) {
+			t.Fatalf("%s: %s no longer contains %q — the runbook calls it load-bearing, so this guard refuses to run a procedure without it:\n%s", runbookPath, required.name, required.substr, required.command)
+		}
+	}
+
+	commands := runbookCommands{backup: backup, drop: drop, replay: replay}
+	for _, command := range []string{commands.backup, commands.drop, commands.replay} {
+		if !strings.Contains(command, composeExecPrefix) {
+			t.Fatalf("%s: documented command does not reach the database through %q, so this guard cannot run it as written:\n%s", runbookPath, composeExecPrefix, command)
+		}
+	}
+
+	commands.dumpFile = agreedDumpFile(t, commands)
+	return commands
+}
+
+// runbookSectionText returns the text of one section of the runbook, from its
+// heading to the next one.
+func runbookSectionText(t *testing.T, heading string) string {
+	t.Helper()
+
+	path := filepath.Join(repoRoot(t), filepath.FromSlash(runbookPath))
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", runbookPath, err)
+	}
+
+	document := strings.ReplaceAll(string(content), "\r\n", "\n")
+	start := strings.Index(document, "\n"+heading+"\n")
+	if start < 0 {
+		t.Fatalf("%s: section %q not found — a renamed heading leaves this guard reading nothing, so it fails here instead", runbookPath, heading)
+	}
+	rest := document[start+1:]
+	end := strings.Index(rest[len(heading):], "\n## ")
+	if end < 0 {
+		return rest
+	}
+	return rest[:len(heading)+end]
+}
+
+// agreedDumpFile returns the dump path named by both the backup and the replay,
+// failing when they disagree.
+func agreedDumpFile(t *testing.T, commands runbookCommands) string {
+	t.Helper()
+
+	written := ""
+	for _, line := range strings.Split(commands.backup, "\n") {
+		if match := dumpRedirect.FindStringSubmatch(strings.TrimSpace(line)); match != nil {
+			written = match[1]
+		}
+	}
+	if written == "" {
+		t.Fatalf("%s: the backup block redirects to no .sql file:\n%s", runbookPath, commands.backup)
+	}
+
+	match := replaySource.FindStringSubmatch(strings.TrimSpace(commands.replay))
+	if match == nil {
+		t.Fatalf("%s: the dump replay reads from no .sql file:\n%s", runbookPath, commands.replay)
+	}
+	if match[1] != written {
+		t.Fatalf("%s: the backup writes %q but the restore replays %q — following the runbook as written would restore the wrong file, or none", runbookPath, written, match[1])
+	}
+	return written
+}
+
+// splitBlankLineSeparated splits a shell block into the commands an operator
+// runs one at a time.
+func splitBlankLineSeparated(block string) []string {
+	var commands []string
+	for _, chunk := range strings.Split(block, "\n\n") {
+		if trimmed := strings.TrimSpace(chunk); trimmed != "" {
+			commands = append(commands, trimmed)
+		}
+	}
+	return commands
+}
+
+// TestDocumentedPostgresCommandsAreTheOnesThisGuardRuns pins the extraction
+// itself, so a reader can see which strings the executable guard below actually
+// takes out of the runbook — and so the fail-closed branches are exercised
+// against fixtures rather than only in the day they fire for real.
+func TestDocumentedPostgresCommandsAreTheOnesThisGuardRuns(t *testing.T) {
+	commands := documentedPostgresCommands(t)
+
+	if !strings.Contains(commands.backup, composeExecPrefix+" sh -lc 'pg_dump") {
+		t.Errorf("backup command is not the documented pg_dump call: %q", commands.backup)
+	}
+	if !strings.HasPrefix(commands.drop, composeExecPrefix) {
+		t.Errorf("schema-drop step does not start with the documented transport: %q", commands.drop)
+	}
+	if !strings.HasPrefix(commands.replay, "cat ") {
+		t.Errorf("dump replay does not pipe the dump file into psql: %q", commands.replay)
+	}
+	if commands.dumpFile == "" {
+		t.Error("no dump file path agreed between the backup and the restore")
+	}
+}
+
+// TestChangeDetectionRunsTheGoLanesForARunbookOnlyDiff asserts that CI still
+// detects a change to the document this package executes, and still lets that
+// detection reach the lanes that run it.
+//
+// Both halves matter and neither implies the other. The Go lanes are skipped
+// for a diff CI judges to be documentation only, and this runbook is
+// documentation by every spelling the filter knows — the `docs/` prefix and
+// the `.md` suffix both — so it is detected on its own and then FORCES
+// `run_core`, the ground the Go lanes derive from. It deliberately does not
+// force `run_e2e`: the guard rides the Go lanes alone, and a runbook typo
+// must not buy a full browser battery that cannot look at it.
+//
+// Measured 2026-08-20: 10 of the 22 commits touching the file since June
+// carried nothing else, so half of all runbook edits ride on this. Every
+// piece of it is a rule keyed on a SPELLING — a rename here, or a tidy-up
+// there, would silently restore the hole. This is the check that makes either
+// fail instead.
+func TestChangeDetectionRunsTheGoLanesForARunbookOnlyDiff(t *testing.T) {
+	path := filepath.Join(repoRoot(t), ".github", "workflows", "ci.yml")
+	workflow, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read the CI workflow: %v", err)
+	}
+
+	for _, required := range []struct {
+		fragment string
+		why      string
+	}{
+		{
+			fragment: "grep -E '^" + strings.ReplaceAll(runbookPath, ".", `\.`) + "$'",
+			why:      "the runbook is no longer detected at all, so a diff touching only it reads as documentation",
+		},
+		{
+			fragment: "if [ -n \"${runbook_changes:-}\" ]; then\n            run_core=true",
+			why:      "the detection no longer forces the core suite, so the Go lanes skip the diff they exist to judge here",
+		},
+		{
+			fragment: "[ -z \"$beyond_specs\" ] && [ -z \"${runbook_changes:-}\" ]",
+			why:      "the browser-spec-only slice takes the forced core suite straight back, since it excuses every docs/ path",
+		},
+	} {
+		if !strings.Contains(string(workflow), required.fragment) {
+			t.Errorf(".github/workflows/ci.yml no longer carries %q: %s, and this guard would not run on a change to %s", required.fragment, required.why, runbookPath)
+		}
+	}
+}
+
+// TestSplitBlankLineSeparatedKeepsOperatorSteps proves the restore block is cut
+// where an operator would cut it, using fixtures rather than the real document.
+func TestSplitBlankLineSeparatedKeepsOperatorSteps(t *testing.T) {
+	cases := []struct {
+		name  string
+		block string
+		want  []string
+	}{
+		{"two steps", "first --flag\n\nsecond --flag\n", []string{"first --flag", "second --flag"}},
+		{"one step", "only --flag\n", []string{"only --flag"}},
+		{"trailing blank lines are not a step", "first\n\n\nsecond\n\n", []string{"first", "second"}},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := splitBlankLineSeparated(testCase.block)
+			if len(got) != len(testCase.want) {
+				t.Fatalf("got %d commands %q, want %d", len(got), got, len(testCase.want))
+			}
+			for i := range got {
+				if got[i] != testCase.want[i] {
+					t.Fatalf("command %d: got %q, want %q", i, got[i], testCase.want[i])
+				}
+			}
+		})
+	}
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("go.mod not found above %s", dir)
+		}
+		dir = parent
+	}
+}

--- a/scripts/backuprestoredoc/postgres_roundtrip_test.go
+++ b/scripts/backuprestoredoc/postgres_roundtrip_test.go
@@ -1,0 +1,408 @@
+package backuprestoredoc
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/db"
+	"github.com/ovumcy/ovumcy-web/internal/models"
+	"github.com/ovumcy/ovumcy-web/internal/testdb"
+	"gorm.io/gorm"
+)
+
+// TestDocumentedPostgresRestoreReplacesDriftedDataWithTheBackedUpGeneration
+// runs the runbook's Postgres backup and restore, as the runbook writes them,
+// against an ephemeral database carrying the application's own schema.
+//
+// The shape is the one the claim needs and no smaller: generation 1 is seeded
+// and dumped, generation 2 deliberately drifts it — a row written, a row
+// changed, a row deleted — and only then is the documented restore run. Without
+// the drift, a restore that moved nothing would pass, which is precisely the
+// failure the runbook's own table warns about.
+//
+// It closes with that failure as a counterfactual: the same replay with the two
+// additions the runbook calls load-bearing taken away, asserted to exit 0 while
+// changing nothing at all. That is what keeps this from being a test of
+// Postgres rather than a test of the procedure.
+func TestDocumentedPostgresRestoreReplacesDriftedDataWithTheBackedUpGeneration(t *testing.T) {
+	commands := documentedPostgresCommands(t)
+	dsn, container := testdb.StartPostgres(t, "ovumcy_runbook_restore")
+	config := db.Config{Driver: db.DriverPostgres, PostgresURL: dsn}
+
+	seeded := seedGenerationOne(t, config)
+
+	// The operator's working directory: the runbook's `mkdir -p backups` and
+	// its `backups/…sql` paths are relative to wherever the commands are run,
+	// and the restore has to find the dump the backup wrote.
+	backupDir := t.TempDir()
+	backupExport := runDocumentedBackup(t, container, backupDir, commands)
+
+	driftToGenerationTwo(t, config, seeded)
+	driftedExport := runDocumentedBackup(t, container, t.TempDir(), commands)
+	if exportsMatch(backupExport, driftedExport) {
+		t.Fatal("generation 2 left the dump unchanged: the drift is not observable, so a restore that moved nothing would pass this guard")
+	}
+
+	restoreOutput := runDocumentedRestore(t, container, backupDir, commands)
+	if strings.Contains(restoreOutput, "ERROR:") {
+		t.Fatalf("the documented restore printed errors, which the runbook says it does not:\n%s", restoreOutput)
+	}
+
+	restoredExport := runDocumentedBackup(t, container, t.TempDir(), commands)
+	assertExportMatchesApartFromRestoreResidue(t, backupExport, restoredExport)
+
+	assertGenerationOneReadsBack(t, config, seeded)
+
+	assertRestoreWithoutTheDocumentedAdditionsChangesNothing(t, config, container, backupDir, commands, backupExport, seeded)
+}
+
+// assertRestoreWithoutTheDocumentedAdditionsChangesNothing replays the dump the
+// way the runbook says NOT to — into a database that still holds its schema,
+// with `-v ON_ERROR_STOP=1` removed — and asserts the outcome the runbook's
+// table records for that row: a clean exit that moved nothing. Both halves of
+// the broken command are derived from the documented one, never spelled here,
+// so the counterfactual cannot drift away from the procedure it is the negative
+// of.
+func assertRestoreWithoutTheDocumentedAdditionsChangesNothing(
+	t *testing.T,
+	config db.Config,
+	container string,
+	backupDir string,
+	commands runbookCommands,
+	backupExport []byte,
+	seeded seededGeneration,
+) {
+	t.Helper()
+
+	driftToGenerationTwo(t, config, seeded)
+	driftedExport := runDocumentedBackup(t, container, t.TempDir(), commands)
+
+	replay := strings.Replace(commands.replay, onErrorStopFlag+" ", "", 1)
+	if replay == commands.replay {
+		t.Fatalf("removing %q from the documented replay changed nothing, so the counterfactual would run the documented command instead:\n%s", onErrorStopFlag, commands.replay)
+	}
+
+	output, err := runRunbookScript(t, container, backupDir, replay)
+	if err != nil {
+		t.Fatalf("the runbook records this case as exiting 0; it failed instead: %v\n%s", err, output)
+	}
+	if !strings.Contains(output, "ERROR:") {
+		t.Fatalf("replaying into a database that still holds its schema printed no errors at all — the runbook's account of why the drop step is needed no longer holds:\n%s", output)
+	}
+
+	afterExport := runDocumentedBackup(t, container, t.TempDir(), commands)
+	if exportsMatch(afterExport, backupExport) {
+		t.Fatal("the dump replayed in full without dropping the schema first: the runbook's stated reason for the drop step is wrong")
+	}
+
+	// Not a row moved: `CREATE TABLE` and `COPY` both fail against a schema
+	// that still holds its tables, and `COPY` is all-or-nothing per table.
+	if !sameLines(copyData(driftedExport), copyData(afterExport)) {
+		t.Fatalf("the failed replay moved rows, which the runbook's table says it does not:\n%s", differenceReport(driftedExport, afterExport))
+	}
+
+	// The sequences, though, are not rows. `setval` is the one statement in a
+	// plain dump that succeeds against a populated schema, so a replay that
+	// restored nothing still rewinds every sequence to the backup's value and
+	// leaves the next insert colliding with an id already in use. The runbook
+	// records this row as "changed nothing"; this is the part that is not
+	// nothing, and it is asserted in both directions so that a Postgres release
+	// which stops doing it makes the runbook's wording stale here rather than
+	// silently.
+	if !sameLines(sequenceSettings(afterExport), sequenceSettings(backupExport)) {
+		t.Fatalf("the failed replay did not rewind the sequences to the backup's values, which the runbook now warns it does:\n  after the failed replay: %v\n  in the backup:           %v", sequenceSettings(afterExport), sequenceSettings(backupExport))
+	}
+	if sameLines(sequenceSettings(afterExport), sequenceSettings(driftedExport)) {
+		t.Fatalf("the sequences did not move at all, so this case cannot demonstrate the collision the runbook warns about: %v", sequenceSettings(afterExport))
+	}
+
+	// And the consequence itself, rather than only its cause: the next write
+	// lands on an id that is already taken. One attempt, because Postgres
+	// advances the sequence past the collision as it fails.
+	withRepositories(t, config, func(repos *db.Repositories) {
+		entry := models.DailyLog{UserID: seeded.ownerID, Date: runbookDay(t, "2026-04-01"), Notes: "written after the failed replay"}
+		if err := repos.DailyLogs.Create(context.Background(), &entry); err == nil {
+			t.Error("the first write after the failed replay succeeded: the rewound sequence no longer collides, and the runbook's warning about it is stale")
+		}
+	})
+}
+
+// runDocumentedBackup runs the documented backup command in dir and returns the
+// dump it wrote — the "export" the runbook's claim is about. Every dump this
+// guard compares is produced by this one command, so the comparison is like
+// with like and no pg_dump invocation is ever spelled by the test itself.
+func runDocumentedBackup(t *testing.T, container string, dir string, commands runbookCommands) []byte {
+	t.Helper()
+
+	output, err := runRunbookScript(t, container, dir, commands.backup)
+	if err != nil {
+		t.Fatalf("the documented backup command failed: %v\n%s", err, output)
+	}
+
+	export, err := os.ReadFile(filepath.Join(dir, filepath.FromSlash(commands.dumpFile)))
+	if err != nil {
+		t.Fatalf("read the dump the documented backup command wrote to %s: %v", commands.dumpFile, err)
+	}
+	if !bytes.Contains(export, []byte("COPY public.users")) {
+		t.Fatalf("the dump written to %s carries no users table, so it is not a dump of this application's database (%d bytes)", commands.dumpFile, len(export))
+	}
+	return export
+}
+
+// runDocumentedRestore runs the two commands of the documented restore, in the
+// documented order, and returns their combined output.
+func runDocumentedRestore(t *testing.T, container string, dir string, commands runbookCommands) string {
+	t.Helper()
+
+	output, err := runRunbookScript(t, container, dir, commands.drop, commands.replay)
+	if err != nil {
+		t.Fatalf("the documented restore failed: %v\n%s", err, output)
+	}
+	return output
+}
+
+// runRunbookScript runs Postgres commands taken verbatim from the runbook,
+// with the compose transport swapped for a direct `docker exec -i` against
+// container. That substitution is the only one this half makes; runScript
+// refuses to execute whatever a substitution missed.
+func runRunbookScript(t *testing.T, container string, dir string, commands ...string) (string, error) {
+	t.Helper()
+
+	script := strings.Join(commands, "\n")
+	script = strings.ReplaceAll(script, composeExecPrefix, "docker exec -i "+container)
+	return runScript(t, dir, script)
+}
+
+// seededGeneration is what generation 1 put into the database, kept so the
+// restored generation can be read back through the application's own
+// repositories and not only compared as dump lines.
+type seededGeneration struct {
+	ownerID     uint
+	ownerEmail  string
+	displayName string
+	logDates    []time.Time
+}
+
+// seedGenerationOne fills a freshly migrated database with an owner and a few
+// representative day logs — the same fixture shape the SQLite backup guard
+// uses (internal/db/sqlite_backup_restore_test.go), so the two documented
+// procedures are judged on comparable data.
+func seedGenerationOne(t *testing.T, config db.Config) seededGeneration {
+	t.Helper()
+
+	var seeded seededGeneration
+	withRepositories(t, config, func(repos *db.Repositories) {
+		seeded = seedGenerationInto(t, repos)
+	})
+	return seeded
+}
+
+// seedGenerationInto is the same fixture against an already open database, for
+// the SQLite half, which has to hold the connection open while it snapshots
+// the volume: closing checkpoints the WAL away, and the WAL is part of what
+// that half is there to prove.
+func seedGenerationInto(t *testing.T, repos *db.Repositories) seededGeneration {
+	t.Helper()
+
+	seeded := seededGeneration{
+		ownerEmail:  "owner@example.com",
+		displayName: "generation one",
+		logDates: []time.Time{
+			runbookDay(t, "2026-02-01"),
+			runbookDay(t, "2026-02-02"),
+			runbookDay(t, "2026-02-15"),
+		},
+	}
+	{
+		user := &models.User{
+			DisplayName:      seeded.displayName,
+			Email:            seeded.ownerEmail,
+			PasswordHash:     "hash",
+			RecoveryCodeHash: "recovery",
+			Role:             models.RoleOwner,
+			CycleLength:      models.DefaultCycleLength,
+			PeriodLength:     models.DefaultPeriodLength,
+			AutoPeriodFill:   true,
+			CreatedAt:        time.Now().UTC(),
+		}
+		if err := repos.Users.Create(context.Background(), user); err != nil {
+			t.Fatalf("seed the owner: %v", err)
+		}
+		seeded.ownerID = user.ID
+
+		bbt := 36.5
+		logs := []models.DailyLog{
+			{
+				UserID: user.ID, Date: seeded.logDates[0],
+				IsPeriod: true, CycleStart: true, Flow: "heavy", Mood: 3,
+				Notes:           "first day, cramps",
+				SymptomIDs:      []uint{1, 4, 7},
+				CycleFactorKeys: []string{"stress", "travel"},
+			},
+			{
+				UserID: user.ID, Date: seeded.logDates[1],
+				IsPeriod: true, Flow: "light", BBT: &bbt,
+			},
+			{
+				UserID: user.ID, Date: seeded.logDates[2],
+				SexActivity: "protected", CervicalMucus: "eggwhite",
+			},
+		}
+		for i := range logs {
+			if err := repos.DailyLogs.Create(context.Background(), &logs[i]); err != nil {
+				t.Fatalf("seed day log %d: %v", i, err)
+			}
+		}
+	}
+
+	return seeded
+}
+
+// driftToGenerationTwo moves the database away from the backed-up generation in
+// all three directions a restore has to undo: a row written, a row changed, a
+// row deleted. Anything less and a restore that did nothing would still leave
+// the database looking right.
+func driftToGenerationTwo(t *testing.T, config db.Config, seeded seededGeneration) {
+	t.Helper()
+
+	withRepositories(t, config, func(repos *db.Repositories) {
+		driftToGenerationTwoInto(t, repos, seeded)
+	})
+}
+
+// driftToGenerationTwoInto is the same drift against an already open database.
+func driftToGenerationTwoInto(t *testing.T, repos *db.Repositories, seeded seededGeneration) {
+	t.Helper()
+	{
+		// Written: an account that must not survive the restore.
+		stranger := &models.User{
+			DisplayName:      "generation two",
+			Email:            "drifted@example.com",
+			PasswordHash:     "hash",
+			RecoveryCodeHash: "recovery",
+			Role:             models.RoleOwner,
+			CycleLength:      models.DefaultCycleLength,
+			PeriodLength:     models.DefaultPeriodLength,
+			CreatedAt:        time.Now().UTC(),
+		}
+		if err := repos.Users.Create(context.Background(), stranger); err != nil {
+			t.Fatalf("drift: create the second account: %v", err)
+		}
+
+		// Changed: a column of the account that does survive it.
+		if err := repos.Users.UpdateDisplayName(context.Background(), seeded.ownerID, "drifted display name"); err != nil {
+			t.Fatalf("drift: rename the owner: %v", err)
+		}
+
+		// Deleted: health data the restore has to bring back.
+		firstDay := seeded.logDates[0]
+		if err := repos.DailyLogs.DeleteByUserAndDayRange(context.Background(), seeded.ownerID, firstDay, firstDay.Add(24*time.Hour)); err != nil {
+			t.Fatalf("drift: delete a day log: %v", err)
+		}
+
+		// Written again, on the health-data side.
+		extra := models.DailyLog{UserID: seeded.ownerID, Date: runbookDay(t, "2026-03-09"), Notes: "logged after the dump"}
+		if err := repos.DailyLogs.Create(context.Background(), &extra); err != nil {
+			t.Fatalf("drift: create a day log: %v", err)
+		}
+	}
+}
+
+// assertGenerationOneReadsBack reads the restored database back through the
+// application's own repositories. The dump comparison already proves the export
+// matches; this proves the three drifted directions were each undone, and says
+// which one was not in a form a human can act on — the runbook's own
+// Post-Restore Verification step 5, run as code.
+func assertGenerationOneReadsBack(t *testing.T, config db.Config, seeded seededGeneration) {
+	t.Helper()
+
+	withRepositories(t, config, func(repos *db.Repositories) {
+		assertGenerationOneReadsBackFrom(t, repos, seeded)
+	})
+}
+
+// assertGenerationOneReadsBackFrom is the same read-back against an already
+// open database.
+func assertGenerationOneReadsBackFrom(t *testing.T, repos *db.Repositories, seeded seededGeneration) {
+	t.Helper()
+	{
+		users, err := repos.Users.CountUsers(context.Background())
+		if err != nil {
+			t.Fatalf("count the restored accounts: %v", err)
+		}
+		if users != 1 {
+			t.Errorf("restored database holds %d accounts, want 1: the account written after the dump survived the restore", users)
+		}
+
+		owner, err := repos.Users.FindByID(context.Background(), seeded.ownerID)
+		if err != nil {
+			t.Fatalf("find the restored owner: %v", err)
+		}
+		if owner.Email != seeded.ownerEmail {
+			t.Errorf("restored owner email is %q, want %q", owner.Email, seeded.ownerEmail)
+		}
+		if owner.DisplayName != seeded.displayName {
+			t.Errorf("restored owner display name is %q, want %q: the change made after the dump survived the restore", owner.DisplayName, seeded.displayName)
+		}
+
+		logs, err := repos.DailyLogs.ListByUser(context.Background(), seeded.ownerID)
+		if err != nil {
+			t.Fatalf("list the restored day logs: %v", err)
+		}
+		restored := make(map[string]bool, len(logs))
+		for _, log := range logs {
+			restored[log.Date.Format("2006-01-02")] = true
+		}
+		for _, day := range seeded.logDates {
+			if !restored[day.Format("2006-01-02")] {
+				t.Errorf("restored database is missing the day log for %s", day.Format("2006-01-02"))
+			}
+		}
+		if len(logs) != len(seeded.logDates) {
+			t.Errorf("restored database holds %d day logs, want %d: a log written after the dump survived the restore", len(logs), len(seeded.logDates))
+		}
+	}
+}
+
+// withRepositories opens the application's own database layer against config,
+// hands the repositories to fn, and closes the pool before returning. Closing
+// is not tidiness: the runbook restores "with the app stopped", and an open
+// pool is the app.
+func withRepositories(t *testing.T, config db.Config, fn func(repos *db.Repositories)) {
+	t.Helper()
+
+	database, err := db.OpenDatabase(config)
+	if err != nil {
+		t.Fatalf("open the postgres database: %v", err)
+	}
+	defer closeDatabase(t, database)
+
+	fn(db.NewRepositories(database))
+}
+
+func closeDatabase(t *testing.T, database *gorm.DB) {
+	t.Helper()
+
+	sqlDB, err := database.DB()
+	if err != nil {
+		t.Fatalf("reach the sql database handle: %v", err)
+	}
+	if err := sqlDB.Close(); err != nil {
+		t.Fatalf("close the sql database handle: %v", err)
+	}
+}
+
+func runbookDay(t *testing.T, value string) time.Time {
+	t.Helper()
+
+	parsed, err := time.ParseInLocation("2006-01-02", value, time.UTC)
+	if err != nil {
+		t.Fatalf("parse day %q: %v", value, err)
+	}
+	return parsed
+}

--- a/scripts/backuprestoredoc/shell_test.go
+++ b/scripts/backuprestoredoc/shell_test.go
@@ -1,0 +1,92 @@
+package backuprestoredoc
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// runbookCommandTimeout bounds one documented command. Every step here is a
+// dump, an archive or a replay of a fixture-sized database against a container
+// on the same host: a step that has not finished inside this budget is hung,
+// not slow, and an unbounded hang would run to the job timeout, which GitHub
+// reports as a cancelled job with no failed step to read.
+const runbookCommandTimeout = 2 * time.Minute
+
+// refusedInAnExecutedCommand is the safety net under every command this package
+// runs. Each entry is a literal that a documented command legitimately contains
+// and that MUST have been substituted away before execution, so the check is
+// not a style rule but the thing that keeps `go test ./...` on a developer's
+// own machine from reaching a real deployment:
+//
+//   - `docker compose` would address the operator's compose project — the
+//     running application, its database, its volumes;
+//   - `ovumcy_data` is the operator's real data volume, and the restore the
+//     runbook documents begins by DELETING it. A run that got this far with the
+//     literal intact would destroy a self-hoster's health data on a machine
+//     where the guard was only supposed to read a document.
+//
+// Each caller substitutes for its own reasons — an ephemeral container, an
+// ephemeral volume — and this refuses to run whatever a substitution missed.
+var refusedInAnExecutedCommand = []struct {
+	literal string
+	why     string
+}{
+	{"docker compose", "addresses a compose project this guard has not started"},
+	{dataVolumeName, "still names the operator's own data volume, which the documented restore deletes"},
+}
+
+// runScript runs commands taken verbatim from the runbook, in dir, after every
+// substitution the caller owes has already been made.
+//
+// `set -euo pipefail` is the harness, not part of the procedure: an operator
+// runs these commands one at a time and reads each result before starting the
+// next, and this is what makes a failed first step stop the run rather than
+// leave the verdict to whatever the last command reported.
+func runScript(t *testing.T, dir string, script string) (string, error) {
+	t.Helper()
+
+	for _, refused := range refusedInAnExecutedCommand {
+		if strings.Contains(script, refused.literal) {
+			t.Fatalf("refusing to run a command that %s (%q survived substitution):\n%s", refused.why, refused.literal, script)
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), runbookCommandTimeout)
+	defer cancel()
+
+	command := exec.CommandContext(ctx, bashPath(t), "-c", "set -euo pipefail\n"+script)
+	command.Dir = dir
+	// MSYS_NO_PATHCONV/MSYS2_ARG_CONV_EXCL are a Windows-dev-host shim and
+	// nothing else: Git Bash rewrites arguments that look like POSIX paths
+	// before handing them to a native binary, which turns the runbook's
+	// `-v "$PWD/backups:/backup"` into a Windows path pair and mounts the
+	// wrong thing (measured: `/backup` arrived as `C:/Program Files/Git/backup`).
+	// On the Linux runner neither variable exists or means anything, so this
+	// changes what CI executes not at all.
+	command.Env = append(os.Environ(), "MSYS_NO_PATHCONV=1", "MSYS2_ARG_CONV_EXCL=*")
+
+	output, err := command.CombinedOutput()
+	if ctx.Err() != nil {
+		t.Fatalf("a documented command did not finish inside %s:\n%s\n%s", runbookCommandTimeout, script, output)
+	}
+	return string(output), err
+}
+
+// bashPath locates the shell the runbook's commands are written for. The
+// redirections, the pipe and the line continuations are load-bearing parts of
+// the documented procedure — the `-T` of `docker compose exec` exists so the
+// dump can arrive on stdin — so the commands are run by a shell rather than
+// reassembled as argv.
+func bashPath(t *testing.T) string {
+	t.Helper()
+
+	path, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skipf("bash is required to run the runbook's commands as written: %v", err)
+	}
+	return path
+}

--- a/scripts/backuprestoredoc/volume_test.go
+++ b/scripts/backuprestoredoc/volume_test.go
@@ -1,0 +1,568 @@
+package backuprestoredoc
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/db"
+	"gorm.io/gorm"
+)
+
+// The SQLite half of the runbook: the named-volume archive and restore an
+// operator of the default compose deployment actually follows. Same shape as
+// the Postgres half — the commands are read out of the document and executed —
+// with two substitutions instead of one, and both of them fail closed:
+//
+//   - the volume name. `ovumcy_data` is the operator's REAL data volume and the
+//     documented restore begins by deleting it, so a guard that ran the command
+//     as written would destroy a self-hoster's health data the first time
+//     someone ran `go test ./...` on a machine hosting the stack. Every command
+//     is rewritten onto an ephemeral volume, and runScript refuses to execute a
+//     script in which the literal survived (see refusedInAnExecutedCommand).
+//   - `docker compose down` / `docker compose up -d`. These are lifecycle
+//     bracketing around the mechanics, not the mechanics: this guard never
+//     starts the application at all, it writes the volume and reads it back
+//     itself. They are asserted PRESENT and then removed, so a runbook that
+//     stops stopping the app, or that grows a third compose command between
+//     them, fails extraction rather than being silently half-executed.
+//
+// Everything else — the `alpine` image and its tag, `tar czf`/`tar xzf`, the
+// mounts, `$BACKUP_FILE`, `docker volume rm`/`create` — runs exactly as the
+// document writes it.
+
+const (
+	volumeBackupSection  = "## Docker Named Volume Backup"
+	volumeRestoreSection = "## Docker Named Volume Restore"
+
+	// dataVolumeName is the volume the runbook names, and the literal this
+	// guard substitutes away before running anything.
+	dataVolumeName = "ovumcy_data"
+
+	// The lifecycle commands: asserted present, never executed.
+	composeDownCommand = "docker compose down"
+	composeUpCommand   = "docker compose up -d"
+
+	// sqliteDatabaseFile is the database inside the data volume. The two
+	// sidecars beside it are what `docs/self-hosted.md` promises the
+	// whole-volume archive captures together with it — the claim
+	// assertArchiveCarriesTheWholeWALSet checks.
+	sqliteDatabaseFile = "ovumcy.db"
+
+	dockerCommandTimeout = 3 * time.Minute
+)
+
+// walSetFiles is the trio the runbook names. In WAL mode the rows most recently
+// written live in the `-wal` file until a checkpoint, which is exactly why an
+// archive that carries only `ovumcy.db` restores an instance that boots clean
+// and empty — the failure the runbook's Post-Restore Verification describes.
+var walSetFiles = []string{sqliteDatabaseFile, sqliteDatabaseFile + "-wal", sqliteDatabaseFile + "-shm"}
+
+var (
+	backupFileAssignment = regexp.MustCompile(`(?m)^BACKUP_FILE="([^"]+)"$`)
+	archiveHostDirMount  = regexp.MustCompile(`-v "\$PWD/([^:"]+):/backup`)
+	runbookImageRef      = regexp.MustCompile(`(?m)^\s*(alpine:[^\s\\]+)`)
+)
+
+// volumeCommands is the named-volume procedure as the document spells it.
+type volumeCommands struct {
+	// backup is the whole fenced block of the backup section.
+	backup string
+	// restore is the restore block with the two compose lifecycle commands
+	// removed, and nothing else changed.
+	restore string
+	// image is the container image both blocks run the archive tooling in,
+	// read out of the document so a tag bump needs no edit here.
+	image string
+	// archiveDir and archiveFile are where the archive lands, relative to the
+	// directory the operator runs in. Both blocks must agree on both.
+	archiveDir  string
+	archiveFile string
+}
+
+// documentedVolumeCommands reads the named-volume backup and restore out of the
+// runbook. Every shape assertion fails CLOSED, for the same reason the Postgres
+// extraction does: an extraction that found nothing, or found something it does
+// not recognise, is this guard's own failure rather than a licence to run less.
+func documentedVolumeCommands(t *testing.T) volumeCommands {
+	t.Helper()
+
+	backup := singleShellBlock(t, volumeBackupSection)
+	restoreBlock := singleShellBlock(t, volumeRestoreSection)
+
+	for _, required := range []struct {
+		command string
+		name    string
+		substr  string
+	}{
+		{backup, "the archive command", "tar czf"},
+		{backup, "the archive command", dataVolumeName},
+		{restoreBlock, "the restore", "tar xzf"},
+		{restoreBlock, "the restore", "docker volume rm " + dataVolumeName},
+		{restoreBlock, "the restore", "docker volume create " + dataVolumeName},
+	} {
+		if !strings.Contains(required.command, required.substr) {
+			t.Fatalf("%s: %s no longer contains %q, so this guard cannot run the documented procedure:\n%s", runbookPath, required.name, required.substr, required.command)
+		}
+	}
+
+	commands := volumeCommands{
+		backup:      backup,
+		restore:     withoutLifecycleCommands(t, restoreBlock),
+		image:       agreedValue(t, "container image", runbookImageRef, backup, restoreBlock),
+		archiveFile: agreedValue(t, "archive file name", backupFileAssignment, backup, restoreBlock),
+		archiveDir:  agreedValue(t, "archive directory", archiveHostDirMount, backup, restoreBlock),
+	}
+	return commands
+}
+
+// withoutLifecycleCommands removes the two compose commands that bracket the
+// documented restore, having first asserted that both are there and that they
+// are the ONLY compose commands in the block.
+func withoutLifecycleCommands(t *testing.T, block string) string {
+	t.Helper()
+
+	var (
+		kept    []string
+		removed = map[string]int{composeDownCommand: 0, composeUpCommand: 0}
+		other   []string
+	)
+	for _, line := range strings.Split(block, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if count, ok := removed[trimmed]; ok {
+			removed[trimmed] = count + 1
+			continue
+		}
+		if strings.Contains(trimmed, "docker compose") {
+			other = append(other, trimmed)
+		}
+		kept = append(kept, line)
+	}
+
+	for command, count := range removed {
+		if count != 1 {
+			t.Fatalf("%s: the documented restore names %q %d times, want exactly 1 — this guard removes those two lines instead of executing them, so it refuses to guess at a block that changed shape:\n%s", runbookPath, command, count, block)
+		}
+	}
+	if len(other) > 0 {
+		t.Fatalf("%s: the documented restore grew compose command(s) this guard does not know how to skip: %v", runbookPath, other)
+	}
+	return strings.TrimSpace(strings.Join(kept, "\n"))
+}
+
+// agreedValue extracts one value with pattern from every block and requires
+// them all to name the same thing. A backup that writes one archive and a
+// restore that replays another documents a restore that cannot work, and no
+// assertion about either block alone would see it.
+func agreedValue(t *testing.T, name string, pattern *regexp.Regexp, blocks ...string) string {
+	t.Helper()
+
+	agreed := ""
+	for _, block := range blocks {
+		match := pattern.FindStringSubmatch(block)
+		if match == nil {
+			t.Fatalf("%s: no %s found in:\n%s", runbookPath, name, block)
+		}
+		if agreed == "" {
+			agreed = match[1]
+			continue
+		}
+		if match[1] != agreed {
+			t.Fatalf("%s: the two named-volume blocks disagree on the %s: %q against %q — following the runbook as written would back up one thing and restore another", runbookPath, name, agreed, match[1])
+		}
+	}
+	return agreed
+}
+
+// singleShellBlock returns the one fenced shell block of a runbook section.
+func singleShellBlock(t *testing.T, heading string) string {
+	t.Helper()
+
+	blocks := bashBlock.FindAllStringSubmatch(runbookSectionText(t, heading), -1)
+	if len(blocks) != 1 {
+		t.Fatalf("%s: expected exactly 1 shell block under %q, found %d — the extraction no longer matches the document", runbookPath, heading, len(blocks))
+	}
+	return strings.TrimSpace(blocks[0][1])
+}
+
+// TestDocumentedVolumeRestoreReplacesDriftedDataWithTheArchivedGeneration runs
+// the runbook's named-volume archive and restore, as the runbook writes them,
+// against an ephemeral volume holding the application's own SQLite database.
+//
+// It mirrors the Postgres half step for step — seed, archive, drift, restore,
+// read back through the repositories — and adds the claim that is specific to
+// this half: the database runs in WAL mode, so the archive has to carry
+// `ovumcy.db-wal` and `ovumcy.db-shm` beside `ovumcy.db`. The fixture is
+// written with the connection held OPEN, which is what puts those rows in the
+// WAL rather than in the database file, so an archive that missed the sidecars
+// cannot pass by accident.
+func TestDocumentedVolumeRestoreReplacesDriftedDataWithTheArchivedGeneration(t *testing.T) {
+	commands := documentedVolumeCommands(t)
+	requireDocker(t)
+
+	volume := ephemeralVolume(t)
+	workdir := t.TempDir()
+
+	seeded := seedVolumeGenerationOne(t, volume, commands)
+
+	if output, err := runVolumeScript(t, workdir, volume, commands.backup); err != nil {
+		t.Fatalf("the documented archive command failed: %v\n%s", err, output)
+	}
+	archivePath := filepath.Join(workdir, filepath.FromSlash(commands.archiveDir), commands.archiveFile)
+	assertArchiveCarriesTheWholeWALSet(t, archivePath)
+
+	driftVolumeToGenerationTwo(t, volume, commands, seeded)
+	assertVolumeHoldsGenerationTwo(t, volume, commands)
+
+	if output, err := runVolumeScript(t, workdir, volume, commands.restore); err != nil {
+		t.Fatalf("the documented restore failed: %v\n%s", err, output)
+	}
+
+	withVolumeCopy(t, volume, commands, func(_ string, repos *db.Repositories) {
+		assertGenerationOneReadsBackFrom(t, repos, seeded)
+	})
+}
+
+// TestDocumentedVolumeRunbookKeepsTheLifecycleBracket pins the two commands
+// this guard deliberately does not execute. They are the operator's whole
+// protection against archiving a database that is being written to, so their
+// disappearance from the runbook would be a real regression — and one this
+// package would otherwise be the last to notice, since it skips them.
+func TestDocumentedVolumeRunbookKeepsTheLifecycleBracket(t *testing.T) {
+	restore := singleShellBlock(t, volumeRestoreSection)
+
+	for _, command := range []string{composeDownCommand, composeUpCommand} {
+		if !strings.Contains(restore, command) {
+			t.Errorf("%s: the documented restore no longer stops and starts the app with %q", runbookPath, command)
+		}
+	}
+	if index := strings.Index(restore, composeDownCommand); index >= 0 {
+		if strings.Index(restore, composeUpCommand) < index {
+			t.Errorf("%s: the documented restore starts the app before it stops it", runbookPath)
+		}
+	}
+}
+
+// TestRunbookStillClaimsTheWholeWALSetIsCaptured ties the archive assertion to
+// the sentence it enforces. assertArchiveCarriesTheWholeWALSet requires all
+// three files because docs/self-hosted.md promises all three; if that promise
+// were quietly dropped from the runbook, the guard would go on enforcing a
+// claim the operator is no longer given — and, worse, the sharp edge it exists
+// for would have left the document with nothing failing.
+func TestRunbookStillClaimsTheWholeWALSetIsCaptured(t *testing.T) {
+	contract := runbookSectionText(t, postgresSection)
+
+	for _, name := range walSetFiles {
+		if !strings.Contains(contract, name) {
+			t.Errorf("%s: section %q no longer names %s, which this guard asserts every archive carries", runbookPath, postgresSection, name)
+		}
+	}
+	if !strings.Contains(contract, "WAL mode") {
+		t.Errorf("%s: section %q no longer explains that the database runs in WAL mode, which is why the sidecars matter", runbookPath, postgresSection)
+	}
+}
+
+// seedVolumeGenerationOne fills a fresh database with generation 1 and puts it
+// into the volume WITH THE CONNECTION STILL OPEN — the rows are in the WAL at
+// that moment, which is the state the runbook's claim is about.
+func seedVolumeGenerationOne(t *testing.T, volume string, commands volumeCommands) seededGeneration {
+	t.Helper()
+
+	dir := t.TempDir()
+	database := openVolumeDatabase(t, dir)
+	seeded := seedGenerationInto(t, db.NewRepositories(database))
+
+	assertWALSetOnDisk(t, dir)
+	writeVolume(t, volume, commands.image, dir)
+	closeDatabase(t, database)
+
+	return seeded
+}
+
+// driftVolumeToGenerationTwo takes the volume's own copy of the database, reads
+// generation 1 back out of it — which already proves the sidecars survived the
+// round trip — drifts it, and puts it back.
+func driftVolumeToGenerationTwo(t *testing.T, volume string, commands volumeCommands, seeded seededGeneration) {
+	t.Helper()
+
+	withVolumeCopy(t, volume, commands, func(dir string, repos *db.Repositories) {
+		assertGenerationOneReadsBackFrom(t, repos, seeded)
+		driftToGenerationTwoInto(t, repos, seeded)
+		assertWALSetOnDisk(t, dir)
+		writeVolume(t, volume, commands.image, dir)
+	})
+}
+
+// assertVolumeHoldsGenerationTwo is the drift's own proof: without it, a
+// snapshot that silently failed to land would leave generation 1 in the volume,
+// and the restore would be asserted against a database it never had to change.
+func assertVolumeHoldsGenerationTwo(t *testing.T, volume string, commands volumeCommands) {
+	t.Helper()
+
+	withVolumeCopy(t, volume, commands, func(_ string, repos *db.Repositories) {
+		accounts, err := repos.Users.CountUsers(context.Background())
+		if err != nil {
+			t.Fatalf("count the accounts in the drifted volume: %v", err)
+		}
+		if accounts != 2 {
+			t.Fatalf("the drifted volume holds %d accounts, want 2: the drift never reached the volume, so a restore that did nothing would pass", accounts)
+		}
+	})
+}
+
+// assertArchiveCarriesTheWholeWALSet checks the runbook's claim that the
+// whole-volume archive captures `ovumcy.db`, `ovumcy.db-wal` and
+// `ovumcy.db-shm` together. Nothing checked it before this guard.
+func assertArchiveCarriesTheWholeWALSet(t *testing.T, archivePath string) {
+	t.Helper()
+
+	file, err := os.Open(archivePath)
+	if err != nil {
+		t.Fatalf("open the archive the documented command wrote: %v", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	compressed, err := gzip.NewReader(file)
+	if err != nil {
+		t.Fatalf("the documented archive is not gzip-compressed, which `tar czf` makes it: %v", err)
+	}
+	defer func() { _ = compressed.Close() }()
+
+	carried := map[string]int64{}
+	archive := tar.NewReader(compressed)
+	for {
+		header, err := archive.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("read the documented archive: %v", err)
+		}
+		if header.Typeflag == tar.TypeReg {
+			carried[path.Base(header.Name)] = header.Size
+		}
+	}
+
+	var missing []string
+	for _, name := range walSetFiles {
+		if _, ok := carried[name]; !ok {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) > 0 {
+		t.Fatalf("the documented archive is missing %v — %s promises it captures all three together, and an archive without the WAL restores an instance that boots clean and empty. It carried: %v", missing, runbookPath, sortedNames(carried))
+	}
+	if carried[sqliteDatabaseFile] == 0 {
+		t.Fatalf("the documented archive carries an empty %s", sqliteDatabaseFile)
+	}
+}
+
+// assertWALSetOnDisk fails when SQLite is not in the state this half's claim is
+// about. A fixture that produced no `-wal` would make the archive assertion
+// vacuous, so it is checked rather than assumed.
+func assertWALSetOnDisk(t *testing.T, dir string) {
+	t.Helper()
+
+	for _, name := range walSetFiles {
+		if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
+			t.Fatalf("%s is not on disk beside the open database: the fixture is not in the WAL state this guard is about (%v)", name, err)
+		}
+	}
+}
+
+// withVolumeCopy extracts the volume into a temporary directory, opens the
+// application's own database layer over it, and closes the pool afterwards.
+func withVolumeCopy(t *testing.T, volume string, commands volumeCommands, fn func(dir string, repos *db.Repositories)) {
+	t.Helper()
+
+	dir := t.TempDir()
+	readVolume(t, volume, commands.image, dir)
+	database := openVolumeDatabase(t, dir)
+	defer closeDatabase(t, database)
+
+	fn(dir, db.NewRepositories(database))
+}
+
+func openVolumeDatabase(t *testing.T, dir string) *gorm.DB {
+	t.Helper()
+
+	database, err := db.OpenDatabase(db.Config{Driver: db.DriverSQLite, SQLitePath: filepath.Join(dir, sqliteDatabaseFile)})
+	if err != nil {
+		t.Fatalf("open the sqlite database in %s: %v", dir, err)
+	}
+	return database
+}
+
+// runVolumeScript substitutes the ephemeral volume for the one the runbook
+// names and runs the rest verbatim. runScript refuses the script if the
+// substitution missed anything.
+func runVolumeScript(t *testing.T, dir string, volume string, script string) (string, error) {
+	t.Helper()
+
+	return runScript(t, dir, strings.ReplaceAll(script, dataVolumeName, volume))
+}
+
+// ephemeralVolume creates the volume this run works on and removes it
+// afterwards. Its name deliberately cannot contain the documented one: the
+// substitution's safety check looks for that literal, and a name built around
+// it would defeat the check it depends on.
+func ephemeralVolume(t *testing.T) string {
+	t.Helper()
+
+	name := fmt.Sprintf("ovumcyguard%dtestdata", time.Now().UnixNano())
+	if strings.Contains(name, dataVolumeName) {
+		t.Fatalf("the ephemeral volume name %q contains %q, which would defeat the check that keeps this guard away from a real deployment", name, dataVolumeName)
+	}
+
+	runDocker(t, nil, "volume", "create", name)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), dockerCommandTimeout)
+		defer cancel()
+		// The documented restore removes and recreates this volume itself, so
+		// its absence here is not an error worth failing a passing test over.
+		_ = exec.CommandContext(ctx, "docker", "volume", "rm", "-f", name).Run()
+	})
+	return name
+}
+
+// writeVolume replaces the volume's contents with the files in dir. This is the
+// guard's own plumbing, standing in for the running application that would
+// normally own the volume — never a documented command.
+func writeVolume(t *testing.T, volume string, image string, dir string) {
+	t.Helper()
+
+	runDocker(t, tarDirectory(t, dir),
+		"run", "--rm", "-i", "-v", volume+":/target", image,
+		"sh", "-c", "cd /target && rm -rf ./* ./.[!.]* 2>/dev/null; tar xf -",
+	)
+}
+
+// readVolume copies the volume's contents into dir.
+func readVolume(t *testing.T, volume string, image string, dir string) {
+	t.Helper()
+
+	archive := runDocker(t, nil,
+		"run", "--rm", "-i", "-v", volume+":/source:ro", image,
+		"sh", "-c", "cd /source && tar cf - .",
+	)
+	untarInto(t, []byte(archive), dir)
+}
+
+// requireDocker skips when there is no docker to talk to, the same idiom the
+// repository's other container-backed tests use. CI has docker, so this is a
+// developer-host allowance and not a way for the guard to go quiet in the lane
+// that matters.
+func requireDocker(t *testing.T) {
+	t.Helper()
+
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Skipf("docker is required to run the documented named-volume commands: %v", err)
+	}
+}
+
+// runDocker runs one docker command with stdin, returning its stdout.
+func runDocker(t *testing.T, stdin []byte, args ...string) string {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), dockerCommandTimeout)
+	defer cancel()
+
+	command := exec.CommandContext(ctx, "docker", args...)
+	if stdin != nil {
+		command.Stdin = bytes.NewReader(stdin)
+	}
+	var stdout, stderr bytes.Buffer
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+
+	if err := command.Run(); err != nil {
+		if ctx.Err() != nil {
+			t.Fatalf("docker %s did not finish inside %s", strings.Join(args, " "), dockerCommandTimeout)
+		}
+		t.Fatalf("docker %s failed: %v: %s", strings.Join(args, " "), err, strings.TrimSpace(stderr.String()))
+	}
+	return stdout.String()
+}
+
+// tarDirectory packs the regular files of dir — the database and its sidecars —
+// into an uncompressed tar stream.
+func tarDirectory(t *testing.T, dir string) []byte {
+	t.Helper()
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read %s: %v", dir, err)
+	}
+
+	var buffer bytes.Buffer
+	archive := tar.NewWriter(&buffer)
+	for _, entry := range entries {
+		if !entry.Type().IsRegular() {
+			continue
+		}
+		content, err := os.ReadFile(filepath.Join(dir, entry.Name()))
+		if err != nil {
+			t.Fatalf("read %s: %v", entry.Name(), err)
+		}
+		header := &tar.Header{Name: "./" + entry.Name(), Mode: 0o600, Size: int64(len(content)), Typeflag: tar.TypeReg}
+		if err := archive.WriteHeader(header); err != nil {
+			t.Fatalf("write tar header for %s: %v", entry.Name(), err)
+		}
+		if _, err := archive.Write(content); err != nil {
+			t.Fatalf("write tar entry for %s: %v", entry.Name(), err)
+		}
+	}
+	if err := archive.Close(); err != nil {
+		t.Fatalf("close the tar stream: %v", err)
+	}
+	return buffer.Bytes()
+}
+
+// untarInto unpacks a flat tar stream into dir. Only regular files are taken,
+// and only by base name: the archive comes from a volume this test created, and
+// a flat extraction cannot be walked out of the directory.
+func untarInto(t *testing.T, stream []byte, dir string) {
+	t.Helper()
+
+	archive := tar.NewReader(bytes.NewReader(stream))
+	for {
+		header, err := archive.Next()
+		if err == io.EOF {
+			return
+		}
+		if err != nil {
+			t.Fatalf("read the volume archive: %v", err)
+		}
+		if header.Typeflag != tar.TypeReg {
+			continue
+		}
+		content, err := io.ReadAll(archive)
+		if err != nil {
+			t.Fatalf("read %s out of the volume archive: %v", header.Name, err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, filepath.Base(header.Name)), content, 0o600); err != nil {
+			t.Fatalf("write %s: %v", header.Name, err)
+		}
+	}
+}
+
+func sortedNames(carried map[string]int64) []string {
+	names := make([]string, 0, len(carried))
+	for name := range carried {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}


### PR DESCRIPTION
## The gap

`docs/self-hosted.md` documents two destructive procedures — the Postgres one (`DROP SCHEMA public CASCADE`, then a `psql -v ON_ERROR_STOP=1` replay) and the SQLite named-volume one (`docker volume rm ovumcy_data`, then `tar xzf` through Alpine) — and makes a correctness claim about each. Nothing in the repository ran a single one of those commands: a search for `pg_dump|ON_ERROR_STOP|DROP SCHEMA|docker volume rm|tar czf|tar xzf` matched `docs/self-hosted.md`, `CHANGELOG.md` and one changelog fragment, and **nothing** under `.github/`, `scripts/`, `internal/` or `cmd/`. The only backup test in the repository, `internal/db/sqlite_backup_restore_test.go`, copies a file with `io.Copy`. A real incident would have been the first end-to-end run of either procedure.

## What this adds

Both halves read their commands **out of the runbook** and execute them verbatim against ephemeral resources.

### The Postgres half

`postgres_roundtrip_test.go` runs the documented dump and restore against an ephemeral Postgres carrying the application's own migrated schema.

- The only rewrite is the transport: `docker compose exec -T postgres` → `docker exec -i <container>`, the same call against a container named directly instead of resolved by service name. Everything to its right — quoting, the `>` redirect, the `cat … |` pipe — runs as written, under `bash`, in a working directory that plays the operator's. No command is restated as a Go literal, so **prose that drifts from a procedure that works turns CI red** (`scripts/backuprestoredoc/main_test.go:115`).
- The extraction fails closed: a renamed section, a restore block that is no longer two commands, a missing `DROP SCHEMA public CASCADE` / `CREATE SCHEMA public` / `-v ON_ERROR_STOP=1`, or a backup and a replay that name different dump files are each this guard's own failure rather than a reason to test less.
- The round trip is generation 1 → dump → **deliberate drift** (a row written, a row changed, a row deleted) → documented restore → compare, then the owner and the day logs are read back through the repositories (`scripts/backuprestoredoc/postgres_roundtrip_test.go:40`). Without the drift a restore that moved nothing would pass — the runbook's own warning.
- It closes with that failure as a permanent counterfactual: the replay with the two additions the runbook calls load-bearing taken away, derived from the documented command rather than spelled, asserted to exit `0`, print `ERROR:` lines, restore no row — and to rewind the sequences and collide on the next write (`postgres_roundtrip_test.go:79`).

### The SQLite named-volume half

`volume_test.go` does the same for the archive flow, against an ephemeral volume holding the application's own SQLite database.

- Two substitutions, both fail-closed. The volume name becomes a throwaway volume — **this is safety, not convenience**: the documented restore begins by deleting `ovumcy_data`, so a guard running it as written would destroy a self-hoster's health data the first time they ran `go test ./...` on the machine hosting their stack. `runScript` refuses to execute any command in which the literal survived substitution (`scripts/backuprestoredoc/shell_test.go:34`). And `docker compose down` / `up -d` are asserted present and then **removed rather than run** — this guard never starts the application, it writes the volume and reads it back itself; a block that grows a third compose command, or loses one of these two, fails extraction (`volume_test.go:134`).
- Everything else runs as written: the `alpine:3.24.1` image and its tag (read out of the document, so a tag bump needs no edit here), `tar czf`/`tar xzf`, the `$PWD/backups` mount, `$BACKUP_FILE`, `docker volume rm`/`create`. The archive file name, the archive directory and the image are cross-checked between the two blocks — a backup that writes one path and a restore that replays another is a runbook that cannot work.
- Same round trip: seed → archive → drift (written/changed/deleted) → documented restore → read back through the repositories.
- **The WAL claim, which nothing checked before.** `docs/self-hosted.md:311` promises the whole-volume archive captures `ovumcy.db`, `ovumcy.db-wal` and `ovumcy.db-shm` together. The fixture is written with the connection held **open**, so the rows are in the `-wal` rather than in the database file; the archive is then opened in Go and required to carry all three, and the final read-back only succeeds if the sidecars really travelled. An archive that missed them restores the clean, empty instance Post-Restore Verification warns about.

## What running it proved wrong in the document

Both doc changes are corrections the guard produced, and both are now what it asserts.

1. **The byte-identity claim was false.** Two dumps of the same data are never byte-equal: `pg_dump` 17.6+ wraps every dump in a fresh random `\restrict` token, and the documented restore recreates `public`, so every later dump carries an `ALTER SCHEMA public OWNER` / `COMMENT ON SCHEMA public` / `REVOKE USAGE ON SCHEMA public` block the original did not. Neither is data — but the old wording invited an operator to verify with a byte-for-byte `diff` and read a good restore as a failed one. The runbook now names both differences and says to compare `COPY` blocks and `setval` lines. `scripts/backuprestoredoc/export_compare_test.go:10` carries the measurement, and each residue statement must actually appear, so a pg_dump release that stops emitting one makes the runbook's wording stale loudly.
2. **"Changed nothing" understated the failure case.** Replaying into a database that still holds its schema restores no row — but `setval` is the one statement in a plain dump that still succeeds, so every sequence is rewound to the backup's value and the next insert lands on an id already taken. The guard asserts the rows are untouched, the sequences match the backup's, and the next write fails.

The SQLite half found no drift: its commands and its WAL claim hold exactly as written, so that section of the runbook is unchanged.

`CHANGELOG.md` is untouched; the fragment is `changelog.d/guard-documented-backup-restore.md`.

## Red, then green

**RED 1 — the documented dump command drifts** (`pg_dump` → `pg_dump --data-only` in the runbook; nothing else changed). The replay lands in a freshly dropped schema that has no tables, `ON_ERROR_STOP` stops it, `psql` exits 3:

```
--- FAIL: TestDocumentedPostgresRestoreReplacesDriftedDataWithTheBackedUpGeneration (5.71s)
    postgres_roundtrip_test.go:59: the documented restore failed: exit status 3
        NOTICE:  drop cascades to 8 other objects
        DETAIL:  drop cascades to table schema_migrations
        drop cascades to table users
        drop cascades to table symptom_types
        drop cascades to table daily_logs
        drop cascades to table oidc_identities
        drop cascades to table oidc_logout_states
        drop cascades to table register_pickup_tokens
        drop cascades to table app_state
        DROP SCHEMA
        CREATE SCHEMA
        SET
        [… ten more SET/set_config lines …]
        ERROR:  relation "public.app_state" does not exist
FAIL
```

**RED 2 — the runbook loses its `DROP SCHEMA public CASCADE` step** (the historical defect this section was written to fix). The guard refuses before it runs anything, and names the missing step:

```
--- FAIL: TestDocumentedPostgresCommandsAreTheOnesThisGuardRuns (0.02s)
    main_test.go:241: docs/self-hosted.md: expected the restore block to be exactly 2 commands (drop the schema, then replay the dump), found 1:
        cat backups/ovumcy-postgres.sql | docker compose exec -T postgres sh -lc 'psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" "$POSTGRES_DB"'
--- FAIL: TestDocumentedPostgresRestoreReplacesDriftedDataWithTheBackedUpGeneration (0.00s)
    postgres_roundtrip_test.go:33: docs/self-hosted.md: expected the restore block to be exactly 2 commands (drop the schema, then replay the dump), found 1:
        cat backups/ovumcy-postgres.sql | docker compose exec -T postgres sh -lc 'psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" "$POSTGRES_DB"'
FAIL
```

**RED 3 — the restore replays the wrong generation** (the runbook untouched; the guard restores the drifted dump instead of the backup, which is the "an export that comes back unchanged" failure Post-Restore Verification step 5 warns about). The row comparison fires on the drifted data itself:

```
--- FAIL: TestDocumentedPostgresRestoreReplacesDriftedDataWithTheBackedUpGeneration (6.42s)
    postgres_roundtrip_test.go:66: the documented restore did not reproduce the dumped database — docs/self-hosted.md claims it does:
          before the dump:   1	1	2026-02-01	t	heavy	[1,4,7]	first day, cramps	…
          after the restore: 2	1	2026-02-02	t	light	\N		…
          before the dump:   1	owner@example.com	hash	recovery	f	owner	…	generation one	…
          after the restore: 2	drifted@example.com	hash	recovery	f	owner	…	generation two	…
          before the dump:   \.
          after the restore: 1	owner@example.com	hash	recovery	f	owner	…	drifted display name	…
          before the dump:   SELECT pg_catalog.setval('public.daily_logs_id_seq', 3, true);
          after the restore: \.
          …
FAIL
```

**RED 4 — the documented archive stops capturing the WAL sidecars** (`tar czf "/backup/$BACKUP_FILE" .` → `... ovumcy.db` in the runbook, the per-file copy the document itself warns about). The claim at `docs/self-hosted.md:311` fails, naming what was carried:

```
--- FAIL: TestDocumentedVolumeRestoreReplacesDriftedDataWithTheArchivedGeneration (2.12s)
    volume_test.go:224: the documented archive is missing [ovumcy.db-wal ovumcy.db-shm] — docs/self-hosted.md promises it captures all three together, and an archive without the WAL restores an instance that boots clean and empty. It carried: [ovumcy.db]
FAIL
```

**RED 5 — the documented restore does not run at all** (the runbook untouched; the restore step removed from the guard). This is the "restore that did nothing" the register named, and all three drifted directions report:

```
--- FAIL: TestDocumentedVolumeRestoreReplacesDriftedDataWithTheArchivedGeneration (5.35s)
    volume_test.go:232: restored database holds 2 accounts, want 1: the account written after the dump survived the restore
    volume_test.go:232: restored owner display name is "drifted display name", want "generation one": the change made after the dump survived the restore
    volume_test.go:232: restored database is missing the day log for 2026-02-01
FAIL
```

**GREEN — the runbook as it now stands:**

```
--- PASS: TestCanonicalExportKeepsDataAndDropsOnlyPerDumpNoise (0.00s)
--- PASS: TestExportsMatchSeesALostRow (0.00s)
--- PASS: TestDocumentedPostgresCommandsAreTheOnesThisGuardRuns (0.00s)
--- PASS: TestChangeDetectionRunsTheGoLanesForARunbookOnlyDiff (0.00s)
--- PASS: TestSplitBlankLineSeparatedKeepsOperatorSteps (0.00s)
--- PASS: TestDocumentedPostgresRestoreReplacesDriftedDataWithTheBackedUpGeneration (8.67s)
--- PASS: TestDocumentedVolumeRestoreReplacesDriftedDataWithTheArchivedGeneration (7.90s)
--- PASS: TestDocumentedVolumeRunbookKeepsTheLifecycleBracket (0.00s)
--- PASS: TestRunbookStillClaimsTheWholeWALSetIsCaptured (0.00s)
PASS
ok  	github.com/ovumcy/ovumcy-web/scripts/backuprestoredoc	19.864s
```

## Where it runs, and what it does not cover

It runs in the **existing Go lanes**, not a new job: `./scripts/...` is in `test-go-rest`'s package set, so the guard executes inside the required `test` gate on every pull request and in the merge queue, on a runner that already has docker (`internal/db`'s Postgres tests depend on the same). No skip switch, no `RUN_HEAVY`.

One consequence had to be repaired in `changes`: the runbook is documentation by both spellings the relevance filter knows, so a diff touching only that file would have cleared the Go lanes — 10 of the 22 commits touching it since June carried nothing else. It is detected on its own (`.github/workflows/ci.yml:973`) and **forces `run_core`** (`:1016`), the ground the Go lanes derive from — deliberately not `run_e2e`, which gates the browser battery the guard does not ride; a runbook typo must not buy a Playwright run that cannot look at it. The force sits before the `push` branch, so a commit the merge queue already proved still skips both. Simulated over the real filter: `docs/self-hosted.md` alone → `e2e=false core=true unit=true race=false`; any other doc → all false, unchanged; a `.go` diff → all true, unchanged; the same file on `push` → all false. Every piece of that is keyed on a spelling, so `TestChangeDetectionRunsTheGoLanesForARunbookOnlyDiff` pins the detection, the force and the browser-spec slice that would otherwise take the force straight back — and each was red-checked: neutering the force in the workflow fails that test, naming the exact fragment it can no longer find.

**Covered — both documented procedures, end to end.** Postgres: the `pg_dump` command; the `DROP SCHEMA public CASCADE` + `CREATE SCHEMA public` step; the `-v ON_ERROR_STOP=1` replay; the claim about what the restore leaves behind, over the application's own schema, with a drifted intermediate generation; and the failure row of the same section as a counterfactual. SQLite: the `tar czf` archive through Alpine; `docker volume rm` + `docker volume create`; the `tar xzf` restore; the same drift and read-back through the repositories; and the whole-WAL-set claim at `docs/self-hosted.md:311`, which nothing checked before.

**Not covered, and named rather than implied:** `docker compose down` / `docker compose up -d` themselves. They bracket the restore in the runbook and are asserted present, in that order, and then skipped — this guard never starts the application, so it can judge that the runbook still stops it, but not that stopping it works. The operator-side Post-Restore Verification checklist (sign in, open the calendar, compare a `Settings → Export`) is likewise performed against a running instance and stays outside; and an operator's own out-of-repo rehearsal cannot be seen from a repository at all. Within the Postgres section, the "partial loss" row of the failure table is not exercised.

## Risk and rollback

Test, docs and CI-filter only; no runtime code, no schema, no public contract. The one class of risk worth naming is the guard reaching a real deployment, and it is closed by construction: every executed command is refused if `ovumcy_data` or `docker compose` survived substitution, so the destructive commands can only ever address the throwaway container and the throwaway volume this test created. `internal/testdb.StartPostgres` is a new exported helper returning the container id alongside the DSN; `StartPostgresDSN` keeps its signature and now delegates. Single-commit revert.

Verified locally: `go test ./... -timeout 30m` (exit 0, 21 packages), `gofmt -l`, `golangci-lint run --max-issues-per-linter=0 --max-same-issues=0`, `staticcheck`, `actionlint .github/workflows/ci.yml`, `go run ./scripts/changelogd check` — all clean.
