### PR TITLE
fix(ci): refuse to publish a release image main has not judged

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,6 +36,23 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    # Never offer a pre-release golang builder. Dependabot treats `1.27rc2` as
+    # simply newer than `1.26.6` and opened exactly that bump, which merged: the
+    # release image was then compiled by a release candidate while every CI Go
+    # job kept resolving its toolchain from go.mod's 1.26.6 — GOTOOLCHAIN
+    # upgrades but never downgrades, so nothing pulled the builder back. CI now
+    # asserts the two are equal (`Builder toolchain matches go.mod` in ci.yml),
+    # but that assertion would only redden on the next such bump; this is what
+    # keeps it from being offered.
+    #
+    # One pattern, because Go publishes exactly one pre-release channel to this
+    # image — `1.27rc1`, `1.27rc2`, never an alpha or a beta — and it is the
+    # spelling that actually got in. A real release tag is picked up unchanged:
+    # `1.26.6-alpine3.24` contains no `rc`.
+    ignore:
+      - dependency-name: "golang"
+        versions:
+          - "*rc*"
 
   # docker-compose (GA since 2025) tracks image: tags in compose manifests —
   # the operator baseline at the repo root plus every example stack under

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,18 +346,33 @@ jobs:
           builder_tag="$(sed -n 's/^FROM golang:\([^@[:space:]]*\).*/\1/p' Dockerfile)"
           builder_version="${builder_tag%%-*}"
 
-          go_directive="$(sed -n 's/^go \([0-9][0-9A-Za-z.]*\)[[:space:]]*$/\1/p' go.mod)"
-          if [ -z "$go_directive" ]; then
-            echo "::error file=go.mod::could not read the \`go\` directive."
+          # `toolchain` wins where it is present, because that is what
+          # actions/setup-go does with `go-version-file: go.mod`: the `go` line
+          # is a MINIMUM, the `toolchain` line is the version actually built
+          # with. Reading only the `go` line would leave this guard comparing
+          # the builder against a directive CI had stopped building under, so
+          # the drift it exists to catch would pass green the day one is added —
+          # a guard that holds only until a routine event re-arms it. go.mod
+          # carries no `toolchain` line today; this is what keeps that from
+          # being load-bearing. `toolchain default` names no version and so
+          # falls through to the `go` line, which is what it means anyway.
+          directive="toolchain"
+          wanted="$(sed -n 's/^toolchain go\([0-9][0-9A-Za-z.]*\)[[:space:]]*$/\1/p' go.mod)"
+          if [ -z "$wanted" ]; then
+            directive="go"
+            wanted="$(sed -n 's/^go \([0-9][0-9A-Za-z.]*\)[[:space:]]*$/\1/p' go.mod)"
+          fi
+          if [ -z "$wanted" ]; then
+            echo "::error file=go.mod::could not read a \`go\` or \`toolchain\` directive."
             exit 1
           fi
 
-          if [ "$builder_version" != "$go_directive" ]; then
-            echo "::error file=Dockerfile::the builder stage is golang:${builder_tag} (Go ${builder_version}) but go.mod asks for ${go_directive}. Every CI Go job resolves its toolchain from go.mod, so the published binary would be built by a toolchain nothing in this repository tests. Pin the builder to ${go_directive}, or move go.mod first."
+          if [ "$builder_version" != "$wanted" ]; then
+            echo "::error file=Dockerfile::the builder stage is golang:${builder_tag} (Go ${builder_version}) but go.mod's \`${directive}\` directive asks for ${wanted}. Every CI Go job resolves its toolchain from go.mod, so the published binary would be built by a toolchain nothing in this repository tests. Pin the builder to ${wanted}, or move go.mod first."
             exit 1
           fi
 
