### PR TITLE
fix(db): refuse a migration replay that would discard health data

### DIFF
--- a/changelog.d/fix-refuse-destructive-migration-replay.md
+++ b/changelog.d/fix-refuse-destructive-migration-replay.md
@@ -25,10 +25,13 @@
   way the database is left exactly as it was, and the refusal names the migration, the table, the
   columns it protected and what to restore.
 
-  Both losses stay expressible, each by something the author writes out and names: a column
-  removed by an explicit `ALTER TABLE … DROP COLUMN` in the migration's own SQL, and a table
-  retired for good by the marker line `-- ovumcy:removes-table <name>`, which authorizes the one
-  table it names. A bare `DROP TABLE` is deliberately not read as consent — it is the middle
+  Every disappearance a migration means stays expressible, each by something the author writes
+  out and names: a column retired by an explicit `ALTER TABLE … DROP COLUMN`, a column moved by
+  `ALTER TABLE … RENAME COLUMN old TO new` — which loses nothing, since the values are under the
+  new name — and a table retired for good by the marker line `-- ovumcy:removes-table <name>`,
+  which authorizes the one table it names. Each authorizes only what it names: renaming one
+  column does not excuse a second one going missing beside it. A bare `DROP TABLE` is
+  deliberately not read as consent — it is the middle
   statement of every rebuild in the tree, and reading it as consent is how migration 003 came to
   discard eight health columns while reporting success.
 
@@ -59,7 +62,9 @@
   the same code path: both SQLite rebuild idioms, each in a narrowing and a preserving variant so
   the refusal cannot be credited to a check that refuses everything; a table removal with the
   marker, without it, with a marker naming a different table, and with the marker words buried in
-  prose; and an explicit column drop, which must still apply.
+  prose; an explicit column drop and a column rename, both of which must still apply; and a
+  rebuild that renames one column while quietly losing another, which must still be refused,
+  naming the column that was really lost and not the renamed one.
 
 - **An account with a role this product does not have is refused where it is written.** Ovumcy is
   owner-role-only — every account is the sole owner of its own data, and there is no viewer or

--- a/changelog.d/fix-refuse-destructive-migration-replay.md
+++ b/changelog.d/fix-refuse-destructive-migration-replay.md
@@ -11,19 +11,33 @@
   instance that was already fully migrated, with the boot reporting success. Migration 024 has the
   same shape and is destructive today only because nothing was added to `daily_logs` after it.
 
-  The runner now refuses a migration that drops a table when the database has moved past it,
-  measured two ways so neither state of the ledger is uncovered: a recorded LATER version means
-  the migration is spent and nothing is executed at all, and — for a ledger lost entirely, where
-  no later version exists to compare against — a table that comes back from a rebuild without a
-  column it had before fails the migration inside its own transaction, so every statement it ran
-  is rolled back. Either way the database is left exactly as it was, and the refusal names the
-  migration, the table, the columns it protected and what to restore. A migration that means to
-  remove a column still does it the visible way, with an explicit `DROP COLUMN`, which the check
-  does not look at.
+  The runner now refuses a migration that narrows the schema it is applied to, measured two ways
+  so neither state of the ledger is uncovered. A recorded LATER version means a migration that
+  drops a table is spent, so nothing is executed at all. And — for a ledger lost entirely, where
+  no later version exists to compare against — the columns of every table are read before the
+  migration's first statement and again after its last, inside the migration's own transaction,
+  so a table that ends up without a column it had before fails the migration and every statement
+  it ran is rolled back. Reading the whole schema rather than the tables a migration names is
+  what makes that check about the effect instead of the spelling: SQLite rebuilds a table either
+  by dropping the original and renaming a replacement onto its name, as migrations 003 and 024
+  do, or by renaming the original away first and recreating it — the second narrows the table
+  just as much while dropping only a name that did not exist when the migration began. Either
+  way the database is left exactly as it was, and the refusal names the migration, the table, the
+  columns it protected and what to restore.
 
-  Nothing changes for a clean install or a normal upgrade: on both, no migration numbered above
-  the one being applied is recorded, and the rebuilds preserve every column they copy. What
-  changes is that the one situation in which a boot used to destroy records now stops instead.
+  Both losses stay expressible, each by something the author writes out and names: a column
+  removed by an explicit `ALTER TABLE … DROP COLUMN` in the migration's own SQL, and a table
+  retired for good by the marker line `-- ovumcy:removes-table <name>`, which authorizes the one
+  table it names. A bare `DROP TABLE` is deliberately not read as consent — it is the middle
+  statement of every rebuild in the tree, and reading it as consent is how migration 003 came to
+  discard eight health columns while reporting success.
+
+  Nothing changes for a clean install or a normal upgrade beyond the time it takes: on both, no
+  migration numbered above the one being applied is recorded, and the rebuilds preserve every
+  column they copy. Reading the schema between statements costs about 150 ms once, over a clean
+  SQLite bootstrap of the whole set (mean 300 ms against 113 ms over twenty runs); an instance
+  with no migration to apply pays nothing, because the ledger check comes first. What changes is
+  that the one situation in which a boot used to destroy records now stops instead.
 
 ### Internal
 
@@ -40,6 +54,12 @@
   sweep runs on SQLite, where the rebuild pattern lives, a second test asserts the premise that
   makes that enough: the Postgres tree drops no table at all today, and a rebuild landing there
   later fails until the sweep is extended to it.
+
+  The shapes the embedded tree does not contain are covered by synthetic migrations run through
+  the same code path: both SQLite rebuild idioms, each in a narrowing and a preserving variant so
+  the refusal cannot be credited to a check that refuses everything; a table removal with the
+  marker, without it, with a marker naming a different table, and with the marker words buried in
+  prose; and an explicit column drop, which must still apply.
 
 - **An account with a role this product does not have is refused where it is written.** Ovumcy is
   owner-role-only — every account is the sole owner of its own data, and there is no viewer or

--- a/changelog.d/fix-refuse-destructive-migration-replay.md
+++ b/changelog.d/fix-refuse-destructive-migration-replay.md
@@ -1,0 +1,56 @@
+### Fixed
+
+- **A missing `schema_migrations` row no longer costs health data.** The migration runner
+  re-applies any migration whose ledger row is absent — a restore from a backup taken before the
+  row was written, or a pruned bookkeeping table — and what made that safe was a single skip that
+  recognizes `ALTER TABLE ... ADD COLUMN` and nothing else. Migration 003 reconciles `daily_logs`
+  by rebuilding it, and its replacement table is the table as it looked at version 003: replaying
+  it on a database that later migrations had widened copied the nine columns of migration 001 and
+  dropped `mood`, `sex_activity`, `bbt`, `cervical_mucus`, `cycle_start`, `is_uncertain`,
+  `cycle_factor_keys` and `pregnancy_test` — eight health columns and every value in them — on an
+  instance that was already fully migrated, with the boot reporting success. Migration 024 has the
+  same shape and is destructive today only because nothing was added to `daily_logs` after it.
+
+  The runner now refuses a migration that drops a table when the database has moved past it,
+  measured two ways so neither state of the ledger is uncovered: a recorded LATER version means
+  the migration is spent and nothing is executed at all, and — for a ledger lost entirely, where
+  no later version exists to compare against — a table that comes back from a rebuild without a
+  column it had before fails the migration inside its own transaction, so every statement it ran
+  is rolled back. Either way the database is left exactly as it was, and the refusal names the
+  migration, the table, the columns it protected and what to restore. A migration that means to
+  remove a column still does it the visible way, with an explicit `DROP COLUMN`, which the check
+  does not look at.
+
+  Nothing changes for a clean install or a normal upgrade: on both, no migration numbered above
+  the one being applied is recorded, and the rebuilds preserve every column they copy. What
+  changes is that the one situation in which a boot used to destroy records now stops instead.
+
+### Internal
+
+- **The migration replay path is swept rather than sampled.** A new `internal/db` test deletes
+  each `schema_migrations` row in turn from a fully migrated database, reopens it through the real
+  boot path, and requires that the reopen cost neither a column nor a stored value — passing on
+  either outcome, a completed boot or a refusal by name, since both are non-destructive. Two cases
+  spell out the failures behind it: removing only the row for 003 on a current database, and
+  losing the whole ledger, each with a seeded day carrying a value in every column added after
+  003. It is deliberately narrower than "the schema is unchanged", and the file says so:
+  indexes are out of scope, because migrations 001 and 024 both end with
+  `CREATE INDEX IF NOT EXISTS idx_daily_logs_date`, which migration 025 later drops, so replaying
+  either recreates a redundant index — write amplification, never a column or a row. Because the
+  sweep runs on SQLite, where the rebuild pattern lives, a second test asserts the premise that
+  makes that enough: the Postgres tree drops no table at all today, and a rebuild landing there
+  later fails until the sweep is extended to it.
+
+- **An account with a role this product does not have is refused where it is written.** Ovumcy is
+  owner-role-only — every account is the sole owner of its own data, and there is no viewer or
+  partner role — but the `users` column has carried `CHECK (role IN ('owner', 'partner'))` since
+  the initial schema on both engines, while nothing else in the tree mentions `partner`: no
+  constant, no handler, no template, no locale key. The database would have accepted such an
+  account and only the login policy would have turned it away afterwards. Both account-creating
+  repository methods now reject any role other than owner before the insert, so the refused
+  account leaves no row and no seeded symptom behind; an unset role still means "the column
+  default", which is written out as owner rather than left to the tag and the migration agreeing.
+  The constraint itself is left alone on purpose and the reason is recorded next to the check:
+  SQLite has no `ALTER` for a `CHECK`, so narrowing it means rebuilding `users` — and with
+  `foreign_keys=ON` a dropped table fires every `ON DELETE CASCADE` hanging off it, which would
+  make a migration that tightened one unused constant delete every day log on the instance.

