### PR TITLE
fix(errors): give the two layers one already-consumed sentinel

### DIFF
--- a/changelog.d/fix-cross-layer-sentinel-identity.md
+++ b/changelog.d/fix-cross-layer-sentinel-identity.md
@@ -1,0 +1,15 @@
+none
+
+No user-visible effect today, and that is the whole reason the defect was
+invisible: `ErrResetTokenAlreadyConsumed` was declared twice with byte-identical
+text — once in the persistence layer, which raises it on a lost
+compare-and-swap, and once in the business layer, which is where callers reach
+for it. Two `errors.New` values are never `errors.Is`-equal, so the comparison
+was false for an error whose message is character-for-character the one being
+asked about. Nothing in the shipped request paths made that comparison, so no
+flow misbehaved; the first caller to add one would have got a silent miss.
+
+The value now lives once, in the transport-free model layer both sides already
+import, and each layer re-exports it under its own name. Neither layer's
+dependency set grows. A sweep over the shipped source keeps the class closed for
+sentinels added later.

--- a/internal/db/errors.go
+++ b/internal/db/errors.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"strings"
 
+	"github.com/ovumcy/ovumcy-web/internal/models"
 	"gorm.io/gorm"
 )
 
@@ -12,7 +13,12 @@ import (
 // matches 0 rows — i.e. the reset token has already been redeemed or the
 // password state changed since the token was issued. It indicates a replay
 // or concurrent redeem, not a DB error.
-var ErrResetTokenAlreadyConsumed = errors.New("reset token already consumed")
+//
+// It is the shared value from internal/models, not a second one with the same
+// text: internal/services names the same fact and cannot import this package,
+// so callers there compare against services.ErrResetTokenAlreadyConsumed and
+// must match the error this layer raises.
+var ErrResetTokenAlreadyConsumed = models.ErrResetTokenAlreadyConsumed
 
 // ErrUnsupportedUserRole is returned by the two account-creating repository
 // methods when the row they were handed carries a role this product does not

--- a/internal/models/errors.go
+++ b/internal/models/errors.go
@@ -1,0 +1,30 @@
+package models
+
+import "errors"
+
+// Sentinels that more than one layer has to name.
+//
+// internal/services deliberately does not import internal/db: the business
+// layer would then carry the driver and the migration set in its build graph.
+// A fact both layers speak about therefore has nowhere to live inside either of
+// them, and declaring it in both produces two errors.New values with identical
+// text — never errors.Is-equal, so a comparison across the boundary is false
+// for an error whose message is character-for-character the one being tested
+// for, while reading as a working check.
+//
+// internal/models is the one package both already import, and it costs nothing
+// to reach: it is transport-free, and neither layer's dependency set grows by a
+// single package. Each layer re-exports the value under its own name, so both
+// spellings are the same error.
+//
+// A sentinel belongs here only when both layers need it. One that a single
+// layer raises and only its own callers inspect stays in that layer.
+// Regression: TestNoErrorSentinelTextIsDeclaredInMoreThanOneLayer.
+var (
+	// ErrResetTokenAlreadyConsumed reports that a password-reset redeem lost
+	// the compare-and-swap: the token had already been redeemed, or the
+	// password state changed after the token was issued. Raised by the CAS
+	// update in the user repository and surfaced unchanged by the auth
+	// service, it marks a replay or a concurrent redeem, not a DB failure.
+	ErrResetTokenAlreadyConsumed = errors.New("reset token already consumed")
+)

--- a/internal/services/auth_service.go
+++ b/internal/services/auth_service.go
@@ -11,25 +11,31 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
+// ErrResetTokenAlreadyConsumed is the shared value from internal/models, not a
+// second one with the same text. It is raised by the repository's CAS update
+// and reaches callers here unchanged, and this package cannot import
+// internal/db — a redeclaration would leave errors.Is false across the layer
+// boundary for the very error being tested for.
+var ErrResetTokenAlreadyConsumed = models.ErrResetTokenAlreadyConsumed
+
 var (
-	ErrRecoveryCodeNotFound      = errors.New("recovery code not found")
-	ErrInvalidResetToken         = errors.New("invalid reset token")
-	ErrResetTokenAlreadyConsumed = errors.New("reset token already consumed")
-	ErrAuthUserRequired          = errors.New("auth user is required")
-	ErrAuthUserNotFound          = errors.New("auth user not found")
-	ErrAuthUserLookupFailed      = errors.New("auth user lookup failed")
-	ErrRecoveryCodeGenerate      = errors.New("recovery code generation failed")
-	ErrRecoveryCodeUpdate        = errors.New("recovery code update failed")
-	ErrAuthRegisterInvalid       = errors.New("auth register invalid input")
-	ErrAuthEmailExists           = errors.New("auth email already exists")
-	ErrAuthRegisterFailed        = errors.New("auth register failed")
-	ErrAuthPasswordMismatch      = errors.New("auth register password mismatch")
-	ErrAuthWeakPassword          = errors.New("auth register weak password")
-	ErrAuthPasswordTooLong       = errors.New("auth register password too long")
-	ErrAuthInvalidCreds          = errors.New("auth invalid credentials")
-	ErrAuthResetInvalid          = errors.New("auth reset invalid input")
-	ErrAuthPasswordHash          = errors.New("auth password hash failed")
-	ErrAuthPasswordUpdate        = errors.New("auth password update failed")
+	ErrRecoveryCodeNotFound = errors.New("recovery code not found")
+	ErrInvalidResetToken    = errors.New("invalid reset token")
+	ErrAuthUserRequired     = errors.New("auth user is required")
+	ErrAuthUserNotFound     = errors.New("auth user not found")
+	ErrAuthUserLookupFailed = errors.New("auth user lookup failed")
+	ErrRecoveryCodeGenerate = errors.New("recovery code generation failed")
+	ErrRecoveryCodeUpdate   = errors.New("recovery code update failed")
+	ErrAuthRegisterInvalid  = errors.New("auth register invalid input")
+	ErrAuthEmailExists      = errors.New("auth email already exists")
+	ErrAuthRegisterFailed   = errors.New("auth register failed")
+	ErrAuthPasswordMismatch = errors.New("auth register password mismatch")
+	ErrAuthWeakPassword     = errors.New("auth register weak password")
+	ErrAuthPasswordTooLong  = errors.New("auth register password too long")
+	ErrAuthInvalidCreds     = errors.New("auth invalid credentials")
+	ErrAuthResetInvalid     = errors.New("auth reset invalid input")
+	ErrAuthPasswordHash     = errors.New("auth password hash failed")
+	ErrAuthPasswordUpdate   = errors.New("auth password update failed")
 )
 
 // recoveryCodeTimingEqualizationHash and credentialsTimingEqualizationHash are

--- a/internal/services/layer_sentinel_duplication_barrier_test.go
+++ b/internal/services/layer_sentinel_duplication_barrier_test.go
@@ -1,0 +1,244 @@
+package services
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// Barrier for the duplicated cross-layer sentinel class.
+//
+// internal/services does not import internal/db — doing so would drag the
+// driver and the migration set into the business layer's build graph — so a
+// sentinel that both layers need has historically been declared twice, once per
+// package, with byte-identical text. Two separate errors.New values are never
+// errors.Is-equal, so a caller testing the services-level name against an error
+// the repository raised gets false for an error whose message is
+// character-for-character the one it asked about. It reads as a working
+// comparison in every review and in every log line.
+//
+// The one home both layers already import is internal/models, and a sentinel
+// that lives there is a single value each layer re-exports under its own name.
+// This sweep reads the shipped source rather than a list of known sites, so a
+// sentinel added later is covered the moment it is written.
+//
+// internal/models is swept alongside the two layers on purpose, and it is the
+// half that is easy to leave out. Once a value has moved there, re-splitting it
+// takes only ONE side: a layer that goes back to its own errors.New with the
+// same text is the whole defect again, while the other layer's re-export is not
+// an errors.New at all and a db-versus-services comparison sees a single
+// declaration. Every pair of the three packages is therefore checked.
+//
+// What it cannot see, stated here and repeated in the failure text: it reads
+// package-level `var … = errors.New("literal")` declarations only. A sentinel
+// assembled with fmt.Errorf, built from a constant, or declared in some fourth
+// package is invisible to it, as is an errors.New inside a function body —
+// which is not a sentinel at all, since no caller can hold its identity.
+var layerSentinelBarrierPackages = []string{
+	"internal/models",
+	"internal/db",
+	"internal/services",
+}
+
+// TestNoErrorSentinelTextIsDeclaredInMoreThanOneLayer fails when the same
+// sentinel text is declared by errors.New in two of the swept packages,
+// whichever of them added it.
+func TestNoErrorSentinelTextIsDeclaredInMoreThanOneLayer(t *testing.T) {
+	root := layerSentinelBarrierRepoRoot(t)
+
+	// scanPackage fails on a package it could not read a single source file
+	// from, so a moved directory or a renamed package cannot turn this into a
+	// clean verdict about a tree nobody looked at. The anchor counts FILES
+	// rather than sentinels on purpose: a layer that legitimately declares none
+	// is a state this tree can reach, and an anchor conditioned on the data
+	// being judged stops firing on the day that data empties.
+	scanned := make(map[string]map[string]string, len(layerSentinelBarrierPackages))
+	for _, pkg := range layerSentinelBarrierPackages {
+		scanned[pkg] = layerSentinelBarrierScanPackage(t, root, pkg)
+	}
+
+	var duplicates []string
+	for first := range layerSentinelBarrierPackages {
+		for second := first + 1; second < len(layerSentinelBarrierPackages); second++ {
+			duplicates = append(duplicates, layerSentinelBarrierDuplicates(
+				scanned[layerSentinelBarrierPackages[first]],
+				scanned[layerSentinelBarrierPackages[second]],
+			)...)
+		}
+	}
+	if len(duplicates) > 0 {
+		sort.Strings(duplicates)
+		t.Fatalf("sentinel text declared separately in two packages, so errors.Is across the layer boundary is false for the very error being tested for — keep one value in internal/models and re-export it from each layer:\n%s\n(the sweep sees package-level `var … = errors.New(\"literal\")` only)", strings.Join(duplicates, "\n"))
+	}
+}
+
+// TestLayerSentinelBarrierClassifiesItsOwnFixtures proves the sweep can report
+// both verdicts, on sources the test owns rather than on the tree it judges.
+func TestLayerSentinelBarrierClassifiesItsOwnFixtures(t *testing.T) {
+	const shared = `package fixture
+
+import "errors"
+
+var ErrShared = errors.New("shared sentinel text")
+`
+	const distinct = `package fixture
+
+import "errors"
+
+var ErrDistinct = errors.New("some other text")
+
+func caller() error { return errors.New("shared sentinel text") }
+`
+
+	duplicated := layerSentinelBarrierScanSource(t, "a/shared.go", shared)
+	other := layerSentinelBarrierScanSource(t, "b/shared.go", shared)
+	if hits := layerSentinelBarrierDuplicates(duplicated, other); len(hits) != 1 {
+		t.Fatalf("two packages declaring the same sentinel text must report exactly one duplicate, got %d: %v", len(hits), hits)
+	}
+
+	clean := layerSentinelBarrierScanSource(t, "b/distinct.go", distinct)
+	if hits := layerSentinelBarrierDuplicates(duplicated, clean); len(hits) != 0 {
+		t.Fatalf("a distinct sentinel plus a function-local errors.New must report no duplicate, got %v", hits)
+	}
+	if _, found := clean["shared sentinel text"]; found {
+		t.Fatal("a function-local errors.New was recorded as a sentinel — it has no identity a caller can hold, and counting it would flag safe code")
+	}
+}
+
+// layerSentinelBarrierDuplicates returns one line per text declared in both
+// scanned packages, each naming both declaration sites.
+func layerSentinelBarrierDuplicates(first map[string]string, second map[string]string) []string {
+	var duplicates []string
+	for text, siteA := range first {
+		siteB, found := second[text]
+		if !found {
+			continue
+		}
+		duplicates = append(duplicates, fmt.Sprintf("  %q\n    %s\n    %s", text, siteA, siteB))
+	}
+	return duplicates
+}
+
+// layerSentinelBarrierScanPackage maps sentinel text to its declaration site
+// for every non-test file of one package.
+func layerSentinelBarrierScanPackage(t *testing.T, root string, pkg string) map[string]string {
+	t.Helper()
+
+	entries, err := os.ReadDir(filepath.Join(root, filepath.FromSlash(pkg)))
+	if err != nil {
+		t.Fatalf("read %s: %v", pkg, err)
+	}
+
+	sentinels := make(map[string]string)
+	parsed := 0
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		path := filepath.Join(root, filepath.FromSlash(pkg), name)
+		source, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		parsed++
+		for text, site := range layerSentinelBarrierScanSource(t, pkg+"/"+name, string(source)) {
+			sentinels[text] = site
+		}
+	}
+	if parsed == 0 {
+		t.Fatalf("%s yielded no non-test Go file — the sweep read nothing and its verdict about this package is vacuous", pkg)
+	}
+	return sentinels
+}
+
+// layerSentinelBarrierScanSource records the text of every package-level
+// `var … = errors.New("literal")` in one file, keyed by that text.
+func layerSentinelBarrierScanSource(t *testing.T, display string, source string) map[string]string {
+	t.Helper()
+
+	fileSet := token.NewFileSet()
+	file, err := parser.ParseFile(fileSet, display, source, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", display, err)
+	}
+
+	sentinels := make(map[string]string)
+	for _, decl := range file.Decls {
+		general, isGeneral := decl.(*ast.GenDecl)
+		if !isGeneral || general.Tok != token.VAR {
+			continue
+		}
+		for _, spec := range general.Specs {
+			value, isValue := spec.(*ast.ValueSpec)
+			if !isValue {
+				continue
+			}
+			for index, expr := range value.Values {
+				text, isSentinel := layerSentinelBarrierErrorText(expr)
+				if !isSentinel {
+					continue
+				}
+				position := fileSet.Position(expr.Pos())
+				name := "?"
+				if index < len(value.Names) {
+					name = value.Names[index].Name
+				}
+				sentinels[text] = fmt.Sprintf("%s:%d %s", display, position.Line, name)
+			}
+		}
+	}
+	return sentinels
+}
+
+// layerSentinelBarrierErrorText reports the literal handed to errors.New, if
+// the expression is exactly that call on a plain string literal.
+func layerSentinelBarrierErrorText(expr ast.Expr) (string, bool) {
+	call, isCall := expr.(*ast.CallExpr)
+	if !isCall || len(call.Args) != 1 {
+		return "", false
+	}
+	selector, isSelector := call.Fun.(*ast.SelectorExpr)
+	if !isSelector || selector.Sel.Name != "New" {
+		return "", false
+	}
+	pkg, isIdent := selector.X.(*ast.Ident)
+	if !isIdent || pkg.Name != "errors" {
+		return "", false
+	}
+	literal, isLiteral := call.Args[0].(*ast.BasicLit)
+	if !isLiteral || literal.Kind != token.STRING {
+		return "", false
+	}
+	text, err := strconv.Unquote(literal.Value)
+	if err != nil {
+		return "", false
+	}
+	return text, true
+}
+
+func layerSentinelBarrierRepoRoot(t *testing.T) string {
+	t.Helper()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("working directory: %v", err)
+	}
+	for {
+		if _, statErr := os.Stat(filepath.Join(dir, "go.mod")); statErr == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("no go.mod above the working directory — the sweep cannot find the module root")
+		}
+		dir = parent
+	}
+}

