### PR TITLE
test(api): make the clear-data revocation guard able to fail

### DIFF
--- a/changelog.d/test-clear-data-actually-revokes-other-sessions.md
+++ b/changelog.d/test-clear-data-actually-revokes-other-sessions.md
@@ -1,0 +1,9 @@
+none
+
+Tests only: the clear-data session-revocation regression now mints a second,
+genuinely separate login for the same owner and requires it to be bounced to
+/login after the wipe, drives the reissued cookie through /dashboard so the
+inline refresh is proven to work rather than proven non-empty, and requires the
+acting device's pre-wipe cookie to be refused too. It previously replayed the
+acting session's own cookie and asserted only that a value came back, so it
+stayed green against a handler that reissued a dead cookie. No product code.

--- a/internal/api/settings_clear_data_session_revocation_test.go
+++ b/internal/api/settings_clear_data_session_revocation_test.go
@@ -10,17 +10,86 @@ import (
 	"github.com/ovumcy/ovumcy-web/internal/models"
 )
 
-// TestClearAllData_BumpsSessionVersion captures the contract that a
-// successful POST /api/v1/users/current/data-wipe invalidates every auth cookie
-// issued before the wipe. The originating device is refreshed inline so
-// the user that triggered the clear-data flow stays signed in, while a
-// session that existed on a different device (whose cookie was issued
-// before the version bump) is rejected with "revoked session" on its
-// next request.
-func TestClearAllData_BumpsSessionVersion(t *testing.T) {
+// clearDataDashboardProbe drives a real authenticated page request carrying
+// exactly the cookie header it is handed. Every session claim in this file is
+// settled by sending the cookie somewhere it has to be honoured — a cookie that
+// is merely present in a response says nothing about whether it still opens a
+// door.
+func clearDataDashboardProbe(t *testing.T, ctx settingsSecurityTestContext, cookieHeader string) *http.Response {
+	t.Helper()
+
+	request := httptest.NewRequest(http.MethodGet, "/dashboard", nil)
+	request.Header.Set("Accept-Language", "en")
+	request.Header.Set("Cookie", cookieHeader)
+
+	response, err := ctx.app.Test(request, testConfigNoTimeout)
+	if err != nil {
+		t.Fatalf("dashboard probe (%s) failed: %v", cookieHeader, err)
+	}
+	return response
+}
+
+// assertAuthCookieOpensDashboard requires the session to still be live: 200 on
+// /dashboard, not "some status other than the refusal I had in mind".
+func assertAuthCookieOpensDashboard(t *testing.T, ctx settingsSecurityTestContext, cookieHeader string, label string) {
+	t.Helper()
+
+	response := clearDataDashboardProbe(t, ctx, cookieHeader)
+	defer func() { _ = response.Body.Close() }()
+
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("%s: /dashboard status = %d, want 200 (session must be accepted)", label, response.StatusCode)
+	}
+}
+
+// assertAuthCookieIsRevoked requires the exact refusal AuthRequired gives a
+// revoked session on a page route — 303 to /login. Asserting merely "not 200"
+// would also accept a 404, a 500 or an onboarding bounce, none of which prove
+// the session was invalidated.
+func assertAuthCookieIsRevoked(t *testing.T, ctx settingsSecurityTestContext, cookieHeader string, label string) {
+	t.Helper()
+
+	response := clearDataDashboardProbe(t, ctx, cookieHeader)
+	defer func() { _ = response.Body.Close() }()
+
+	if response.StatusCode != http.StatusSeeOther {
+		t.Fatalf("%s: /dashboard status = %d, want 303 (revoked session must be bounced)", label, response.StatusCode)
+	}
+	if location := response.Header.Get("Location"); location != "/login" {
+		t.Fatalf("%s: /dashboard redirect Location = %q, want %q", label, location, "/login")
+	}
+}
+
+// TestClearDataRevokesOtherSessionsAndReissuesTheActingOne pins the contract
+// that a successful POST /api/v1/users/current/data-wipe invalidates every auth
+// cookie issued before the wipe: the originating device is refreshed inline so
+// the owner who triggered the flow stays signed in, while a session that exists
+// on a different device is rejected on its next request.
+//
+// The two halves are exercised through the app, not inferred:
+//   - the "other device" is a genuinely separate login round trip, so it carries
+//     its own session id. Reusing ctx.authCookie here would probe the acting
+//     session — the one the handler deliberately refreshes — and the revocation
+//     claim would hold vacuously.
+//   - the reissued cookie is sent on a real request and must open /dashboard. A
+//     cookie sealed against the pre-bump version is well-formed and non-empty
+//     and dead on first use, so "the response carried a value" is not evidence
+//     the originating device stayed signed in.
+func TestClearDataRevokesOtherSessionsAndReissuesTheActingOne(t *testing.T) {
 	ctx := newSettingsSecurityTestContext(t, "clear-data-bumps-sv@example.com")
-	otherSessionCookie := ctx.authCookie
+
+	otherDeviceCookie := loginAndExtractAuthCookieWithCSRF(t, ctx.app, ctx.user.Email, "StrongPass1")
+	if strings.TrimSpace(otherDeviceCookie) == strings.TrimSpace(ctx.authCookie) {
+		t.Fatal("the second login returned the acting session's cookie; the other-device probe would prove nothing")
+	}
+	actingCookieBeforeWipe := ctx.authCookie
 	preWipeVersion := ctx.user.AuthSessionVersion
+
+	// Positive anchor for the refusals below: both sessions open /dashboard
+	// before the wipe, so a later 303 is the wipe's doing and not a fixture that
+	// never authenticated in the first place.
+	assertAuthCookieOpensDashboard(t, ctx, otherDeviceCookie, "other device before clear-data")
+	assertAuthCookieOpensDashboard(t, ctx, actingCookieBeforeWipe, "acting device before clear-data")
 
 	form := url.Values{"password": {"StrongPass1"}}
 	resp := settingsFormRequestWithCSRF(t, ctx, http.MethodPost, "/api/v1/users/current/data-wipe", form, map[string]string{"Accept": "application/json"})
@@ -41,15 +110,8 @@ func TestClearAllData_BumpsSessionVersion(t *testing.T) {
 	if refreshed == nil || strings.TrimSpace(refreshed.Value) == "" {
 		t.Fatal("clear-data handler must reissue ovumcy_auth so the originating session stays alive")
 	}
+	assertAuthCookieOpensDashboard(t, ctx, cookiePair(refreshed), "reissued acting session after clear-data")
 
-	otherProbe := httptest.NewRequest(http.MethodGet, "/dashboard", nil)
-	otherProbe.Header.Set("Cookie", otherSessionCookie)
-	otherResp, err := ctx.app.Test(otherProbe, testConfigNoTimeout)
-	if err != nil {
-		t.Fatalf("other-session probe: %v", err)
-	}
-	defer func() { _ = otherResp.Body.Close() }()
-	if otherResp.StatusCode == http.StatusOK {
-		t.Fatalf("pre-wipe cookie still accepted on /dashboard (status=%d); clear-data must invalidate other sessions", otherResp.StatusCode)
-	}
+	assertAuthCookieIsRevoked(t, ctx, otherDeviceCookie, "other device after clear-data")
+	assertAuthCookieIsRevoked(t, ctx, actingCookieBeforeWipe, "acting device's pre-wipe cookie after clear-data")
 }


### PR DESCRIPTION
Closes **R2-0378**. PR 1 of 3 for board group G04.

The clear-data revocation test proved neither of its two claims. The "other session" it probed was `ctx.authCookie` — the acting session itself, the one the handler deliberately refreshes. And the reissued cookie was only checked for being non-empty; a cookie sealed against the pre-bump version is well-formed and dead on first use.

Now both halves go through the app: the other device is a real second login, the reissued cookie must open `/dashboard`, and every refusal is the exact one `AuthRequired` gives — 303 to `/login`, not "some status other than 200". Both sessions must open `/dashboard` *before* the wipe, so a later 303 is the wipe's doing and not a fixture that never authenticated.

```
refreshCurrentSession seals a stale-version cookie
  old assertions   PASS          <- vacuous
  new assertions   FAIL  reissued acting session: /dashboard = 303, want 200
auth_session_version + 1 -> + 0
  new assertions   FAIL  version did not advance: before=1 after=1
restored           PASS, no production file in the diff
```

Renamed from `TestClearAllData_BumpsSessionVersion`: the old name promised revocation while the body measured a column, and the package's own `-run` selector did not match it. `SECURITY.md:228` cites the file, not the function.

Rollback: revert; tests only.
