### PR TITLE
test(auth): pin that forced reset outranks the TOTP challenge

### DIFF
--- a/changelog.d/test-forced-reset-precedence.md
+++ b/changelog.d/test-forced-reset-precedence.md
@@ -1,0 +1,10 @@
+none
+
+Tests only: an account carrying both `must_change_password` and `totp_enabled`
+is routed to the forced password reset and is never challenged for TOTP — the
+intentional recovery path for an owner whose second factor is unusable after a
+`SECRET_KEY` rotation. Nothing pinned that ordering, so flipping it reddened no
+test anywhere; three cases now hold it at every caller — the login service, the
+`POST /api/v1/sessions` route, and `POST /auth/oidc/link-confirm`, where a
+reversal would have fallen through to issuing a session because that handler
+branches only on the reset flag. No product code.

--- a/internal/api/auth_login_totp_required_regression_test.go
+++ b/internal/api/auth_login_totp_required_regression_test.go
@@ -7,6 +7,8 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
 )
 
 // TestLogin_TOTPEnabledUser_IssuesPendingCookieAndRedirectsTo2FAChallenge
@@ -67,5 +69,69 @@ func TestLogin_TOTPEnabledUser_IssuesPendingCookieAndRedirectsTo2FAChallenge(t *
 	}
 	if !payload.RememberMe {
 		t.Error("pending cookie remember_me = false, want true (submitted with form)")
+	}
+}
+
+// TestLogin_ForcedResetOutranksTOTP_RoutesToResetAndIssuesNoAuthCookie pins a
+// DECISION at POST /api/v1/sessions, not merely the behaviour that happens to
+// exist today: an account carrying BOTH must_change_password and totp_enabled
+// is routed to /reset-password, is NOT sent to the 2FA challenge, and receives
+// no ovumcy_auth session cookie on the way.
+//
+// The ordering is deliberate, and it is the intentional recovery path for an
+// owner whose second factor is unusable. TOTP secrets are encrypted under a key
+// derived from the application secret, so after a SECRET_KEY rotation the
+// stored ciphertext no longer opens and no code the authenticator produces can
+// ever satisfy the challenge; the operator-forced reset
+// (`ovumcy reset-password <email>`) is the way back in that
+// docs/security/cryptography.md and docs/self-hosted.md instruct an operator to
+// use. Making TOTP win here would withdraw that escape hatch from precisely the
+// accounts whose second factor is already broken, leaving permanent owner
+// lockout with no in-product remedy.
+//
+// It is not a downgrade of session security: the reset still bumps
+// AuthSessionVersion in the same atomic update that writes the new password
+// hash (internal/db/user_repository.go), so every session predating it dies,
+// and this response hands out a reset-password cookie rather than a session.
+//
+// The sibling above pins the TOTP-only account, so the two together fix the
+// precedence at this route from both sides. Read a failure here as "the
+// decision was reversed", not as a stale assertion. The public declaration of
+// this accepted risk is recorded separately from this test.
+func TestLogin_ForcedResetOutranksTOTP_RoutesToResetAndIssuesNoAuthCookie(t *testing.T) {
+	app, database := newOnboardingTestApp(t)
+	user := createOnboardingTestUser(t, database, "forced-reset-totp@example.com", "StrongPass1", true)
+	setupTOTPForUser(t, database, user.ID, []byte("test-secret-key"))
+	if err := database.Model(&models.User{}).Where("id = ?", user.ID).Update("must_change_password", true).Error; err != nil {
+		t.Fatalf("mark user must_change_password: %v", err)
+	}
+
+	form := url.Values{
+		"email":    {user.Email},
+		"password": {"StrongPass1"},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := app.Test(req, testConfigNoTimeout)
+	if err != nil {
+		t.Fatalf("POST /api/v1/sessions: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303", resp.StatusCode)
+	}
+	if loc := resp.Header.Get("Location"); loc != "/reset-password" {
+		t.Fatalf("Location = %q, want /reset-password (forced reset outranks the TOTP challenge)", loc)
+	}
+	if c := responseCookie(resp.Cookies(), authCookieName); c != nil && strings.TrimSpace(c.Value) != "" {
+		t.Error("auth cookie must not be issued on the forced-reset recovery path")
+	}
+	if c := responseCookie(resp.Cookies(), totpPendingCookieName); c != nil && strings.TrimSpace(c.Value) != "" {
+		t.Error("TOTP pending cookie must not be issued when the forced reset wins")
+	}
+	resetCookie := responseCookie(resp.Cookies(), resetPasswordCookieName)
+	if resetCookie == nil || strings.TrimSpace(resetCookie.Value) == "" {
+		t.Fatalf("expected Set-Cookie %q with non-empty value", resetPasswordCookieName)
 	}
 }

--- a/internal/api/auth_oidc_regressions_test.go
+++ b/internal/api/auth_oidc_regressions_test.go
@@ -1007,6 +1007,89 @@ func TestCompleteOIDCLinkConfirmationRoutesMustChangePasswordToReset(t *testing.
 	}
 }
 