-          echo "builder toolchain golang:${builder_tag} matches the go.mod directive ${go_directive}."
+          echo "builder toolchain golang:${builder_tag} matches go.mod's \`${directive}\` directive (${wanted})."
 
       - name: Setup Go
         id: setup-go

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,6 +318,47 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # The published binary is built by the Dockerfile's builder stage; every
+      # job in this workflow builds and tests with the toolchain named by
+      # go.mod's `go` directive (`go-version-file: go.mod`, in this step and in
+      # every other Go lane). Nothing tied the two together, and GOTOOLCHAIN
+      # only ever upgrades: a builder tag AHEAD of the directive is not
+      # downgraded to it, it simply wins. That is how `golang:1.27rc2-alpine3.24`
+      # came to compile the release image while the whole suite ran under 1.26.6
+      # — a release candidate shipping code no test had ever run under.
+      #
+      # Cheap, needs no toolchain, and sits before `Setup Go` so it reports
+      # before anything is installed. This lane feeds the required `test` gate,
+      # and any diff that can move either file (`Dockerfile`, `go.mod`) leaves
+      # `run_unit` true in the `changes` job, so the assertion cannot be skipped
+      # by the very change that breaks it.
+      - name: Builder toolchain matches go.mod
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          matches="$(grep -c '^FROM golang:' Dockerfile || true)"
+          if [ "$matches" != "1" ]; then
+            echo "::error file=Dockerfile::expected exactly one \`FROM golang:\` builder line, found ${matches}."
+            exit 1
+          fi
+
+          builder_tag="$(sed -n 's/^FROM golang:\([^@[:space:]]*\).*/\1/p' Dockerfile)"
+          builder_version="${builder_tag%%-*}"
+
+          go_directive="$(sed -n 's/^go \([0-9][0-9A-Za-z.]*\)[[:space:]]*$/\1/p' go.mod)"
+          if [ -z "$go_directive" ]; then
+            echo "::error file=go.mod::could not read the \`go\` directive."
+            exit 1
+          fi
+
+          if [ "$builder_version" != "$go_directive" ]; then
+            echo "::error file=Dockerfile::the builder stage is golang:${builder_tag} (Go ${builder_version}) but go.mod asks for ${go_directive}. Every CI Go job resolves its toolchain from go.mod, so the published binary would be built by a toolchain nothing in this repository tests. Pin the builder to ${go_directive}, or move go.mod first."
+            exit 1
+          fi
+
+          echo "builder toolchain golang:${builder_tag} matches the go.mod directive ${go_directive}."
+
       - name: Setup Go
         id: setup-go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1595,10 +1595,17 @@ jobs:
     # the same way, since the Docker Image workflow no longer accepts one.
     if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
     # A caller cannot grant a called workflow more than it holds, so this must
-    # match the permissions the publish job declares.
+    # match the permissions the publish job declares — plus `checks: read`, for
+    # the tag gate that workflow now runs ahead of the publish. That gate is
+    # skipped on this path (it is the tag path's substitute for the `needs:`
+    # above, which cannot cross a workflow boundary), but the ceiling has to
+    # cover a job the called workflow declares whether or not it runs. The
+    # publish job itself is unaffected: its own permissions block does not list
+    # `checks`, so it still receives none.
     permissions:
       artifact-metadata: write
       attestations: write
+      checks: read
       contents: read
       id-token: write
       packages: write

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -110,19 +110,34 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-          # The required contexts on `main`, each a thin gate job over a matrix
-          # in ci.yml. Being in main is not enough on its own: a commit reaches
-          # main through the merge queue, and the queue judges the batch it
-          # built, so this asks the checks about this exact commit.
-          REQUIRED_CHECKS: test race e2e
+          # Exactly the five ci.yml's `publish-image` requires before it lets
+          # `:latest` follow `main`. Three of them would have made the RELEASE
+          # path more permissive than the rolling one: a commit whose
+          # `image-smoke` or `e2e-postgres-smoke` failed correctly holds
+          # `:latest` back, and tagging that same commit would then have shipped
+          # a signed, attested release image anyway.
+          #
+          # Being contained in main is not enough on its own to imply these. A
+          # commit reaches main through the merge queue, and the queue's run
+          # judges the batch it built while skipping `image-smoke`,
+          # `e2e-cross-browser` and the Postgres smoke outright — those three
+          # execute only on the `push` that follows. So the question has to be
+          # asked of this exact commit's checks, which is what this does.
+          REQUIRED_CHECKS: test race e2e e2e-postgres-smoke image-smoke
         run: |
           set -euo pipefail
 
           sha="$(git rev-parse "${GITHUB_SHA}^{commit}")"
 
           # The endpoint's default `filter=latest` returns the most recent run