--- a/internal/db/errors.go
+++ b/internal/db/errors.go
@@ -14,6 +14,15 @@ import (
 // or concurrent redeem, not a DB error.
 var ErrResetTokenAlreadyConsumed = errors.New("reset token already consumed")
 
+// ErrUnsupportedUserRole is returned by the two account-creating repository
+// methods when the row they were handed carries a role this product does not
+// have. Ovumcy is owner-role-only — every account is the sole owner of its own
+// data, and there is no viewer or partner role at all
+// (`docs/SECURITY_INVARIANTS.md`) — so a row with any other role would be
+// stored and then read by code written on the assumption that owner is the only
+// role there is.
+var ErrUnsupportedUserRole = errors.New("unsupported user role")
+
 type UniqueConstraintError struct {
 	Constraint string
 	Err        error

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -31,6 +31,7 @@ var migrationFilePattern = regexp.MustCompile(`^(\d+)_.*\.sql$`)
 var addColumnStatementPattern = regexp.MustCompile(`(?i)^ALTER\s+TABLE\s+([^\s]+)\s+ADD\s+COLUMN\s+([^\s]+)\b`)
 var dropTableStatementPattern = regexp.MustCompile(`(?i)^DROP\s+TABLE\s+(?:IF\s+EXISTS\s+)?([^\s;]+)`)
 var dropColumnStatementPattern = regexp.MustCompile(`(?i)^ALTER\s+TABLE\s+([^\s]+)\s+DROP\s+(?:COLUMN\s+)?(?:IF\s+EXISTS\s+)?([^\s;]+)`)
+var renameColumnStatementPattern = regexp.MustCompile(`(?i)^ALTER\s+TABLE\s+([^\s]+)\s+RENAME\s+(?:COLUMN\s+)?([^\s;]+)\s+TO\s+([^\s;]+)`)
 var removedTableMarkerPattern = regexp.MustCompile(`(?im)^[ \t]*--[ \t]*` + regexp.QuoteMeta(removedTableMarker) + `[ \t]+([^\s;]+)[ \t]*$`)
 
 type embeddedMigration struct {
@@ -349,7 +350,7 @@ func snapshotEveryTableColumns(database *gorm.DB) ([]tableColumnsBefore, error) 
 // came to discard eight health columns while reporting success.
 func requireNoTableSilentlyNarrowed(database *gorm.DB, migration embeddedMigration, columnsBefore []tableColumnsBefore, statements []string) error {
 	removedOnPurpose := tablesRemovedOnPurpose(migration)
-	droppedColumns := columnsDroppedExplicitly(statements)
+	accountedFor := columnsAccountedForByName(statements)
 
 	for _, before := range columnsBefore {
 		if !database.Migrator().HasTable(before.Table) {
@@ -372,13 +373,13 @@ func requireNoTableSilentlyNarrowed(database *gorm.DB, migration embeddedMigrati
 		}
 
 		missing := missingColumnNames(before.Columns, columnsNow)
-		missing = withoutExplicitlyDroppedColumns(missing, droppedColumns[before.Table])
+		missing = withoutAccountedForColumns(missing, accountedFor[before.Table])
 		if len(missing) == 0 {
 			continue
 		}
 
 		return fmt.Errorf(
-			"refusing migration %s: table %s lost column(s) %s, which held data before it ran, and no statement in the migration drops them — a rebuild recreates the table from the columns its own version knew about, so re-applying it on a newer schema discards everything added after it. Nothing was written: the migration was rolled back and the database is unchanged; if migration %s is in fact applied, restore its schema_migrations row, otherwise restore from a backup",
+			"refusing migration %s: table %s lost column(s) %s, which held data before it ran, and no statement in the migration drops or renames them — a rebuild recreates the table from the columns its own version knew about, so re-applying it on a newer schema discards everything added after it. Nothing was written: the migration was rolled back and the database is unchanged; if migration %s is in fact applied, restore its schema_migrations row, otherwise restore from a backup",
 			migration.Name,
 			before.Table,
 			strings.Join(missing, ", "),
@@ -411,34 +412,57 @@ func tablesRemovedOnPurpose(migration embeddedMigration) map[string]struct{} {
 	return removed
 }
 
-// columnsDroppedExplicitly returns table -> the columns this migration removes
-// with an `ALTER TABLE ... DROP COLUMN`, the visible form of that intent.
-func columnsDroppedExplicitly(statements []string) map[string]map[string]struct{} {
-	dropped := make(map[string]map[string]struct{})
+// columnsAccountedForByName returns table -> the column names whose
+// disappearance this migration explains in its own SQL. There are two visible
+// forms of that intent and both engines support both:
+//
+//	ALTER TABLE t DROP COLUMN c            -- the column is retired
+//	ALTER TABLE t RENAME COLUMN c TO other -- the column is still there, renamed
+//
+// A rename is not a loss: the values are under the new name, and refusing it
+// would have the guard reporting a data loss that did not happen, which is the
+// mirror of the defect it exists to catch. Only the OLD name of the statement
+// is accounted for — renaming one column says nothing about the rest of the
+// table, so a rebuild that quietly drops a second column is still refused.
+//
+// The `TO` clause is what separates a column rename from a TABLE rename:
+// `ALTER TABLE t RENAME TO t_old` has no name before the TO and therefore
+// matches nothing here, which matters because that statement is the first half
+// of the rename-first rebuild idiom and must never authorize anything.
+func columnsAccountedForByName(statements []string) map[string]map[string]struct{} {
+	accountedFor := make(map[string]map[string]struct{})
+
+	record := func(tableName string, columnName string) {
+		table := normalizeSQLIdentifier(tableName)
+		if accountedFor[table] == nil {
+			accountedFor[table] = make(map[string]struct{})
+		}
+		accountedFor[table][normalizeSQLIdentifier(columnName)] = struct{}{}
+	}
+
 	for _, statement := range statements {
-		matches := dropColumnStatementPattern.FindStringSubmatch(stripLeadingSQLComments(statement))
-		if len(matches) != 3 {
+		body := stripLeadingSQLComments(statement)
+		if matches := dropColumnStatementPattern.FindStringSubmatch(body); len(matches) == 3 {
+			record(matches[1], matches[2])
 			continue
 		}
-		tableName := normalizeSQLIdentifier(matches[1])
-		if dropped[tableName] == nil {
-			dropped[tableName] = make(map[string]struct{})
+		if matches := renameColumnStatementPattern.FindStringSubmatch(body); len(matches) == 4 {
+			record(matches[1], matches[2])
 		}
-		dropped[tableName][normalizeSQLIdentifier(matches[2])] = struct{}{}
 	}
-	return dropped
+	return accountedFor
 }
 
-// withoutExplicitlyDroppedColumns removes from missing the columns the
-// migration itself asked to drop.
-func withoutExplicitlyDroppedColumns(missing []string, droppedColumns map[string]struct{}) []string {
-	if len(droppedColumns) == 0 {
+// withoutAccountedForColumns removes from missing the column names whose
+// disappearance the migration itself explained.
+func withoutAccountedForColumns(missing []string, accountedFor map[string]struct{}) []string {
+	if len(accountedFor) == 0 {
 		return missing
 	}
 
 	kept := make([]string, 0, len(missing))
 	for _, name := range missing {
-		if _, dropped := droppedColumns[name]; dropped {
+		if _, explained := accountedFor[name]; explained {
 			continue
 		}
 		kept = append(kept, name)

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -23,6 +23,7 @@ const sqlLineCommentPrefix = "--"
 
 var migrationFilePattern = regexp.MustCompile(`^(\d+)_.*\.sql$`)
 var addColumnStatementPattern = regexp.MustCompile(`(?i)^ALTER\s+TABLE\s+([^\s]+)\s+ADD\s+COLUMN\s+([^\s]+)\b`)
+var dropTableStatementPattern = regexp.MustCompile(`(?i)^DROP\s+TABLE\s+(?:IF\s+EXISTS\s+)?([^\s;]+)`)
 
 type embeddedMigration struct {
 	Version string
@@ -49,6 +50,10 @@ func applyEmbeddedMigrations(database *gorm.DB, driver Driver) error {
 	for _, migration := range migrations {
 		if _, alreadyApplied := appliedVersions[migration.Version]; alreadyApplied {
 			continue
+		}
+
+		if err := refuseTableDropReplayOnANewerSchema(migration, appliedVersions); err != nil {
+			return err
 		}
 
 		if err := applyMigration(database, migration); err != nil {
@@ -160,6 +165,11 @@ func applyMigration(database *gorm.DB, migration embeddedMigration) error {
 			return errors.New("migration has no SQL statements")
 		}
 
+		columnsBeforeTheDrop, err := snapshotColumnsOfDroppedTables(tx, statements)
+		if err != nil {
+			return fmt.Errorf("inspect migration %s: %w", migration.Name, err)
+		}
+
 		for _, statement := range statements {
 			skip, err := shouldSkipStatement(tx, statement)
 			if err != nil {
@@ -174,6 +184,10 @@ func applyMigration(database *gorm.DB, migration embeddedMigration) error {
 			}
 		}
 
+		if err := requireDroppedTablesKeptTheirColumns(tx, migration, columnsBeforeTheDrop); err != nil {
+			return err
+		}
+
 		if err := tx.Exec(
 			`INSERT INTO schema_migrations(version, name) VALUES (?, ?)`,
 			migration.Version,
@@ -184,6 +198,217 @@ func applyMigration(database *gorm.DB, migration embeddedMigration) error {
 
 		return nil
 	})
+}
+
+// droppedTableColumns is one table a migration is about to DROP, together with
+// the columns it had before the migration ran.
+type droppedTableColumns struct {
+	Table   string
+	Columns []string
+}
+
+// refuseTableDropReplayOnANewerSchema stops a migration that DROPs a table from
+// running against a database that already records a LATER migration as applied.
+//
+// The runner re-applies any migration whose schema_migrations row is missing —
+// a restore from a backup taken before the row was written, or a pruned ledger
+// — and for `ALTER TABLE ... ADD COLUMN` that is safe, because
+// shouldSkipStatement drops the statement when the column is already there. A
+// migration that reconciles a table by rebuilding it (create a replacement,
+// copy, DROP the original, rename) has no such skip: its replacement table is
+// the table as it looked AT THAT VERSION, so a replay on a schema that later
+// migrations have widened copies the columns that version knew about and drops
+// every column added after it, with the rows' values in them. On this schema
+// migration 003 rebuilds daily_logs from the nine columns of migration 001 and
+// would discard the eight health columns migrations 005-023 added.
+//
+// A recorded later version is proof the database moved past this migration:
+// there is nothing left to apply, and the only thing a replay can do is
+// destroy. Refusing runs no statement at all, so the database is left exactly
+// as it was and the operator can restore the missing ledger row or the backup
+// and boot again.
+//
+// It is dialect-neutral by construction — it reads the SQL of whichever tree
+// the driver loaded — and therefore dormant on Postgres, whose 003 is a
+// `SELECT 1;` because its bootstrap schema never needed the rebuild.
+func refuseTableDropReplayOnANewerSchema(migration embeddedMigration, appliedVersions map[string]struct{}) error {
+	droppedTables := tablesDroppedByMigration(migration)
+	if len(droppedTables) == 0 {
+		return nil
+	}
+
+	laterVersion, hasLaterVersion := highestAppliedVersionAfter(appliedVersions, migration.Order)
+	if !hasLaterVersion {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"refusing to re-apply migration %s: it drops table %s, and migration %s is already recorded as applied, so the database schema is newer than the one this migration rebuilds — re-applying it would discard the columns and values added after it. Nothing was executed and the database is unchanged; if migration %s is in fact applied, restore its schema_migrations row, otherwise restore from a backup",
+		migration.Name,
+		strings.Join(droppedTables, ", "),
+		laterVersion,
+		migration.Version,
+	)
+}
+
+// highestAppliedVersionAfter returns the highest recorded migration version
+// numbered above order. A ledger row whose version is not a number is ignored
+// rather than treated as newer: it cannot be ordered against the file set.
+func highestAppliedVersionAfter(appliedVersions map[string]struct{}, order int) (string, bool) {
+	highestVersion := ""
+	highestOrder := order
+	for version := range appliedVersions {
+		versionOrder, err := strconv.Atoi(strings.TrimSpace(version))
+		if err != nil {
+			continue
+		}
+		if versionOrder > highestOrder {
+			highestOrder = versionOrder
+			highestVersion = version
+		}
+	}
+	return highestVersion, highestVersion != ""
+}
+
+// snapshotColumnsOfDroppedTables records the columns of every table the
+// migration's statements DROP, read before any of them runs.
+//
+// It is the second half of the destructive-replay guard and covers the case the
+// version comparison cannot see: a database that lost its schema_migrations
+// content entirely records no later version, so the whole set replays from 001
+// with nothing to compare against. The post-condition below then measures the
+// effect itself.
+func snapshotColumnsOfDroppedTables(database *gorm.DB, statements []string) ([]droppedTableColumns, error) {
+	snapshot := make([]droppedTableColumns, 0)
+	seenTables := make(map[string]struct{})
+
+	for _, statement := range statements {
+		tableName, isDropTable := parseDropTableStatement(statement)
+		if !isDropTable {
+			continue
+		}
+		if _, alreadySeen := seenTables[tableName]; alreadySeen {
+			continue
+		}
+		seenTables[tableName] = struct{}{}
+
+		if !database.Migrator().HasTable(tableName) {
+			continue
+		}
+		columns, err := tableColumnNames(database, tableName)
+		if err != nil {
+			return nil, err
+		}
+		snapshot = append(snapshot, droppedTableColumns{Table: tableName, Columns: columns})
+	}
+
+	return snapshot, nil
+}
+
+// requireDroppedTablesKeptTheirColumns fails the migration — and, being inside
+// its transaction, rolls back every statement it ran — when a table it dropped
+// came back without a column it had before.
+//
+// A migration that means to REMOVE a column says so with an explicit
+// `ALTER TABLE ... DROP COLUMN`, which this check does not look at; what it
+// refuses is a column removed as a side effect of rebuilding a table from a
+// narrower replacement, which is never what the migration author wrote and is
+// always the shape of a replay against a newer schema.
+func requireDroppedTablesKeptTheirColumns(database *gorm.DB, migration embeddedMigration, columnsBeforeTheDrop []droppedTableColumns) error {
+	for _, before := range columnsBeforeTheDrop {
+		if !database.Migrator().HasTable(before.Table) {
+			return fmt.Errorf(
+				"refusing migration %s: it dropped table %s and did not put it back. Nothing was written — the migration was rolled back and the database is unchanged",
+				migration.Name,
+				before.Table,
+			)
+		}
+
+		columnsNow, err := tableColumnNames(database, before.Table)
+		if err != nil {
+			return fmt.Errorf("inspect migration %s: %w", migration.Name, err)
+		}
+
+		missing := missingColumnNames(before.Columns, columnsNow)
+		if len(missing) == 0 {
+			continue
+		}
+
+		return fmt.Errorf(
+			"refusing migration %s: rebuilding table %s would have dropped column(s) %s, which held data before it ran — the migration rebuilds the table from the columns its own version knew about, so re-applying it on a newer schema discards everything added after it. Nothing was written — the migration was rolled back and the database is unchanged; if migration %s is in fact applied, restore its schema_migrations row, otherwise restore from a backup",
+			migration.Name,
+			before.Table,
+			strings.Join(missing, ", "),
+			migration.Version,
+		)
+	}
+
+	return nil
+}
+
+// tablesDroppedByMigration returns, in file order and without repeats, the
+// tables a migration removes with DROP TABLE.
+func tablesDroppedByMigration(migration embeddedMigration) []string {
+	dropped := make([]string, 0)
+	seenTables := make(map[string]struct{})
+	for _, statement := range splitSQLStatements(migration.SQL) {
+		tableName, isDropTable := parseDropTableStatement(statement)
+		if !isDropTable {
+			continue
+		}
+		if _, alreadySeen := seenTables[tableName]; alreadySeen {
+			continue
+		}
+		seenTables[tableName] = struct{}{}
+		dropped = append(dropped, tableName)
+	}
+	return dropped
+}
+
+// parseDropTableStatement reports whether a statement chunk is a
+// `DROP TABLE ...`, returning the table it removes. Like the ADD COLUMN
+// detection it reads past the prose header splitSQLStatements leaves attached
+// to the first statement of a chunk, and for the same reason: the regex is
+// anchored at ^, so a comment line above the statement would hide it.
+func parseDropTableStatement(statement string) (tableName string, isDropTable bool) {
+	matches := dropTableStatementPattern.FindStringSubmatch(stripLeadingSQLComments(statement))
+	if len(matches) != 2 {
+		return "", false
+	}
+	return normalizeSQLIdentifier(matches[1]), true
+}
+
+// tableColumnNames reads one table's column names, lowercased, through the same
+// migrator the runner already uses for the ADD COLUMN skip, so one reader
+// serves both engines.
+func tableColumnNames(database *gorm.DB, tableName string) ([]string, error) {
+	columnTypes, err := database.Migrator().ColumnTypes(tableName)
+	if err != nil {
+		return nil, fmt.Errorf("read columns of table %s: %w", tableName, err)
+	}
+
+	names := make([]string, 0, len(columnTypes))
+	for _, columnType := range columnTypes {
+		names = append(names, strings.ToLower(strings.TrimSpace(columnType.Name())))
+	}
+	return names, nil
+}
+
+// missingColumnNames returns the entries of before that are absent from after,
+// in their original order.
+func missingColumnNames(before []string, after []string) []string {
+	present := make(map[string]struct{}, len(after))
+	for _, name := range after {
+		present[name] = struct{}{}
+	}
+
+	missing := make([]string, 0)
+	for _, name := range before {
+		if _, exists := present[name]; !exists {
+			missing = append(missing, name)
+		}
+	}
+	return missing
 }
 
 func splitSQLStatements(sqlText string) []string {

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -21,9 +21,17 @@ import (
 // an unmatched statement is executed exactly as before.
 const sqlLineCommentPrefix = "--"
 
+// removedTableMarker is how a migration declares that a table it drops is meant
+// to stay gone, rather than being the middle of a table rebuild. It is quoted
+// into the refusal below, so an operator who hits the check reads the exact
+// line the migration is missing.
+const removedTableMarker = "ovumcy:removes-table"
+
 var migrationFilePattern = regexp.MustCompile(`^(\d+)_.*\.sql$`)
 var addColumnStatementPattern = regexp.MustCompile(`(?i)^ALTER\s+TABLE\s+([^\s]+)\s+ADD\s+COLUMN\s+([^\s]+)\b`)
 var dropTableStatementPattern = regexp.MustCompile(`(?i)^DROP\s+TABLE\s+(?:IF\s+EXISTS\s+)?([^\s;]+)`)
+var dropColumnStatementPattern = regexp.MustCompile(`(?i)^ALTER\s+TABLE\s+([^\s]+)\s+DROP\s+(?:COLUMN\s+)?(?:IF\s+EXISTS\s+)?([^\s;]+)`)
+var removedTableMarkerPattern = regexp.MustCompile(`(?im)^[ \t]*--[ \t]*` + regexp.QuoteMeta(removedTableMarker) + `[ \t]+([^\s;]+)[ \t]*$`)
 
 type embeddedMigration struct {
 	Version string
@@ -165,7 +173,7 @@ func applyMigration(database *gorm.DB, migration embeddedMigration) error {
 			return errors.New("migration has no SQL statements")
 		}
 
-		columnsBeforeTheDrop, err := snapshotColumnsOfDroppedTables(tx, statements)
+		columnsBefore, err := snapshotEveryTableColumns(tx)
 		if err != nil {
 			return fmt.Errorf("inspect migration %s: %w", migration.Name, err)
 		}
@@ -184,7 +192,7 @@ func applyMigration(database *gorm.DB, migration embeddedMigration) error {
 			}
 		}
 
-		if err := requireDroppedTablesKeptTheirColumns(tx, migration, columnsBeforeTheDrop); err != nil {
+		if err := requireNoTableSilentlyNarrowed(tx, migration, columnsBefore, statements); err != nil {
 			return err
 		}
 
@@ -200,9 +208,8 @@ func applyMigration(database *gorm.DB, migration embeddedMigration) error {
 	})
 }
 
-// droppedTableColumns is one table a migration is about to DROP, together with
-// the columns it had before the migration ran.
-type droppedTableColumns struct {
+// tableColumnsBefore is one table as it stood before a migration ran.
+type tableColumnsBefore struct {
 	Table   string
 	Columns []string
 }
@@ -270,57 +277,92 @@ func highestAppliedVersionAfter(appliedVersions map[string]struct{}, order int) 
 	return highestVersion, highestVersion != ""
 }
 
-// snapshotColumnsOfDroppedTables records the columns of every table the
-// migration's statements DROP, read before any of them runs.
+// snapshotEveryTableColumns records the columns of EVERY table there is, read
+// before the migration's first statement runs.
 //
 // It is the second half of the destructive-replay guard and covers the case the
 // version comparison cannot see: a database that lost its schema_migrations
 // content entirely records no later version, so the whole set replays from 001
 // with nothing to compare against. The post-condition below then measures the
 // effect itself.
-func snapshotColumnsOfDroppedTables(database *gorm.DB, statements []string) ([]droppedTableColumns, error) {
-	snapshot := make([]droppedTableColumns, 0)
-	seenTables := make(map[string]struct{})
+//
+// It measures every table rather than the tables the migration textually DROPs,
+// because the DROP is an idiom and not the invariant. SQLite has two ways to
+// rebuild a table, and the invariant has to hold for both:
+//
+//	CREATE TABLE t_new (…); INSERT INTO t_new SELECT … FROM t; DROP TABLE t;
+//	ALTER TABLE t_new RENAME TO t;                       -- migrations 003, 024
+//
+//	ALTER TABLE t RENAME TO t_old; CREATE TABLE t (…);
+//	INSERT INTO t SELECT … FROM t_old; DROP TABLE t_old; -- the rename-first form
+//
+// The second narrows t exactly as the first does, and a check keyed on the
+// dropped name sees nothing: t_old does not exist yet when the snapshot is
+// taken, and t is never dropped at all. Reading the whole schema is what makes
+// the guard about the effect instead of about the spelling.
+//
+// The cost is one column read per table per APPLIED migration, and it lands
+// only where a migration actually applies: a boot with nothing to do never
+// reaches applyMigration, because applyEmbeddedMigrations skips on the ledger
+// first, so a running instance pays nothing. Priced on this host 2026-08-20,
+// 20 clean SQLite bootstraps of the whole set each: mean 300 ms with the
+// snapshot against 113 ms without, best 218 ms against 88 ms — roughly 150 ms
+// added once, at install or at an upgrade that applies the whole set. On
+// Postgres the difference did not separate from container startup (9.3 s
+// against 14.3 s, in the wrong direction). Keyed on the schema rather than on
+// the statement text on purpose: a textual precondition for taking the
+// snapshot would have to enumerate the ways a table can lose a column, which
+// is the assumption that let the rename-first form through.
+func snapshotEveryTableColumns(database *gorm.DB) ([]tableColumnsBefore, error) {
+	tables, err := database.Migrator().GetTables()
+	if err != nil {
+		return nil, fmt.Errorf("list tables: %w", err)
+	}
 
-	for _, statement := range statements {
-		tableName, isDropTable := parseDropTableStatement(statement)
-		if !isDropTable {
-			continue
-		}
-		if _, alreadySeen := seenTables[tableName]; alreadySeen {
-			continue
-		}
-		seenTables[tableName] = struct{}{}
-
-		if !database.Migrator().HasTable(tableName) {
-			continue
-		}
-		columns, err := tableColumnNames(database, tableName)
+	snapshot := make([]tableColumnsBefore, 0, len(tables))
+	for _, table := range tables {
+		columns, err := tableColumnNames(database, table)
 		if err != nil {
 			return nil, err
 		}
-		snapshot = append(snapshot, droppedTableColumns{Table: tableName, Columns: columns})
+		snapshot = append(snapshot, tableColumnsBefore{Table: normalizeSQLIdentifier(table), Columns: columns})
 	}
-
 	return snapshot, nil
 }
 
-// requireDroppedTablesKeptTheirColumns fails the migration — and, being inside
-// its transaction, rolls back every statement it ran — when a table it dropped
-// came back without a column it had before.
+// requireNoTableSilentlyNarrowed fails the migration — and, being inside its
+// transaction, rolls back every statement it ran — when a table lost a column,
+// or the table itself, without the migration having said so.
 //
-// A migration that means to REMOVE a column says so with an explicit
-// `ALTER TABLE ... DROP COLUMN`, which this check does not look at; what it
-// refuses is a column removed as a side effect of rebuilding a table from a
-// narrower replacement, which is never what the migration author wrote and is
-// always the shape of a replay against a newer schema.
-func requireDroppedTablesKeptTheirColumns(database *gorm.DB, migration embeddedMigration, columnsBeforeTheDrop []droppedTableColumns) error {
-	for _, before := range columnsBeforeTheDrop {
+// Both losses are expressible, and each escape hatch is a thing the author
+// writes out by hand and names:
+//
+//   - a column removed by an explicit `ALTER TABLE t DROP COLUMN c` in this
+//     migration's own SQL is the visible form of that intent and is allowed;
+//   - a table removed on purpose carries the marker line
+//     `-- ovumcy:removes-table <name>` (see removedTableMarkerPattern), which
+//     names the one table it authorizes.
+//
+// A bare `DROP TABLE t` is deliberately NOT an authorization: it is the middle
+// of the rebuild idiom above, where the author's intent is to replace the
+// table, not to remove it — reading it as consent is exactly how migration 003
+// came to discard eight health columns while reporting success.
+func requireNoTableSilentlyNarrowed(database *gorm.DB, migration embeddedMigration, columnsBefore []tableColumnsBefore, statements []string) error {
+	removedOnPurpose := tablesRemovedOnPurpose(migration)
+	droppedColumns := columnsDroppedExplicitly(statements)
+
+	for _, before := range columnsBefore {
 		if !database.Migrator().HasTable(before.Table) {
+			if _, authorized := removedOnPurpose[before.Table]; authorized {
+				continue
+			}
 			return fmt.Errorf(
-				"refusing migration %s: it dropped table %s and did not put it back. Nothing was written — the migration was rolled back and the database is unchanged",
+				"refusing migration %s: table %s is gone after it ran and the migration does not say it meant to remove it — a rebuild that drops a table must put it back. Nothing was written: the migration was rolled back and the database is unchanged. If the removal is intended, the migration must carry the line `-- %s %s`; if it is not, and migration %s is in fact already applied, restore its schema_migrations row, otherwise restore from a backup",
 				migration.Name,
 				before.Table,
+				removedTableMarker,
+				before.Table,
+				migration.Version,
 			)
 		}
 
@@ -330,12 +372,13 @@ func requireDroppedTablesKeptTheirColumns(database *gorm.DB, migration embeddedM
 		}
 
 		missing := missingColumnNames(before.Columns, columnsNow)
+		missing = withoutExplicitlyDroppedColumns(missing, droppedColumns[before.Table])
 		if len(missing) == 0 {
 			continue
 		}
 
 		return fmt.Errorf(
-			"refusing migration %s: rebuilding table %s would have dropped column(s) %s, which held data before it ran — the migration rebuilds the table from the columns its own version knew about, so re-applying it on a newer schema discards everything added after it. Nothing was written — the migration was rolled back and the database is unchanged; if migration %s is in fact applied, restore its schema_migrations row, otherwise restore from a backup",
+			"refusing migration %s: table %s lost column(s) %s, which held data before it ran, and no statement in the migration drops them — a rebuild recreates the table from the columns its own version knew about, so re-applying it on a newer schema discards everything added after it. Nothing was written: the migration was rolled back and the database is unchanged; if migration %s is in fact applied, restore its schema_migrations row, otherwise restore from a backup",
 			migration.Name,
 			before.Table,
 			strings.Join(missing, ", "),
@@ -344,6 +387,63 @@ func requireDroppedTablesKeptTheirColumns(database *gorm.DB, migration embeddedM
 	}
 
 	return nil
+}
+
+// tablesRemovedOnPurpose returns the tables a migration declares it means to
+// remove for good.
+//
+// The declaration is a comment line of its own naming ONE table:
+//
+//	-- ovumcy:removes-table register_pickup_tokens
+//
+// It lives in the migration because that is where the intent is, reviewed as
+// one file with the statement that carries it out, and it cannot be written by
+// accident: the marker is namespaced, it is not English, and it authorizes only
+// the table it names — a migration that retires one table and rebuilds another
+// still has to put the rebuilt one back. It is read from the raw SQL rather
+// than from a statement chunk because the runner splits on `;` and a comment
+// can land anywhere.
+func tablesRemovedOnPurpose(migration embeddedMigration) map[string]struct{} {
+	removed := make(map[string]struct{})
+	for _, match := range removedTableMarkerPattern.FindAllStringSubmatch(migration.SQL, -1) {
+		removed[normalizeSQLIdentifier(match[1])] = struct{}{}
+	}
+	return removed
+}
+
+// columnsDroppedExplicitly returns table -> the columns this migration removes
+// with an `ALTER TABLE ... DROP COLUMN`, the visible form of that intent.
+func columnsDroppedExplicitly(statements []string) map[string]map[string]struct{} {
+	dropped := make(map[string]map[string]struct{})
+	for _, statement := range statements {
+		matches := dropColumnStatementPattern.FindStringSubmatch(stripLeadingSQLComments(statement))
+		if len(matches) != 3 {
+			continue
+		}
+		tableName := normalizeSQLIdentifier(matches[1])
+		if dropped[tableName] == nil {
+			dropped[tableName] = make(map[string]struct{})
+		}
+		dropped[tableName][normalizeSQLIdentifier(matches[2])] = struct{}{}
+	}
+	return dropped
+}
+
+// withoutExplicitlyDroppedColumns removes from missing the columns the
+// migration itself asked to drop.
+func withoutExplicitlyDroppedColumns(missing []string, droppedColumns map[string]struct{}) []string {
+	if len(droppedColumns) == 0 {
+		return missing
+	}
+
+	kept := make([]string, 0, len(missing))
+	for _, name := range missing {
+		if _, dropped := droppedColumns[name]; dropped {
+			continue
+		}
+		kept = append(kept, name)
+	}
+	return kept
 }
 
 // tablesDroppedByMigration returns, in file order and without repeats, the

--- a/internal/db/migrations_destructive_replay_test.go
+++ b/internal/db/migrations_destructive_replay_test.go
@@ -352,29 +352,98 @@ DROP TABLE register_pickup_tokens;`,
 	}
 }
 
-// TestAnExplicitColumnDropStillApplies keeps the column half expressible. Now
-// that the snapshot covers every table rather than the ones a migration drops,
-// an intentional column removal would be caught with the accidental ones unless
-// the visible form of that intent is read as the authorization it is.
-func TestAnExplicitColumnDropStillApplies(t *testing.T) {
-	databasePath := filepath.Join(t.TempDir(), "drop-column.db")
+// TestAColumnDisappearanceTheMigrationExplainsStillApplies keeps the column
+// half expressible. Now that the snapshot covers every table rather than the
+// ones a migration drops, a column that goes missing on purpose would be
+// refused along with the accidental ones unless the visible forms of that
+// intent are read as the authorization they are.
+//
+// There are two such forms and both engines support both. A DROP COLUMN
+// retires the column. A RENAME COLUMN does not remove anything at all: the
+// values are still there under the new name, so refusing it would have the
+// guard reporting a loss that did not happen — the mirror of the defect it
+// exists to catch — and advising a backup restore for a routine operation.
+func TestAColumnDisappearanceTheMigrationExplainsStillApplies(t *testing.T) {
+	for _, testCase := range []struct {
+		name        string
+		sql         string
+		goneColumn  string
+		addedColumn string
+	}{
+		{
+			name: "an explicit drop",
+			sql: `-- 900 retires the shown_period_tip flag.
+ALTER TABLE users DROP COLUMN shown_period_tip;`,
+			goneColumn: "shown_period_tip",
+		},
+		{
+			name: "a rename, which loses nothing",
+			sql: `-- 900 renames usage_goal to usage_intent.
+ALTER TABLE users RENAME COLUMN usage_goal TO usage_intent;`,
+			goneColumn:  "usage_goal",
+			addedColumn: "usage_intent",
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			databasePath := filepath.Join(t.TempDir(), "column-intent.db")
+			seedFullyMigratedDatabaseWithSentinelDay(t, databasePath)
+
+			requireNoErr(t, applyFixtureMigration(
+				t, databasePath, "900_fixture_column_intent.sql", testCase.sql,
+			), "a column disappearance the migration explains must apply")
+
+			reader := openSQLiteFileForReplayTest(t, databasePath)
+			defer closeReplayDatabase(t, reader)
+
+			if reader.Migrator().HasColumn("users", testCase.goneColumn) {
+				t.Errorf("the migration was accepted but users.%s is still there", testCase.goneColumn)
+			}
+			if testCase.addedColumn != "" && !reader.Migrator().HasColumn("users", testCase.addedColumn) {
+				t.Errorf("the rename was accepted but users.%s is not there", testCase.addedColumn)
+			}
+			if !reader.Migrator().HasColumn("users", "email") {
+				t.Error("the migration took a column it did not name")
+			}
+		})
+	}
+}
+
+// TestARenameDoesNotExcuseAColumnLostBesideIt pins how far the rename hatch
+// reaches: it authorizes the one name the statement renames and nothing else.
+//
+// The fixture renames daily_logs.notes and, in the same migration, rebuilds the
+// table from a replacement that omits every other late column — the shape of a
+// replay against a newer schema, wearing one legitimate rename. The refusal
+// must name what was really lost and must not name the renamed column, or the
+// hatch would be reading one explained disappearance as consent for the rest of
+// the table.
+func TestARenameDoesNotExcuseAColumnLostBesideIt(t *testing.T) {
+	databasePath := filepath.Join(t.TempDir(), "rename-and-lose.db")
 	seedFullyMigratedDatabaseWithSentinelDay(t, databasePath)
 
-	requireNoErr(t, applyFixtureMigration(
-		t, databasePath, "900_fixture_drop_column.sql",
-		`-- 900 retires the shown_period_tip flag.
-ALTER TABLE users DROP COLUMN shown_period_tip;`,
-	), "an explicit column drop must apply")
+	err := applyFixtureMigration(t, databasePath, "900_fixture_rename_and_lose.sql", `ALTER TABLE daily_logs RENAME COLUMN notes TO note_text;
+ALTER TABLE daily_logs RENAME TO daily_logs_old;
+CREATE TABLE daily_logs (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id INTEGER NOT NULL,
+  date DATE NOT NULL,
+  note_text TEXT
+);
+INSERT INTO daily_logs (id, user_id, date, note_text)
+SELECT id, user_id, date, note_text FROM daily_logs_old;
+DROP TABLE daily_logs_old;`)
 
-	reader := openSQLiteFileForReplayTest(t, databasePath)
-	defer closeReplayDatabase(t, reader)
+	if err == nil {
+		t.Fatal("expected a rebuild that loses columns beside a rename to be refused")
+	}
+	if !strings.Contains(err.Error(), "mood") {
+		t.Errorf("the refusal must name the column that was actually lost; got %v", err)
+	}
+	if strings.Contains(err.Error(), "notes") {
+		t.Errorf("the refusal must not name the renamed column, whose values are under the new name; got %v", err)
+	}
 
-	if reader.Migrator().HasColumn("users", "shown_period_tip") {
-		t.Error("the explicit column drop was accepted but the column is still there")
-	}
-	if !reader.Migrator().HasColumn("users", "email") {
-		t.Error("the explicit column drop took a column it did not name")
-	}
+	assertSentinelDayIntact(t, databasePath)
 }
 
 // applyFixtureMigration runs one synthetic migration through the real

--- a/internal/db/migrations_destructive_replay_test.go
+++ b/internal/db/migrations_destructive_replay_test.go
@@ -1,0 +1,496 @@
+package db
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+)
+
+// dropTableTokenPattern finds the DROP TABLE token pair anywhere in a migration.
+// It is deliberately independent of the runner's own anchored detection: the
+// sweep below decides for itself which migrations destroy a table and then
+// requires the runner to agree about them.
+var dropTableTokenPattern = regexp.MustCompile(`(?i)\bDROP\s+TABLE\b`)
+
+// replaySentinelDay is the day row every case here seeds: one value in each
+// daily_logs column that a migration AFTER 003 added, so a rebuild that copies
+// only the nine columns of migration 001 is visible as data and not only as
+// schema.
+type replaySentinelDay struct {
+	Date            string
+	Mood            int
+	SexActivity     string
+	BBT             float64
+	CervicalMucus   string
+	CycleStart      bool
+	IsUncertain     bool
+	CycleFactorKeys string
+	PregnancyTest   string
+}
+
+func replaySentinel() replaySentinelDay {
+	return replaySentinelDay{
+		Date:            "2026-03-05",
+		Mood:            4,
+		SexActivity:     "protected",
+		BBT:             36.55,
+		CervicalMucus:   "creamy",
+		CycleStart:      true,
+		IsUncertain:     true,
+		CycleFactorKeys: `["stress"]`,
+		PregnancyTest:   "positive",
+	}
+}
+
+// TestNoMissingSchemaMigrationsRowCostsAColumnOrARow deletes each
+// schema_migrations row in turn from a fully migrated database, reopens it, and
+// requires that the reopen cost neither a column nor a stored value.
+//
+// The runner re-applies a migration whose ledger row is absent — a restore from
+// a backup taken before the row was written, or an operator pruning the table —
+// and until this guard the only thing that made a replay safe was
+// shouldSkipStatement, which recognizes `ALTER TABLE ... ADD COLUMN` and
+// nothing else. A migration that reconciles a table by rebuilding it copies the
+// columns ITS OWN version knew about and drops the rest: replaying migration
+// 003 on a current database rebuilt daily_logs from the nine columns of
+// migration 001 and silently discarded mood, sex_activity, bbt, cervical_mucus,
+// cycle_start, is_uncertain, cycle_factor_keys and pregnancy_test — eight
+// health columns and every value in them — on a database that was already
+// fully migrated.
+//
+// A case passes on either outcome, because both are non-destructive and which
+// one applies is the runner's business: the boot completes, or the boot is
+// refused by name. What it may never do is change the schema or the data.
+//
+// Deliberately narrower than "the schema is unchanged", and the limit is here
+// so no reader concludes the broader claim: this compares TABLES, their COLUMN
+// names, and the seeded day's stored values. INDEXES are out of scope, and one
+// divergence in that axis is known and measured — migrations 001 and 024 both
+// end with `CREATE INDEX IF NOT EXISTS idx_daily_logs_date`, which migration 025
+// later drops, so replaying either recreates a redundant index. That costs
+// write amplification, never a column or a row, and closing it needs a
+// different mechanism from this one.
+func TestNoMissingSchemaMigrationsRowCostsAColumnOrARow(t *testing.T) {
+	migrations, err := loadEmbeddedMigrations(DriverSQLite)
+	requireNoErr(t, err, "load embedded migrations")
+	if len(migrations) == 0 {
+		t.Fatal("loaded no embedded migrations — the sweep would assert nothing")
+	}
+
+	bootsCompleted := 0
+	bootsRefused := 0
+
+	for _, migration := range migrations {
+		expectRefusal := dropTableTokenPattern.MatchString(migration.SQL)
+
+		t.Run("without the row for "+migration.Version, func(t *testing.T) {
+			databasePath := filepath.Join(t.TempDir(), "replay-"+migration.Version+".db")
+			seedFullyMigratedDatabaseWithSentinelDay(t, databasePath)
+
+			before := readReplaySchemaAndDays(t, databasePath)
+			deleteSchemaMigrationsRows(t, databasePath, migration.Version)
+
+			bootErr := reopenMigratedDatabaseForReplayTest(t, databasePath)
+			after := readReplaySchemaAndDays(t, databasePath)
+
+			if bootErr == nil {
+				bootsCompleted++
+				if expectRefusal {
+					t.Errorf(
+						"migration %s drops a table, so re-applying it against the current schema must be refused, but the boot completed",
+						migration.Name,
+					)
+				}
+			} else {
+				bootsRefused++
+				if !expectRefusal {
+					t.Fatalf(
+						"boot failed after removing the schema_migrations row for %s, which drops no table and must simply re-apply: %v",
+						migration.Name, bootErr,
+					)
+				}
+				if !strings.Contains(bootErr.Error(), migration.Name) {
+					t.Errorf(
+						"the refusal must name the migration it stopped so an operator can act on it; got %v",
+						bootErr,
+					)
+				}
+			}
+
+			assertReplayStateUnchanged(t, migration, before, after)
+		})
+	}
+
+	// Anchor both paths: a harness whose reopen never re-applies anything, or
+	// one whose reopen always fails, would leave one of these at zero and make
+	// every case above agree with itself.
+	if bootsCompleted == 0 {
+		t.Error("no case completed its boot — the sweep never exercised a re-applied migration")
+	}
+	if bootsRefused == 0 {
+		t.Error("no case was refused — the sweep never exercised the destructive-replay guard")
+	}
+}
+
+// TestMigration003ReplayOnACurrentSchemaIsRefusedWithTheHealthColumnsIntact is
+// the destructive-replay case spelled out: the audit's repro deleted only the
+// schema_migrations row for 003, reopened a current database, and watched the
+// live mood column disappear. Here the reopen is refused by name and the column
+// and its value are still there.
+func TestMigration003ReplayOnACurrentSchemaIsRefusedWithTheHealthColumnsIntact(t *testing.T) {
+	databasePath := filepath.Join(t.TempDir(), "replay-003.db")
+	seedFullyMigratedDatabaseWithSentinelDay(t, databasePath)
+	deleteSchemaMigrationsRows(t, databasePath, "003")
+
+	bootErr := reopenMigratedDatabaseForReplayTest(t, databasePath)
+	if bootErr == nil {
+		t.Fatal("expected the boot to refuse re-applying migration 003 against a schema that has moved past it")
+	}
+	for _, expected := range []string{"003_daily_logs_schema_reconcile.sql", "034"} {
+		if !strings.Contains(bootErr.Error(), expected) {
+			t.Errorf("the refusal must name %q so an operator knows what stopped and why; got %v", expected, bootErr)
+		}
+	}
+
+	assertSentinelDayIntact(t, databasePath)
+}
+
+// TestAWipedSchemaMigrationsLedgerKeepsEveryDailyLogsColumn covers the case the
+// version comparison cannot see. When the whole ledger is gone — a data-only
+// restore, a dropped bookkeeping table — no LATER migration is recorded either,
+// so nothing marks 003 as a replay: the set simply runs again from 001. The
+// second half of the guard measures the effect instead of the ledger, inside
+// the migration's own transaction, so the rebuild is rolled back with every
+// column and value still in place.
+func TestAWipedSchemaMigrationsLedgerKeepsEveryDailyLogsColumn(t *testing.T) {
+	databasePath := filepath.Join(t.TempDir(), "replay-wiped-ledger.db")
+	seedFullyMigratedDatabaseWithSentinelDay(t, databasePath)
+	deleteSchemaMigrationsRows(t, databasePath)
+
+	bootErr := reopenMigratedDatabaseForReplayTest(t, databasePath)
+	if bootErr == nil {
+		t.Fatal("expected the boot to refuse rebuilding daily_logs from a wiped schema_migrations ledger")
+	}
+	for _, expected := range []string{"003_daily_logs_schema_reconcile.sql", "daily_logs", "mood"} {
+		if !strings.Contains(bootErr.Error(), expected) {
+			t.Errorf("the refusal must name %q so an operator knows what it protected; got %v", expected, bootErr)
+		}
+	}
+
+	assertSentinelDayIntact(t, databasePath)
+}
+
+// TestThePostgresMigrationTreeContainsNoTableDrop keeps the sweep's coverage
+// claim true of both supported engines.
+//
+// The sweep above runs on SQLite because that is where the rebuild pattern
+// lives: SQLite cannot drop a constraint or a NOT NULL in place, so migrations
+// 003 and 024 reconcile daily_logs by rebuilding it, while their Postgres
+// counterparts are a `SELECT 1;` and an `ALTER TABLE`. The guard itself is in
+// the runner and therefore dialect-neutral, but the sweep that proves it is
+// not — so a rebuild landing in the Postgres tree later would be a destructive
+// replay no test here watches. This asserts the premise instead of assuming
+// it, and needs no container to do so.
+func TestThePostgresMigrationTreeContainsNoTableDrop(t *testing.T) {
+	migrations, err := loadEmbeddedMigrations(DriverPostgres)
+	requireNoErr(t, err, "load embedded postgres migrations")
+	if len(migrations) == 0 {
+		t.Fatal("loaded no embedded postgres migrations — this would assert nothing")
+	}
+
+	for _, migration := range migrations {
+		if dropTableTokenPattern.MatchString(migration.SQL) {
+			t.Errorf(
+				"postgres migration %s drops a table: the destructive-replay sweep runs on SQLite only, so this rebuild would replay unwatched on the other supported engine — extend the sweep to Postgres before landing it",
+				migration.Name,
+			)
+		}
+	}
+}
+
+// TestParseDropTableStatementSeesPastLeadingComments pins the detection the
+// guard rests on: the prose header splitSQLStatements leaves attached to a
+// chunk is skipped, comment text is never read as SQL, and a statement that
+// drops something other than a table stays unrecognized.
+func TestParseDropTableStatementSeesPastLeadingComments(t *testing.T) {
+	for _, testCase := range []struct {
+		name          string
+		statement     string
+		expectedTable string
+		expectedMatch bool
+	}{
+		{
+			name:          "bare drop",
+			statement:     "DROP TABLE daily_logs",
+			expectedTable: "daily_logs",
+			expectedMatch: true,
+		},
+		{
+			name:          "drop behind the chunk's prose header",
+			statement:     "-- 3) Swap old and new tables only after a successful copy.\nDROP TABLE daily_logs",
+			expectedTable: "daily_logs",
+			expectedMatch: true,
+		},
+		{
+			name:          "if exists form",
+			statement:     "DROP TABLE IF EXISTS daily_logs_new",
+			expectedTable: "daily_logs_new",
+			expectedMatch: true,
+		},
+		{
+			name:          "quoted identifier",
+			statement:     `DROP TABLE "daily_logs"`,
+			expectedTable: "daily_logs",
+			expectedMatch: true,
+		},
+		{
+			name:          "a comment mentioning a drop is not a drop",
+			statement:     "-- Rollback: DROP TABLE daily_logs\nCREATE INDEX IF NOT EXISTS idx_daily_logs_user_id ON daily_logs(user_id)",
+			expectedMatch: false,
+		},
+		{
+			name:          "dropping an index is not dropping a table",
+			statement:     "DROP INDEX IF EXISTS idx_daily_logs_date",
+			expectedMatch: false,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			table, isDropTable := parseDropTableStatement(testCase.statement)
+			if isDropTable != testCase.expectedMatch {
+				t.Fatalf("parseDropTableStatement(%q) matched=%v, want %v", testCase.statement, isDropTable, testCase.expectedMatch)
+			}
+			if table != testCase.expectedTable {
+				t.Errorf("parseDropTableStatement(%q) table=%q, want %q", testCase.statement, table, testCase.expectedTable)
+			}
+		})
+	}
+}
+
+// replayState is what a case compares before and after the reopen: every
+// table's column names, and the stored values of the seeded day.
+type replayState struct {
+	Columns map[string][]string
+	Days    []map[string]string
+}
+
+// seedFullyMigratedDatabaseWithSentinelDay boots a clean database through
+// OpenDatabase — so its schema is the one the real migrations produce — and
+// writes one owner and one day carrying a value in every column added after
+// migration 003. The connection is closed before returning, so the caller owns
+// the file.
+func seedFullyMigratedDatabaseWithSentinelDay(t *testing.T, databasePath string) {
+	t.Helper()
+
+	database, err := OpenDatabase(Config{Driver: DriverSQLite, SQLitePath: databasePath})
+	requireNoErr(t, err, "open sqlite for seeding")
+	defer closeReplayDatabase(t, database)
+
+	requireNoErr(t, database.Exec(
+		`INSERT INTO users (email, password_hash, role, created_at) VALUES (?, ?, ?, CURRENT_TIMESTAMP)`,
+		"replay-owner@example.com", "replay-hash", "owner",
+	).Error, "seed owner")
+
+	sentinel := replaySentinel()
+	requireNoErr(t, database.Exec(
+		`INSERT INTO daily_logs (
+			user_id, date, is_period, flow, symptom_ids, notes, created_at, updated_at,
+			mood, sex_activity, bbt, cervical_mucus, cycle_start, is_uncertain,
+			cycle_factor_keys, pregnancy_test
+		) VALUES (
+			(SELECT id FROM users WHERE email = ?), ?, 1, 'light', '[1,2]', 'replay-sentinel',
+			CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, ?, ?, ?, ?, ?, ?, ?, ?
+		)`,
+		"replay-owner@example.com",
+		sentinel.Date,
+		sentinel.Mood,
+		sentinel.SexActivity,
+		sentinel.BBT,
+		sentinel.CervicalMucus,
+		sentinel.CycleStart,
+		sentinel.IsUncertain,
+		sentinel.CycleFactorKeys,
+		sentinel.PregnancyTest,
+	).Error, "seed sentinel day")
+}
+
+// deleteSchemaMigrationsRows removes the named ledger rows, or the whole ledger
+// when no version is given. It opens the file directly rather than through
+// OpenDatabase, so preparing a case can never itself run a migration.
+func deleteSchemaMigrationsRows(t *testing.T, databasePath string, versions ...string) {
+	t.Helper()
+
+	reader := openSQLiteFileForReplayTest(t, databasePath)
+	defer closeReplayDatabase(t, reader)
+
+	if len(versions) == 0 {
+		requireNoErr(t, reader.Exec(`DELETE FROM schema_migrations`).Error, "wipe schema_migrations")
+		return
+	}
+	for _, version := range versions {
+		result := reader.Exec(`DELETE FROM schema_migrations WHERE version = ?`, version)
+		requireNoErr(t, result.Error, "delete schema_migrations row "+version)
+		if result.RowsAffected != 1 {
+			t.Fatalf("expected to delete exactly one schema_migrations row for version %s, deleted %d", version, result.RowsAffected)
+		}
+	}
+}
+
+// reopenMigratedDatabaseForReplayTest reopens the database through the real
+// boot path and returns whatever the migration runner decided, closing the
+// handle when the boot succeeded.
+func reopenMigratedDatabaseForReplayTest(t *testing.T, databasePath string) error {
+	t.Helper()
+
+	database, err := OpenDatabase(Config{Driver: DriverSQLite, SQLitePath: databasePath})
+	if err != nil {
+		return err
+	}
+	closeReplayDatabase(t, database)
+	return nil
+}
+
+// readReplaySchemaAndDays reads the comparison state through a plain connection
+// that applies no migration, so the reader can never repair what it measures.
+func readReplaySchemaAndDays(t *testing.T, databasePath string) replayState {
+	t.Helper()
+
+	reader := openSQLiteFileForReplayTest(t, databasePath)
+	defer closeReplayDatabase(t, reader)
+
+	tables, err := reader.Migrator().GetTables()
+	requireNoErr(t, err, "list tables")
+
+	columns := make(map[string][]string, len(tables))
+	for _, table := range tables {
+		names, err := tableColumnNames(reader, table)
+		requireNoErr(t, err, "read columns of "+table)
+		sort.Strings(names)
+		columns[strings.ToLower(table)] = names
+	}
+
+	return replayState{Columns: columns, Days: readDailyLogRowsForReplayTest(t, reader)}
+}
+
+// readDailyLogRowsForReplayTest renders every daily_logs row as column ->
+// printed value. Reading whole rows rather than named fields is what makes a
+// lost column visible: a scan into a struct would leave the field at its zero
+// value and report nothing.
+func readDailyLogRowsForReplayTest(t *testing.T, reader *gorm.DB) []map[string]string {
+	t.Helper()
+
+	rawRows := make([]map[string]any, 0)
+	requireNoErr(t, reader.Table("daily_logs").Order("id").Find(&rawRows).Error, "read daily_logs rows")
+
+	rows := make([]map[string]string, 0, len(rawRows))
+	for _, rawRow := range rawRows {
+		row := make(map[string]string, len(rawRow))
+		for column, value := range rawRow {
+			row[strings.ToLower(column)] = fmt.Sprintf("%v", value)
+		}
+		rows = append(rows, row)
+	}
+	return rows
+}
+
+// assertReplayStateUnchanged is the sweep's whole verdict: whatever the runner
+// decided, the reopen may not have cost a table, a column or a stored value.
+func assertReplayStateUnchanged(t *testing.T, migration embeddedMigration, before replayState, after replayState) {
+	t.Helper()
+
+	for table, columnsBefore := range before.Columns {
+		columnsAfter, stillThere := after.Columns[table]
+		if !stillThere {
+			t.Fatalf("reopening without the schema_migrations row for %s removed table %s", migration.Name, table)
+		}
+		if strings.Join(columnsBefore, ",") != strings.Join(columnsAfter, ",") {
+			t.Fatalf(
+				"reopening without the schema_migrations row for %s changed the columns of %s\n before: %s\n  after: %s",
+				migration.Name, table, strings.Join(columnsBefore, ","), strings.Join(columnsAfter, ","),
+			)
+		}
+	}
+
+	if len(before.Days) != len(after.Days) {
+		t.Fatalf(
+			"reopening without the schema_migrations row for %s changed the daily_logs row count from %d to %d",
+			migration.Name, len(before.Days), len(after.Days),
+		)
+	}
+	for index, dayBefore := range before.Days {
+		dayAfter := after.Days[index]
+		for column, valueBefore := range dayBefore {
+			valueAfter, stillThere := dayAfter[column]
+			if !stillThere {
+				t.Fatalf("reopening without the schema_migrations row for %s lost daily_logs.%s", migration.Name, column)
+			}
+			if valueBefore != valueAfter {
+				t.Fatalf(
+					"reopening without the schema_migrations row for %s rewrote daily_logs.%s from %q to %q",
+					migration.Name, column, valueBefore, valueAfter,
+				)
+			}
+		}
+	}
+}
+
+// assertSentinelDayIntact names the columns a migration-003 replay destroys and
+// checks each one still holds what was written, so a failure reads as the data
+// loss it is rather than as a schema diff.
+func assertSentinelDayIntact(t *testing.T, databasePath string) {
+	t.Helper()
+
+	reader := openSQLiteFileForReplayTest(t, databasePath)
+	defer closeReplayDatabase(t, reader)
+
+	rows := readDailyLogRowsForReplayTest(t, reader)
+	if len(rows) != 1 {
+		t.Fatalf("expected the seeded day to survive, found %d daily_logs rows", len(rows))
+	}
+
+	sentinel := replaySentinel()
+	for column, expected := range map[string]string{
+		"mood":           fmt.Sprintf("%d", sentinel.Mood),
+		"sex_activity":   sentinel.SexActivity,
+		"bbt":            fmt.Sprintf("%v", sentinel.BBT),
+		"cervical_mucus": sentinel.CervicalMucus,
+		// SQLite stores a boolean as an integer, and the reader prints back
+		// what is stored rather than what the seed passed in.
+		"cycle_start":       "1",
+		"is_uncertain":      "1",
+		"cycle_factor_keys": sentinel.CycleFactorKeys,
+		"pregnancy_test":    sentinel.PregnancyTest,
+	} {
+		value, stillThere := rows[0][column]
+		if !stillThere {
+			t.Errorf("daily_logs.%s is gone — the replay dropped a health column and its values", column)
+			continue
+		}
+		if value != expected {
+			t.Errorf("daily_logs.%s = %q, want %q", column, value, expected)
+		}
+	}
+}
+
+// openSQLiteFileForReplayTest opens the database file directly, bypassing
+// OpenDatabase and therefore the migration runner.
+func openSQLiteFileForReplayTest(t *testing.T, databasePath string) *gorm.DB {
+	t.Helper()
+
+	reader, err := gorm.Open(sqlite.Open(databasePath), &gorm.Config{})
+	requireNoErr(t, err, "open sqlite file directly")
+	return reader
+}
+
+func closeReplayDatabase(t *testing.T, database *gorm.DB) {
+	t.Helper()
+
+	sqlDB, err := database.DB()
+	requireNoErr(t, err, "get sql db handle")
+	requireNoErr(t, sqlDB.Close(), "close sql db handle")
+}

--- a/internal/db/migrations_destructive_replay_test.go
+++ b/internal/db/migrations_destructive_replay_test.go
@@ -186,6 +186,211 @@ func TestAWipedSchemaMigrationsLedgerKeepsEveryDailyLogsColumn(t *testing.T) {
 	assertSentinelDayIntact(t, databasePath)
 }
 
+// TestARebuildNarrowingATableIsRefusedInEitherSQLiteIdiom runs synthetic
+// migrations through the real applyMigration, because the shape that matters
+// most is the one the embedded tree does NOT contain.
+//
+// SQLite has two ways to rebuild a table. Migrations 003 and 024 use the first:
+// create the replacement beside the original, copy, DROP the original, rename
+// the replacement onto its name. The second renames first — `ALTER TABLE t
+// RENAME TO t_old`, create t afresh, copy back, drop t_old — and it narrows t
+// exactly as much, while dropping only a name that did not exist when the
+// migration started. A guard that measured the tables a migration textually
+// drops saw nothing there: t_old is not in the schema to snapshot, and t is
+// never dropped at all. With a ledger lost entirely, which is the case the
+// effect half exists for, such a migration would have replayed and narrowed
+// the table in silence.
+//
+// Each idiom is run twice, and the widening case is the anchor: a rebuild that
+// preserves every column must still apply, or the guard would be passing by
+// refusing everything.
+func TestARebuildNarrowingATableIsRefusedInEitherSQLiteIdiom(t *testing.T) {
+	const narrowReplacement = `CREATE TABLE %s (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id INTEGER NOT NULL,
+  date DATE NOT NULL
+);
+INSERT INTO %s (id, user_id, date) SELECT id, user_id, date FROM %s;`
+
+	const wideReplacement = `CREATE TABLE %s (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id INTEGER NOT NULL,
+  date DATE NOT NULL,
+  is_period BOOLEAN NOT NULL DEFAULT 0,
+  flow TEXT NOT NULL DEFAULT 'none',
+  symptom_ids TEXT,
+  notes TEXT,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  mood INTEGER NOT NULL DEFAULT 0,
+  sex_activity TEXT NOT NULL DEFAULT 'none',
+  bbt REAL,
+  cervical_mucus TEXT NOT NULL DEFAULT 'none',
+  cycle_start BOOLEAN NOT NULL DEFAULT 0,
+  is_uncertain BOOLEAN NOT NULL DEFAULT 0,
+  cycle_factor_keys TEXT NOT NULL DEFAULT '[]',
+  pregnancy_test TEXT NOT NULL DEFAULT 'none'
+);
+INSERT INTO %s SELECT * FROM %s;`
+
+	// dropFirst is the idiom of migrations 003 and 024; renameFirst is the one
+	// the embedded tree does not use and the guard used to miss.
+	dropFirst := func(replacement string) string {
+		return fmt.Sprintf(replacement, "daily_logs_new", "daily_logs_new", "daily_logs") + `
+DROP TABLE daily_logs;
+ALTER TABLE daily_logs_new RENAME TO daily_logs;`
+	}
+	renameFirst := func(replacement string) string {
+		return `ALTER TABLE daily_logs RENAME TO daily_logs_old;
+` + fmt.Sprintf(replacement, "daily_logs", "daily_logs", "daily_logs_old") + `
+DROP TABLE daily_logs_old;`
+	}
+
+	for _, testCase := range []struct {
+		name          string
+		sql           string
+		expectRefusal bool
+	}{
+		{name: "drop-first rebuild that narrows", sql: dropFirst(narrowReplacement), expectRefusal: true},
+		{name: "rename-first rebuild that narrows", sql: renameFirst(narrowReplacement), expectRefusal: true},
+		{name: "drop-first rebuild that preserves every column", sql: dropFirst(wideReplacement)},
+		{name: "rename-first rebuild that preserves every column", sql: renameFirst(wideReplacement)},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			databasePath := filepath.Join(t.TempDir(), "rebuild.db")
+			seedFullyMigratedDatabaseWithSentinelDay(t, databasePath)
+
+			err := applyFixtureMigration(t, databasePath, "900_fixture_rebuild.sql", testCase.sql)
+
+			if !testCase.expectRefusal {
+				requireNoErr(t, err, "a rebuild that preserves every column must apply")
+				assertSentinelDayIntact(t, databasePath)
+				return
+			}
+
+			if err == nil {
+				t.Fatal("expected the narrowing rebuild to be refused")
+			}
+			for _, expected := range []string{"900_fixture_rebuild.sql", "daily_logs", "mood"} {
+				if !strings.Contains(err.Error(), expected) {
+					t.Errorf("the refusal must name %q; got %v", expected, err)
+				}
+			}
+			assertSentinelDayIntact(t, databasePath)
+		})
+	}
+}
+
+// TestRemovingATableNeedsTheMigrationToSayItMeantTo covers the other side of
+// the same check: a table that does not come back is a defect when it is the
+// middle of a rebuild and the whole point when a migration retires a table for
+// good, and only the migration can tell the two apart.
+//
+// The marker is what says so. It is namespaced, it is not prose, and it names
+// the one table it authorizes, so it cannot be written by accident — and a bare
+// `DROP TABLE` deliberately does not count, since that is the middle statement
+// of every rebuild in the tree.
+func TestRemovingATableNeedsTheMigrationToSayItMeantTo(t *testing.T) {
+	for _, testCase := range []struct {
+		name          string
+		sql           string
+		expectRefusal bool
+	}{
+		{
+			name:          "an unmarked removal is refused",
+			sql:           "DROP TABLE register_pickup_tokens;",
+			expectRefusal: true,
+		},
+		{
+			name: "a marker naming a different table does not authorize this one",
+			sql: `-- ovumcy:removes-table oidc_logout_states
+DROP TABLE register_pickup_tokens;`,
+			expectRefusal: true,
+		},
+		{
+			name: "a marker inside prose is not a marker",
+			sql: `-- This migration does not use ovumcy:removes-table register_pickup_tokens yet.
+DROP TABLE register_pickup_tokens;`,
+			expectRefusal: true,
+		},
+		{
+			name: "a marked removal applies",
+			sql: `-- 900 retires register_pickup_tokens, whose flow was withdrawn.
+-- ovumcy:removes-table register_pickup_tokens
+DROP TABLE register_pickup_tokens;`,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			databasePath := filepath.Join(t.TempDir(), "removal.db")
+			seedFullyMigratedDatabaseWithSentinelDay(t, databasePath)
+
+			err := applyFixtureMigration(t, databasePath, "900_fixture_removal.sql", testCase.sql)
+
+			reader := openSQLiteFileForReplayTest(t, databasePath)
+			defer closeReplayDatabase(t, reader)
+
+			if !testCase.expectRefusal {
+				requireNoErr(t, err, "a marked removal must apply")
+				if reader.Migrator().HasTable("register_pickup_tokens") {
+					t.Error("the marked removal was accepted but the table is still there")
+				}
+				return
+			}
+
+			if err == nil {
+				t.Fatal("expected the unmarked removal to be refused")
+			}
+			for _, expected := range []string{"register_pickup_tokens", removedTableMarker} {
+				if !strings.Contains(err.Error(), expected) {
+					t.Errorf("the refusal must name %q so the author can express the intent; got %v", expected, err)
+				}
+			}
+			if !reader.Migrator().HasTable("register_pickup_tokens") {
+				t.Error("the refusal must roll the migration back, but the table is gone")
+			}
+		})
+	}
+}
+
+// TestAnExplicitColumnDropStillApplies keeps the column half expressible. Now
+// that the snapshot covers every table rather than the ones a migration drops,
+// an intentional column removal would be caught with the accidental ones unless
+// the visible form of that intent is read as the authorization it is.
+func TestAnExplicitColumnDropStillApplies(t *testing.T) {
+	databasePath := filepath.Join(t.TempDir(), "drop-column.db")
+	seedFullyMigratedDatabaseWithSentinelDay(t, databasePath)
+
+	requireNoErr(t, applyFixtureMigration(
+		t, databasePath, "900_fixture_drop_column.sql",
+		`-- 900 retires the shown_period_tip flag.
+ALTER TABLE users DROP COLUMN shown_period_tip;`,
+	), "an explicit column drop must apply")
+
+	reader := openSQLiteFileForReplayTest(t, databasePath)
+	defer closeReplayDatabase(t, reader)
+
+	if reader.Migrator().HasColumn("users", "shown_period_tip") {
+		t.Error("the explicit column drop was accepted but the column is still there")
+	}
+	if !reader.Migrator().HasColumn("users", "email") {
+		t.Error("the explicit column drop took a column it did not name")
+	}
+}
+
+// applyFixtureMigration runs one synthetic migration through the real
+// applyMigration against a fully migrated database, so a fixture exercises the
+// guard exactly as an embedded migration would. The version is above every
+// embedded one, so the version-comparison half never fires and what a case
+// measures is the effect half alone.
+func applyFixtureMigration(t *testing.T, databasePath string, name string, sqlText string) error {
+	t.Helper()
+
+	database := openSQLiteFileForReplayTest(t, databasePath)
+	defer closeReplayDatabase(t, database)
+
+	return applyMigration(database, embeddedMigration{Version: "900", Order: 900, Name: name, SQL: sqlText})
+}
+
 // TestThePostgresMigrationTreeContainsNoTableDrop keeps the sweep's coverage
 // claim true of both supported engines.
 //

--- a/internal/db/migrations_inspection_failure_test.go
+++ b/internal/db/migrations_inspection_failure_test.go
@@ -1,0 +1,389 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// The destructive-replay guard decides whether a migration may run by READING
+// the schema: it lists the tables, reads the columns of each one before the
+// first statement, and reads them again after the last. Every one of those
+// reads can fail — a connection lost mid-migration, a catalog read the driver
+// refuses — and what the runner does then is the subject of this file.
+//
+// The answer has to be "refuse", never "continue with what was read": a
+// snapshot that came back empty because the read failed would compare equal to
+// any schema at all, and the guard would wave through exactly the rebuild it
+// exists to stop. The cases below therefore assert two things together — the
+// error names the migration and the read that failed, and NOTHING was written.
+//
+// The failure is injected at the connection pool rather than by breaking the
+// database file, because the branch has to be entered on a schema that is
+// otherwise healthy: a corrupt file would fail the statements too, and the case
+// would no longer be about the inspection at all. The pool is a thin wrapper
+// around a real SQLite connection, so every read that is not the injected one
+// is the real thing.
+
+// sqliteTableListQuery and sqliteTableColumnsQuery are the catalog reads the
+// gorm SQLite migrator issues for GetTables and ColumnTypes respectively. They
+// are matched as substrings of the SQL that reaches the pool, so a case names
+// the read it takes out instead of failing the connection wholesale.
+const (
+	sqliteTableListQuery    = "SELECT name FROM sqlite_master"
+	sqliteTableColumnsQuery = "SELECT sql FROM sqlite_master"
+)
+
+// errInjectedCatalogReadFailure is what the injected read returns. Each case
+// asserts it is still in the chain the runner returns, so a refusal cannot be
+// mistaken for one of the guard's own verdicts.
+var errInjectedCatalogReadFailure = errors.New("injected catalog read failure")
+
+// catalogReadFault is one injected failure: which read fails, and — for the
+// post-condition case — from which moment on.
+//
+// armOnExec is what makes the "after the statements ran" case expressible. The
+// snapshot and the post-condition issue the SAME query, so a fault armed from
+// the start would fail the snapshot and the migration would never reach its
+// statements. Arming on a statement of the migration's own SQL puts the failure
+// exactly between the two reads.
+type catalogReadFault struct {
+	mu        sync.Mutex
+	failQuery string
+	armOnExec string
+	armed     bool
+}
+
+func newCatalogReadFault(failQuery string) *catalogReadFault {
+	return &catalogReadFault{failQuery: failQuery, armed: true}
+}
+
+func newCatalogReadFaultArmedByStatement(failQuery string, armOnExec string) *catalogReadFault {
+	return &catalogReadFault{failQuery: failQuery, armOnExec: armOnExec}
+}
+
+func (fault *catalogReadFault) observeExec(query string) {
+	if fault.armOnExec == "" {
+		return
+	}
+	fault.mu.Lock()
+	defer fault.mu.Unlock()
+	if strings.Contains(query, fault.armOnExec) {
+		fault.armed = true
+	}
+}
+
+func (fault *catalogReadFault) shouldFail(query string) bool {
+	fault.mu.Lock()
+	defer fault.mu.Unlock()
+	return fault.armed && strings.Contains(query, fault.failQuery)
+}
+
+// catalogFaultPool is a gorm.ConnPool that delegates everything to a real
+// *sql.DB and fails only the injected read. It implements gorm.ConnPoolBeginner
+// rather than gorm.TxBeginner on purpose: the latter would hand gorm the raw
+// *sql.Tx and every read inside applyMigration's transaction would bypass the
+// injection, which is the only place the guard runs.
+type catalogFaultPool struct {
+	inner *sql.DB
+	fault *catalogReadFault
+}
+
+func (pool *catalogFaultPool) PrepareContext(ctx context.Context, query string) (*sql.Stmt, error) {
+	return pool.inner.PrepareContext(ctx, query)
+}
+
+func (pool *catalogFaultPool) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
+	pool.fault.observeExec(query)
+	return pool.inner.ExecContext(ctx, query, args...)
+}
+
+func (pool *catalogFaultPool) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
+	if pool.fault.shouldFail(query) {
+		return nil, errInjectedCatalogReadFailure
+	}
+	return pool.inner.QueryContext(ctx, query, args...)
+}
+
+func (pool *catalogFaultPool) QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row {
+	return pool.inner.QueryRowContext(ctx, query, args...)
+}
+
+func (pool *catalogFaultPool) BeginTx(ctx context.Context, opts *sql.TxOptions) (gorm.ConnPool, error) {
+	transaction, err := pool.inner.BeginTx(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+	return &catalogFaultTx{inner: transaction, fault: pool.fault}, nil
+}
+
+// catalogFaultTx carries the same injection into the migration's transaction
+// and commits or rolls it back for real, so a case can assert that a refused
+// migration left nothing behind.
+type catalogFaultTx struct {
+	inner *sql.Tx
+	fault *catalogReadFault
+}
+
+func (transaction *catalogFaultTx) PrepareContext(ctx context.Context, query string) (*sql.Stmt, error) {
+	return transaction.inner.PrepareContext(ctx, query)
+}
+
+func (transaction *catalogFaultTx) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
+	transaction.fault.observeExec(query)
+	return transaction.inner.ExecContext(ctx, query, args...)
+}
+
+func (transaction *catalogFaultTx) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
+	if transaction.fault.shouldFail(query) {
+		return nil, errInjectedCatalogReadFailure
+	}
+	return transaction.inner.QueryContext(ctx, query, args...)
+}
+
+func (transaction *catalogFaultTx) QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row {
+	return transaction.inner.QueryRowContext(ctx, query, args...)
+}
+
+func (transaction *catalogFaultTx) Commit() error {
+	return transaction.inner.Commit()
+}
+
+func (transaction *catalogFaultTx) Rollback() error {
+	return transaction.inner.Rollback()
+}
+
+// openSQLiteWithACatalogReadFault opens an existing database file through the
+// fault-injecting pool. It bypasses OpenDatabase, so opening can never itself
+// run a migration.
+func openSQLiteWithACatalogReadFault(t *testing.T, databasePath string, fault *catalogReadFault) *gorm.DB {
+	t.Helper()
+
+	sqlDB, err := sql.Open("sqlite", databasePath)
+	requireNoErr(t, err, "open sqlite for the fault-injecting pool")
+	t.Cleanup(func() { requireNoErr(t, sqlDB.Close(), "close the fault-injecting pool") })
+
+	database, err := gorm.Open(
+		&sqlite.Dialector{Conn: &catalogFaultPool{inner: sqlDB, fault: fault}},
+		&gorm.Config{Logger: logger.Discard},
+	)
+	requireNoErr(t, err, "open gorm over the fault-injecting pool")
+	return database
+}
+
+// widenDailyLogsFixture is the migration every case here runs: one plain ADD
+// COLUMN, which is the safest statement in the tree. If the runner applied it
+// despite the failed inspection, the column would be there — so its absence is
+// what proves the refusal came before any write.
+const (
+	widenDailyLogsFixtureName   = "900_widen_daily_logs.sql"
+	widenDailyLogsFixtureColumn = "inspection_probe"
+	widenDailyLogsFixtureSQL    = "ALTER TABLE daily_logs ADD COLUMN inspection_probe TEXT;"
+)
+
+// TestAMigrationIsRefusedWhenTheTableListCannotBeRead covers the first read the
+// guard makes. GetTables is what decides which tables the post-condition will
+// compare; a failure there leaves the guard with an empty snapshot, which would
+// compare equal to every possible outcome.
+func TestAMigrationIsRefusedWhenTheTableListCannotBeRead(t *testing.T) {
+	databasePath := filepath.Join(t.TempDir(), "table-list-read.db")
+	seedFullyMigratedDatabaseWithSentinelDay(t, databasePath)
+
+	fault := newCatalogReadFault(sqliteTableListQuery)
+	database := openSQLiteWithACatalogReadFault(t, databasePath, fault)
+
+	err := applyMigration(database, embeddedMigration{
+		Version: "900",
+		Order:   900,
+		Name:    widenDailyLogsFixtureName,
+		SQL:     widenDailyLogsFixtureSQL,
+	})
+
+	requireInspectionRefusal(t, err, "list tables")
+	assertFixtureColumnAbsent(t, databasePath)
+	assertSentinelDayIntact(t, databasePath)
+}
+
+// TestAMigrationIsRefusedWhenATableColumnListCannotBeRead covers the read
+// underneath it: the table list came back, and reading one table's columns
+// failed. The refusal must name the table, because that is the only thing that
+// tells an operator which read to look at.
+func TestAMigrationIsRefusedWhenATableColumnListCannotBeRead(t *testing.T) {
+	databasePath := filepath.Join(t.TempDir(), "column-list-read.db")
+	seedFullyMigratedDatabaseWithSentinelDay(t, databasePath)
+
+	fault := newCatalogReadFault(sqliteTableColumnsQuery)
+	database := openSQLiteWithACatalogReadFault(t, databasePath, fault)
+
+	err := applyMigration(database, embeddedMigration{
+		Version: "900",
+		Order:   900,
+		Name:    widenDailyLogsFixtureName,
+		SQL:     widenDailyLogsFixtureSQL,
+	})
+
+	requireInspectionRefusal(t, err, "read columns of table ")
+	assertFixtureColumnAbsent(t, databasePath)
+	assertSentinelDayIntact(t, databasePath)
+}
+
+// TestAMigrationIsRolledBackWhenTheColumnsCannotBeReReadAfterItRan covers the
+// second half of the same read pair, and it is the one with something to lose:
+// here the statements have already executed inside the transaction, so
+// "refuse" has to mean "roll back" and not merely "report".
+//
+// The fixture creates a table whose name arms the injection, which is what puts
+// the failure between the snapshot and the post-condition. Both the created
+// table and the ADD COLUMN must be gone afterwards.
+func TestAMigrationIsRolledBackWhenTheColumnsCannotBeReReadAfterItRan(t *testing.T) {
+	const armingTable = "inspection_probe_arming_table"
+
+	databasePath := filepath.Join(t.TempDir(), "post-condition-read.db")
+	seedFullyMigratedDatabaseWithSentinelDay(t, databasePath)
+
+	fault := newCatalogReadFaultArmedByStatement(sqliteTableColumnsQuery, armingTable)
+	database := openSQLiteWithACatalogReadFault(t, databasePath, fault)
+
+	err := applyMigration(database, embeddedMigration{
+		Version: "900",
+		Order:   900,
+		Name:    widenDailyLogsFixtureName,
+		SQL:     "CREATE TABLE " + armingTable + " (id INTEGER);\n" + widenDailyLogsFixtureSQL,
+	})
+
+	requireInspectionRefusal(t, err, "read columns of table ")
+	assertFixtureColumnAbsent(t, databasePath)
+	assertTableAbsentAfterRollback(t, databasePath, armingTable)
+	assertSentinelDayIntact(t, databasePath)
+}
+
+// requireInspectionRefusal holds every case above to the same contract: the
+// runner returned an error, it names the migration and the read that failed,
+// and the injected cause is still in the chain.
+func requireInspectionRefusal(t *testing.T, err error, readDescription string) {
+	t.Helper()
+
+	if err == nil {
+		t.Fatalf("a migration whose schema inspection failed must be refused, got no error")
+	}
+	if !errors.Is(err, errInjectedCatalogReadFailure) {
+		t.Fatalf("the refusal must carry the underlying read failure; got %v", err)
+	}
+	if !strings.Contains(err.Error(), "inspect migration "+widenDailyLogsFixtureName) {
+		t.Errorf("the refusal must name the migration it stopped; got %v", err)
+	}
+	if !strings.Contains(err.Error(), readDescription) {
+		t.Errorf("the refusal must name the read that failed (%q); got %v", readDescription, err)
+	}
+}
+
+// assertFixtureColumnAbsent reads the schema back through a connection that
+// applies no migration, so the reader can never repair what it measures.
+func assertFixtureColumnAbsent(t *testing.T, databasePath string) {
+	t.Helper()
+
+	reader := openSQLiteFileForReplayTest(t, databasePath)
+	defer closeReplayDatabase(t, reader)
+
+	columns, err := tableColumnNames(reader, "daily_logs")
+	requireNoErr(t, err, "read daily_logs columns back")
+	for _, column := range columns {
+		if column == widenDailyLogsFixtureColumn {
+			t.Fatalf("the refused migration must not have written anything, but daily_logs.%s is there", widenDailyLogsFixtureColumn)
+		}
+	}
+}
+
+func assertTableAbsentAfterRollback(t *testing.T, databasePath string, tableName string) {
+	t.Helper()
+
+	reader := openSQLiteFileForReplayTest(t, databasePath)
+	defer closeReplayDatabase(t, reader)
+
+	if reader.Migrator().HasTable(tableName) {
+		t.Fatalf("the refused migration must have been rolled back, but table %s is still there", tableName)
+	}
+}
+
+// TestALedgerVersionThatCannotBeOrderedIsNotReadAsANewerSchema pins how the
+// version half reads a schema_migrations row it cannot place.
+//
+// The refusal fires when the ledger records a migration numbered ABOVE the one
+// about to replay, so the comparison has to be numeric. A row whose version is
+// not a number — an operator's hand-written marker, a row from a tool that
+// stamped a date — cannot be ordered against the file set at all, and the two
+// wrong answers are symmetric: read as newer (a string comparison puts
+// "baseline" above "003") it refuses a migration that must run and blocks a
+// legitimate boot; read as a reason to stop looking it would hide the numeric
+// row beside it. It is ignored, and only ignored.
+func TestALedgerVersionThatCannotBeOrderedIsNotReadAsANewerSchema(t *testing.T) {
+	migration := embeddedMigration{
+		Version: "003",
+		Order:   3,
+		Name:    "003_rebuild_daily_logs.sql",
+		SQL:     "DROP TABLE daily_logs_old;",
+	}
+
+	t.Run("a version that is not a number is not newer than anything", func(t *testing.T) {
+		err := refuseTableDropReplayOnANewerSchema(migration, ledgerVersions("001", "002", "baseline", "2024-05-01-init"))
+		if err != nil {
+			t.Fatalf("a ledger holding no numerically later version must let the migration run; got %v", err)
+		}
+	})
+
+	t.Run("and it does not hide the numeric version beside it", func(t *testing.T) {
+		err := refuseTableDropReplayOnANewerSchema(migration, ledgerVersions("baseline", "024", "zzz"))
+		if err == nil {
+			t.Fatalf("a ledger recording migration 024 must refuse the replay of 003")
+		}
+		if !strings.Contains(err.Error(), "migration 024 is already recorded") {
+			t.Errorf("the refusal must name the numeric version it found; got %v", err)
+		}
+		for _, unorderable := range []string{"baseline", "zzz"} {
+			if strings.Contains(err.Error(), unorderable) {
+				t.Errorf("the refusal must not name the unorderable row %q; got %v", unorderable, err)
+			}
+		}
+	})
+}
+
+// TestTheReplayRefusalNamesEachDroppedTableOnceInFileOrder pins the list the
+// operator is handed. The refusal is the whole user interface of this guard —
+// it is read once, under a failed boot — so the tables it names are in the
+// order the migration drops them and each appears once, however many DROP
+// statements mention it.
+func TestTheReplayRefusalNamesEachDroppedTableOnceInFileOrder(t *testing.T) {
+	migration := embeddedMigration{
+		Version: "003",
+		Order:   3,
+		Name:    "003_rebuild_daily_logs.sql",
+		SQL: `DROP TABLE IF EXISTS daily_logs_old;
+CREATE TABLE daily_logs_old (id INTEGER);
+DROP TABLE IF EXISTS symptom_types_old;
+DROP TABLE IF EXISTS daily_logs_old;`,
+	}
+
+	err := refuseTableDropReplayOnANewerSchema(migration, ledgerVersions("024"))
+	if err == nil {
+		t.Fatalf("a ledger recording migration 024 must refuse the replay of 003")
+	}
+	if !strings.Contains(err.Error(), "it drops table daily_logs_old, symptom_types_old, and migration 024") {
+		t.Errorf("the refusal must list each dropped table once, in file order; got %v", err)
+	}
+}
+
+func ledgerVersions(versions ...string) map[string]struct{} {
+	applied := make(map[string]struct{}, len(versions))
+	for _, version := range versions {
+		applied[version] = struct{}{}
+	}
+	return applied
+}

--- a/internal/db/user_repository.go
+++ b/internal/db/user_repository.go
@@ -102,12 +102,52 @@ func (repo *UserRepository) RenormalizeUserEmail(ctx context.Context, userID uin
 	return result.RowsAffected == 1, result.Error
 }
 
+// requireOwnerRole is the persistence half of the owner-role-only boundary, and
+// it runs on both account-creating methods below — the only two writes in this
+// package that put a role into the users table.
+//
+// The column's CHECK still admits 'partner', a role the product does not have:
+// no constant declares it, no handler or template reads it, and narrowing the
+// constraint would mean rebuilding the users table on SQLite, which has no
+// ALTER for a CHECK. That rebuild would DROP the account table, and with
+// foreign_keys=ON a DROP TABLE fires every ON DELETE CASCADE hanging off it, so
+// the migration that tightened one unused constant would delete every day log
+// on the instance. The value is therefore refused where it is written instead
+// of where it is stored, which is also the only place any current caller can
+// reach: containment used to be web-policy only
+// (`docs/SECURITY_INVARIANTS.md` → the owner-role-only privacy boundary), and a
+// row carrying another role would be accepted by the database and then read by
+// code written on the assumption that owner is the only role.
+//
+// An empty role is the one value that is not a rejection: it means "take the
+// column default", which is owner. It is written out explicitly so the row
+// never depends on the gorm tag and the migration default agreeing.
+func requireOwnerRole(user *models.User) error {
+	if user == nil {
+		return ErrUnsupportedUserRole
+	}
+	if user.Role == "" {
+		user.Role = models.RoleOwner
+		return nil
+	}
+	if user.Role != models.RoleOwner {
+		return ErrUnsupportedUserRole
+	}
+	return nil
+}
+
 func (repo *UserRepository) Create(ctx context.Context, user *models.User) error {
+	if err := requireOwnerRole(user); err != nil {
+		return err
+	}
 	err := repo.database.WithContext(ctx).Create(user).Error
 	return classifyUserCreateError(err)
 }
 
 func (repo *UserRepository) CreateUserWithSymptoms(ctx context.Context, user *models.User, symptoms []models.SymptomType) error {
+	if err := requireOwnerRole(user); err != nil {
+		return err
+	}
 	return repo.database.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := classifyUserCreateError(tx.Create(user).Error); err != nil {
 			return err

--- a/internal/db/user_repository_role_test.go
+++ b/internal/db/user_repository_role_test.go
@@ -90,6 +90,32 @@ func TestUserRepositoryRefusesAnAccountWithARoleTheProductDoesNotHave(t *testing
 	}
 }
 
+// TestUserRepositoryRefusesAnAbsentAccountAtTheRoleCheck covers the one input
+// that carries no role to inspect at all.
+//
+// A nil account is invalid input, never a reason to skip the comparison: the
+// role check reads a field off the value it is handed, so an implementation
+// that let nil through would not fall back to some safe default — it would
+// panic inside the repository, on the path that creates accounts. Refusing it
+// with the same error as an unsupported role keeps the guard total over its
+// input, and the callers below prove the refusal still happens before the
+// write.
+func TestUserRepositoryRefusesAnAbsentAccountAtTheRoleCheck(t *testing.T) {
+	for _, writer := range userCreatingRepositoryMethods() {
+		t.Run(writer.Name, func(t *testing.T) {
+			database := openSQLiteForMigrationBootstrapTest(t, filepath.Join(t.TempDir(), "absent-account.db"))
+			repository := NewUserRepository(database)
+
+			err := writer.Create(context.Background(), repository, nil)
+
+			if !errors.Is(err, ErrUnsupportedUserRole) {
+				t.Fatalf("%s(nil) error = %v, want ErrUnsupportedUserRole", writer.Name, err)
+			}
+			assertNoUserRowsStored(t, database)
+		})
+	}
+}
+
 // userCreatingRepositoryMethod names one repository entry point that writes a
 // role into users, so the cases above run against every one of them rather than
 // against whichever came to mind.

--- a/internal/db/user_repository_role_test.go
+++ b/internal/db/user_repository_role_test.go
@@ -1,0 +1,150 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+	"gorm.io/gorm"
+)
+
+// TestUserRepositoryRefusesAnAccountWithARoleTheProductDoesNotHave holds both
+// account-creating repository methods to the owner-role-only privacy boundary.
+//
+// Ovumcy has one role: every account is the sole owner of its own data, an
+// instance may host several independent owners, and there is no viewer or
+// partner role at all. The users column, however, still carries
+// `CHECK (role IN ('owner', 'partner'))` on both engines, so until now the
+// database would have accepted a partner account and only the web policy
+// (services.ValidateSupportedWebUser, at login) would have turned it away —
+// containment after the fact, not refusal at the write.
+//
+// The negative cases are what the guard is for; the two positive cases are the
+// anchor, because a Create that rejected everything would satisfy the negatives
+// alone. Both methods are covered on purpose: they are the only two writes in
+// this package that put a role into users, and a class refused at one of two
+// write sites is a new defect rather than half a fix.
+func TestUserRepositoryRefusesAnAccountWithARoleTheProductDoesNotHave(t *testing.T) {
+	for _, testCase := range []struct {
+		name          string
+		role          string
+		expectStored  string
+		expectRefusal bool
+	}{
+		{
+			name:          "partner is not a role this product has",
+			role:          "partner",
+			expectRefusal: true,
+		},
+		{
+			name:          "nor is any other value the column would accept later",
+			role:          "viewer",
+			expectRefusal: true,
+		},
+		{
+			name:          "a role differing only in case is not the owner role",
+			role:          "Owner",
+			expectRefusal: true,
+		},
+		{
+			name:         "owner is written through",
+			role:         models.RoleOwner,
+			expectStored: models.RoleOwner,
+		},
+		{
+			name:         "an unset role takes the column default, which is owner",
+			role:         "",
+			expectStored: models.RoleOwner,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			for _, writer := range userCreatingRepositoryMethods() {
+				t.Run(writer.Name, func(t *testing.T) {
+					database := openSQLiteForMigrationBootstrapTest(t, filepath.Join(t.TempDir(), "roles.db"))
+					repository := NewUserRepository(database)
+
+					user := &models.User{
+						Email:        "role-case@example.com",
+						PasswordHash: "hash",
+						Role:         testCase.role,
+					}
+					err := writer.Create(context.Background(), repository, user)
+
+					if testCase.expectRefusal {
+						if !errors.Is(err, ErrUnsupportedUserRole) {
+							t.Fatalf("%s(role=%q) error = %v, want ErrUnsupportedUserRole", writer.Name, testCase.role, err)
+						}
+						assertNoUserRowsStored(t, database)
+						return
+					}
+
+					if err != nil {
+						t.Fatalf("%s(role=%q) unexpected error: %v", writer.Name, testCase.role, err)
+					}
+					assertStoredUserRole(t, database, "role-case@example.com", testCase.expectStored)
+				})
+			}
+		})
+	}
+}
+
+// userCreatingRepositoryMethod names one repository entry point that writes a
+// role into users, so the cases above run against every one of them rather than
+// against whichever came to mind.
+type userCreatingRepositoryMethod struct {
+	Name   string
+	Create func(ctx context.Context, repository *UserRepository, user *models.User) error
+}
+
+func userCreatingRepositoryMethods() []userCreatingRepositoryMethod {
+	return []userCreatingRepositoryMethod{
+		{
+			Name: "Create",
+			Create: func(ctx context.Context, repository *UserRepository, user *models.User) error {
+				return repository.Create(ctx, user)
+			},
+		},
+		{
+			Name: "CreateUserWithSymptoms",
+			Create: func(ctx context.Context, repository *UserRepository, user *models.User) error {
+				return repository.CreateUserWithSymptoms(ctx, user, []models.SymptomType{
+					{Name: "Cramps", Icon: "cramps", Color: "#ff0000", IsBuiltin: true},
+				})
+			},
+		},
+	}
+}
+
+// assertNoUserRowsStored proves the refusal happened BEFORE the write: a method
+// that returned the error after inserting would leave the row the product
+// cannot serve exactly where the guard says it must never be. The seeded
+// symptoms are checked with it, since CreateUserWithSymptoms writes both.
+func assertNoUserRowsStored(t *testing.T, database *gorm.DB) {
+	t.Helper()
+
+	for _, table := range []string{"users", "symptom_types"} {
+		var count int64
+		if err := database.Table(table).Count(&count).Error; err != nil {
+			t.Fatalf("count %s rows: %v", table, err)
+		}
+		if count != 0 {
+			t.Fatalf("expected the refused account to leave %s empty, found %d row(s)", table, count)
+		}
+	}
+}
+
+func assertStoredUserRole(t *testing.T, database *gorm.DB, email string, expectedRole string) {
+	t.Helper()
+
+	var stored struct {
+		Role string `gorm:"column:role"`
+	}
+	if err := database.Raw(`SELECT role FROM users WHERE email = ?`, email).Scan(&stored).Error; err != nil {
+		t.Fatalf("read back the stored role: %v", err)
+	}
+	if stored.Role != expectedRole {
+		t.Fatalf("stored role = %q, want %q", stored.Role, expectedRole)
+	}
+}


### PR DESCRIPTION
A migration whose `schema_migrations` row is missing is re-applied. For `ALTER TABLE … ADD COLUMN` that is safe, because the runner skips a statement whose column is already there. For a migration that reconciles a table by rebuilding it, there is no such skip: its replacement table is the table as it looked *at that version*, so a replay on a schema later migrations have widened copies the columns that version knew about and discards every column added after it, values included — and the boot reports success.

That is not hypothetical on this schema. Delete only the `schema_migrations` row for 003, reopen a current database, and migration 003 rebuilds `daily_logs` from the nine columns of migration 001, dropping the eight health columns migrations 005–023 added. A restore from a backup taken before the row was written, or a pruned ledger, is enough to reach it.

No migration file is touched: applied migrations are immutable. The fix is in the runner.

## The two halves, and why both

**Refuse before anything runs** — a migration containing a table drop is refused when a strictly higher version is already recorded. A recorded later version is proof the database moved past this migration: there is nothing left to apply, and the only thing a replay can do is destroy. No statement executes, so the database is untouched and the operator can restore the ledger row or the backup, which the error text names.

**Measure the effect, inside the migration's own transaction** — the columns of every table are read before the first statement and compared after the last. This is the half that covers a ledger lost *entirely*: a data-only restore records no later version, so the whole set replays from 001 with nothing to compare against, and only the effect gives it away. A failure rolls the transaction back.

The second half reads the whole schema rather than the tables the migration textually drops, because the drop is an idiom and not the invariant. SQLite rebuilds a table in two shapes — create a replacement, copy, drop the original, rename it into place (migrations 003 and 024), or rename the original aside, create the new one, copy, drop the aside. The second narrows the table exactly as the first does while dropping a table that did not exist when the migration began, so a check keyed on the dropped name sees nothing at all.

Cost, measured rather than assumed: 20 clean SQLite bootstraps of the whole set, mean 300 ms with the snapshot against 113 ms without — roughly 150 ms once, at install or at an upgrade that applies the whole set. A running instance pays nothing: a boot with nothing to apply never reaches the migration body, because the ledger skip comes first. On Postgres the difference did not separate from container startup and is reported as not separable rather than as a number.

## Losing something on purpose stays possible

Each hatch is written out by hand and authorizes only what it names:

- a column removed by an explicit `ALTER TABLE t DROP COLUMN c`;
- a column that disappears under a new name by `ALTER TABLE t RENAME COLUMN old TO new` — a rename loses nothing, and refusing it would report a loss that did not happen;
- a table retired for good by the marker line `-- ovumcy:removes-table <name>`.

A bare table drop is deliberately not consent: it is the middle statement of every rebuild in the tree, and reading it as consent is how migration 003 came to discard eight health columns while reporting success. Renaming one column authorizes that one name on that one table — the mixed case, one column renamed and another silently lost in the same migration, stays refused and the refusal names only the lost one.

## The role the product does not have

Both dialects declare `role TEXT NOT NULL CHECK (role IN ('owner', 'partner'))`. The model declares only `RoleOwner`; no handler, template or locale key mentions the other. Containment was web-policy only, and the repository applied no role validation at all.

The CHECK is **not** narrowed, and the reason is written at `internal/db/user_repository.go:105`: SQLite has no `ALTER` for a `CHECK`, so narrowing means rebuilding the `users` table, and with `foreign_keys=ON` dropping the account table fires every `ON DELETE CASCADE` hanging off it — a migration tightening one unused constant would delete every day log on the instance. That is precisely the class the other half of this PR exists to refuse. A Postgres-only `ALTER` was rejected too: it would break effect-equivalence between the two trees.

Instead the role is refused where it is written — `requireOwnerRole` on the only two methods in the package that put a role into `users`, with an empty role normalized to owner explicitly rather than left to the tag and the column default agreeing. Residual, stated plainly: the column still admits the other value, so a direct SQL writer is unaffected. Containment moved from web-policy-only to the write path.

## Evidence

Each guard was proved able to fail before it was wired in.

**Both halves disabled** — the audit's defect reproduced verbatim: sweep case `003` red with `before: bbt, cervical_mucus, …, mood, …` against `after: created_at, date, flow, id, is_period, notes, symptom_ids, updated_at, user_id`, eight health columns gone and the boot green; case `024` red as well. Restored → green.

**Half 1 alone disabled** — the replay case red: the data was still saved by half 2, but the refusal no longer named the recorded later version.

**Half 2 alone disabled** — the wiped-ledger case red: "expected the boot to refuse".

**The pre-review snapshot restored verbatim** — exactly one case red, `rename-first rebuild that narrows`; the drop-first form stayed refused. This is the idiom gap, shown rather than argued.

**The rename branch removed** — the rename case red with "table users lost column(s) usage_goal, which held data before it ran … restore from a backup", the false loss report; and the mixed case red on the wrong column. Restored → both green, the mixed case still refused, naming `mood` and not `notes`, with its sentinel row surviving the rollback.

**The role guard disabled** — `role="partner"` stored by *both* creation methods with a nil error, the audit's claim exactly; `viewer` and `Owner` refused only by the column CHECK. Restored → green, including the positive anchors.

Guards live in `internal/db/migrations_destructive_replay_test.go`: a sweep over 34 cases that deletes each ledger row in turn, reopens through `OpenDatabase` and requires no column and no stored value to change (passing on either a completed boot or a named refusal, with counters anchoring that both paths were exercised), the explicit replay and wiped-ledger cases, synthetic migrations in both rebuild idioms, the hatch cases, and a test that the Postgres tree contains no table drop — the sweep runs on SQLite, so the premise that makes that sufficient is asserted rather than assumed.

## Blast radius

The new code runs on every boot of both binaries and both engines, and inside every migration application. On a clean install and on any normal forward upgrade nothing becomes reachable that was not before: no version above the one being applied is recorded, and both rebuilds preserve every column they copy. What newly executes is the column read per table per applied migration, and one refusal path that turns a formerly silent, data-losing boot into a boot that stops. It is dormant on Postgres, whose tree has no table drop — now pinned by a test. Nothing is written on the refusal path, so there is nothing to roll back; the operator restores the ledger row or the backup, both documented in `docs/self-hosted.md`.

## Also in scope, and closed without a change

R2-0117 — "the cross-dialect parity test compares migration names, never their effect" — is already closed by `174a5f80` and `bc5975c5`: `internal/db/schema_parity_test.go` compares the two migrated schemas by table set, column set and column type family, with a positive anchor so a driver reporting no types cannot make the comparison vacuous, and nullability excluded with the measurement written into the file header. No overlapping second guard was added. What remains is narrower than the record: DEFAULT expressions (`CURRENT_TIMESTAMP` against `NOW()`) and column ordering go unmeasured. Reported, not landed.

## Deliberately out of scope

The account default `auto_period_fill`, the security-doc pair, and the onboarding date window belong to the next change in this group. No migration file added or edited; no persisted data rewritten. The index that migrations 001 and 024 recreate after 025 drops it is left alone — it costs write amplification, never a column or a row, and the limit is written into the test file so no reader concludes more.