--- a/internal/services/password_reset_sentinel_identity_test.go
+++ b/internal/services/password_reset_sentinel_identity_test.go
@@ -1,0 +1,51 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/ovumcy/ovumcy-web/internal/db"
+)
+
+// TestResetPasswordCASMissPropagatesTheSharedAlreadyConsumedSentinel drives a
+// CAS miss through the REAL user repository and asserts that what comes back
+// out of the service still satisfies errors.Is against the sentinel a
+// services- or api-level caller would test.
+//
+// The stub in password_reset_cas_regression_test.go returns the services-level
+// value from its own fake repository, so it agrees with itself no matter what
+// the db layer raises; only the real repository can show whether the value that
+// crosses the layer boundary is the value callers compare against.
+//
+// Both spellings are asserted on purpose. db.ErrResetTokenAlreadyConsumed is
+// what the repository raises and ErrResetTokenAlreadyConsumed is what a caller
+// in this package reaches for; the invariant is that they are one value, so a
+// future change that re-splits them fails here whichever side it re-declares.
+func TestResetPasswordCASMissPropagatesTheSharedAlreadyConsumedSentinel(t *testing.T) {
+	database := newTwoOwnerIntegrationDatabase(t, "ovumcy-reset-sentinel-identity")
+	service := NewAuthService(db.NewUserRepository(database))
+
+	owner := createTwoOwnerUser(t, database, "reset-sentinel@example.com", withLocalCredentials(t, "OwnerPass1"))
+	target := readTwoOwnerUser(t, database, owner.ID)
+
+	// A stale oldPasswordHash is exactly the state a replayed or concurrent
+	// redeem reaches the UPDATE in: the CAS predicate matches 0 rows.
+	_, err := service.ResetPasswordAndRotateRecoveryCodeCAS(context.Background(), &target, "not-the-stored-hash", "EvenStronger2")
+	if err == nil {
+		t.Fatal("expected a CAS miss on a stale password hash, got no error")
+	}
+	if !errors.Is(err, db.ErrResetTokenAlreadyConsumed) {
+		t.Fatalf("CAS miss did not match the db-layer sentinel it is raised from: got %v", err)
+	}
+	if !errors.Is(err, ErrResetTokenAlreadyConsumed) {
+		t.Fatalf("CAS miss did not match the services-level sentinel callers test against: got %v (%q) — the two layers declare separate values with identical text, so errors.Is is false for the very error being tested for", err, err.Error())
+	}
+
+	// Positive anchor: the same call on the CURRENT hash must succeed, or the
+	// assertions above would hold on a service that fails every reset.
+	fresh := readTwoOwnerUser(t, database, owner.ID)
+	if _, err := service.ResetPasswordAndRotateRecoveryCodeCAS(context.Background(), &fresh, fresh.PasswordHash, "EvenStronger2"); err != nil {
+		t.Fatalf("expected the reset to succeed against the current password hash: %v", err)
+	}
+}