-          # per check name — the same view branch protection takes, so a red
-          # re-run after a green one counts as red here too.
+          # per name PER CHECK SUITE, and a commit on main carries two: the
+          # merge-queue run that validated it and the push run that followed. So
+          # each of these names legitimately appears TWICE, and for
+          # `image-smoke` the two disagree — `skipped` in the queue suite,
+          # `success` in the push one (verified on 6a95d01d and fc30f490).
+          # Every row is therefore judged, not the first one found: taking the
+          # first would make the verdict depend on the order the API happened to
+          # return, and a failure in either suite must block the tag.
           runs="$(
             gh api --paginate \
               "repos/${GITHUB_REPOSITORY}/commits/${sha}/check-runs?per_page=100" \
@@ -134,14 +149,32 @@ jobs:
 
           failed=0
           for name in $REQUIRED_CHECKS; do
-            conclusion="$(printf '%s\n' "$runs" | awk -F'\t' -v n="$name" '$1 == n { print $2; exit }')"
-            if [ -z "$conclusion" ]; then
-              echo "::error::no \`${name}\` check run exists for ${sha}. A tag push starts no CI run, so this commit's checks must already have run on main."
+            conclusions="$(printf '%s\n' "$runs" | awk -F'\t' -v n="$name" '$1 == n { print $2 }')"
+
+            if [ -z "$conclusions" ]; then
+              echo "::error::no \`${name}\` check run exists for ${sha}. A tag push starts no CI run of its own, so this commit's checks must already have run on main."
               failed=1
-            elif [ "$conclusion" != "success" ]; then
-              echo "::error::the \`${name}\` check on ${sha} concluded \"${conclusion}\"."
-              failed=1
+              continue
             fi
+
+            # `skipped` passes, here and for the same reason ci.yml's own `test`
+            # gate accepts it: the `changes` job decided this run did not need
+            # that lane — a decision not to run, not a failure to run. It is not
+            # a hole a tag can be aimed at either, since `changes` clears a lane
+            # only for a diff that cannot reach it. Insisting on `success`
+            # instead would block a tag on a docs-only commit forever:
+            # `image-smoke` gates on `run_e2e`, so there it is skipped in BOTH
+            # suites. `pending` is not `skipped` — a queued or still-running
+            # check is no verdict, and this refuses on it.
+            while IFS= read -r conclusion; do
+              case "$conclusion" in
+                success|skipped) ;;
+                *)
+                  echo "::error::a \`${name}\` check run on ${sha} concluded \"${conclusion}\"."
+                  failed=1
+                  ;;
+              esac
+            done <<< "$conclusions"
           done
 
           if [ "$failed" -ne 0 ]; then
@@ -149,7 +182,7 @@ jobs:
             exit 1
           fi
 
-          echo "every required check (${REQUIRED_CHECKS}) succeeded on ${sha}."
+          echo "every required check (${REQUIRED_CHECKS}) passed on ${sha}."
 
   publish:
     needs:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -36,7 +36,133 @@ permissions:
   contents: read
 
 jobs:
+  # The tag path had no gate at all. ci.yml's `push:` trigger is
+  # `branches: [main]`, so pushing `v1.2.3` starts NO CI run — no `test`, no
+  # `race`, no `e2e`, nothing — and the publish job below went straight to
+  # `docker build --push` with only its own pre-publish Trivy scan in the way.
+  # A tag on a branch that never merged, or on a commit whose checks went red,
+  # published a signed and attested release image regardless. ci.yml's
+  # `publish-image` deliberately excludes the release event because "release
+  # tags publish from their own tag push" — so this is where that gate is owed.
+  #
+  # `needs:` cannot cross workflow boundaries, so the gate cannot be an edge to
+  # ci.yml's jobs; it re-derives the same verdict from what those jobs left
+  # behind on the commit: it is contained in `main`, and its required checks
+  # concluded successfully.
+  #
+  # It FAILS the workflow, and there is no bypass input on purpose. A gate that
+  # publishes anyway while the operator remembers to look at a warning is the
+  # defect being closed, not a fix for it. If a tag is legitimately blocked,
+  # the remedy is to make the commit green — re-run the failed or stuck CI run
+  # on it, or merge it to `main` first — then delete and re-push the tag.
+  verify-release-tag:
+    # Tag path only. The `workflow_call` path from ci.yml already carries
+    # `needs: [test, race, e2e, e2e-postgres-smoke, image-smoke]`, so re-gating
+    # it here would be redundant, and a check run named `test` on a commit whose
+    # `test` job is still running (it is the caller) could not conclude.
+    #
+    # The discriminator is the ref TYPE, not the event name: inside a called
+    # workflow `github.event_name` is the CALLER's event — `push` there too —
+    # while `github.ref` stays the caller's ref, `refs/heads/main`. The same
+    # distinction the "Select public image reference" step below already draws.
+    if: ${{ github.ref_type == 'tag' }}
+    runs-on: ubuntu-latest
+    permissions:
+      # `checks: read` is the whole of the widening, and it lives here, not on
+      # the publish job below, which keeps exactly the permissions it had.
+      checks: read
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The ancestry question is unanswerable on a shallow clone: with the
+          # default depth of 1 there is no history for merge-base to walk and
+          # the check would fail every tag, or worse, be "fixed" by weakening it
+          # into a string search.
+          fetch-depth: 0
+
+      - name: Assert the tagged commit is contained in main
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Dereference first: for an annotated tag the pushed object is the tag,
+          # not the commit, and merge-base wants a commit.
+          sha="$(git rev-parse "${GITHUB_SHA}^{commit}")"
+
+          # Explicit refspec rather than trusting the checkout's ref layout on a
+          # tag event.
+          git fetch --no-tags --force origin "+refs/heads/main:refs/remotes/origin/main"
+          main_sha="$(git rev-parse origin/main)"
+
+          # `--is-ancestor`, never a string search through `git log`: the
+          # question is reachability, and only the commit graph answers it.
+          if ! git merge-base --is-ancestor "$sha" origin/main; then
+            echo "::error::tag ${GITHUB_REF_NAME} points at ${sha}, which is not contained in main (${main_sha}). Nothing on this repository's release path has judged that commit, and branch protection guards merges into main, not tags. Merge it to main first."
+            exit 1
+          fi
+
+          echo "tag ${GITHUB_REF_NAME} -> ${sha}, contained in main (${main_sha})."
+
+      - name: Assert the required checks passed on the tagged commit
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          # The required contexts on `main`, each a thin gate job over a matrix
+          # in ci.yml. Being in main is not enough on its own: a commit reaches
+          # main through the merge queue, and the queue judges the batch it
+          # built, so this asks the checks about this exact commit.
+          REQUIRED_CHECKS: test race e2e
+        run: |
+          set -euo pipefail
+
+          sha="$(git rev-parse "${GITHUB_SHA}^{commit}")"
+
+          # The endpoint's default `filter=latest` returns the most recent run
+          # per check name — the same view branch protection takes, so a red
+          # re-run after a green one counts as red here too.
+          runs="$(
+            gh api --paginate \
+              "repos/${GITHUB_REPOSITORY}/commits/${sha}/check-runs?per_page=100" \
+              --jq '.check_runs[] | [.name, .conclusion // "pending"] | @tsv'
+          )"
+
+          echo "check runs on ${sha}:"
+          printf '%s\n' "$runs"
+
+          failed=0
+          for name in $REQUIRED_CHECKS; do
+            conclusion="$(printf '%s\n' "$runs" | awk -F'\t' -v n="$name" '$1 == n { print $2; exit }')"
+            if [ -z "$conclusion" ]; then
+              echo "::error::no \`${name}\` check run exists for ${sha}. A tag push starts no CI run, so this commit's checks must already have run on main."
+              failed=1
+            elif [ "$conclusion" != "success" ]; then
+              echo "::error::the \`${name}\` check on ${sha} concluded \"${conclusion}\"."
+              failed=1
+            fi
+          done
+
+          if [ "$failed" -ne 0 ]; then
+            echo "::error::refusing to publish a release image for ${GITHUB_REF_NAME}: the required checks on ${sha} are not green."
+            exit 1
+          fi
+
+          echo "every required check (${REQUIRED_CHECKS}) succeeded on ${sha}."
+
   publish:
+    needs:
+      - verify-release-tag
+    # A skipped `needs:` dependency blocks the dependent job unless its own `if`
+    # says otherwise, and on the `workflow_call` path the gate above is skipped
+    # by design — without this, `:latest` would simply stop publishing.
+    #
+    # Written in the fail-safe direction: the gate's `success` is the only thing
+    # that lets a TAG through, and `skipped` is accepted only where it is
+    # expected, off the tag path. A gate that somehow skipped on a tag push
+    # therefore blocks the publish rather than waving it past.
+    if: ${{ !cancelled() && (needs.verify-release-tag.result == 'success' || (needs.verify-release-tag.result == 'skipped' && github.ref_type != 'tag')) }}
     runs-on: ubuntu-latest
     permissions:
       artifact-metadata: write

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -117,55 +117,88 @@ jobs:
           # `:latest` back, and tagging that same commit would then have shipped
           # a signed, attested release image anyway.
           #
-          # Being contained in main is not enough on its own to imply these. A
-          # commit reaches main through the merge queue, and the queue's run
-          # judges the batch it built while skipping `image-smoke`,
-          # `e2e-cross-browser` and the Postgres smoke outright — those three
-          # execute only on the `push` that follows. So the question has to be
-          # asked of this exact commit's checks, which is what this does.
+          # Being contained in main is not enough on its own to imply these, and
+          # neither is the merge queue's verdict. Measured on 6a95d01d, whose
+          # two suites the endpoint below returns side by side: in the QUEUE
+          # suite (87906745947, head_branch `gh-readonly-queue/main/pr-542-…`)
+          # `image-smoke` is `skipped` — it gates on the event and the queue is
+          # not one — while `e2e-postgres-smoke` reports `success` there with
+          # its own steps gated off by `RUN_HEAVY`, which is a green with no
+          # work behind it. Only the suite that ran on `main` itself
+          # (87908743276) carries a real verdict for either. So the gate asks
+          # that suite, and no other.
           REQUIRED_CHECKS: test race e2e e2e-postgres-smoke image-smoke
         run: |
           set -euo pipefail
 
           sha="$(git rev-parse "${GITHUB_SHA}^{commit}")"
 
+          # Which suites ran on `main` ITSELF. A merge-queue run lives on a
+          # `gh-readonly-queue/...` ref, so its head_branch is never `main`,
+          # and this is the only field that separates the two — the check_suite
+          # object nested in a check-run response carries an id and nothing
+          # else (probed 2026-08-21).
+          #
+          # Asking for this FIRST is what closes the window between the merge
+          # landing and the push run's suite being created. In that window the
+          # queue suite is the only one on the sha, and it reports `image-smoke`
+          # as `skipped`, which the judging below accepts — so a tag pushed
+          # there would have published a release image for a commit `image-smoke`
+          # never looked at. A suite that exists but has not finished is already
+          # safe: its conclusions are null, mapped to `pending` below, and
+          # `pending` refuses. The hole was strictly the suite that did not
+          # exist yet, and an absent suite is now its own refusal.
+          main_suite_ids="$(
+            gh api --paginate \
+              "repos/${GITHUB_REPOSITORY}/commits/${sha}/check-suites?per_page=100" \
+              --jq '.check_suites[] | select(.head_branch == "main") | .id'
+          )"
+
+          if [ -z "$main_suite_ids" ]; then
+            echo "::error::no check suite for ${sha} ran on \`main\` itself — only the merge queue's, if any. The lanes that judge a release image (\`image-smoke\`, \`e2e-postgres-smoke\`) run on the push to \`main\`, not in the queue, so this commit has no verdict from them yet. Wait for that run to finish, then re-push the tag."
+            exit 1
+          fi
+
           # The endpoint's default `filter=latest` returns the most recent run
-          # per name PER CHECK SUITE, and a commit on main carries two: the
-          # merge-queue run that validated it and the push run that followed. So
-          # each of these names legitimately appears TWICE, and for
-          # `image-smoke` the two disagree — `skipped` in the queue suite,
-          # `success` in the push one (verified on 6a95d01d and fc30f490).
-          # Every row is therefore judged, not the first one found: taking the
-          # first would make the verdict depend on the order the API happened to
-          # return, and a failure in either suite must block the tag.
+          # per name PER CHECK SUITE, so each of these names appears once per
+          # suite on the sha. Every row from a `main` suite is judged, never the
+          # first one found: taking the first would make the verdict depend on
+          # the order the API happened to return.
           runs="$(
             gh api --paginate \
               "repos/${GITHUB_REPOSITORY}/commits/${sha}/check-runs?per_page=100" \
