### PR TITLE
test(api): observe a local-password refusal as state, not as a redirect

### DIFF
--- a/changelog.d/test-local-password-refusal-is-observed.md
+++ b/changelog.d/test-local-password-refusal-is-observed.md
@@ -1,0 +1,6 @@
+none
+
+Tests only: the local-password step-up error paths now read the account after a
+refusal — local auth still off, `AuthSessionVersion` untouched — instead of
+trusting a 303 to `/settings` that a completed enrollment produces just as well.
+No product code.

--- a/internal/api/settings_oidc_local_password_error_path_test.go
+++ b/internal/api/settings_oidc_local_password_error_path_test.go
@@ -124,6 +124,22 @@ func TestOIDCStartLocalPasswordSetupStartReauthError(t *testing.T) {
 	}
 }
 
+// reloadStepupUser re-reads the step-up fixture's owner from the database.
+//
+// Both callback refusals below answer with the same 303 to /settings that a
+// completed flow can also produce, so the transport alone cannot tell a refusal
+// from an enrollment. The refusal is observed in the account's state instead:
+// local auth still off and AuthSessionVersion untouched, the pair
+// FinalizeLocalPasswordSetup would have moved.
+func reloadStepupUser(t *testing.T, fixture *oidcStepupFixture) models.User {
+	t.Helper()
+	var persisted models.User
+	if err := fixture.database.First(&persisted, fixture.user.ID).Error; err != nil {
+		t.Fatalf("reload user: %v", err)
+	}
+	return persisted
+}
+
 func TestOIDCCompleteLocalPasswordSetupStateMismatch(t *testing.T) {
 	t.Parallel()
 
@@ -132,6 +148,7 @@ func TestOIDCCompleteLocalPasswordSetupStateMismatch(t *testing.T) {
 	startResponse := fixture.postStart(t, "EvenStronger2", "EvenStronger2")
 	defer func() { _ = startResponse.Body.Close() }()
 	stepupCookie := readStepupCookie(t, startResponse)
+	before := reloadStepupUser(t, fixture)
 
 	callbackResponse := postOIDCStepupCallback(t, fixture, stepupCookie, "wrong-state-value", "code")
 	defer func() { _ = callbackResponse.Body.Close() }()
@@ -141,6 +158,14 @@ func TestOIDCCompleteLocalPasswordSetupStateMismatch(t *testing.T) {
 	}
 	if location := callbackResponse.Header.Get("Location"); location != "/settings" {
 		t.Fatalf("expected redirect to /settings, got %q", location)
+	}
+
+	after := reloadStepupUser(t, fixture)
+	if after.LocalAuthEnabled {
+		t.Fatal("state mismatch must not enable local auth")
+	}
+	if after.AuthSessionVersion != before.AuthSessionVersion {
+		t.Fatalf("state mismatch must not bump AuthSessionVersion: was %d, now %d", before.AuthSessionVersion, after.AuthSessionVersion)
 	}
 }
 
@@ -153,6 +178,7 @@ func TestOIDCCompleteLocalPasswordSetupProviderErrorParam(t *testing.T) {
 	defer func() { _ = startResponse.Body.Close() }()
 	stepupCookie := readStepupCookie(t, startResponse)
 	state := extractStepupCallbackState(t, fixture)
+	before := reloadStepupUser(t, fixture)
 
 	form := url.Values{
 		"state": {state},
@@ -173,6 +199,14 @@ func TestOIDCCompleteLocalPasswordSetupProviderErrorParam(t *testing.T) {
 	}
 	if flashValue := responseCookieValue(callbackResponse.Cookies(), flashCookieName); flashValue == "" {
 		t.Fatal("expected flash cookie on provider error callback")
+	}
+
+	after := reloadStepupUser(t, fixture)
+	if after.LocalAuthEnabled {
+		t.Fatal("a provider error must not enable local auth")
+	}
+	if after.AuthSessionVersion != before.AuthSessionVersion {
+		t.Fatalf("a provider error must not bump AuthSessionVersion: was %d, now %d", before.AuthSessionVersion, after.AuthSessionVersion)
 	}
 }
 


### PR DESCRIPTION
Closes **R2-0408**. PR 3 of 3 for board group G04.

Both callback refusals answer with the same 303 to `/settings` that a completed flow produces, and the test asserted only that status and `Location`, never reloading the user. So moving `FinalizeLocalPasswordSetup` above the refusal branches — enrolling a password on a request that should have been refused — kept the test green.

The refusal is now observed in the account's state: local auth still off, `AuthSessionVersion` untouched. That pair is exactly what `FinalizeLocalPasswordSetup` would have moved. The existing status and `Location` assertions stay.

```
FinalizeLocalPasswordSetup hoisted above the refusal branches
  old assertions   PASS          <- vacuous, both refusal tests
  new assertions   FAIL  state mismatch must not enable local auth
                   FAIL  a provider error must not enable local auth
LocalAuthEnabled clause removed, so the version clause stands alone
  new assertions   FAIL  must not bump AuthSessionVersion: was 1, now 2
restored           PASS, handler byte-identical to main
```

The second mutant is there because a green set says the set suffices, never that a member is necessary — without it, `AuthSessionVersion` would have been carried by its neighbour.

Noted, not touched: `settings_oidc_local_password_setup_test.go` checks `LocalAuthEnabled` on its stale-reauth and identity-mismatch refusals but not `AuthSessionVersion`, so the bump is still unobserved there. Another record's file.

Rollback: revert; tests only.
