### PR TITLE
fix(ci): drop the dependabot ignore condition that invalidated the whole file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,23 +36,20 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
-    # Never offer a pre-release golang builder. Dependabot treats `1.27rc2` as
-    # simply newer than `1.26.6` and opened exactly that bump, which merged: the
-    # release image was then compiled by a release candidate while every CI Go
-    # job kept resolving its toolchain from go.mod's 1.26.6 — GOTOOLCHAIN
-    # upgrades but never downgrades, so nothing pulled the builder back. CI now
-    # asserts the two are equal (`Builder toolchain matches go.mod` in ci.yml),
-    # but that assertion would only redden on the next such bump; this is what
-    # keeps it from being offered.
+    # A pre-release golang builder is refused by CI, not here. Dependabot treats
+    # `1.27rc2` as simply newer than `1.26.6` and opened exactly that bump, which
+    # merged: the release image was then compiled by a release candidate while
+    # every CI Go job kept resolving its toolchain from go.mod's 1.26.6 —
+    # GOTOOLCHAIN upgrades but never downgrades, so nothing pulled the builder
+    # back. `Builder toolchain matches go.mod` in ci.yml now fails any diff where
+    # the two disagree, which is what closes that lane.
     #
-    # One pattern, because Go publishes exactly one pre-release channel to this
-    # image — `1.27rc1`, `1.27rc2`, never an alpha or a beta — and it is the
-    # spelling that actually got in. A real release tag is picked up unchanged:
-    # `1.26.6-alpine3.24` contains no `rc`.
-    ignore:
-      - dependency-name: "golang"
-        versions:
-          - "*rc*"
+    # An `ignore` entry here would only stop the pull request being offered, and
+    # it cannot be written: a docker ignore condition takes version requirements,
+    # so `"*rc*"` is rejected outright — and an invalid file stops Dependabot for
+    # EVERY ecosystem in this repository, not just this entry. Trading a working
+    # security-update feed for a pull request CI already refuses is the wrong way
+    # round.
 
   # docker-compose (GA since 2025) tracks image: tags in compose manifests —
   # the operator baseline at the repo root plus every example stack under

--- a/changelog.d/fix-dependabot-config-invalid-ignore.md
+++ b/changelog.d/fix-dependabot-config-invalid-ignore.md
@@ -1,0 +1,9 @@
+none
+
+CI only: the Dependabot config no longer carries an `ignore` entry for
+pre-release `golang` builder tags. A docker ignore condition takes version
+requirements, so the pattern was rejected by Dependabot outright and the whole
+file was invalid — which stops dependency and security updates for every
+ecosystem in the repository, not just that entry. The builder is still held to
+go.mod by the `Builder toolchain matches go.mod` CI step, which fails any diff
+where the two disagree. No product code.


### PR DESCRIPTION
Fixes a defect introduced by #544.

The `ignore` entry added there is not a valid docker ignore condition — that field takes version requirements, and `"*rc*"` is not one:

```
The property '#/updates/3/ignore/0/versions' includes invalid version
requirements for a docker ignore condition
```

An invalid file is not partially applied: Dependabot stops parsing it, so **no ecosystem in the repository gets updates**, security ones included. The entry only ever stopped a pull request being *offered* — CI already refuses the bump itself.

Removed. `Builder toolchain matches go.mod` in ci.yml, also from #544, fails any diff where the builder tag and the `go`/`toolchain` directive disagree, so the RC lane stays closed. The comment now records why no `ignore` entry can be written here.

The check that caught this reports on the default branch, and #544 was merged before it ran; it was flagged in that PR as unverifiable locally, with the wrong checkpoint.

`yaml.safe_load` parses: version 2, five update blocks, no `ignore` keys left.

Rollback: revert — restores the invalid file and stops Dependabot again.
