### PR TITLE
test(db): let the postgres suite fail instead of skipping itself away

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,21 @@ jobs:
     permissions:
       contents: read
 
+    # This is the only lane that runs the Postgres integration suite —
+    # internal/db, internal/services and scripts/backuprestoredoc all reach it
+    # through internal/testdb, and internal/api (test-go-shard) has none of it.
+    # Those tests start a throwaway container, and without this variable a host
+    # that cannot start one SKIPS them; a skipped test is a lane reporting
+    # success for a suite that never ran, and no job asserted the suite ran.
+    # The ubuntu runner has docker, so here an unavailable docker is a broken
+    # runner, not a legitimate absence: the variable turns that skip into a
+    # failure. It is deliberately NOT set at workflow level and NOT on
+    # test-go-shard — a lane with no Postgres test would only be asserting
+    # something about a suite it does not run — and it is absent from a
+    # developer machine, where no docker still means "not my test to run".
+    env:
+      OVUMCY_REQUIRE_POSTGRES: "1"
+
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/changelog.d/test-fail-closed-postgres-integration-suite.md
+++ b/changelog.d/test-fail-closed-postgres-integration-suite.md
@@ -1,0 +1,10 @@
+none
+
+CI and tests only: the Postgres integration suite can now fail. One helper ran
+the image pull, the container start and the port lookup, and skipped on any
+error, so a broken runner reported the same "docker is unavailable" verdict as a
+developer machine with no docker — and the whole suite passed having tested
+nothing. Only the docker-absent probe may skip now; every docker error after it
+fails. `OVUMCY_REQUIRE_POSTGRES`, set on the one CI job that runs the suite,
+turns that last skip into a failure too. Unset, a machine without docker skips
+exactly as before. No product code.