### PR DESCRIPTION
## What was wrong

`internal/db` and `internal/services` each declared `ErrResetTokenAlreadyConsumed`
with byte-identical text and no wrapping between them. Two `errors.New` values are
never `errors.Is`-equal, so the comparison a caller would naturally write was
**false for an error whose message is character-for-character the one being asked
about** — and it reads as a working check in review and in the log line beside it.

It was live, not latent. `internal/db/user_repository.go:638` raises the db value on
a CAS miss; `internal/services/auth_service.go:507` returns it unwrapped, so the
db value crosses into the business layer untranslated. The propagation comments at
`internal/services/password_reset_service.go:105` and `auth_service.go:491` — "the
loser receives `ErrResetTokenAlreadyConsumed`" — described a match the
services-level sentinel could not produce. Nothing in the shipped request paths
made that comparison (`internal/api` names the sentinel nowhere), which is the only
reason no flow misbehaved; the first caller to add one would have got a silent miss.

## The measured extent: one site on `main`, not two

Every package-level `errors.New` in both packages was extracted and compared by
exact text (`go/parser`, non-test sources, then again including tests):

| text | `internal/db` | `internal/services` |
| --- | --- | --- |
| `reset token already consumed` | `errors.go:15` | `auth_service.go:17` |

That is the whole list. `ErrUnsupportedUserRole` ("unsupported user role") and
`ErrAuthUnsupportedRole` ("auth unsupported role") are a near miss with different
text and different names, so `errors.Is` was never plausible between them. One pair
appears only in tests — `errors.New("write failed")` in `internal/db/helpers_test.go`
and five services fakes — which is not the class: those are per-test doubles, never
compared across a boundary.

