### PR TITLE
test(calendar-feed): observe the owner id revoke carries into the clear

### DIFF
--- a/changelog.d/test-calendar-feed-revoke-owner-scope.md
+++ b/changelog.d/test-calendar-feed-revoke-owner-scope.md
@@ -1,0 +1,13 @@
+none
+
+Test-only guard: revoking the calendar feed is now observed to carry the owner id
+it was asked to revoke. The service double recorded only that a clear had
+happened, and every route regression armed a single owner, so replacing the
+handler's owner id with a constant on the way into the service left both suites
+green — the repository layer is scoped and proven on its own, and the untested
+link was the argument between them. The double now records the id it was called
+with on its own field, and a two-owner route case revokes as one owner and reads
+the verdict from both rows and both subscribe URLs: the other owner's feed must
+still serve, and the revoking owner's must 404. No production change — the
+forwarding was already correct; what was missing was anything that would notice
+if it stopped being.

--- a/internal/api/settings_calendar_feed_regressions_test.go
+++ b/internal/api/settings_calendar_feed_regressions_test.go
@@ -540,6 +540,82 @@ func TestCalendarFeedGenerateScopedToOwner(t *testing.T) {
 	}
 }
 
+// TestCalendarFeedRevokeScopedToOwner is the revoke-side arm of the cross-owner
+// IDOR guard, and the only place the api→services owner-id threading of revoke is
+// observed end to end. Both single-owner revoke regressions above stay green when
+// the handler's user.ID is replaced by a constant on the way to the service, and
+// so does the repository suite, which is scoped and proven on its own — the
+// untested link was the argument in between.
+//
+// Two owners are armed, owner B revokes, and the verdict is read from both rows
+// and both feed URLs: A must keep serving (the containment must not spill) and B
+// must 404 (it must actually land). A's still-serving feed is also the positive
+// anchor for B's 404 — a revoke that killed every feed on the instance would
+// satisfy the 404 alone.
+func TestCalendarFeedRevokeScopedToOwner(t *testing.T) {
+	ctx := newSettingsSecurityTestContext(t, "feed-revoke-owner-a@example.com")
+
+	// Owner A arms a feed and keeps it.
+	tokenA := armCalendarFeedForUser(t, ctx.database, ctx.user.ID)
+	ownerABefore := reloadUserForCalendarFeedAPI(t, ctx, ctx.user.ID)
+
+	// A second independent owner B arms one of their own — the feed the revoke
+	// below is actually aimed at.
+	ownerB := createOnboardingTestUser(t, ctx.database, "feed-revoke-owner-b@example.com", "StrongPass1", true)
+	tokenB := armCalendarFeedForUser(t, ctx.database, ownerB.ID)
+
+	// Both feeds serve before the revoke, so neither verdict below can be
+	// satisfied by a URL that never worked.
+	for label, token := range map[string]string{"A": tokenA, "B": tokenB} {
+		before := mustAppResponse(t, ctx.app, httptest.NewRequest(http.MethodGet, calendarFeedURL(token), nil))
+		if before.StatusCode != http.StatusOK {
+			t.Fatalf("expected owner %s's feed to serve before the revoke, got %d", label, before.StatusCode)
+		}
+		_ = before.Body.Close()
+	}
+
+	// Owner B revokes, on owner B's own session.
+	authB := loginAndExtractAuthCookieWithCSRF(t, ctx.app, ownerB.Email, "StrongPass1")
+	csrfCookieB, csrfTokenB := loadSettingsCSRFContext(t, ctx.app, authB)
+
+	formB := url.Values{"csrf_token": {csrfTokenB}}
+	requestB := httptest.NewRequest(http.MethodDelete, "/api/v1/users/current/calendar-feed", strings.NewReader(formB.Encode()))
+	requestB.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	requestB.Header.Set("Accept", "application/json")
+	requestB.Header.Set("Cookie", settingsCookieHeader(authB, csrfCookieB))
+	responseB, err := ctx.app.Test(requestB, testConfigNoTimeout)
+	if err != nil {
+		t.Fatalf("owner B feed revoke failed: %v", err)
+	}
+	defer func() { _ = responseB.Body.Close() }()
+	assertStatusCode(t, responseB, http.StatusOK)
+
+	// Owner B's columns are the ones that were cleared.
+	ownerBAfter := reloadUserForCalendarFeedAPI(t, ctx, ownerB.ID)
+	if ownerBAfter.CalendarFeedSelector != "" || ownerBAfter.CalendarFeedVerifierHash != "" || ownerBAfter.CalendarFeedVerifierMAC != "" {
+		t.Fatalf("expected owner B's feed columns cleared by owner B's revoke, got selector=%q hash=%q mac=%q",
+			ownerBAfter.CalendarFeedSelector, ownerBAfter.CalendarFeedVerifierHash, ownerBAfter.CalendarFeedVerifierMAC)
+	}
+	feedB := mustAppResponse(t, ctx.app, httptest.NewRequest(http.MethodGet, calendarFeedURL(tokenB), nil))
+	defer func() { _ = feedB.Body.Close() }()
+	if feedB.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected owner B's revoked feed URL to 404, got %d", feedB.StatusCode)
+	}
+
+	// Owner A's row is untouched and A's URL still serves.
+	ownerAAfter := reloadUserForCalendarFeedAPI(t, ctx, ctx.user.ID)
+	if ownerAAfter.CalendarFeedSelector != ownerABefore.CalendarFeedSelector ||
+		ownerAAfter.CalendarFeedVerifierHash != ownerABefore.CalendarFeedVerifierHash ||
+		ownerAAfter.CalendarFeedVerifierMAC != ownerABefore.CalendarFeedVerifierMAC {
+		t.Fatal("owner A's feed columns must not change when owner B revokes")
+	}
+	feedA := mustAppResponse(t, ctx.app, httptest.NewRequest(http.MethodGet, calendarFeedURL(tokenA), nil))
+	defer func() { _ = feedA.Body.Close() }()
+	if feedA.StatusCode != http.StatusOK {
+		t.Fatalf("expected owner A's feed to keep serving after owner B's revoke, got %d", feedA.StatusCode)
+	}
+}
+
 // failingCalendarFeedRepo forces the feed settings repository to error on every
 // write/clear, so the handler's service-error tails (and the shared 500 error
 // spec) can be exercised without tearing down a real database mid-request.