--- a/internal/testdb/postgres.go
+++ b/internal/testdb/postgres.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 	"testing"
@@ -45,9 +46,7 @@ func StartPostgresDSN(t *testing.T, databaseName string) string {
 func StartPostgres(t *testing.T, databaseName string) (dsn string, containerID string) {
 	t.Helper()
 
-	if _, err := exec.LookPath("docker"); err != nil {
-		t.Skip("docker is required for postgres tests")
-	}
+	requireDockerBinary(t)
 
 	databaseName = strings.TrimSpace(databaseName)
 	if databaseName == "" {
@@ -152,17 +151,85 @@ func ensurePostgresImageAvailable(t *testing.T) {
 	runDockerCommand(t, "pull", postgresTestImage)
 }
 
-func runDockerCommand(t *testing.T, args ...string) string {
+// requirePostgresEnv arms fail-closed mode. Unset — the default on a developer
+// machine — a host that cannot run the Postgres suite skips it, exactly as
+// before. Set, a skip becomes a failure, because on the CI job that owns this
+// suite a skip is a lane reporting success for tests that never ran.
+const requirePostgresEnv = "OVUMCY_REQUIRE_POSTGRES"
+
+// postgresIsRequired reads the gate fail-closed: anything other than an absent,
+// empty or explicitly false value arms it. A gate that disarmed on an
+// unexpected value would restore the silence it exists to remove, and would do
+// it invisibly — the lane would simply go green again.
+func postgresIsRequired() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(requirePostgresEnv))) {
+	case "", "0", "false":
+		return false
+	default:
+		return true
+	}
+}
+
+// testingT is the slice of *testing.T the docker helpers below actually use.
+// It exists so the failure-mode guard can observe WHICH verdict a docker error
+// reaches — a skip or a failure — without a docker daemon and without failing
+// the test that does the observing. *testing.T satisfies it unchanged.
+type testingT interface {
+	Helper()
+	Fatalf(format string, args ...any)
+	Skipf(format string, args ...any)
+}
+
+// skipUnlessPostgresRequired is the ONLY place in this package that may skip,
+// and requireDockerBinary is its only caller.
+func skipUnlessPostgresRequired(t testingT, format string, args ...any) {
+	t.Helper()
+
+	reason := fmt.Sprintf(format, args...)
+	if postgresIsRequired() {
+		t.Fatalf("%s is set, so a skipped postgres suite is a failure: %s", requirePostgresEnv, reason)
+		return
+	}
+	t.Skipf("%s", reason)
+}
+
+// requireDockerBinary is the one probe allowed to skip: a host with no docker
+// binary at all cannot run these tests, and on a developer machine that is not
+// an operational failure. Every docker error AFTER this point is one.
+func requireDockerBinary(t testingT) {
+	t.Helper()
+
+	if _, err := dockerLookPath("docker"); err != nil {
+		skipUnlessPostgresRequired(t, "docker is required for postgres tests: %v", err)
+	}
+}
+
+// runDockerCommand runs a docker command that has already cleared the
+// docker-absent preflight, so its failure is operational — a broken image, an
+// exhausted port range, a pull that timed out — and fails the test. It used to
+// skip, and the image pull, the container start and the port lookup all come
+// through here: a broken runner therefore reported the identical "docker is
+// unavailable" skip as a host with no docker at all, and the package went green
+// having tested nothing. The two readiness waits already failed loudly and are
+// unchanged.
+func runDockerCommand(t testingT, args ...string) string {
 	t.Helper()
 
 	output, err := runDockerCommandWithError(args...)
 	if err != nil {
-		t.Skipf("docker is unavailable for postgres tests: %v", err)
+		t.Fatalf("the docker-absent preflight passed, so this is an operational failure and not a reason to skip: %v", err)
+		return ""
 	}
 	return output
 }
 
-func runDockerCommandWithError(args ...string) (string, error) {
+// dockerLookPath and runDockerCommandWithError are variables, not plain
+// functions, so the failure-mode guard can inject "docker is absent" and "a
+// docker command failed" separately. Production code reads them as ordinary
+// calls.
+var dockerLookPath = exec.LookPath
+
+var runDockerCommandWithError = func(args ...string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), dockerTimeoutFor(args...))
 	defer cancel()
 

--- a/internal/testdb/postgres_failure_mode_test.go
+++ b/internal/testdb/postgres_failure_mode_test.go
@@ -1,0 +1,171 @@
+package testdb
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// recordingT records the verdict a docker helper reaches instead of delivering
+// it. It is deliberately not a general test double: the only thing this file
+// needs to observe is WHICH of the two verdicts a docker error produces, and a
+// real *testing.T cannot report that — a helper that calls Fatalf on it fails
+// the very test asking the question, and one that calls Skipf ends it.
+//
+// Fatalf and Skipf on a real *testing.T never return; here they record and do
+// return, so a helper under observation runs on to its own `return`. Every
+// assertion below is about the recorder, never about what the helper returned.
+type recordingT struct {
+	fatal   string
+	skipped string
+}
+
+func (r *recordingT) Helper() {}
+
+func (r *recordingT) Fatalf(format string, args ...any) {
+	r.fatal = fmt.Sprintf(format, args...)
+}
+
+func (r *recordingT) Skipf(format string, args ...any) {
+	r.skipped = fmt.Sprintf(format, args...)
+}
+
+func (r *recordingT) verdict() string {
+	switch {
+	case r.fatal != "" && r.skipped != "":
+		return fmt.Sprintf("both (fatal=%q skip=%q)", r.fatal, r.skipped)
+	case r.fatal != "":
+		return "fatal: " + r.fatal
+	case r.skipped != "":
+		return "skip: " + r.skipped
+	default:
+		return "neither"
+	}
+}
+
+// injectDockerCommandFailure makes every docker invocation fail, as a broken
+// image, an exhausted port range or a pull that timed out would.
+func injectDockerCommandFailure(t *testing.T, failure error) {
+	t.Helper()
+
+	original := runDockerCommandWithError
+	runDockerCommandWithError = func(args ...string) (string, error) {
+		return "", fmt.Errorf("docker %s: %w", strings.Join(args, " "), failure)
+	}
+	t.Cleanup(func() { runDockerCommandWithError = original })
+}
+
+// injectMissingDockerBinary makes the docker-absent preflight fail, as a
+// developer machine with no docker installed would.
+func injectMissingDockerBinary(t *testing.T) {
+	t.Helper()
+
+	original := dockerLookPath
+	dockerLookPath = func(file string) (string, error) {
+		return "", fmt.Errorf("%s: %w", file, exec.ErrNotFound)
+	}
+	t.Cleanup(func() { dockerLookPath = original })
+}
+
+// TestDockerCommandFailureAfterThePreflightFailsRatherThanSkips pins the
+// distinction the whole package rests on: the docker-absent probe may skip,
+// and nothing after it may. The three argument sets are the three real
+// post-preflight call sites — the image pull, the container start and the port
+// lookup — which all reach the daemon through the same helper, so a skip there
+// reported a broken runner exactly as it reported a host with no docker.
+func TestDockerCommandFailureAfterThePreflightFailsRatherThanSkips(t *testing.T) {
+	callSites := map[string][]string{
+		"image pull":      {"pull", postgresTestImage},
+		"container start": {"run", "-d", "--rm", "-P", postgresTestImage},
+		"port lookup":     {"port", "abc123", "5432/tcp"},
+	}
+
+	for name, args := range callSites {
+		t.Run(name, func(t *testing.T) {
+			injectDockerCommandFailure(t, errors.New("no space left on device"))
+
+			recorder := &recordingT{}
+			runDockerCommand(recorder, args...)
+
+			if recorder.skipped != "" {
+				t.Fatalf("a docker %q failure after the preflight must fail the test, not skip it; got %s", args[0], recorder.verdict())
+			}
+			if recorder.fatal == "" {
+				t.Fatalf("a docker %q failure after the preflight must fail the test; got %s", args[0], recorder.verdict())
+			}
+			if !strings.Contains(recorder.fatal, "no space left on device") {
+				t.Fatalf("the failure must carry the underlying docker error; got %s", recorder.verdict())
+			}
+		})
+	}
+}
+
+// TestMissingDockerBinaryStillSkipsWithoutTheRequireGate is the other half of
+// the same rule, and the one that protects the developer machine: with the
+// gate unset, no docker binary still means "not my test to run".
+func TestMissingDockerBinaryStillSkipsWithoutTheRequireGate(t *testing.T) {
+	t.Setenv(requirePostgresEnv, "")
+	injectMissingDockerBinary(t)
+
+	recorder := &recordingT{}
+	requireDockerBinary(recorder)
+
+	if recorder.fatal != "" {
+		t.Fatalf("an absent docker binary must skip when %s is unset; got %s", requirePostgresEnv, recorder.verdict())
+	}
+	if recorder.skipped == "" {
+		t.Fatalf("an absent docker binary must skip when %s is unset; got %s", requirePostgresEnv, recorder.verdict())
+	}
+}
+
+// TestMissingDockerBinaryFailsWhenPostgresIsRequired arms the gate CI sets on
+// the job that runs the Postgres suite: there a skipped suite is a lane
+// reporting success for tests that never ran, so the last remaining skip
+// becomes a failure too.
+func TestMissingDockerBinaryFailsWhenPostgresIsRequired(t *testing.T) {
+	t.Setenv(requirePostgresEnv, "1")
+	injectMissingDockerBinary(t)
+
+	recorder := &recordingT{}
+	requireDockerBinary(recorder)
+
+	if recorder.skipped != "" {
+		t.Fatalf("with %s=1 an absent docker binary must fail; got %s", requirePostgresEnv, recorder.verdict())
+	}
+	if recorder.fatal == "" {
+		t.Fatalf("with %s=1 an absent docker binary must fail; got %s", requirePostgresEnv, recorder.verdict())
+	}
+	if !strings.Contains(recorder.fatal, requirePostgresEnv) {
+		t.Fatalf("the failure must name the gate that turned the skip into one; got %s", recorder.verdict())
+	}
+}
+
+// TestPostgresIsRequiredReadsTheGateFailClosed pins the value handling: a gate
+// that silently disarms on an unexpected value is worse than no gate, because
+// the lane keeps reporting success. Only an absent, empty or explicitly false
+// value disarms it.
+func TestPostgresIsRequiredReadsTheGateFailClosed(t *testing.T) {
+	cases := map[string]bool{
+		"":      false,
+		" ":     false,
+		"0":     false,
+		"false": false,
+		"FALSE": false,
+		"1":     true,
+		"true":  true,
+		"yes":   true,
+		"y3s":   true,
+	}
+
+	for value, want := range cases {
+		t.Run(fmt.Sprintf("%q", value), func(t *testing.T) {
+			t.Setenv(requirePostgresEnv, value)
+
+			if got := postgresIsRequired(); got != want {
+				t.Fatalf("%s=%q: expected required=%v, got %v", requirePostgresEnv, value, want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes register records **R2-0143** and **R2-0609** (group G03, technical-debt fix board).

## What was wrong

One helper ran the image pull, the container start and the port lookup, and skipped on any error:

```go
func runDockerCommand(t *testing.T, args ...string) string {
	output, err := runDockerCommandWithError(args...)
	if err != nil {
		t.Skipf("docker is unavailable for postgres tests: %v", err)
	}
	return output
}
```

A broken image, an exhausted port range or a pull that timed out therefore reported the identical `docker is unavailable` verdict as a host with no docker at all — and the package went green having tested nothing. Only the two readiness waits failed loudly. No CI job asserted the suite had run.

## What changed

- Only the docker-absent probe (`exec.LookPath`) may skip. Every docker error after that preflight is operational and fails the test.
- `OVUMCY_REQUIRE_POSTGRES`, read fail-closed, turns that last remaining skip into a failure too. It is set at job level on `test-go-rest` — the one lane that runs this suite — and nowhere else. Unset, a developer machine without docker skips exactly as before.
- Two injection seams (`dockerLookPath`, `runDockerCommandWithError`) let the guard observe which verdict a docker error reaches, without a daemon.

`internal/db/postgres_test_helpers_test.go` and `internal/db/postgres_bootstrap_test.go` are named by R2-0609 but needed no edit — they inherit the gate through `testdb.StartPostgresDSN`, as the evidence below shows against those exact tests.

## Evidence

### 1. The guard is red before the fix

Seam in place, verdicts still `t.Skipf` as on `main`:

```
$ go test ./internal/testdb/ -run 'TestDockerCommandFailureAfterThePreflightFailsRatherThanSkips|TestMissingDockerBinary' -v
=== RUN   TestDockerCommandFailureAfterThePreflightFailsRatherThanSkips/port_lookup
    postgres_failure_mode_test.go:93: a docker "port" failure after the preflight must fail the test, not skip it; got skip: docker is unavailable for postgres tests: docker port abc123 5432/tcp: no space left on device
=== RUN   TestDockerCommandFailureAfterThePreflightFailsRatherThanSkips/image_pull
    postgres_failure_mode_test.go:93: a docker "pull" failure after the preflight must fail the test, not skip it; got skip: docker is unavailable for postgres tests: docker pull postgres:17-alpine: no space left on device
=== RUN   TestDockerCommandFailureAfterThePreflightFailsRatherThanSkips/container_start
    postgres_failure_mode_test.go:93: a docker "run" failure after the preflight must fail the test, not skip it; got skip: docker is unavailable for postgres tests: docker run -d --rm -P postgres:17-alpine: no space left on device
--- FAIL: TestDockerCommandFailureAfterThePreflightFailsRatherThanSkips (0.00s)
=== RUN   TestMissingDockerBinaryFailsWhenPostgresIsRequired
    postgres_failure_mode_test.go:135: with OVUMCY_REQUIRE_POSTGRES=1 an absent docker binary must fail; got skip: docker is required for postgres tests: docker: executable file not found in %PATH%
--- FAIL: TestMissingDockerBinaryFailsWhenPostgresIsRequired (0.00s)
FAIL	github.com/ovumcy/ovumcy-web/internal/testdb	1.818s
```

### 2. Green with the fix wired in

```
$ go test ./internal/testdb/ -run 'TestDocker|TestMissing|TestPostgresIsRequired' -v
--- PASS: TestDockerCommandFailureAfterThePreflightFailsRatherThanSkips (0.00s)
--- PASS: TestMissingDockerBinaryStillSkipsWithoutTheRequireGate (0.00s)
--- PASS: TestMissingDockerBinaryFailsWhenPostgresIsRequired (0.00s)
--- PASS: TestPostgresIsRequiredReadsTheGateFailClosed (0.00s)
ok  	github.com/ovumcy/ovumcy-web/internal/testdb	0.962s
```

End to end through the real caller, gate armed, docker present:

```
$ OVUMCY_REQUIRE_POSTGRES=1 go test ./internal/db/ -run 'TestOpenPostgres|TestUserRepositoryCreateTranslatesPostgresUniqueViolation' -timeout 20m -v
--- PASS: TestOpenPostgresAppliesEmbeddedMigrationsOnCleanDatabase (25.22s)
--- PASS: TestOpenPostgresMigrationBootstrapIsIdempotent (18.70s)
--- PASS: TestUserRepositoryCreateTranslatesPostgresUniqueViolation (20.63s)
ok  	github.com/ovumcy/ovumcy-web/internal/db	69.336s
```

The same binary with the gate armed but docker absent — what a broken runner now reports:

```
$ PATH= OVUMCY_REQUIRE_POSTGRES=1 ./db.test.exe -test.run TestOpenPostgres -test.v
    postgres_bootstrap_test.go:14: OVUMCY_REQUIRE_POSTGRES is set, so a skipped postgres suite is a failure: docker is required for postgres tests: exec: "docker": executable file not found in %PATH%
--- FAIL: TestOpenPostgresAppliesEmbeddedMigrationsOnCleanDatabase (0.00s)
FAIL
```

### 3. The local-developer skip path is unchanged

Same compiled binary, no `OVUMCY_REQUIRE_POSTGRES`, docker absent from `PATH`:

```
$ PATH= ./db.test.exe -test.run TestOpenPostgres -test.v
    postgres_bootstrap_test.go:14: docker is required for postgres tests: exec: "docker": executable file not found in %PATH%
--- SKIP: TestOpenPostgresAppliesEmbeddedMigrationsOnCleanDatabase (0.00s)
PASS
```

## Verification

`go build ./...` clean; `go vet ./...` clean over the whole module; `gofmt -l` prints nothing for both touched Go files; `golangci-lint run ./internal/testdb/... ./internal/db/...` reports 0 issues; `actionlint v1.7.12` on `ci.yml` clean; `go test ./internal/testdb/... ./internal/db/...` gives `ok internal/testdb 1.929s` and `ok internal/db 190.215s` against real containers (docker 29.7.2); `go run ./scripts/changelogd check` OK.

## Blast radius worth knowing

The gate is job-level, so it also arms `internal/services/day_service_integration_test.go` and `scripts/backuprestoredoc/postgres_roundtrip_test.go`, which reach the same helper. That is intended — the runner has docker — but it does widen what a docker outage on `test-go-rest` now reddens.

## Rollback

Single-commit revert. Tests and CI only; no product code, no persisted data, no public contract.