+// TestCompleteOIDCLinkConfirmationRoutesAForcedResetTOTPTargetToResetWithoutASession
+// is the mirror of the test above for a target carrying BOTH
+// must_change_password and totp_enabled, and it pins a DECISION rather than
+// merely the behaviour that happens to exist today: the forced reset outranks
+// the TOTP challenge, so link-confirm must land on /reset-password with a
+// reset-password cookie and must NOT issue an ovumcy_auth session.
+//
+// The ordering is deliberate, and it is the intentional recovery path for an
+// owner whose second factor is unusable. TOTP secrets are encrypted under a key
+// derived from the application secret, so after a SECRET_KEY rotation the
+// stored ciphertext no longer opens and no code the authenticator produces can
+// ever satisfy the challenge; the operator-forced reset
+// (`ovumcy reset-password <email>`) is the way back in that
+// docs/security/cryptography.md and docs/self-hosted.md instruct an operator to
+// use. Making the second factor win would withdraw that escape hatch from
+// precisely the accounts whose second factor is already broken. It is not a
+// downgrade of session security: the reset still bumps AuthSessionVersion in
+// the same atomic update that writes the new password hash
+// (internal/db/user_repository.go).
+//
+// This handler is the sharp end of that decision, and the reason the case has
+// to exist HERE and not only at the login route or in the service. It branches
+// on the LoginService result's RequiresPasswordReset and has no RequiresTOTP
+// branch at all — its own second-factor gate reads targetUser.TOTPEnabled and
+// runs earlier. So were the service's precedence reversed, this target would
+// come back with RequiresPasswordReset == false, the reset branch would be
+// skipped, and control would fall through to setAuthCookie: a forced-rotation
+// account handed a live session by the link-confirm route while the login route
+// still refuses it. The sibling above cannot see that, because its fixture
+// never enables TOTP. The submission below therefore carries a VALID totp_code
+// — the handler's own gate must be satisfied for the fall-through to be
+// reachable at all, and an assertion that stopped at the gate would prove
+// nothing about the precedence.
+//
+// Read a failure here as "the decision was reversed", not as a stale assertion.
+// The public declaration of this accepted risk is recorded separately from this
+// test.
+func TestCompleteOIDCLinkConfirmationRoutesAForcedResetTOTPTargetToResetWithoutASession(t *testing.T) {
+	t.Parallel()
+
+	stub := newStubOIDCWorkflowService(true)
+	app, database := newOnboardingTestAppWithOptions(t, onboardingTestAppOptions{
+		cookieSecure: true,
+		oidcService:  stub,
+	})
+	user := createOnboardingTestUser(t, database, "link-reset-totp@example.com", "StrongPass1", true)
+	rawSecret := setupTOTPForUser(t, database, user.ID, []byte(testHandlerSecretKey))
+	if err := database.Model(&user).Update("must_change_password", true).Error; err != nil {
+		t.Fatalf("set must_change_password: %v", err)
+	}
+
+	pendingPayload, err := newOIDCLinkPendingPayload(time.Now().UTC(), user.ID, "https://idp.example", "subject-reset-totp", user.Email)
+	if err != nil {
+		t.Fatalf("newOIDCLinkPendingPayload: %v", err)
+	}
+	cookie := sealLinkPendingCookieForTest(t, pendingPayload)
+
+	code, err := totp.GenerateCode(rawSecret, time.Now())
+	if err != nil {
+		t.Fatalf("GenerateCode: %v", err)
+	}
+
+	postRequest := httptest.NewRequest(http.MethodPost, oidcLinkConfirmPath, strings.NewReader(url.Values{
+		"password":  {"StrongPass1"},
+		"totp_code": {code},
+	}.Encode()))
+	postRequest.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	postRequest.Header.Set("Cookie", oidcLinkPendingCookieName+"="+cookie)
+
+	response := mustAppResponse(t, app, postRequest)
+	assertStatusCode(t, response, http.StatusSeeOther)
+	if location := response.Header.Get("Location"); location != "/reset-password" {
+		t.Fatalf("expected redirect to /reset-password for a forced-rotation target with TOTP enabled, got %q", location)
+	}
+	resetCookie := responseCookie(response.Cookies(), resetPasswordCookieName)
+	if resetCookie == nil || strings.TrimSpace(resetCookie.Value) == "" {
+		t.Fatal("expected reset-password cookie on the forced-reset recovery path")
+	}
+	if authCookie := responseCookie(response.Cookies(), authCookieName); authCookie != nil && strings.TrimSpace(authCookie.Value) != "" {
+		t.Fatal("did not expect an auth cookie for a forced-rotation target with TOTP enabled")
+	}
+}
+
 func TestCompleteOIDCLinkConfirmationWithLocalAuthDisabledRefusesUnavailable(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/login_service_test.go
+++ b/internal/services/login_service_test.go
@@ -85,6 +85,58 @@ func TestLoginServiceAuthenticateForcedResetIssuesToken(t *testing.T) {
 	}
 }
 
