### PR TITLE
test(api): let the erasure step-up notice the other owner

### DIFF
--- a/changelog.d/test-erasure-stepup-observes-the-other-owner.md
+++ b/changelog.d/test-erasure-stepup-observes-the-other-owner.md
@@ -1,0 +1,9 @@
+none
+
+Test-only guard: the erasure step-up's foreign-session case now seeds the second
+owner with a day entry of its own and asserts that entry survives alongside the
+first owner's, plus that the refusal is the identity-mismatch one rather than any
+other check on the way. No user-visible change — the callback already required
+the session to be the account the sealed step-up payload names; every count the
+test read belonged to that one account, so a callback that erased the session's
+own account instead moved no number and stayed green.

--- a/internal/api/settings_erasure_stepup_flow_test.go
+++ b/internal/api/settings_erasure_stepup_flow_test.go
@@ -36,21 +36,37 @@ func postErasureStepupStart(t *testing.T, fixture *oidcStepupFixture, path strin
 func seedStepupDayEntry(t *testing.T, fixture *oidcStepupFixture) {
 	t.Helper()
 
+	seedStepupDayEntryFor(t, fixture, fixture.user.ID, time.Date(2026, 5, 13, 0, 0, 0, 0, time.UTC))
+}
+
+// seedStepupDayEntryFor seeds a day entry for any owner on the instance, not
+// just the one the fixture acts as. An owner with no rows at all is
+// indistinguishable from an owner whose rows were just wiped, so a second owner
+// only becomes evidence once it has something to lose.
+func seedStepupDayEntryFor(t *testing.T, fixture *oidcStepupFixture, userID uint, day time.Time) {
+	t.Helper()
+
 	entry := models.DailyLog{
-		UserID: fixture.user.ID,
-		Date:   time.Date(2026, 5, 13, 0, 0, 0, 0, time.UTC),
+		UserID: userID,
+		Date:   day,
 	}
 	if err := fixture.database.Create(&entry).Error; err != nil {
-		t.Fatalf("seed day entry: %v", err)
+		t.Fatalf("seed day entry for user %d: %v", userID, err)
 	}
 }
 
 func countStepupDayEntries(t *testing.T, fixture *oidcStepupFixture) int64 {
 	t.Helper()
 
+	return countStepupDayEntriesFor(t, fixture, fixture.user.ID)
+}
+
+func countStepupDayEntriesFor(t *testing.T, fixture *oidcStepupFixture, userID uint) int64 {
+	t.Helper()
+
 	var count int64
-	if err := fixture.database.Model(&models.DailyLog{}).Where("user_id = ?", fixture.user.ID).Count(&count).Error; err != nil {
-		t.Fatalf("count day entries: %v", err)
+	if err := fixture.database.Model(&models.DailyLog{}).Where("user_id = ?", userID).Count(&count).Error; err != nil {
+		t.Fatalf("count day entries for user %d: %v", userID, err)
 	}
 	return count
 }
@@ -265,7 +281,12 @@ func TestErasureStepupStartReturnsAnInterstitialForBrowsers(t *testing.T) {
 
 // TestErasureStepupCallbackRefusesAForeignSession covers the identity binding:
 // a step-up cookie minted for one owner, presented with another owner's
-// session, must erase nothing.
+// session, must erase nothing — neither the owner the sealed payload names nor
+// the owner whose session carried it in. Both accounts therefore hold a day
+// entry: with only the payload's owner countable, "refused" and "erased the
+// session's account instead" read the same, and the id inside a sealed payload
+// is exactly the kind that has to be combined with the session's own, never
+// swapped for it.
 func TestErasureStepupCallbackRefusesAForeignSession(t *testing.T) {
 	t.Parallel()
 
@@ -291,6 +312,7 @@ func TestErasureStepupCallbackRefusesAForeignSession(t *testing.T) {
 	if err := fixture.database.Create(&intruder).Error; err != nil {
 		t.Fatalf("create second owner: %v", err)
 	}
+	seedStepupDayEntryFor(t, fixture, intruder.ID, time.Date(2026, 6, 21, 0, 0, 0, 0, time.UTC))
 
 	form := url.Values{"state": {state}, "code": {"callback-code"}}
 	request := httptest.NewRequest(http.MethodPost, "/auth/oidc/callback", strings.NewReader(form.Encode()))
@@ -301,6 +323,19 @@ func TestErasureStepupCallbackRefusesAForeignSession(t *testing.T) {
 
 	if got := countStepupDayEntries(t, fixture); got != 1 {
 		t.Fatalf("a step-up presented with another owner's session must erase nothing, day entries = %d", got)
+	}
+	if got := countStepupDayEntriesFor(t, fixture, intruder.ID); got != 1 {
+		t.Fatalf("the erasure must not follow the session onto the other owner, second owner's day entries = %d", got)
+	}
+
+	// Every earlier refusal in the callback also leaves both diaries intact, so
+	// the counts alone cannot say which check stopped this. Pin the mismatch key.
+	flashCookie := responseCookie(response.Cookies(), flashCookieName)
+	if flashCookie == nil || strings.TrimSpace(flashCookie.Value) == "" {
+		t.Fatal("expected a flash cookie carrying the refusal")
+	}
+	if payload := decodeFlashCookieForTest(t, flashCookie.Value); payload.AuthError != settingsOIDCReauthMismatchErrorSpec().Key {
+		t.Fatalf("expected the identity-mismatch refusal %q, got %q", settingsOIDCReauthMismatchErrorSpec().Key, payload.AuthError)
 	}
 }
 


### PR DESCRIPTION
Closes **R2-0388**. PR 2 of 3 for board group G04.

The erasure step-up test seeded the intruder owner **no day entry**, so an erasure that followed the session onto the wrong account would have changed no count the test read. With only one owner countable, "refused" and "erased the other account instead" look identical.

The second owner now holds a sentinel entry and both diaries are asserted intact. Every earlier refusal in the callback also leaves both intact, so the counts alone cannot say which check stopped this — the refusal is pinned to `settingsOIDCReauthMismatchErrorSpec().Key` through the sealed flash cookie.

Closest invariant: an id carried in a sealed payload is combined with the session's own, never swapped for it.

```
handlers_settings_danger_stepup.go:156 erases the session user instead of refusing
  old assertions   PASS          <- vacuous, whole Erasure|Stepup family too
  new assertions   FAIL  second owner's day entries = 0
refusal spec swapped for authOIDCAuthenticationFailed
  new assertions   FAIL  expected "oidc reauth identity mismatch", got "sso authentication failed"
restored           PASS, no production file in the diff
```

One deviation from the brief, deliberately: it asked for "the acting owner's data is gone AND the intruder's is untouched", but this callback *refuses*, so nothing may be erased. Asserting "gone" would contradict the guard. It asserts neither owner's data changed, which is what kills the mutant; the "gone" half is the positive anchor directly above, in `TestErasureStepupClearsDataOnlyAfterAFreshReauth`.

Rollback: revert; tests only.