-              --jq '.check_runs[] | [.name, .conclusion // "pending"] | @tsv'
+              --jq '.check_runs[] | [(.check_suite.id | tostring), .name, .conclusion // "pending"] | @tsv'
           )"
 
-          echo "check runs on ${sha}:"
-          printf '%s\n' "$runs"
+          main_runs="$(
+            printf '%s\n' "$runs" | awk -F'\t' -v ids="$(printf '%s ' $main_suite_ids)" '
+              BEGIN { n = split(ids, a, " "); for (i = 1; i <= n; i++) if (a[i] != "") keep[a[i]] = 1 }
+              keep[$1] { print $2 "\t" $3 }
+            '
+          )"
+
+          echo "check runs on ${sha} from a suite that ran on main:"
+          printf '%s\n' "$main_runs"
 
           failed=0
           for name in $REQUIRED_CHECKS; do
-            conclusions="$(printf '%s\n' "$runs" | awk -F'\t' -v n="$name" '$1 == n { print $2 }')"
+            conclusions="$(printf '%s\n' "$main_runs" | awk -F'\t' -v n="$name" '$1 == n { print $2 }')"
 
             if [ -z "$conclusions" ]; then
-              echo "::error::no \`${name}\` check run exists for ${sha}. A tag push starts no CI run of its own, so this commit's checks must already have run on main."
+              echo "::error::no \`${name}\` check run exists for ${sha} in a suite that ran on \`main\`. A tag push starts no CI run of its own, so this commit's checks must already have run there."
               failed=1
               continue
             fi
 
             # `skipped` passes, here and for the same reason ci.yml's own `test`
-            # gate accepts it: the `changes` job decided this run did not need
-            # that lane — a decision not to run, not a failure to run. It is not
-            # a hole a tag can be aimed at either, since `changes` clears a lane
-            # only for a diff that cannot reach it. Insisting on `success`
-            # instead would block a tag on a docs-only commit forever:
-            # `image-smoke` gates on `run_e2e`, so there it is skipped in BOTH
-            # suites. `pending` is not `skipped` — a queued or still-running
-            # check is no verdict, and this refuses on it.
+            # gate accepts it: the `changes` job decided that run did not need
+            # the lane — a decision not to run, not a failure to run — and it
+            # clears a lane only for a diff that cannot reach it. Insisting on
+            # `success` would block a tag on a docs-only commit forever, since
+            # `image-smoke` gates on `run_e2e` and is skipped on the push there
+            # too. What made `skipped` unsafe was reading it off the QUEUE
+            # suite, which is no longer consulted. `pending` is not `skipped` —
+            # a queued or still-running check is no verdict, and this refuses.
             while IFS= read -r conclusion; do
               case "$conclusion" in
                 success|skipped) ;;

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,14 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.27rc2-alpine3.24@sha256:dcbb18cc5fa1082364dc6aa95224b6b55429d09cbb9631a053d8064c1c367300 AS builder
+# The builder tag must stay equal to the `go` directive in go.mod. Every CI Go
+# job resolves its toolchain with `go-version-file: go.mod`, so a builder ahead
+# of that directive ships a binary compiled by a toolchain no unit, race or e2e
+# run ever exercised — GOTOOLCHAIN only ever upgrades, never downgrades, so the
+# newer image simply wins. A release candidate reached this line that way. CI
+# now asserts the equality (`Builder toolchain matches go.mod` in
+# .github/workflows/ci.yml), and Dependabot is told to leave pre-release tags of
+# this image alone.
+FROM golang:1.26.6-alpine3.24@sha256:1a9c10cf505a9e6b1e96ea77ebdbfe79a0f10380181faf88bc3b51d7e4315fae AS builder
 WORKDIR /src
 
 COPY go.mod go.sum ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 # syntax=docker/dockerfile:1
 