`ErrOIDCLogoutStateUnattributed` is **not on `main`**. `internal/db/errors.go`
declares two sentinels and that is not one of them, and the name appears nowhere in
`internal/` at this commit; it lives only on the unmerged `fix-oidc-logout-state-owner-scope`
branch. It is left to that branch — but the sweep below fails the moment both
declarations land, so it cannot merge unnoticed.

## The home, and why

`internal/services` must not import `internal/db`: that would put the driver and the
migration set in the business layer's build graph. `internal/models` is the only
package both layers already import, and it is free:

```
$ go list -deps ./internal/services | grep ovumcy
internal/models
internal/security
internal/services
$ go list -deps ./internal/db | grep ovumcy
internal/models
migrations
internal/db
```

244 packages in the services graph before this change, 244 after — `internal/models`
was already there, so the sentinel costs neither layer a single package. (Worth
recording against the assumption that models is dependency-free: it is not.
`internal/models/daily_log.go:6` imports `gorm.io/gorm` for `gorm.DeletedAt`, so
gorm sits in the services graph already; the driver and the migrations, which are
what importing `internal/db` would actually add, do not.)

The layer contract calls `internal/models` transport-free types. A sentinel is a
value rather than a type, which is the arguable part — but it is transport-free
domain vocabulary that both layers name, and the alternatives are worse: a new
package for one value, or inverting a layer. Each layer keeps its own exported name
as a re-export of the one value, so no call site moves and both spellings are the
same error. `internal/models/errors.go` states the rule for the next sentinel:
it belongs there only when both layers need it.