+// TestLoginServiceForcedResetOutranksTOTPForAnAccountWithBothFlags pins a
+// DECISION, not merely the behaviour that happens to exist today: for an
+// account carrying BOTH MustChangePassword and TOTPEnabled, Authenticate
+// routes to the forced password reset and raises NO TOTP challenge.
+//
+// The ordering is deliberate, and it is the intentional recovery path for an
+// owner whose second factor is unusable. TOTP secrets are encrypted under a key
+// derived from the application secret, so after a SECRET_KEY rotation the
+// stored ciphertext no longer opens and the 2FA challenge can never be answered
+// by any code the authenticator produces; the operator-forced reset
+// (`ovumcy reset-password <email>`) is the way back in that
+// docs/security/cryptography.md and docs/self-hosted.md instruct an operator to
+// use. Making TOTP win would withdraw that escape hatch from precisely the
+// accounts whose second factor is already broken, leaving permanent owner
+// lockout with no in-product remedy.
+//
+// It is not a downgrade of session security: the reset still bumps
+// AuthSessionVersion in the same atomic update that writes the new password
+// hash (internal/db/user_repository.go), so every session predating it dies.
+//
+// Both halves of the assertion matter — RequiresPasswordReset alone would still
+// pass if the service started returning both flags at once, which the callers
+// resolve inconsistently. No other test in this package pins the ordering, so
+// deleting this case makes reversing the decision free and silent: read a
+// failure here as "the decision was reversed", never as a stale assertion. The
+// public declaration of this accepted risk is recorded separately from this
+// test.
+func TestLoginServiceForcedResetOutranksTOTPForAnAccountWithBothFlags(t *testing.T) {
+	service, reset := newLoginServiceForTest(
+		models.User{ID: 21, MustChangePassword: true, TOTPEnabled: true},
+		nil,
+		"issued-reset-token",
+	)
+
+	result, err := service.Authenticate(context.Background(), []byte("secret"), "127.0.0.1", "user@example.com", "StrongPass1", loginServiceTestTTL, loginServiceTestNow)
+	if err != nil {
+		t.Fatalf("Authenticate() unexpected error: %v", err)
+	}
+	if !result.RequiresPasswordReset {
+		t.Fatalf("expected forced reset to outrank the TOTP challenge for an account with both flags")
+	}
+	if result.RequiresTOTP {
+		t.Fatalf("expected no TOTP challenge on the forced-reset recovery path")
+	}
+	if result.ResetToken != "issued-reset-token" {
+		t.Fatalf("expected issued reset token, got %q", result.ResetToken)
+	}
+	if !reset.called || reset.lastUserID != 21 {
+		t.Fatalf("expected reset token issuance for user 21")
+	}
+}
+
 func TestLoginServiceAuthenticatePropagatesInvalidCredentials(t *testing.T) {
 	authErr := ErrAuthInvalidCreds
 	service, reset := newLoginServiceForTest(models.User{}, authErr, "unused")


### PR DESCRIPTION
**None of the three guards in this branch is naturally red.** Production is correct today and stays untouched; every one of them fails only under a deliberate mutation of `internal/services/login_service.go`. Read them as a decision being pinned, not as a defect being fixed.

The decision: an account carrying both `MustChangePassword` and `TOTPEnabled` is routed to the forced password reset and is never challenged for TOTP. That ordering is intentional. A `SECRET_KEY` rotation leaves `users.totp_secret` undecryptable, so no code the authenticator produces can ever satisfy the challenge, and the operator-forced reset is the way back in that `docs/security/cryptography.md` and `docs/self-hosted.md` instruct an operator to use. Letting TOTP win would withdraw that escape hatch from exactly the accounts whose second factor is already broken. It is not a weakening of session containment either — the reset bumps `AuthSessionVersion` in the same atomic update that writes the new password hash.

## What this bought

Nothing pinned that ordering at all. Flipping the precedence reddened **zero** tests; `TOTPEnabled` appeared in no `internal/services` login test, and no such test had ever existed. That measurement is the whole argument for the branch. I re-ran it here under the mutant across the full `internal/services` and `internal/api` suites, and the only three failures were the three cases this branch adds:

```
login_service_test.go:127: expected forced reset to outrank the TOTP challenge for an account with both flags
auth_login_totp_required_regression_test.go:125: Location = "/auth/2fa", want /reset-password (forced reset outranks the TOTP challenge)
auth_oidc_regressions_test.go:1082: expected redirect to /reset-password for a forced-rotation target with TOTP enabled, got "/dashboard"
```

Restoring the line exactly (`git diff origin/main` on the production file: empty) turns all three green again, alongside their pre-existing siblings.

## Why the third case had to be at link-confirm

`POST /auth/oidc/link-confirm` branches only on `RequiresPasswordReset` and has **no `RequiresTOTP` arm at all**. With the precedence reversed, a target holding both flags comes back with `RequiresPasswordReset == false`, the reset branch is skipped, and control falls through to `setAuthCookie` — a forced-rotation account handed a live session by this route while the login route still refuses it. The mutant's `/dashboard` above is that fall-through, observed. The existing sibling cannot see it, because its fixture never enables TOTP. The new case submits a **valid** `totp_code` on purpose: the handler's own `targetUser.TOTPEnabled` gate runs earlier, so without a valid code the request stops at the gate and the fall-through is never reached.

Pinning the service and one caller would have left the other free to drift, which is the N-of-N+1 shape this work exists to remove — hence all three.

## Scope and rollback

Test-only: three test files and one changelog fragment, 211 added lines, no production path in the diff. Rollback is a single-commit revert with no runtime effect.

Two things deliberately left out, so they do not read as oversights:

- `SECURITY.md`'s link-confirm forced-rotation row still cites only `TestCompleteOIDCLinkConfirmationRoutesMustChangePasswordToReset`. Adding the new case to that row belongs to the docs-only follow-up, which is currently held.
- The recovery-code path is a second, wider site of the same shape and is being addressed on its own branch. **This PR does not close that class** — it pins one decision at its three callers.

Checks: `go vet` clean, `golangci-lint run` 0 issues, full `go test ./internal/services/... ./internal/api/...` green, `go run ./scripts/changelogd check` OK.