-# The builder tag must stay equal to the `go` directive in go.mod. Every CI Go
-# job resolves its toolchain with `go-version-file: go.mod`, so a builder ahead
-# of that directive ships a binary compiled by a toolchain no unit, race or e2e
-# run ever exercised — GOTOOLCHAIN only ever upgrades, never downgrades, so the
-# newer image simply wins. A release candidate reached this line that way. CI
+# The builder tag must stay equal to the toolchain go.mod asks for — its
+# `toolchain` directive where there is one, otherwise the `go` line, which is
+# the order actions/setup-go reads them in. Every CI Go job resolves its
+# toolchain with `go-version-file: go.mod`, so a builder ahead of that directive
+# ships a binary compiled by a toolchain no unit, race or e2e run ever
+# exercised — GOTOOLCHAIN only ever upgrades, never downgrades, so the newer
+# image simply wins. A release candidate reached this line that way. CI
 # now asserts the equality (`Builder toolchain matches go.mod` in
 # .github/workflows/ci.yml), and Dependabot is told to leave pre-release tags of
 # this image alone.

--- a/changelog.d/ci-gate-release-image-on-green-checks.md
+++ b/changelog.d/ci-gate-release-image-on-green-checks.md
@@ -1,0 +1,19 @@
+### Security
+
+- **A release tag no longer publishes an image on its own say-so.** Pushing `v*` starts no CI run —
+  CI is triggered by pushes to `main` — so the tag went straight to build-and-push with only the
+  pre-publish vulnerability scan between it and the registry. A tag on a commit that never merged,
+  or on one whose checks went red, produced a signed, attested release image regardless. The publish
+  workflow now runs a gate first: the tagged commit must be contained in `main`, and its `test`,
+  `race` and `e2e` checks must have concluded successfully. A tag that fails either condition fails
+  the workflow and publishes nothing; there is no override. Publishing `latest` from `main` is
+  unchanged — that path already waited on the same checks.
+
+### Fixed
+
+- **The release image is built by the Go toolchain the test suite actually runs.** The builder stage
+  had been bumped to `golang:1.27rc2-alpine3.24` while every CI job kept resolving its toolchain
+  from `go.mod` (1.26.6), and `GOTOOLCHAIN` only ever upgrades — so the published binary was
+  compiled by a release candidate that no unit, race or browser test had ever run under. The builder
+  is pinned back to `golang:1.26.6-alpine3.24`. CI now fails when the builder tag and the `go.mod`
+  directive disagree, and Dependabot no longer offers pre-release tags of that image.

--- a/changelog.d/ci-gate-release-image-on-green-checks.md
+++ b/changelog.d/ci-gate-release-image-on-green-checks.md
@@ -4,10 +4,12 @@
   CI is triggered by pushes to `main` — so the tag went straight to build-and-push with only the
   pre-publish vulnerability scan between it and the registry. A tag on a commit that never merged,
   or on one whose checks went red, produced a signed, attested release image regardless. The publish
-  workflow now runs a gate first: the tagged commit must be contained in `main`, and its `test`,
-  `race` and `e2e` checks must have concluded successfully. A tag that fails either condition fails
-  the workflow and publishes nothing; there is no override. Publishing `latest` from `main` is
-  unchanged — that path already waited on the same checks.
+  workflow now runs a gate first: the tagged commit must be contained in `main`, and the same five
+  checks that `latest` waits on — `test`, `race`, `e2e`, `e2e-postgres-smoke` and `image-smoke` —
+  must have passed on the run that judged it on `main` itself. A merge-queue run's verdict is not
+  accepted in their place: it does not run the image or Postgres smokes at all. A tag that fails
+  either condition fails the workflow and publishes nothing; there is no override. Publishing
+  `latest` from `main` is unchanged — that path already waited on these checks.
 
 ### Fixed
 


### PR DESCRIPTION
Closes **R2-0779**, **R2-0780**.

A tag push started no CI at all, so a release image published ungated. And the builder was `golang:1.27rc2` while go.mod says `1.26.6` — GOTOOLCHAIN only upgrades, so the RC won.

Now a gate job asserts the commit is in `main` and that all five checks `:latest` waits on concluded there. No bypass. Builder pinned back to `1.26.6-alpine3.24` at its historical digest; CI fails on drift; Dependabot skips pre-release tags.

Only suites that ran on `main` count — the queue's are not a verdict:

```
1d117f8d (in main, queue suites only)
  old step EXIT=0    new step EXIT=1
```

Unexercised: the tag event, and Dependabot's `*rc*` glob.

Rollback: revert per commit; reverting restores the RC digest.