## The guards

**1. Propagation, through the real path.** `TestResetPasswordCASMissPropagatesTheSharedAlreadyConsumedSentinel`
(`internal/services/password_reset_sentinel_identity_test.go`) drives a CAS miss
through the **real** `UserRepository` and `AuthService.ResetPasswordAndRotateRecoveryCodeCAS`,
then asserts both spellings. The existing stub in `password_reset_cas_regression_test.go:43`
returns the services-level value from its own fake repository, so it agrees with
itself whatever the db layer raises — it could never have caught this.

Red on the split declarations:

```
--- FAIL: TestResetPasswordCASMissPropagatesTheSharedAlreadyConsumedSentinel (0.66s)
    CAS miss did not match the services-level sentinel callers test against:
    got reset token already consumed ("reset token already consumed") — the two
    layers declare separate values with identical text, so errors.Is is false for
    the very error being tested for
```

**2. The class, not the instance.** `TestNoErrorSentinelTextIsDeclaredInMoreThanOneLayer`
(`internal/services/layer_sentinel_duplication_barrier_test.go`) sweeps the shipped
source of `internal/models`, `internal/db` and `internal/services` and fails on any
text declared by `errors.New` in two of them. It reads the tree rather than a list
of known sites, so a sentinel added later is covered the moment it is written, and
there is no allowlist. Red on `main`'s declarations:

```
--- FAIL: TestNoErrorSentinelTextIsDeclaredInMoreThanOneLayer (0.03s)
      "reset token already consumed"
        internal/db/errors.go:15 ErrResetTokenAlreadyConsumed
        internal/services/auth_service.go:17 ErrResetTokenAlreadyConsumed
```

Green after the fix, both of them, with `TestLayerSentinelBarrierClassifiesItsOwnFixtures`
green throughout — it classifies a duplicate pair and a distinct pair on synthetic
sources the test owns, so the sweep's verdict never rests on the tree it judges.
`scanPackage` fails on a package it read no source file from, for the same reason.

## Two mutants, run separately

Reverting **one** side is the regression this fix invites, and the first version of
the sweep survived it. With the value in `internal/models`, re-declaring
`errors.New("reset token already consumed")` in `internal/services` alone leaves a
single `errors.New` of that text in the db-versus-services comparison — the sweep
went green while the defect was fully back. The sweep now checks every pair of the
three packages, and both mutants are killed by both guards:

```
services re-split:  barrier RED, naming internal/models/errors.go + auth_service.go
                    propagation RED
db re-split:        barrier RED, naming internal/models/errors.go + internal/db/errors.go
                    propagation RED
```

## Blast radius

No control flow, no error text and no behaviour a caller can observe changes other
than error identity. Every existing `errors.Is` against either sentinel keeps the
verdict it had: the two db tests compare the db value against a db-raised error, and
the two services tests compare the services value against their own fake's return.
No comparison anywhere resolves differently. Nothing newly executes: `internal/api`
does not name the sentinel, so no route reaches new code.

Rollback is the revert — the three declarations go back to two `errors.New` values
and the guards go red on their own diagnosis.

## Passed on, not fixed

- `gofmt -l` flags five files untouched by this change on `main`
  (`internal/api/calendar_ovulation_tag_regression_test.go`,
  `internal/api/owner_only_coverage_regression_test.go`,
  `internal/services/day_service.go`, `settings_view_service.go`,
  `webhook_reminder.go`): over-aligned blocks — on `day_service.go` a struct whose
  longest field name is gone. `gofmt` is not among the enabled linters, so CI does
  not see it.
  `internal/services/auth_service.go` is in this PR's diff for the same reason —
  dropping the longest name from the sentinel block re-aligned it.
- `errors.New("write failed")` is duplicated across six test files as an ad-hoc
  double; harmless today, but a shared helper would stop it drifting into the class
  above.

## Checks

`go build ./...`; `internal/db`, `internal/services` and `internal/api` suites green;
`golangci-lint run` clean on `internal/models`, `internal/db`, `internal/services`;
`go run ./scripts/changelogd check` OK.
