### PR TITLE
test(api): decode the payload, not the whole sealed cookie value

### DIFF
--- a/changelog.d/test-sealed-cookie-assertions-can-fail.md
+++ b/changelog.d/test-sealed-cookie-assertions-can-fail.md
@@ -1,0 +1,7 @@
+none
+
+Tests only: the two sealing assertions on the flash and recovery-code cookies
+decoded the whole cookie value instead of the payload behind the `v2.` version
+envelope, so the decode always failed and the check nested behind it never ran.
+Both now split the envelope, decode only the payload, and refuse a hand-built
+`v2.` + base64url(plaintext JSON) cookie. No product code.

--- a/internal/api/flash_cookie_security_regressions_test.go
+++ b/internal/api/flash_cookie_security_regressions_test.go
@@ -8,6 +8,8 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/gofiber/fiber/v3"
 )
 
 func TestFlashCookieUsesSealedTransport(t *testing.T) {
@@ -31,12 +33,90 @@ func TestFlashCookieUsesSealedTransport(t *testing.T) {
 		t.Fatalf("did not expect flash cookie to expose email in plaintext: %q", flashCookie.Value)
 	}
 
-	decoded, err := base64.RawURLEncoding.DecodeString(flashCookie.Value)
-	if err == nil {
-		payload := FlashPayload{}
-		if json.Unmarshal(decoded, &payload) == nil {
-			t.Fatalf("expected flash cookie to be sealed; got plaintext payload: %#v", payload)
-		}
+	assertSealedCookieEnvelope(t, flashCookie.Value, &FlashPayload{})
+}
+
+// TestSealedEnvelopeAroundPlaintextFlashPayloadIsRefused pins the half of the
+// "sealed cookies" invariant that a shape check on the response cannot reach: a
+// value wearing the v2 envelope over base64url(plaintext JSON) is not a sealed
+// cookie, and the login page must refuse it. The same payload bytes are
+// presented twice — once sealed under the app's own key, once merely encoded —
+// so the seal is the only difference between the two requests, and the sealed
+// one is the positive anchor proving the page has a rendering path to lose.
+func TestSealedEnvelopeAroundPlaintextFlashPayloadIsRefused(t *testing.T) {
+	app, _ := newOnboardingTestApp(t)
+
+	serialized, err := json.Marshal(FlashPayload{
+		AuthError:   "invalid credentials",
+		ForgotEmail: "forged-flash@example.com",
+	})
+	if err != nil {
+		t.Fatalf("marshal flash payload: %v", err)
+	}
+
+	// Positive anchor: sealed, the very same payload renders its error.
+	sealedResponse := loginPageWithFlashCookie(t, app, sealCookieForTestApp(t, flashCookieName, serialized))
+	sealedBody := mustReadBodyString(t, sealedResponse.Body)
+	if htmlAuthErrorByKey(mustParseHTMLDocument(t, sealedBody), "auth.error.invalid_credentials") == nil {
+		t.Fatal("expected a sealed flash payload to surface its auth error via data-error-key")
+	}
+
+	// The forgery: same bytes, same envelope, no seal.
+	forged := secureCookieVersion + "." + base64.RawURLEncoding.EncodeToString(serialized)
+	forgedResponse := loginPageWithFlashCookie(t, app, forged)
+	forgedBody := mustReadBodyString(t, forgedResponse.Body)
+	if htmlAuthErrorByKey(mustParseHTMLDocument(t, forgedBody), "auth.error.invalid_credentials") != nil {
+		t.Fatal("a plaintext flash payload behind the version envelope must not be honored")
+	}
+	assertBodyNotContainsAll(t, forgedBody,
+		bodyStringMatch{fragment: "forged-flash@example.com", message: "did not expect a forged flash email to reach the page"},
+	)
+
+	cleared := responseCookie(forgedResponse.Cookies(), flashCookieName)
+	if cleared == nil || cleared.Value != "" {
+		t.Fatalf("expected the refused flash cookie to be cleared, got %#v", cleared)
+	}
+}
+
+func loginPageWithFlashCookie(t *testing.T, app *fiber.App, flashValue string) *http.Response {
+	t.Helper()
+
+	request := httptest.NewRequest(http.MethodGet, "/login", nil)
+	request.Header.Set("Accept-Language", "en")
+	request.Header.Set("Cookie", flashCookieName+"="+flashValue)
+
+	response := mustAppResponse(t, app, request)
+	assertStatusCode(t, response, http.StatusOK)
+	return response
+}
+
+// assertSealedCookieEnvelope is the shared sealing assertion for cookie values
+// carried in the "<version>.<base64url payload>" envelope that
+// secureCookieCodec.seal writes. It decodes the payload only: decoding the whole
+// value fails unconditionally on the "." separator, which is what left the
+// earlier form of this check — a plaintext test nested under `if err == nil` —
+// permanently unexecuted. plaintextTarget is a pointer to the struct the cookie
+// would carry in the clear; a payload that parses into it is not ciphertext.
+func assertSealedCookieEnvelope(t *testing.T, rawValue string, plaintextTarget any) {
+	t.Helper()
+
+	version, encodedPayload, found := strings.Cut(strings.TrimSpace(rawValue), ".")
+	if !found {
+		t.Fatalf("expected a %q version envelope in cookie value, got %q", secureCookieVersion+".", rawValue)
+	}
+	if version != secureCookieVersion {
+		t.Fatalf("expected cookie envelope version %q, got %q", secureCookieVersion, version)
+	}
+
+	payload, err := base64.RawURLEncoding.DecodeString(strings.TrimSpace(encodedPayload))
+	if err != nil {
+		t.Fatalf("expected a base64url sealed payload, got %q: %v", encodedPayload, err)
+	}
+	if len(payload) == 0 {
+		t.Fatal("expected a non-empty sealed payload")
+	}
+	if json.Unmarshal(payload, plaintextTarget) == nil {
+		t.Fatalf("expected the cookie payload to be sealed ciphertext; it parsed as plaintext %T: %#v", plaintextTarget, plaintextTarget)
 	}
 }
 

--- a/internal/api/recovery_code_cookie_encoding_regression_test.go
+++ b/internal/api/recovery_code_cookie_encoding_regression_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/base64"
 	"encoding/json"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -23,17 +24,68 @@ func TestRecoveryCodeCookieIsNotPlaintextJSON(t *testing.T) {
 		t.Fatal("expected recovery cookie in register response")
 	}
 
-	decoded, err := base64.RawURLEncoding.DecodeString(recoveryCookie)
-	if err == nil {
-		payload := recoveryCodePagePayload{}
-		if json.Unmarshal(decoded, &payload) == nil {
-			t.Fatalf("expected recovery cookie to be sealed; got plaintext payload: %#v", payload)
-		}
-	}
+	assertSealedCookieEnvelope(t, recoveryCookie, &recoveryCodePagePayload{})
 
 	if strings.Contains(recoveryCookie, "OVUM-") {
 		t.Fatalf("expected recovery cookie value not to expose plaintext recovery code")
 	}
+}
+
+// TestSealedEnvelopeAroundPlaintextRecoveryPayloadIsRefused is the recovery-code
+// arm of TestSealedEnvelopeAroundPlaintextFlashPayloadIsRefused: the v2 envelope
+// is framing, not a seal, so base64url(plaintext JSON) behind it must reveal no
+// code. Both requests carry the same payload bytes, attributed to the same
+// account, and differ only in whether the codec sealed them — the sealed one is
+// the positive anchor proving the page still reveals what it should.
+func TestSealedEnvelopeAroundPlaintextRecoveryPayloadIsRefused(t *testing.T) {
+	app, database := newOnboardingTestApp(t)
+	owner := createOnboardingTestUser(t, database, "recovery-cookie-forged-envelope@example.com", "StrongPass1", true)
+	authCookie := loginAndExtractAuthCookie(t, app, owner.Email, "StrongPass1")
+
+	const revealedCode = "OVUM-ENVELOPE-COD"
+	serialized, err := json.Marshal(recoveryCodePagePayload{
+		UserID:         owner.ID,
+		RecoveryCode:   revealedCode,
+		ContinuePath:   "/dashboard",
+		ContinueTarget: recoveryCodeContinueTargetDashboard,
+		Surface:        recoveryCodeSurfaceDedicated,
+	})
+	if err != nil {
+		t.Fatalf("marshal recovery payload: %v", err)
+	}
+
+	// Positive anchor: sealed, this payload reveals its code to its owner.
+	sealedResponse := recoveryCodePageWithCookie(t, app, authCookie, sealCookieForTestApp(t, recoveryCodeCookieName, serialized))
+	if sealedResponse.StatusCode != http.StatusOK {
+		t.Fatalf("expected the owner's sealed recovery payload to render, got %d", sealedResponse.StatusCode)
+	}
+	if !strings.Contains(mustReadBodyString(t, sealedResponse.Body), revealedCode) {
+		t.Fatal("expected the sealed recovery payload to reveal its code")
+	}
+
+	// The forgery: same bytes, same envelope, no seal.
+	forged := secureCookieVersion + "." + base64.RawURLEncoding.EncodeToString(serialized)
+	forgedResponse := recoveryCodePageWithCookie(t, app, authCookie, forged)
+	if forgedResponse.StatusCode != http.StatusSeeOther {
+		t.Fatalf("expected a plaintext recovery payload behind the version envelope to be refused with a redirect, got %d", forgedResponse.StatusCode)
+	}
+	if strings.Contains(mustReadBodyString(t, forgedResponse.Body), revealedCode) {
+		t.Fatal("a plaintext recovery payload must not surface its code")
+	}
+
+	cleared := responseCookie(forgedResponse.Cookies(), recoveryCodeCookieName)
+	if cleared == nil || cleared.Value != "" {
+		t.Fatalf("expected the refused recovery cookie to be cleared, got %#v", cleared)
+	}
+}
+
+func recoveryCodePageWithCookie(t *testing.T, app *fiber.App, authCookie string, recoveryCookie string) *http.Response {
+	t.Helper()
+
+	request := httptest.NewRequest(http.MethodGet, "/recovery-code", nil)
+	request.Header.Set("Accept-Language", "en")
+	request.Header.Set("Cookie", authCookie+"; "+recoveryCodeCookieName+"="+recoveryCookie)
+	return mustAppResponse(t, app, request)
 }
 
 func TestRecoveryCodeCookieRoundTripPreservesPayload(t *testing.T) {


### PR DESCRIPTION
Closes **R2-0296**.

Both tests decoded the *whole* cookie (`v2.` + base64url), so `err != nil` always and the only sealing assertion never ran. Now: cut the envelope, decode the payload, fail if it unmarshals as plaintext — plus a bare `v2.`+base64(JSON) fixture the route must refuse, with the sealed twin as anchor.

No production change. The codec was independently audited and is correct; both blocks were born dead in the sealing commits.

Coverage cannot show this — Go does not instrument `_test.go` — so a temporary unconditional `t.Fatal` went inside each dead body:

```
--- PASS: TestFlashCookieUsesSealedTransport
--- PASS: TestRecoveryCodeCookieIsNotPlaintextJSON
```

New assertion on the plaintext fixture: `it parsed as plaintext *api.FlashPayload`. Green after; nine codec tests untouched.

Rollback: revert; tests only, no wire format moves.
