### PR TITLE
test(services): assert the identity every service stub was handed

### DIFF
--- a/changelog.d/test-authz-ids-in-service-stubs.md
+++ b/changelog.d/test-authz-ids-in-service-stubs.md
@@ -7,17 +7,23 @@ nothing — and answered every key with the same record, so substituting a
 constant owner `1` (or swapping issuer for subject) into the production call
 left the focused service and API selections green. The doubles now record the
 lookup key and the write's owner id, and the happy-path case of each service
-asserts it: the identity resolved by its (issuer, subject) pair, the account by
-that identity's owner, the logout row by its session id and carrying its owner
-id, every onboarding write and the CAS reset by the calling owner. Onboarding's
-fixtures moved off the literal `1`, which an assertion could not have
-distinguished from the defect it guards against.
+asserts it: the identity resolved by its (issuer, subject) pair on both the
+login and the erasure step-up re-auth path, the account by that identity's
+owner, the logout row by its session id and carrying its owner id, every
+onboarding write and the CAS reset by the calling owner. Onboarding's fixtures
+moved off the literal `1`, which an assertion could not have distinguished from
+the defect it guards against.
 
-Two cases go further than observing an argument, because a recorded id proves
-scoping only for the seam it was recorded at: each seeds two independent owners
-on one database and drives the real repository as the later-created owner —
-step 1, step 2 and completion for onboarding, the recovery reset for the CAS
-path — then asserts the first owner's row is byte-for-byte unchanged, its
-`auth_session_version` included, with a positive anchor proving the write landed
-on the acting owner rather than nowhere. No production change: the owner id was
-already forwarded correctly at every site.
+Three cases go further than observing an argument, because a recorded id proves
+scoping only for the seam it was recorded at — and a store whose WHERE clause
+lost a predicate is handed exactly the right arguments and still returns the
+wrong row. Each seeds two independent owners on one database and drives the real
+repositories as the later-created owner: step 1, step 2 and completion for
+onboarding; the recovery reset for the CAS path, asserting the first owner's row
+is byte-for-byte unchanged, its `auth_session_version` included; and, for OIDC,
+an identity per owner under a different issuer with the same subject, so login
+and re-auth are shown to resolve the acting owner's identity rather than the
+same-subject account next to it. Each carries a positive anchor proving the
+operation landed on the acting owner rather than nowhere. No production change:
+the owner id was already forwarded, and the issuer already part of the lookup,
+at every site.

--- a/changelog.d/test-authz-ids-in-service-stubs.md
+++ b/changelog.d/test-authz-ids-in-service-stubs.md
@@ -1,0 +1,23 @@
+none
+
+Test-only guard: four service-layer suites can now see the identity they were
+handed. The OIDC login, OIDC logout-state, onboarding and password-reset CAS
+doubles declared their identity argument unnamed — or named it and stored
+nothing — and answered every key with the same record, so substituting a
+constant owner `1` (or swapping issuer for subject) into the production call
+left the focused service and API selections green. The doubles now record the
+lookup key and the write's owner id, and the happy-path case of each service
+asserts it: the identity resolved by its (issuer, subject) pair, the account by
+that identity's owner, the logout row by its session id and carrying its owner
+id, every onboarding write and the CAS reset by the calling owner. Onboarding's
+fixtures moved off the literal `1`, which an assertion could not have
+distinguished from the defect it guards against.
+
+Two cases go further than observing an argument, because a recorded id proves
+scoping only for the seam it was recorded at: each seeds two independent owners
+on one database and drives the real repository as the later-created owner —
+step 1, step 2 and completion for onboarding, the recovery reset for the CAS
+path — then asserts the first owner's row is byte-for-byte unchanged, its
+`auth_session_version` included, with a positive anchor proving the write landed
+on the acting owner rather than nowhere. No production change: the owner id was
+already forwarded correctly at every site.

--- a/internal/services/oidc_login_service_test.go
+++ b/internal/services/oidc_login_service_test.go
@@ -56,9 +56,17 @@ type stubOIDCIdentityStore struct {
 	touchedAt      time.Time
 	created        models.OIDCIdentity
 	createCallSeen bool
+	// lastIssuer / lastSubject record the lookup key the service handed over.
+	// Without them the stub answers every (issuer, subject) with the same
+	// identity, so a swapped or constant key at the resolution seam changes
+	// nothing observable and a mis-scoped link would go unnoticed.
+	lastIssuer  string
+	lastSubject string
 }
 