--- a/internal/services/calendar_feed_settings_service_test.go
+++ b/internal/services/calendar_feed_settings_service_test.go
@@ -14,14 +14,19 @@ import (
 // clear happened, and can force errors, so the settings service's mint/persist/
 // clear/status behavior can be asserted without a database.
 type stubCalendarFeedSettingsRepo struct {
-	saved      *models.CalendarFeedTokenColumns
-	cleared    bool
-	saveErr    error
-	clearErr   error
-	findErr    error
-	claimErr   error
-	findUser   models.User
-	findUserID uint
+	saved   *models.CalendarFeedTokenColumns
+	cleared bool
+	// clearedUserID keeps the owner id the CLEAR was called with on its own
+	// field. Reusing findUserID would make the assertion ambiguous — the save
+	// and claim paths write that one too, so a revoke case could read an id no
+	// revoke ever supplied.
+	clearedUserID uint
+	saveErr       error
+	clearErr      error
+	findErr       error
+	claimErr      error
+	findUser      models.User
+	findUserID    uint
 }
 
 func (s *stubCalendarFeedSettingsRepo) SaveCalendarFeedToken(_ context.Context, userID uint, columns models.CalendarFeedTokenColumns) error {
@@ -61,6 +66,7 @@ func (s *stubCalendarFeedSettingsRepo) ClearCalendarFeedToken(_ context.Context,
 		return s.clearErr
 	}
 	s.cleared = true
+	s.clearedUserID = userID
 	s.findUser.ID = userID
 	s.findUser.CalendarFeedSelector = ""
 	s.findUser.CalendarFeedVerifierHash = ""
@@ -201,7 +207,12 @@ func TestGenerateFeedTokenFailsClosedWithoutSecretKey(t *testing.T) {
 	}
 }
 
-// TestRevokeFeedTokenClearsColumns proves revoke delegates to the clear path.
+// TestRevokeFeedTokenClearsColumns proves revoke delegates to the clear path AND
+// that it forwards the owner id it was asked to revoke. "The mock was called" is
+// not the outcome: revoke is the containment action behind the one sanctioned
+// secret-in-transport exception, so the operand it carries is the whole guard —
+// a clear aimed at a constant row would still set this flag. The mint path is
+// pinned the same way above; this closes the same seam on the revoke side.
 func TestRevokeFeedTokenClearsColumns(t *testing.T) {
 	repo := &stubCalendarFeedSettingsRepo{}
 	service := NewCalendarFeedSettingsService(repo, []byte(calendarFeedTestSecretKey))
@@ -211,6 +222,9 @@ func TestRevokeFeedTokenClearsColumns(t *testing.T) {
 	}
 	if !repo.cleared {
 		t.Fatal("expected ClearCalendarFeedToken to be called")
+	}
+	if repo.clearedUserID != 9 {
+		t.Fatalf("expected the clear scoped to user 9, got %d", repo.clearedUserID)
 	}
 }
 


### PR DESCRIPTION
## What this is

Test-only. **Production is already correct, and neither new guard is naturally red.**
Both are red only under a deliberate mutation of `RevokeFeedToken`. The value here is
closing a mutation-survivable gap on the one sanctioned secret-in-transport exception
(the calendar-feed capability token), not repairing a live defect. Nothing in the final
diff touches production code.

## The gap

Revoking the calendar feed is the containment action behind that exception, and nothing
observed the owner id it forwards:

- `internal/services/calendar_feed_settings_service_test.go` — `TestRevokeFeedTokenClearsColumns`
  asserted exactly one thing, `if !repo.cleared`. That is a mock-was-called check, not an
  outcome, and the double's `ClearCalendarFeedToken` discarded the `userID` it received.
  The mint path next to it already pins its operand.
- `internal/api/settings_calendar_feed_regressions_test.go` — every revoke regression armed
  exactly one owner, so a clear aimed at a constant row cleared the only row under test.

The db layer is scoped (`internal/db/user_repository.go:503`, `Where("id = ?", userID)`) and
proven on its own (`internal/db/user_repository_calendar_feed_test.go:208-215`). The untested
link was the argument in between: `internal/api/handlers_settings_calendar_feed.go:122` →
`internal/services/calendar_feed_settings_service.go:102`.

## What was added

- `TestRevokeFeedTokenClearsColumns` (`internal/services/calendar_feed_settings_service_test.go:216`)
  — the double records the clear's owner id on a dedicated `clearedUserID` field and the case
  asserts it. A dedicated field on purpose: `findUserID` is also written by `SaveCalendarFeedToken`
  and `ClaimCalendarFeedReveal`, so reading it in a revoke case would be ambiguous.
- `TestCalendarFeedRevokeScopedToOwner` (`internal/api/settings_calendar_feed_regressions_test.go:555`)
  — two owners are armed, owner B revokes through `DELETE /api/v1/users/current/calendar-feed`
  on B's own session, and the verdict is read from both rows and both `/calendar/feed/:token.ics`
  URLs: A must still return 200, B must return 404. Both feeds are checked to serve **before**
  the revoke, so neither verdict rests on a URL that never worked, and A's still-serving feed is
  the positive anchor for B's 404 — a revoke that killed every feed on the instance would satisfy
  the 404 alone.

## Mutation evidence

The mutation, applied to `internal/services/calendar_feed_settings_service.go:103`:

```diff
-	if err := service.users.ClearCalendarFeedToken(ctx, userID); err != nil {
+	if err := service.users.ClearCalendarFeedToken(ctx, 1); err != nil {
```

**Step 3 — before the guards existed, the same mutation left the suite GREEN** (re-measured on
this branch's base, `bf8b5961`, with no test edits present):

```
$ go test -count=1 -run '^TestRevokeFeedToken' ./internal/services
ok  	github.com/ovumcy/ovumcy-web/internal/services	6.736s
$ go test -count=1 -timeout 20m -run '^TestCalendarFeedRevoke' ./internal/api
ok  	github.com/ovumcy/ovumcy-web/internal/api	8.982s
```

**Step 1 — with the guards, the same mutation FAILS both:**

```
$ go test -count=1 -run '^TestRevokeFeedTokenClearsColumns$' -v ./internal/services
=== RUN   TestRevokeFeedTokenClearsColumns
    calendar_feed_settings_service_test.go:227: expected the clear scoped to user 9, got 1
--- FAIL: TestRevokeFeedTokenClearsColumns (0.00s)
FAIL	github.com/ovumcy/ovumcy-web/internal/services	5.193s

$ go test -count=1 -timeout 20m -run '^TestCalendarFeedRevokeScopedToOwner$' -v ./internal/api
=== RUN   TestCalendarFeedRevokeScopedToOwner
    settings_calendar_feed_regressions_test.go:596: expected owner B's feed columns cleared by
      owner B's revoke, got selector="9CW7MA6BNFMBVY8L" hash="$2a$12$YBDAV…" mac="c9fa67b4…"
--- FAIL: TestCalendarFeedRevokeScopedToOwner (1.68s)
FAIL	github.com/ovumcy/ovumcy-web/internal/api	7.461s
```

**Step 2 — production line restored exactly, both PASS:**

```
$ go test -count=1 -run '^TestRevokeFeedTokenClearsColumns$' -v ./internal/services
--- PASS: TestRevokeFeedTokenClearsColumns (0.00s)
ok  	github.com/ovumcy/ovumcy-web/internal/services	3.510s

$ go test -count=1 -timeout 20m -run '^TestCalendarFeedRevokeScopedToOwner$' -v ./internal/api
--- PASS: TestCalendarFeedRevokeScopedToOwner (1.50s)
ok  	github.com/ovumcy/ovumcy-web/internal/api	4.834s
```

The mutation is not in the diff: `git diff origin/main --name-only` lists only the two test
files and the changelog fragment.

## Verification

```
go vet ./internal/api/... ./internal/services/...        → clean
golangci-lint run ./internal/api/... ./internal/services/... → 0 issues
go test -count=1 -timeout 20m ./internal/services/...    → ok (129.5s)
go test -count=1 -timeout 25m ./internal/api/...         → ok (397.6s)
go run ./scripts/changelogd check                        → OK
```

No pre-existing failures observed on this run.

## Scope

Closes audit record R2-0451 only. No production change; `internal/api/calendar_feed_reveal_cookie.go`
is deliberately untouched (owned by the sibling PR in this split). Other doubles that discard an
owner argument are separate records and are not addressed here.