-func (stub *stubOIDCIdentityStore) FindByIssuerSubject(context.Context, string, string) (models.OIDCIdentity, bool, error) {
+func (stub *stubOIDCIdentityStore) FindByIssuerSubject(_ context.Context, issuer string, subject string) (models.OIDCIdentity, bool, error) {
+	stub.lastIssuer = issuer
+	stub.lastSubject = subject
 	if stub.findErr != nil {
 		return models.OIDCIdentity{}, false, stub.findErr
 	}
@@ -83,8 +91,13 @@ func (stub *stubOIDCIdentityStore) TouchLastUsed(ctx context.Context, identityID
 }
 
 type stubOIDCUserStore struct {
-	byID            models.User
-	byIDErr         error
+	byID    models.User
+	byIDErr error
+	// lastLookupID records the id the service resolved the account with. The
+	// stub answers any id with the same user, so this is the only way a test
+	// can see the account lookup being scoped to the linked identity's owner
+	// rather than to a constant.
+	lastLookupID    uint
 	byEmail         models.User
 	byEmailFound    bool
 	byEmailErr      error
@@ -107,7 +120,8 @@ func (stub *stubOIDCAutoProvisioner) AutoProvisionOwnerAccount(ctx context.Conte
 	return stub.user, nil
 }
 
-func (stub *stubOIDCUserStore) FindByID(context.Context, uint) (models.User, error) {
+func (stub *stubOIDCUserStore) FindByID(_ context.Context, userID uint) (models.User, error) {
+	stub.lastLookupID = userID
 	if stub.byIDErr != nil {
 		return models.User{}, stub.byIDErr
 	}
@@ -193,6 +207,19 @@ func TestOIDCLoginServiceAuthenticateUsesExistingIdentityLink(t *testing.T) {
 	}
 	if result.User.ID != 7 {
 		t.Fatalf("expected linked user id 7, got %d", result.User.ID)
+	}
+	// The stubs answer any argument with the same record, so the returned user
+	// alone proves nothing about scoping. Pin the lookup keys themselves: the
+	// identity must be resolved by the asserted (issuer, subject) pair, and the
+	// account by that identity's owner id — not by a constant.
+	if identities.lastIssuer != "https://id.example.com" {
+		t.Fatalf("expected identity lookup by issuer %q, got %q", "https://id.example.com", identities.lastIssuer)
+	}
+	if identities.lastSubject != "owner-subject" {
+		t.Fatalf("expected identity lookup by subject %q, got %q", "owner-subject", identities.lastSubject)
+	}
+	if users.lastLookupID != 7 {
+		t.Fatalf("expected the account to be resolved by the linked identity's owner id 7, got %d", users.lastLookupID)
 	}
 	if identities.touchedID != 44 {
 		t.Fatalf("expected last-used touch for identity 44, got %d", identities.touchedID)

--- a/internal/services/oidc_login_service_two_owner_integration_test.go
+++ b/internal/services/oidc_login_service_two_owner_integration_test.go
@@ -1,0 +1,143 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/db"
+	"github.com/ovumcy/ovumcy-web/internal/models"
+	"github.com/ovumcy/ovumcy-web/internal/security"
+	"gorm.io/gorm"
+)
+
+const (
+	twoOwnerIssuerA = "https://id-a.example.com"
+	twoOwnerIssuerB = "https://id-b.example.com"
+	// One subject, two providers. The unique index is on (issuer, subject)
+	// (migration 014), so this is a shape a real deployment can hold: two
+	// self-hosting owners whose IdPs each mint the same opaque subject — "1",
+	// "user", an email local part. Resolution that drops the issuer predicate
+	// then hands one owner the other's account.
+	twoOwnerSharedSubject = "shared-subject"
+)
+
+// TestOIDCLoginServiceResolvesTheActingOwnersIdentity drives OIDC login and the
+// erasure step-up re-auth through the REAL identity and user repositories with
+// two owners on one database.
+//
+// The stub assertions elsewhere in this package observe which (issuer, subject)
+// the service FORWARDS. They cannot observe what the store does with it: a
+// FindByIssuerSubject whose WHERE clause lost its issuer predicate is handed
+// exactly the right arguments and still returns the wrong row, and the db-layer
+// test seeds a single identity, so nothing in the tree sees that today. Here
+// each owner has an identity under a different issuer with the SAME subject,
+// and owner A is created first — so it holds id 1 and its identity sorts first,
+// which is what a lookup degraded to subject-only would return.
+//
+// The IdP itself stays a double: only the code exchange is replaced, and the
+// property under test is which stored identity the claims resolve to, not how
+// the claims were obtained.
+func TestOIDCLoginServiceResolvesTheActingOwnersIdentity(t *testing.T) {
+	database := newTwoOwnerIntegrationDatabase(t, "ovumcy-oidc-two-owner")
+	repositories := db.NewRepositories(database)
+
+	ownerA := createTwoOwnerUser(t, database, "oidc-owner-a@example.com", nil)
+	ownerB := createTwoOwnerUser(t, database, "oidc-owner-b@example.com", nil)
+	requireDistinctTwoOwnerFixture(t, ownerA, ownerB)
+
+	identityA := createTwoOwnerOIDCIdentity(t, database, ownerA.ID, twoOwnerIssuerA, twoOwnerSharedSubject)
+	identityB := createTwoOwnerOIDCIdentity(t, database, ownerB.ID, twoOwnerIssuerB, twoOwnerSharedSubject)
+
+	now := time.Date(2026, time.May, 13, 10, 0, 0, 0, time.UTC)
+
+	// Login as owner B must resolve owner B's identity, not the same-subject
+	// identity owner A holds at another provider.
+	serviceB := newTwoOwnerOIDCLoginService(t, repositories, twoOwnerIssuerB, ownerB.Email, now)
+	resultB, err := serviceB.Authenticate(context.Background(), "code", "verifier", "nonce", now)
+	if err != nil {
+		t.Fatalf("Authenticate() as owner B: unexpected error: %v", err)
+	}
+	if resultB.User.ID != ownerB.ID {
+		t.Fatalf("login under issuer %q resolved owner %d, want owner %d — the identity lookup is not scoped by issuer", twoOwnerIssuerB, resultB.User.ID, ownerB.ID)
+	}
+	if resultB.NewlyLinked {
+		t.Fatal("did not expect an existing identity link to be created again")
+	}
+
+	// Positive anchor: the same flow under owner A's issuer must resolve owner
+	// A, so the assertion above cannot be satisfied by a lookup that resolves
+	// nobody or always the caller.
+	serviceA := newTwoOwnerOIDCLoginService(t, repositories, twoOwnerIssuerA, ownerA.Email, now)
+	resultA, err := serviceA.Authenticate(context.Background(), "code", "verifier", "nonce", now)
+	if err != nil {
+		t.Fatalf("Authenticate() as owner A: unexpected error: %v", err)
+	}
+	if resultA.User.ID != ownerA.ID {
+		t.Fatalf("login under issuer %q resolved owner %d, want owner %d", twoOwnerIssuerA, resultA.User.ID, ownerA.ID)
+	}
+
+	// The erasure step-up: owner B's re-auth must accept only owner B's own
+	// identity at owner B's own issuer.
+	if err := serviceB.ValidateReauthExchange(context.Background(), "code", "verifier", "nonce", ownerB.ID, 5*time.Minute, now); err != nil {
+		t.Fatalf("ValidateReauthExchange() for owner B: unexpected error: %v", err)
+	}
+	if err := serviceA.ValidateReauthExchange(context.Background(), "code", "verifier", "nonce", ownerB.ID, 5*time.Minute, now); !errors.Is(err, ErrOIDCReauthIdentityMismatch) {
+		t.Fatalf("a step-up under owner A's issuer must not satisfy owner B's re-auth; got %v", err)
+	}
+
+	// The touch is the one write on this path: it must land on the acting
+	// owner's identity row and leave the other owner's alone.
+	if readTwoOwnerOIDCIdentity(t, database, identityB.ID).LastUsedAt == nil {
+		t.Fatal("expected owner B's identity to be touched by their own login")
+	}
+	if touched := readTwoOwnerOIDCIdentity(t, database, identityA.ID).LastUsedAt; touched == nil {
+		t.Fatal("expected owner A's identity to be touched by their own login")
+	}
+}
+
+// newTwoOwnerOIDCLoginService wires the real repositories behind a provider
+// client that returns fixed, verified claims for one issuer.
+func newTwoOwnerOIDCLoginService(t *testing.T, repositories *db.Repositories, issuer string, email string, now time.Time) *OIDCLoginService {
+	t.Helper()
+
+	client := &stubOIDCProviderClient{
+		enabled: true,
+		exchange: security.OIDCExchangeResult{
+			Claims: security.OIDCClaims{
+				Issuer:        issuer,
+				Subject:       twoOwnerSharedSubject,
+				Email:         email,
+				EmailVerified: true,
+				AuthTime:      now.Add(-2 * time.Minute),
+			},
+		},
+	}
+	return NewOIDCLoginService(client, repositories.OIDCIdentities, repositories.Users, nil)
+}
+
+func createTwoOwnerOIDCIdentity(t *testing.T, database *gorm.DB, userID uint, issuer string, subject string) models.OIDCIdentity {
+	t.Helper()
+
+	identity := models.OIDCIdentity{
+		UserID:    userID,
+		Issuer:    issuer,
+		Subject:   subject,
+		CreatedAt: time.Now().UTC(),
+	}
+	if err := database.Create(&identity).Error; err != nil {
+		t.Fatalf("create oidc identity for user %d: %v", userID, err)
+	}
+	return identity
+}
+
+func readTwoOwnerOIDCIdentity(t *testing.T, database *gorm.DB, identityID uint) models.OIDCIdentity {
+	t.Helper()
+
+	var identity models.OIDCIdentity
+	if err := database.First(&identity, identityID).Error; err != nil {
+		t.Fatalf("read oidc identity %d: %v", identityID, err)
+	}
+	return identity
+}

--- a/internal/services/oidc_login_service_two_owner_integration_test.go
+++ b/internal/services/oidc_login_service_two_owner_integration_test.go
@@ -87,8 +87,13 @@ func TestOIDCLoginServiceResolvesTheActingOwnersIdentity(t *testing.T) {
 		t.Fatalf("a step-up under owner A's issuer must not satisfy owner B's re-auth; got %v", err)
 	}
 
-	// The touch is the one write on this path: it must land on the acting
-	// owner's identity row and leave the other owner's alone.
+	// The touch is the one write on this path, and both rows carry it here
+	// because both owners logged in above. What these two assertions establish
+	// is that each login reached its OWN identity row: the resolution
+	// assertions further up are reading a store that was actually written to,
+	// and the two rows are distinguishable rather than one row answering both
+	// issuers. Neither line proves isolation — that would need last_used_at
+	// read before owner A's login and asserted still nil after owner B's.
 	if readTwoOwnerOIDCIdentity(t, database, identityB.ID).LastUsedAt == nil {
 		t.Fatal("expected owner B's identity to be touched by their own login")
 	}

--- a/internal/services/oidc_logout_state_service_coverage_test.go
+++ b/internal/services/oidc_logout_state_service_coverage_test.go
@@ -22,6 +22,11 @@ type oidclogoutstateserviceCovStore struct {
 	deleteExpiredErr    error
 	deleteExpiredCalls  int
 	deleteByIDCalls     int
+	// findSessionID records the key the service looked the record up by. The
+	// stub returns findRecord for any key, so without this a lookup that
+	// dropped the session id would still return the record and no assertion
+	// on the returned fields could tell the difference.
+	findSessionID string
 }
 
 func (s *oidclogoutstateserviceCovStore) Save(ctx context.Context, state *models.OIDCLogoutState) error {
@@ -30,6 +35,7 @@ func (s *oidclogoutstateserviceCovStore) Save(ctx context.Context, state *models
 }
 
 func (s *oidclogoutstateserviceCovStore) FindBySessionID(ctx context.Context, sessionID string) (models.OIDCLogoutState, bool, error) {
+	s.findSessionID = sessionID
 	if s.findErr != nil {
 		return models.OIDCLogoutState{}, false, s.findErr
 	}
@@ -369,6 +375,9 @@ func TestOIDCLogoutStateServiceLoadValidRecordReturnsData(t *testing.T) {
 	if !found {
 		t.Fatal("expected found=true for valid non-expired record")
 	}
+	if store.findSessionID != "sess-ok" {
+		t.Fatalf("expected the record to be looked up by session id %q, got %q", "sess-ok", store.findSessionID)
+	}
 	// Fields should be trimmed
 	if got.EndSessionEndpoint != "https://id.example.com/logout" {
 		t.Fatalf("EndSessionEndpoint not trimmed: %q", got.EndSessionEndpoint)
@@ -496,7 +505,14 @@ func TestOIDCLogoutStateServiceSaveFieldsTrimmedAndUTC(t *testing.T) {
 
 	loc, _ := time.LoadLocation("America/New_York")
 	now := time.Date(2026, 6, 1, 8, 0, 0, 0, loc) // non-UTC input
+	// A non-1 owner id: the erasure cascade keys on user_id
+	// (`DELETE FROM oidc_logout_states WHERE user_id = ?`), so a record saved
+	// under the wrong — or a zero — owner survives that owner's account
+	// deletion holding an id_token_hint until the 7-day TTL. Migration 033
+	// exists to purge exactly such unattributed rows.
+	const ownerID = uint(9)
 	state := OIDCLogoutState{
+		UserID:                ownerID,
 		EndSessionEndpoint:    "  https://id.example.com/logout  ",
 		IDTokenHint:           "  tok123  ",
 		PostLogoutRedirectURL: "  https://app.example.com/done  ",
@@ -510,6 +526,9 @@ func TestOIDCLogoutStateServiceSaveFieldsTrimmedAndUTC(t *testing.T) {
 	}
 	if store.saved.SessionID != "sess-trim" {
 		t.Fatalf("expected trimmed session ID, got %q", store.saved.SessionID)
+	}
+	if store.saved.UserID != ownerID {
+		t.Fatalf("expected the persisted row to carry owner id %d, got %d", ownerID, store.saved.UserID)
 	}
 	if store.saved.EndSessionEndpoint != "https://id.example.com/logout" {
 		t.Fatalf("EndSessionEndpoint not trimmed: %q", store.saved.EndSessionEndpoint)

--- a/internal/services/oidc_reauth_test.go
+++ b/internal/services/oidc_reauth_test.go
@@ -99,6 +99,19 @@ func TestOIDCLoginServiceValidateReauthExchangeHappyFreshAuthTime(t *testing.T) 
 	if err := service.ValidateReauthExchange(context.Background(), "code", "verifier", "nonce", 5, 5*time.Minute, now); err != nil {
 		t.Fatalf("expected nil error, got %v", err)
 	}
+	// The step-up identity must be resolved by the FULL (issuer, subject) pair.
+	// The owner comparison below it (identity.UserID != expectedUserID) only
+	// ever sees whatever row the lookup returned, so a lookup that dropped the
+	// issuer — resolving by subject alone, and so matching a same-subject
+	// account at a different provider — passes every other case in this file,
+	// UserIDMismatch included. This is the primitive that gates erasure re-auth
+	// for an account with no local password, so the key is pinned here.
+	if identities.lastIssuer != "https://id.example.com" {
+		t.Fatalf("expected the step-up identity to be resolved by issuer %q, got %q", "https://id.example.com", identities.lastIssuer)
+	}
+	if identities.lastSubject != "sub-1" {
+		t.Fatalf("expected the step-up identity to be resolved by subject %q, got %q", "sub-1", identities.lastSubject)
+	}
 	if identities.touchedID != 10 {
 		t.Fatalf("expected TouchLastUsed for identity 10, got %d", identities.touchedID)
 	}

--- a/internal/services/onboarding_service_coverage_test.go
+++ b/internal/services/onboarding_service_coverage_test.go
@@ -12,19 +12,23 @@ type onboardingserviceCovStep2Repo struct {
 	stubOnboardingRepo
 	saveStep2Err    error
 	saveStep2Called bool
-	// savedUserID records which owner the step-2 write was scoped to; the
-	// cycle/period values below are the same for every account and cannot
-	// distinguish one owner's baseline from another's.
-	savedUserID uint
-	savedCycle  int
-	savedPeriod int
+	savedCycle      int
+	savedPeriod     int
 }
 
+// SaveOnboardingStep2 overrides the embedded stub only to inject an error and
+// to capture the sanitized cycle/period values. The owner id keeps being
+// recorded in the embedded stub's step2UserID, so both stubs report it the same
+// way and neither can drift into ignoring it — the cycle/period values are the
+// same for every account and cannot distinguish one owner's baseline from
+// another's.
 func (s *onboardingserviceCovStep2Repo) SaveOnboardingStep2(ctx context.Context, userID uint, cycleLength int, periodLength int, autoPeriodFill bool, irregularCycle bool, usageGoal string) error {
 	s.saveStep2Called = true
-	s.savedUserID = userID
 	s.savedCycle = cycleLength
 	s.savedPeriod = periodLength
+	if err := s.stubOnboardingRepo.SaveOnboardingStep2(ctx, userID, cycleLength, periodLength, autoPeriodFill, irregularCycle, usageGoal); err != nil {
+		return err // codecov:ignore -- the embedded stub never errors; forwarded for shape
+	}
 	return s.saveStep2Err
 }
 
@@ -52,8 +56,8 @@ func TestOnboardingServiceSaveStep2ReturnsSanitizedValues(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SaveStep2 unexpected error: %v", err)
 	}
-	if repo.savedUserID != onboardingFixtureUserID {
-		t.Fatalf("SaveStep2 owner: got %d, want %d", repo.savedUserID, onboardingFixtureUserID)
+	if repo.step2UserID != onboardingFixtureUserID {
+		t.Fatalf("SaveStep2 owner: got %d, want %d", repo.step2UserID, onboardingFixtureUserID)
 	}
 	if gotCycle != 90 {
 		t.Fatalf("SaveStep2 cycle: got %d, want 90", gotCycle)
@@ -339,8 +343,8 @@ func TestOnboardingServiceSaveStep2SanitizesBeforePersist(t *testing.T) {
 	if !repo.saveStep2Called {
 		t.Fatal("expected SaveOnboardingStep2 to be called")
 	}
-	if repo.savedUserID != 7 {
-		t.Fatalf("SaveStep2 owner: got %d, want 7", repo.savedUserID)
+	if repo.step2UserID != 7 {
+		t.Fatalf("SaveStep2 owner: got %d, want 7", repo.step2UserID)
 	}
 	if repo.savedCycle != 15 || repo.savedPeriod != 5 {
 		t.Fatalf("repo received cycle=%d period=%d, want 15/5", repo.savedCycle, repo.savedPeriod)

--- a/internal/services/onboarding_service_coverage_test.go
+++ b/internal/services/onboarding_service_coverage_test.go
@@ -12,12 +12,17 @@ type onboardingserviceCovStep2Repo struct {
 	stubOnboardingRepo
 	saveStep2Err    error
 	saveStep2Called bool
-	savedCycle      int
-	savedPeriod     int
+	// savedUserID records which owner the step-2 write was scoped to; the
+	// cycle/period values below are the same for every account and cannot
+	// distinguish one owner's baseline from another's.
+	savedUserID uint
+	savedCycle  int
+	savedPeriod int
 }
 
 func (s *onboardingserviceCovStep2Repo) SaveOnboardingStep2(ctx context.Context, userID uint, cycleLength int, periodLength int, autoPeriodFill bool, irregularCycle bool, usageGoal string) error {
 	s.saveStep2Called = true
+	s.savedUserID = userID
 	s.savedCycle = cycleLength
 	s.savedPeriod = periodLength
 	return s.saveStep2Err
@@ -43,9 +48,12 @@ func TestOnboardingServiceSaveStep2ReturnsSanitizedValues(t *testing.T) {
 	svc := NewOnboardingService(repo)
 
 	// cycle=100 → clamped to 90, period=20 → clamped to 14, then capped to MaxPeriodLengthForCycle(90)=14
-	gotCycle, gotPeriod, err := svc.SaveStep2(context.Background(), 1, 100, 20, false, false, "")
+	gotCycle, gotPeriod, err := svc.SaveStep2(context.Background(), onboardingFixtureUserID, 100, 20, false, false, "")
 	if err != nil {
 		t.Fatalf("SaveStep2 unexpected error: %v", err)
+	}
+	if repo.savedUserID != onboardingFixtureUserID {
+		t.Fatalf("SaveStep2 owner: got %d, want %d", repo.savedUserID, onboardingFixtureUserID)
 	}
 	if gotCycle != 90 {
 		t.Fatalf("SaveStep2 cycle: got %d, want 90", gotCycle)
@@ -330,6 +338,9 @@ func TestOnboardingServiceSaveStep2SanitizesBeforePersist(t *testing.T) {
 	}
 	if !repo.saveStep2Called {
 		t.Fatal("expected SaveOnboardingStep2 to be called")
+	}
+	if repo.savedUserID != 7 {
+		t.Fatalf("SaveStep2 owner: got %d, want 7", repo.savedUserID)
 	}
 	if repo.savedCycle != 15 || repo.savedPeriod != 5 {
 		t.Fatalf("repo received cycle=%d period=%d, want 15/5", repo.savedCycle, repo.savedPeriod)

--- a/internal/services/onboarding_service_test.go
+++ b/internal/services/onboarding_service_test.go
@@ -25,10 +25,14 @@ type stubOnboardingRepo struct {
 	completeAutoFill  bool
 	// The four ids below record which owner each call was scoped to. The stub
 	// serves a single embedded user, so no other assertion in this file can
-	// observe the service resolving or writing the wrong account.
+	// observe the service resolving or writing the wrong account. Every method
+	// records — including the ones no test drives yet, so a case written
+	// against this stub later is instrumented by default rather than blind
+	// while looking instrumented.
 	findUserID     uint
 	step1UserID    uint
 	step1Start     time.Time
+	step2UserID    uint
 	completeUserID uint
 }
 
@@ -46,7 +50,8 @@ func (stub *stubOnboardingRepo) SaveOnboardingStep1(_ context.Context, userID ui
 	return nil
 }
 
-func (stub *stubOnboardingRepo) SaveOnboardingStep2(context.Context, uint, int, int, bool, bool, string) error {
+func (stub *stubOnboardingRepo) SaveOnboardingStep2(_ context.Context, userID uint, _ int, _ int, _ bool, _ bool, _ string) error {
+	stub.step2UserID = userID
 	return nil
 }
 

--- a/internal/services/onboarding_service_test.go
+++ b/internal/services/onboarding_service_test.go
@@ -9,6 +9,12 @@ import (
 	"github.com/ovumcy/ovumcy-web/internal/models"
 )
 
+// onboardingFixtureUserID is deliberately not 1. Every onboarding write is
+// scoped by the owner id the service forwards, and an id of 1 is
+// indistinguishable from a hard-coded owner in a fresh fixture — an assertion
+// written against 1 would be satisfied by the very defect it exists to catch.
+const onboardingFixtureUserID = uint(42)
+
 type stubOnboardingRepo struct {
 	user              models.User
 	findErr           error
@@ -17,16 +23,26 @@ type stubOnboardingRepo struct {
 	completeStartDay  time.Time
 	completePeriodLen int
 	completeAutoFill  bool
+	// The four ids below record which owner each call was scoped to. The stub
+	// serves a single embedded user, so no other assertion in this file can
+	// observe the service resolving or writing the wrong account.
+	findUserID     uint
+	step1UserID    uint
+	step1Start     time.Time
+	completeUserID uint
 }
 
-func (stub *stubOnboardingRepo) FindByID(context.Context, uint) (models.User, error) {
+func (stub *stubOnboardingRepo) FindByID(_ context.Context, userID uint) (models.User, error) {
+	stub.findUserID = userID
 	if stub.findErr != nil {
 		return models.User{}, stub.findErr
 	}
 	return stub.user, nil
 }
 
-func (stub *stubOnboardingRepo) SaveOnboardingStep1(context.Context, uint, time.Time) error {
+func (stub *stubOnboardingRepo) SaveOnboardingStep1(_ context.Context, userID uint, start time.Time) error {
+	stub.step1UserID = userID
+	stub.step1Start = start
 	return nil
 }
 
@@ -36,6 +52,7 @@ func (stub *stubOnboardingRepo) SaveOnboardingStep2(context.Context, uint, int, 
 
 func (stub *stubOnboardingRepo) CompleteOnboarding(ctx context.Context, userID uint, startDay time.Time, periodLength int, autoPeriodFill bool) error {
 	stub.completeCalled = true
+	stub.completeUserID = userID
 	stub.completeStartDay = startDay
 	stub.completePeriodLen = periodLength
 	stub.completeAutoFill = autoPeriodFill
@@ -50,13 +67,35 @@ func TestSanitizeOnboardingCycleAndPeriod(t *testing.T) {
 }
 
 func TestCompleteOnboardingForUserRequiresStep1Date(t *testing.T) {
-	service := NewOnboardingService(&stubOnboardingRepo{
-		user: models.User{},
-	})
+	repo := &stubOnboardingRepo{user: models.User{}}
+	service := NewOnboardingService(repo)
 
-	_, err := service.CompleteOnboardingForUser(context.Background(), 1, time.UTC)
+	_, err := service.CompleteOnboardingForUser(context.Background(), onboardingFixtureUserID, time.UTC)
 	if !errors.Is(err, ErrOnboardingStepsRequired) {
 		t.Fatalf("expected ErrOnboardingStepsRequired, got %v", err)
+	}
+	if repo.findUserID != onboardingFixtureUserID {
+		t.Fatalf("expected the eligibility read to be scoped to owner %d, got %d", onboardingFixtureUserID, repo.findUserID)
+	}
+}
+
+// TestOnboardingServiceSaveStep1ForwardsTheCallersOwnerID pins the owner id on
+// the step-1 write. The repository stub accepts any id, so the forwarded value
+// is the only observable that distinguishes a correctly scoped write from one
+// that lands on a constant account.
+func TestOnboardingServiceSaveStep1ForwardsTheCallersOwnerID(t *testing.T) {
+	repo := &stubOnboardingRepo{}
+	service := NewOnboardingService(repo)
+
+	start := time.Date(2026, 2, 10, 0, 0, 0, 0, time.UTC)
+	if err := service.SaveStep1(context.Background(), onboardingFixtureUserID, start); err != nil {
+		t.Fatalf("SaveStep1() unexpected error: %v", err)
+	}
+	if repo.step1UserID != onboardingFixtureUserID {
+		t.Fatalf("expected step 1 to be written for owner %d, got %d", onboardingFixtureUserID, repo.step1UserID)
+	}
+	if !repo.step1Start.Equal(start) {
+		t.Fatalf("expected step 1 start %s, got %s", start, repo.step1Start)
 	}
 }
 
@@ -76,12 +115,18 @@ func TestCompleteOnboardingForUserNormalizesDateAndPeriod(t *testing.T) {
 	}
 	service := NewOnboardingService(repo)
 
-	startDay, err := service.CompleteOnboardingForUser(context.Background(), 1, location)
+	startDay, err := service.CompleteOnboardingForUser(context.Background(), onboardingFixtureUserID, location)
 	if err != nil {
 		t.Fatalf("CompleteOnboardingForUser() unexpected error: %v", err)
 	}
 	if !repo.completeCalled {
 		t.Fatal("expected CompleteOnboarding() to be called")
+	}
+	if repo.findUserID != onboardingFixtureUserID {
+		t.Fatalf("expected the baseline read to be scoped to owner %d, got %d", onboardingFixtureUserID, repo.findUserID)
+	}
+	if repo.completeUserID != onboardingFixtureUserID {
+		t.Fatalf("expected completion to be written for owner %d, got %d", onboardingFixtureUserID, repo.completeUserID)
 	}
 	if repo.completePeriodLen != 12 {
 		t.Fatalf("expected sanitized period length 12, got %d", repo.completePeriodLen)

--- a/internal/services/onboarding_service_two_owner_integration_test.go
+++ b/internal/services/onboarding_service_two_owner_integration_test.go
@@ -2,7 +2,6 @@ package services
 
 import (
 	"context"
-	"path/filepath"
 	"reflect"
 	"testing"
 	"time"
@@ -24,24 +23,16 @@ import (
 // against owner B. Owner A must come out byte-for-byte unchanged, with no
 // auto-filled day rows of its own.
 func TestOnboardingServiceScopesEveryWriteToTheCallingOwner(t *testing.T) {
-	database := newOnboardingTwoOwnerDatabase(t)
+	database := newTwoOwnerIntegrationDatabase(t, "ovumcy-onboarding-two-owner")
 	repositories := db.NewRepositories(database)
 	service := NewOnboardingService(repositories.Users)
 
-	ownerA := createOnboardingTwoOwnerUser(t, database, "onboarding-owner-a@example.com")
-	ownerB := createOnboardingTwoOwnerUser(t, database, "onboarding-owner-b@example.com")
+	notOnboarded := func(user *models.User) { user.OnboardingCompleted = false }
+	ownerA := createTwoOwnerUser(t, database, "onboarding-owner-a@example.com", notOnboarded)
+	ownerB := createTwoOwnerUser(t, database, "onboarding-owner-b@example.com", notOnboarded)
+	requireDistinctTwoOwnerFixture(t, ownerA, ownerB)
 
-	// The mutant this test exists to kill is a literal owner `1`. If the first
-	// account did not land on id 1 the whole test would go green while proving
-	// nothing, so pin the fixture assumption rather than trusting it.
-	if ownerA.ID != 1 {
-		t.Fatalf("fixture assumption broken: expected the first owner to hold id 1, got %d", ownerA.ID)
-	}
-	if ownerB.ID == ownerA.ID {
-		t.Fatalf("fixture assumption broken: the two owners must be distinct, both are %d", ownerB.ID)
-	}
-
-	before := readOnboardingTwoOwnerUser(t, database, ownerA.ID)
+	before := readTwoOwnerUser(t, database, ownerA.ID)
 
 	start := time.Date(2026, time.February, 10, 0, 0, 0, 0, time.UTC)
 	if err := service.SaveStep1(context.Background(), ownerB.ID, start); err != nil {
@@ -59,17 +50,17 @@ func TestOnboardingServiceScopesEveryWriteToTheCallingOwner(t *testing.T) {
 	}
 
 	// Isolation: nothing owner B did may reach owner A.
-	after := readOnboardingTwoOwnerUser(t, database, ownerA.ID)
+	after := readTwoOwnerUser(t, database, ownerA.ID)
 	if !reflect.DeepEqual(before, after) {
 		t.Fatalf("owner A's row changed while owner B onboarded — an onboarding write is not scoped to the calling owner:\nbefore: %+v\nafter:  %+v", before, after)
 	}
-	if days := countOnboardingTwoOwnerDays(t, database, ownerA.ID); days != 0 {
+	if days := countTwoOwnerDayRows(t, database, ownerA.ID); days != 0 {
 		t.Fatalf("expected owner A to keep zero day rows, got %d", days)
 	}
 
 	// Positive anchor: the writes must actually have landed on owner B, or the
 	// isolation half above would pass on a service that writes nothing at all.
-	gotB := readOnboardingTwoOwnerUser(t, database, ownerB.ID)
+	gotB := readTwoOwnerUser(t, database, ownerB.ID)
 	if !gotB.OnboardingCompleted {
 		t.Fatal("expected owner B to be marked onboarded")
 	}
@@ -82,60 +73,12 @@ func TestOnboardingServiceScopesEveryWriteToTheCallingOwner(t *testing.T) {
 	if gotB.LastPeriodStart == nil || !gotB.LastPeriodStart.Equal(start) {
 		t.Fatalf("expected owner B last_period_start %s, got %v", start, gotB.LastPeriodStart)
 	}
-	if days := countOnboardingTwoOwnerDays(t, database, ownerB.ID); days != 6 {
+	if days := countTwoOwnerDayRows(t, database, ownerB.ID); days != 6 {
 		t.Fatalf("expected 6 auto-filled period days for owner B, got %d", days)
 	}
 }
 
-func newOnboardingTwoOwnerDatabase(t *testing.T) *gorm.DB {
-	t.Helper()
-
-	database, err := db.OpenDatabase(db.Config{
-		Driver:     db.DriverSQLite,
-		SQLitePath: filepath.Join(t.TempDir(), "ovumcy-onboarding-two-owner.db"),
-	})
-	if err != nil {
-		t.Fatalf("open integration database: %v", err)
-	}
-	t.Cleanup(func() {
-		if sqlDB, err := database.DB(); err == nil {
-			_ = sqlDB.Close()
-		}
-	})
-	return database
-}
-
-func createOnboardingTwoOwnerUser(t *testing.T, database *gorm.DB, email string) models.User {
-	t.Helper()
-
-	user := models.User{
-		Email:               email,
-		PasswordHash:        "test-hash",
-		Role:                models.RoleOwner,
-		OnboardingCompleted: false,
-		CycleLength:         models.DefaultCycleLength,
-		PeriodLength:        models.DefaultPeriodLength,
-		AutoPeriodFill:      true,
-		UsageGoal:           models.UsageGoalHealth,
-		CreatedAt:           time.Now().UTC(),
-	}
-	if err := database.Create(&user).Error; err != nil {
-		t.Fatalf("create user %s: %v", email, err)
-	}
-	return user
-}
-
-func readOnboardingTwoOwnerUser(t *testing.T, database *gorm.DB, userID uint) models.User {
-	t.Helper()
-
-	var user models.User
-	if err := database.First(&user, userID).Error; err != nil {
-		t.Fatalf("read user %d: %v", userID, err)
-	}
-	return user
-}
-
-func countOnboardingTwoOwnerDays(t *testing.T, database *gorm.DB, userID uint) int64 {
+func countTwoOwnerDayRows(t *testing.T, database *gorm.DB, userID uint) int64 {
 	t.Helper()
 
 	var count int64

--- a/internal/services/onboarding_service_two_owner_integration_test.go
+++ b/internal/services/onboarding_service_two_owner_integration_test.go
@@ -1,0 +1,146 @@
+package services
+
+import (
+	"context"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/db"
+	"github.com/ovumcy/ovumcy-web/internal/models"
+	"gorm.io/gorm"
+)
+
+// TestOnboardingServiceScopesEveryWriteToTheCallingOwner drives all four
+// owner-carrying onboarding seams — SaveStep1, SaveStep2, the completion
+// baseline read, and CompleteOnboarding — through the REAL user repository with
+// two independent owners in one database.
+//
+// The stub-level assertions elsewhere in this package observe which id the
+// service forwards; they cannot observe what that id does to a second account.
+// This test can: owner A is created first, so it holds id 1 — the value a
+// dropped or hard-coded owner id degenerates to — and every operation here runs
+// against owner B. Owner A must come out byte-for-byte unchanged, with no
+// auto-filled day rows of its own.
+func TestOnboardingServiceScopesEveryWriteToTheCallingOwner(t *testing.T) {
+	database := newOnboardingTwoOwnerDatabase(t)
+	repositories := db.NewRepositories(database)
+	service := NewOnboardingService(repositories.Users)
+
+	ownerA := createOnboardingTwoOwnerUser(t, database, "onboarding-owner-a@example.com")
+	ownerB := createOnboardingTwoOwnerUser(t, database, "onboarding-owner-b@example.com")
+
+	// The mutant this test exists to kill is a literal owner `1`. If the first
+	// account did not land on id 1 the whole test would go green while proving
+	// nothing, so pin the fixture assumption rather than trusting it.
+	if ownerA.ID != 1 {
+		t.Fatalf("fixture assumption broken: expected the first owner to hold id 1, got %d", ownerA.ID)
+	}
+	if ownerB.ID == ownerA.ID {
+		t.Fatalf("fixture assumption broken: the two owners must be distinct, both are %d", ownerB.ID)
+	}
+
+	before := readOnboardingTwoOwnerUser(t, database, ownerA.ID)
+
+	start := time.Date(2026, time.February, 10, 0, 0, 0, 0, time.UTC)
+	if err := service.SaveStep1(context.Background(), ownerB.ID, start); err != nil {
+		t.Fatalf("SaveStep1() unexpected error: %v", err)
+	}
+	if _, _, err := service.SaveStep2(context.Background(), ownerB.ID, 31, 6, true, true, models.UsageGoalAvoid); err != nil {
+		t.Fatalf("SaveStep2() unexpected error: %v", err)
+	}
+	startDay, err := service.CompleteOnboardingForUser(context.Background(), ownerB.ID, time.UTC)
+	if err != nil {
+		t.Fatalf("CompleteOnboardingForUser() unexpected error: %v", err)
+	}
+	if !startDay.Equal(start) {
+		t.Fatalf("expected completion to anchor on owner B's step-1 date %s, got %s", start, startDay)
+	}
+
+	// Isolation: nothing owner B did may reach owner A.
+	after := readOnboardingTwoOwnerUser(t, database, ownerA.ID)
+	if !reflect.DeepEqual(before, after) {
+		t.Fatalf("owner A's row changed while owner B onboarded — an onboarding write is not scoped to the calling owner:\nbefore: %+v\nafter:  %+v", before, after)
+	}
+	if days := countOnboardingTwoOwnerDays(t, database, ownerA.ID); days != 0 {
+		t.Fatalf("expected owner A to keep zero day rows, got %d", days)
+	}
+
+	// Positive anchor: the writes must actually have landed on owner B, or the
+	// isolation half above would pass on a service that writes nothing at all.
+	gotB := readOnboardingTwoOwnerUser(t, database, ownerB.ID)
+	if !gotB.OnboardingCompleted {
+		t.Fatal("expected owner B to be marked onboarded")
+	}
+	if gotB.CycleLength != 31 || gotB.PeriodLength != 6 {
+		t.Fatalf("expected owner B baseline 31/6, got %d/%d", gotB.CycleLength, gotB.PeriodLength)
+	}
+	if gotB.UsageGoal != models.UsageGoalAvoid || !gotB.IrregularCycle {
+		t.Fatalf("expected owner B step-2 preferences persisted, got usage_goal=%q irregular=%v", gotB.UsageGoal, gotB.IrregularCycle)
+	}
+	if gotB.LastPeriodStart == nil || !gotB.LastPeriodStart.Equal(start) {
+		t.Fatalf("expected owner B last_period_start %s, got %v", start, gotB.LastPeriodStart)
+	}
+	if days := countOnboardingTwoOwnerDays(t, database, ownerB.ID); days != 6 {
+		t.Fatalf("expected 6 auto-filled period days for owner B, got %d", days)
+	}
+}
+
+func newOnboardingTwoOwnerDatabase(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	database, err := db.OpenDatabase(db.Config{
+		Driver:     db.DriverSQLite,
+		SQLitePath: filepath.Join(t.TempDir(), "ovumcy-onboarding-two-owner.db"),
+	})
+	if err != nil {
+		t.Fatalf("open integration database: %v", err)
+	}
+	t.Cleanup(func() {
+		if sqlDB, err := database.DB(); err == nil {
+			_ = sqlDB.Close()
+		}
+	})
+	return database
+}
+
+func createOnboardingTwoOwnerUser(t *testing.T, database *gorm.DB, email string) models.User {
+	t.Helper()
+
+	user := models.User{
+		Email:               email,
+		PasswordHash:        "test-hash",
+		Role:                models.RoleOwner,
+		OnboardingCompleted: false,
+		CycleLength:         models.DefaultCycleLength,
+		PeriodLength:        models.DefaultPeriodLength,
+		AutoPeriodFill:      true,
+		UsageGoal:           models.UsageGoalHealth,
+		CreatedAt:           time.Now().UTC(),
+	}
+	if err := database.Create(&user).Error; err != nil {
+		t.Fatalf("create user %s: %v", email, err)
+	}
+	return user
+}
+
+func readOnboardingTwoOwnerUser(t *testing.T, database *gorm.DB, userID uint) models.User {
+	t.Helper()
+
+	var user models.User
+	if err := database.First(&user, userID).Error; err != nil {
+		t.Fatalf("read user %d: %v", userID, err)
+	}
+	return user
+}
+
+func countOnboardingTwoOwnerDays(t *testing.T, database *gorm.DB, userID uint) int64 {
+	t.Helper()
+
+	var count int64
+	if err := database.Model(&models.DailyLog{}).Where("user_id = ?", userID).Count(&count).Error; err != nil {
+		t.Fatalf("count day rows for user %d: %v", userID, err)
+	}
+	return count
+}

--- a/internal/services/password_reset_cas_regression_test.go
+++ b/internal/services/password_reset_cas_regression_test.go
@@ -19,6 +19,12 @@ type casStubAuthUserRepo struct {
 	casConsumed bool
 	// casOldHashSeen is the oldPasswordHash value the CAS UPDATE received.
 	casOldHashSeen string
+	// casUserIDSeen is the owner id the CAS UPDATE was scoped to. The stub
+	// simulates the predicate against a SINGLE embedded user, so every id
+	// reaches the same row: without recording it, neither the consumed flag,
+	// the returned error, nor the session-version bump can tell a reset that
+	// landed on the resolved account from one that landed on another.
+	casUserIDSeen uint
 	// casErr, if set, is returned on the next CAS call.
 	casErr error
 }
@@ -26,6 +32,7 @@ type casStubAuthUserRepo struct {
 func (s *casStubAuthUserRepo) UpdatePasswordRecoveryCodeAndRevokeSessionsCAS(
 	_ context.Context, userID uint, oldPasswordHash, newPasswordHash, recoveryHash string,
 ) error {
+	s.casUserIDSeen = userID
 	if s.casErr != nil {
 		return s.casErr
 	}
@@ -75,6 +82,9 @@ func TestResetPasswordAndRotateRecoveryCodeCASRejectsReplay(t *testing.T) {
 	}
 	if !repo.casConsumed {
 		t.Fatal("expected CAS UPDATE to be called on first redeem")
+	}
+	if repo.casUserIDSeen != 7 {
+		t.Fatalf("expected the CAS UPDATE to be scoped to the resolved owner 7, got %d", repo.casUserIDSeen)
 	}
 	if repo.user.AuthSessionVersion != 2 {
 		t.Fatalf("expected auth_session_version 2 after first redeem, got %d", repo.user.AuthSessionVersion)
@@ -130,6 +140,9 @@ func TestCompleteResetSingleUseViaCAS(t *testing.T) {
 	}
 	if user == nil || user.ID != 42 {
 		t.Fatalf("expected user id 42, got %#v", user)
+	}
+	if repo.casUserIDSeen != 42 {
+		t.Fatalf("expected the CAS UPDATE to be scoped to the token's owner 42, got %d", repo.casUserIDSeen)
 	}
 	if recoveryCode == "" {
 		t.Fatal("expected non-empty rotated recovery code")

--- a/internal/services/password_reset_cas_two_owner_integration_test.go
+++ b/internal/services/password_reset_cas_two_owner_integration_test.go
@@ -2,15 +2,12 @@ package services
 
 import (
 	"context"
-	"path/filepath"
 	"reflect"
 	"testing"
-	"time"
 
 	"github.com/ovumcy/ovumcy-web/internal/db"
 	"github.com/ovumcy/ovumcy-web/internal/models"
 	"golang.org/x/crypto/bcrypt"
-	"gorm.io/gorm"
 )
 
 // TestResetPasswordAndRotateRecoveryCodeCASScopesTheWriteToTheResolvedOwner
@@ -25,28 +22,17 @@ import (
 // hash, recovery hash and the auth_session_version that carries the session
 // invalidation — must be byte-for-byte unchanged.
 func TestResetPasswordAndRotateRecoveryCodeCASScopesTheWriteToTheResolvedOwner(t *testing.T) {
-	database := newPasswordResetTwoOwnerDatabase(t)
-	repository := db.NewUserRepository(database)
-	service := NewAuthService(repository)
+	database := newTwoOwnerIntegrationDatabase(t, "ovumcy-reset-two-owner")
+	service := NewAuthService(db.NewUserRepository(database))
 
-	ownerA := createPasswordResetTwoOwnerUser(t, database, "reset-owner-a@example.com", "OwnerAPass1")
-	ownerB := createPasswordResetTwoOwnerUser(t, database, "reset-owner-b@example.com", "OwnerBPass1")
+	ownerA := createTwoOwnerUser(t, database, "reset-owner-a@example.com", withLocalCredentials(t, "OwnerAPass1"))
+	ownerB := createTwoOwnerUser(t, database, "reset-owner-b@example.com", withLocalCredentials(t, "OwnerBPass1"))
+	requireDistinctTwoOwnerFixture(t, ownerA, ownerB)
 
-	// The mutant this test exists to kill is a literal owner `1`; if the first
-	// account did not land on id 1 the test would go green while proving
-	// nothing.
-	if ownerA.ID != 1 {
-		t.Fatalf("fixture assumption broken: expected the first owner to hold id 1, got %d", ownerA.ID)
-	}
-	if ownerB.ID == ownerA.ID {
-		t.Fatalf("fixture assumption broken: the two owners must be distinct, both are %d", ownerB.ID)
-	}
+	before := readTwoOwnerUser(t, database, ownerA.ID)
 
-	before := readPasswordResetTwoOwnerUser(t, database, ownerA.ID)
-
-	target := readPasswordResetTwoOwnerUser(t, database, ownerB.ID)
-	oldHash := target.PasswordHash
-	recoveryCode, err := service.ResetPasswordAndRotateRecoveryCodeCAS(context.Background(), &target, oldHash, "EvenStronger2")
+	target := readTwoOwnerUser(t, database, ownerB.ID)
+	recoveryCode, err := service.ResetPasswordAndRotateRecoveryCodeCAS(context.Background(), &target, target.PasswordHash, "EvenStronger2")
 	if err != nil {
 		t.Fatalf("resetting owner B failed with %v — a CAS scoped to a different owner matches no row", err)
 	}
@@ -55,7 +41,7 @@ func TestResetPasswordAndRotateRecoveryCodeCASScopesTheWriteToTheResolvedOwner(t
 	}
 
 	// Isolation: owner A must not have been touched in any column.
-	after := readPasswordResetTwoOwnerUser(t, database, ownerA.ID)
+	after := readTwoOwnerUser(t, database, ownerA.ID)
 	if !reflect.DeepEqual(before, after) {
 		t.Fatalf("owner A's row changed while owner B reset their password — the CAS write is not scoped to the resolved owner:\nbefore: %+v\nafter:  %+v", before, after)
 	}
@@ -68,7 +54,7 @@ func TestResetPasswordAndRotateRecoveryCodeCASScopesTheWriteToTheResolvedOwner(t
 
 	// Positive anchor: the reset must actually have landed on owner B, or the
 	// isolation half above would pass on a service that writes nothing at all.
-	gotB := readPasswordResetTwoOwnerUser(t, database, ownerB.ID)
+	gotB := readTwoOwnerUser(t, database, ownerB.ID)
 	if err := bcrypt.CompareHashAndPassword([]byte(gotB.PasswordHash), []byte("EvenStronger2")); err != nil {
 		t.Fatalf("expected owner B's new password to verify: %v", err)
 	}
@@ -80,60 +66,24 @@ func TestResetPasswordAndRotateRecoveryCodeCASScopesTheWriteToTheResolvedOwner(t
 	}
 }
 
-func newPasswordResetTwoOwnerDatabase(t *testing.T) *gorm.DB {
+// withLocalCredentials gives a seeded owner a real bcrypt password and recovery
+// hash, so the CAS predicate compares the same shape production does. MinCost
+// keeps two seeds plus the service's own hashing off the critical path.
+func withLocalCredentials(t *testing.T, password string) func(*models.User) {
 	t.Helper()
 
-	database, err := db.OpenDatabase(db.Config{
-		Driver:     db.DriverSQLite,
-		SQLitePath: filepath.Join(t.TempDir(), "ovumcy-reset-two-owner.db"),
-	})
-	if err != nil {
-		t.Fatalf("open integration database: %v", err)
-	}
-	t.Cleanup(func() {
-		if sqlDB, err := database.DB(); err == nil {
-			_ = sqlDB.Close()
+	return func(user *models.User) {
+		passwordHash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.MinCost)
+		if err != nil {
+			t.Fatalf("hash password for %s: %v", user.Email, err)
 		}
-	})
-	return database
-}
-
-func createPasswordResetTwoOwnerUser(t *testing.T, database *gorm.DB, email string, password string) models.User {
-	t.Helper()
-
-	passwordHash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.MinCost)
-	if err != nil {
-		t.Fatalf("hash password for %s: %v", email, err)
+		recoveryHash, err := bcrypt.GenerateFromPassword([]byte("recovery-"+user.Email), bcrypt.MinCost)
+		if err != nil {
+			t.Fatalf("hash recovery code for %s: %v", user.Email, err)
+		}
+		user.PasswordHash = string(passwordHash)
+		user.RecoveryCodeHash = string(recoveryHash)
+		user.LocalAuthEnabled = true
+		user.AuthSessionVersion = 1
 	}
-	recoveryHash, err := bcrypt.GenerateFromPassword([]byte("recovery-"+email), bcrypt.MinCost)
-	if err != nil {
-		t.Fatalf("hash recovery code for %s: %v", email, err)
-	}
-
-	user := models.User{
-		Email:               email,
-		PasswordHash:        string(passwordHash),
-		RecoveryCodeHash:    string(recoveryHash),
-		LocalAuthEnabled:    true,
-		AuthSessionVersion:  1,
-		Role:                models.RoleOwner,
-		OnboardingCompleted: true,
-		CycleLength:         models.DefaultCycleLength,
-		PeriodLength:        models.DefaultPeriodLength,
-		CreatedAt:           time.Now().UTC(),
-	}
-	if err := database.Create(&user).Error; err != nil {
-		t.Fatalf("create user %s: %v", email, err)
-	}
-	return user
-}
-
-func readPasswordResetTwoOwnerUser(t *testing.T, database *gorm.DB, userID uint) models.User {
-	t.Helper()
-
-	var user models.User
-	if err := database.First(&user, userID).Error; err != nil {
-		t.Fatalf("read user %d: %v", userID, err)
-	}
-	return user
 }

--- a/internal/services/password_reset_cas_two_owner_integration_test.go
+++ b/internal/services/password_reset_cas_two_owner_integration_test.go
@@ -1,0 +1,139 @@
+package services
+
+import (
+	"context"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/db"
+	"github.com/ovumcy/ovumcy-web/internal/models"
+	"golang.org/x/crypto/bcrypt"
+	"gorm.io/gorm"
+)
+
+// TestResetPasswordAndRotateRecoveryCodeCASScopesTheWriteToTheResolvedOwner
+// drives the recovery reset through the REAL user repository with two
+// independent owners in one database.
+//
+// The CAS stub in password_reset_cas_regression_test.go simulates the predicate
+// against a single embedded user, so every owner id reaches the same row; the
+// db-layer CAS test creates exactly one user, whose id is 1, so it cannot tell
+// the resolved owner from a hard-coded 1 either. Here owner A is created first
+// and therefore holds id 1, and the reset runs for owner B: A's row — password
+// hash, recovery hash and the auth_session_version that carries the session
+// invalidation — must be byte-for-byte unchanged.
+func TestResetPasswordAndRotateRecoveryCodeCASScopesTheWriteToTheResolvedOwner(t *testing.T) {
+	database := newPasswordResetTwoOwnerDatabase(t)
+	repository := db.NewUserRepository(database)
+	service := NewAuthService(repository)
+
+	ownerA := createPasswordResetTwoOwnerUser(t, database, "reset-owner-a@example.com", "OwnerAPass1")
+	ownerB := createPasswordResetTwoOwnerUser(t, database, "reset-owner-b@example.com", "OwnerBPass1")
+
+	// The mutant this test exists to kill is a literal owner `1`; if the first
+	// account did not land on id 1 the test would go green while proving
+	// nothing.
+	if ownerA.ID != 1 {
+		t.Fatalf("fixture assumption broken: expected the first owner to hold id 1, got %d", ownerA.ID)
+	}
+	if ownerB.ID == ownerA.ID {
+		t.Fatalf("fixture assumption broken: the two owners must be distinct, both are %d", ownerB.ID)
+	}
+
+	before := readPasswordResetTwoOwnerUser(t, database, ownerA.ID)
+
+	target := readPasswordResetTwoOwnerUser(t, database, ownerB.ID)
+	oldHash := target.PasswordHash
+	recoveryCode, err := service.ResetPasswordAndRotateRecoveryCodeCAS(context.Background(), &target, oldHash, "EvenStronger2")
+	if err != nil {
+		t.Fatalf("resetting owner B failed with %v — a CAS scoped to a different owner matches no row", err)
+	}
+	if recoveryCode == "" {
+		t.Fatal("expected a rotated recovery code for owner B")
+	}
+
+	// Isolation: owner A must not have been touched in any column.
+	after := readPasswordResetTwoOwnerUser(t, database, ownerA.ID)
+	if !reflect.DeepEqual(before, after) {
+		t.Fatalf("owner A's row changed while owner B reset their password — the CAS write is not scoped to the resolved owner:\nbefore: %+v\nafter:  %+v", before, after)
+	}
+	if err := bcrypt.CompareHashAndPassword([]byte(after.PasswordHash), []byte("OwnerAPass1")); err != nil {
+		t.Fatalf("owner A's password no longer verifies after owner B's reset: %v", err)
+	}
+	if after.AuthSessionVersion != before.AuthSessionVersion {
+		t.Fatalf("owner A's auth_session_version moved from %d to %d — another owner's reset revoked their sessions", before.AuthSessionVersion, after.AuthSessionVersion)
+	}
+
+	// Positive anchor: the reset must actually have landed on owner B, or the
+	// isolation half above would pass on a service that writes nothing at all.
+	gotB := readPasswordResetTwoOwnerUser(t, database, ownerB.ID)
+	if err := bcrypt.CompareHashAndPassword([]byte(gotB.PasswordHash), []byte("EvenStronger2")); err != nil {
+		t.Fatalf("expected owner B's new password to verify: %v", err)
+	}
+	if gotB.RecoveryCodeHash == "" || gotB.RecoveryCodeHash == ownerB.RecoveryCodeHash {
+		t.Fatal("expected owner B's recovery code hash to be rotated")
+	}
+	if gotB.AuthSessionVersion != 2 {
+		t.Fatalf("expected owner B's auth_session_version to be bumped to 2, got %d", gotB.AuthSessionVersion)
+	}
+}
+
+func newPasswordResetTwoOwnerDatabase(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	database, err := db.OpenDatabase(db.Config{
+		Driver:     db.DriverSQLite,
+		SQLitePath: filepath.Join(t.TempDir(), "ovumcy-reset-two-owner.db"),
+	})
+	if err != nil {
+		t.Fatalf("open integration database: %v", err)
+	}
+	t.Cleanup(func() {
+		if sqlDB, err := database.DB(); err == nil {
+			_ = sqlDB.Close()
+		}
+	})
+	return database
+}
+
+func createPasswordResetTwoOwnerUser(t *testing.T, database *gorm.DB, email string, password string) models.User {
+	t.Helper()
+
+	passwordHash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.MinCost)
+	if err != nil {
+		t.Fatalf("hash password for %s: %v", email, err)
+	}
+	recoveryHash, err := bcrypt.GenerateFromPassword([]byte("recovery-"+email), bcrypt.MinCost)
+	if err != nil {
+		t.Fatalf("hash recovery code for %s: %v", email, err)
+	}
+
+	user := models.User{
+		Email:               email,
+		PasswordHash:        string(passwordHash),
+		RecoveryCodeHash:    string(recoveryHash),
+		LocalAuthEnabled:    true,
+		AuthSessionVersion:  1,
+		Role:                models.RoleOwner,
+		OnboardingCompleted: true,
+		CycleLength:         models.DefaultCycleLength,
+		PeriodLength:        models.DefaultPeriodLength,
+		CreatedAt:           time.Now().UTC(),
+	}
+	if err := database.Create(&user).Error; err != nil {
+		t.Fatalf("create user %s: %v", email, err)
+	}
+	return user
+}
+
+func readPasswordResetTwoOwnerUser(t *testing.T, database *gorm.DB, userID uint) models.User {
+	t.Helper()
+
+	var user models.User
+	if err := database.First(&user, userID).Error; err != nil {
+		t.Fatalf("read user %d: %v", userID, err)
+	}
+	return user
+}

--- a/internal/services/password_reset_service_test.go
+++ b/internal/services/password_reset_service_test.go
@@ -163,6 +163,12 @@ func TestPasswordResetServiceCompleteReset(t *testing.T) {
 	if user == nil || user.ID != 42 {
 		t.Fatalf("expected resolved user 42, got %#v", user)
 	}
+	// The repository stub serves one embedded user, so the returned struct
+	// would look identical for a write scoped to any account. Pin the id the
+	// credential write was actually addressed to.
+	if repo.updatedUserID != 42 {
+		t.Fatalf("expected the reset write to be scoped to owner 42, got %d", repo.updatedUserID)
+	}
 	if recoveryCode == "" {
 		t.Fatalf("expected non-empty rotated recovery code")
 	}

--- a/internal/services/two_owner_integration_test.go
+++ b/internal/services/two_owner_integration_test.go
@@ -1,0 +1,102 @@
+package services
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/db"
+	"github.com/ovumcy/ovumcy-web/internal/models"
+	"gorm.io/gorm"
+)
+
+// Shared setup for this package's two-owner owner-scoping integration cases
+// (onboarding, the password-reset CAS, OIDC identity resolution). Each of those
+// seeds two independent owners on ONE database and drives the real repository
+// as the later-created owner, so they need the same three things: a database,
+// an owner row, and a re-read of an owner row.
+//
+// The config is separated from the setup exactly as in
+// day_service_integration_test.go, so a Postgres variant of any of these cases
+// is a five-line constructor over testdb.StartPostgresDSN rather than a fourth
+// copy of the open/cleanup dance.
+
+func newTwoOwnerIntegrationDatabase(t *testing.T, name string) *gorm.DB {
+	t.Helper()
+
+	return newTwoOwnerIntegrationDatabaseWithConfig(t, db.Config{
+		Driver:     db.DriverSQLite,
+		SQLitePath: filepath.Join(t.TempDir(), name+".db"),
+	})
+}
+
+func newTwoOwnerIntegrationDatabaseWithConfig(t *testing.T, databaseConfig db.Config) *gorm.DB {
+	t.Helper()
+
+	database, err := db.OpenDatabase(databaseConfig)
+	if err != nil {
+		t.Fatalf("open integration database: %v", err)
+	}
+	sqlDB, err := database.DB()
+	if err != nil {
+		t.Fatalf("open sql db: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = sqlDB.Close()
+	})
+	return database
+}
+
+// createTwoOwnerUser seeds one owner. customize may adjust the row before the
+// insert; the defaults are a plain onboarded owner with the shipped cycle
+// baseline. The FIRST owner a case creates lands on id 1 — the value a dropped
+// or hard-coded owner id degenerates to — which is what makes the second owner
+// the acting one in every case below.
+func createTwoOwnerUser(t *testing.T, database *gorm.DB, email string, customize func(*models.User)) models.User {
+	t.Helper()
+
+	user := models.User{
+		Email:               email,
+		PasswordHash:        "test-hash",
+		Role:                models.RoleOwner,
+		OnboardingCompleted: true,
+		CycleLength:         models.DefaultCycleLength,
+		PeriodLength:        models.DefaultPeriodLength,
+		AutoPeriodFill:      true,
+		UsageGoal:           models.UsageGoalHealth,
+		CreatedAt:           time.Now().UTC(),
+	}
+	if customize != nil {
+		customize(&user)
+	}
+	if err := database.Create(&user).Error; err != nil {
+		t.Fatalf("create user %s: %v", email, err)
+	}
+	return user
+}
+
+func readTwoOwnerUser(t *testing.T, database *gorm.DB, userID uint) models.User {
+	t.Helper()
+
+	var user models.User
+	if err := database.First(&user, userID).Error; err != nil {
+		t.Fatalf("read user %d: %v", userID, err)
+	}
+	return user
+}
+
+// requireDistinctTwoOwnerFixture pins the fixture assumption every case here
+// rests on: the mutant they exist to kill is a literal owner `1`, so the first
+// owner must hold id 1 and the acting owner must be a different account. A
+// fixture that drifted off either would leave the case green while proving
+// nothing.
+func requireDistinctTwoOwnerFixture(t *testing.T, first models.User, acting models.User) {
+	t.Helper()
+
+	if first.ID != 1 {
+		t.Fatalf("fixture assumption broken: expected the first owner to hold id 1, got %d", first.ID)
+	}
+	if acting.ID == first.ID {
+		t.Fatalf("fixture assumption broken: the two owners must be distinct, both are %d", acting.ID)
+	}
+}


### PR DESCRIPTION
Four service-layer suites could not see the identity they were handed. The doubles behind OIDC login and step-up re-auth, the OIDC logout-state store, onboarding and the password-reset CAS declared their identity argument unnamed — or named it and stored nothing — and answered every key with the same record. Substituting a constant owner `1` into the production call, or swapping issuer for subject, left the focused service and API selections green.

Tests only: no production file is touched by this branch.

## What each record was, and what now guards it

**R2-0522 — the logout row's owner was never asserted.** Erasure keys on it (`DELETE FROM oidc_logout_states WHERE user_id = ?`), so a row saved under the wrong or a zero owner survives that owner's account deletion holding an `id_token_hint` until the TTL. The save test now fixes a non-1 owner and asserts the persisted `UserID`.

**R2-0523 — the OIDC lookup keys.** `stubOIDCIdentityStore` and `stubOIDCUserStore` now record the `(issuer, subject)` pair and the resolved account id, asserted on the login path and — the seam that matters most — on `ValidateReauthExchange`, the primitive that gates erasure re-auth for an account with no local password.

**R2-0946 — onboarding.** Every stub method records the owner it was called for, the fixtures move off the literal `1` (an assertion against `1` is satisfied by the very defect it guards against), and a new case pins the step-1 write.

**R2-0948 — the password-reset CAS.** The CAS stub records the owner the UPDATE was scoped to, asserted in both CAS cases and in the reset service's completion path.

Three cases go further than observing an argument, because a recorded id proves scoping only at the seam it was recorded at. Each seeds two independent owners on one database and drives the real repositories: onboarding steps 1, 2 and completion; the recovery reset; and OIDC login plus step-up re-auth with **one subject under two different issuers**, a shape the `(issuer, subject)` unique index permits and a real household deployment can hold. Owner A is created first and therefore holds id 1 — the value a dropped or hard-coded owner degenerates to — and every operation runs as owner B. Each case carries a positive anchor, so the isolation half cannot pass on a service that writes nothing.

## Evidence

Each guard was proved able to fail before it was wired in: break the production behaviour, show the test still passes, add the assertion, show it fails on the identity, restore, show it green.

**R2-0522** — `oidc_logout_state_service.go:47` `UserID: state.UserID` → `1`: **ok 7.6s** → assertion in → **FAIL** `expected the persisted row to carry owner id 9, got 1` → restored **ok 3.5s**.

**R2-0523, account lookup** — `oidc_login_service.go:334` `FindByID(ctx, identity.UserID)` → `FindByID(ctx, 1)`: **ok 4.2s** → **FAIL** `expected the account to be resolved by the linked identity's owner id 7, got 1` → restored **ok 5.2s**.

**R2-0523, identity key** — `oidc_login_service.go:326` arguments swapped: **ok 3.8s** → **FAIL** `expected identity lookup by issuer "https://id.example.com", got "owner-subject"` → restored **ok 5.3s**.

**R2-0523, the step-up seam** — `oidc_login_service.go:191` → `FindByIssuerSubject(ctx, "", exchange.Claims.Subject)`, resolution by subject alone: all 17 cases of `oidc_reauth_test.go` **ok 6.7s**, `UserIDMismatch` included → assertion in → **FAIL** `expected the step-up identity to be resolved by issuer "https://id.example.com", got ""` → restored **ok 5.6s**.

**R2-0523, the store's own predicate** — `oidc_identity_repository.go:23` `Where("issuer = ? AND subject = ?", …)` → `Where("subject = ?", …)`: every stub case stays **PASS**, `lastIssuer`/`lastSubject` assertions included, because the arguments *are* forwarded correctly; only the two-owner case fails — `login under issuer "https://id-b.example.com" resolved owner 1, want owner 2 — the identity lookup is not scoped by issuer`. Restored **ok**.

**R2-0523, logout lookup** — `oidc_logout_state_service.go:88` `FindBySessionID(ctx, sessionID)` → a constant: **ok 5.7s** → **FAIL** on the session id → restored **ok 7.1s**.

**R2-0946** — all four production sites forced to owner `1` (`onboarding_service.go:38,80,111,121`): `./internal/services -run Onboarding` **ok 6.3s** and `./internal/api -run Onboarding` **ok 22.8s** → guards in → **five stub failures** plus `owner A's row changed while owner B onboarded` with the full before/after diff → restored **ok 5.8s**.

**R2-0948** — `auth_service.go:501` `user.ID` → `1`, reproducing the audit's three green suites: services **ok 8.2s**, `./internal/db -run …CAS` **ok 4.4s**, `./internal/api -run 'Reset|Recovery|OwnerIsolation'` **ok 42.5s** → guards in → **four failures**, including `resetting owner B failed with reset token already consumed — a CAS scoped to a different owner matches no row` → restored **ok 9.7s**.

Full runs on the finished branch: `go build ./...` · `./internal/services/...` · `./internal/db/...` · `./internal/api/...` all green; `gofmt -l` clean on every touched file; `golangci-lint` 0 issues.

## Deliberately out of scope

Postgres variants of the three integration cases. They exercise `WHERE id = ?` and `WHERE issuer = ? AND subject = ?`, predicates identical across dialects with no per-dialect SQL, so the SQLite run pins the property; `newTwoOwnerIntegrationDatabaseWithConfig` keeps the config separated from the setup, so each variant is one short constructor over `testdb.StartPostgresDSN` if that changes.

Sibling doubles that drop an argument elsewhere are left untouched — each has its own finding and belongs in its own change: `stubOIDCProviderClient.ExchangeCode`, `stubAuthUserRepo.FindByID` and `FindByNormalizedEmail`, `internal/db/user_repository_cas_test.go` and `internal/db/oidc_identity_repository_test.go` (both seed a single row, so neither can distinguish a resolved owner from a constant), and the onboarding double in `internal/api/security_event_logging_mutation_regression_test.go`.
