### PR TITLE
security(auth): equalize timing for stored hashes below the current cost

### DIFF
--- a/changelog.d/security-auth-timing-equalizes-legacy-hash-cost.md
+++ b/changelog.d/security-auth-timing-equalizes-legacy-hash-cost.md
@@ -1,0 +1,15 @@
+### Security
+
+- **A refused sign-in or recovery reset now costs the same whether or not the address has an
+  account — including accounts created before the password hashing cost was raised.** The
+  equalizers that make an unknown address spend the same bcrypt work as a wrong password were
+  pinned to the current cost, while the real comparison spends only the cost stored in the row. An
+  account still holding a hash from before the raise was therefore refused about four times faster
+  than an address with no account at all, and that gap told anyone measuring it which addresses are
+  registered. A refusal now buys the missing work at the missing cost steps, derived from the
+  configured cost and the stored one rather than from a fixed pair, so the totals match again.
+  Recovery codes are the case that could not heal itself: their hashes are never re-minted on use,
+  so a cost written years ago stays where it was.
+- No stored hash is rewritten by this change and nothing about signing in changes for an owner: a
+  successful sign-in still upgrades a stale password hash in place, as it has since the cost was
+  raised.

--- a/internal/services/auth_service.go
+++ b/internal/services/auth_service.go
@@ -306,6 +306,12 @@ func (service *AuthService) AuthenticateCredentials(ctx context.Context, email s
 		return models.User{}, ErrAuthInvalidCreds
 	}
 	if bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(password)) != nil {
+		// The comparison above spends only the work the STORED hash carries.
+		// An account whose hash predates the current cost is therefore rejected
+		// measurably faster than an address with no account, which pays a full
+		// passwordHashCost comparison in the equalized branches above — the
+		// account-enumeration oracle in reverse. Buy the difference here.
+		topUpAuthCredentialsTiming(user.PasswordHash, password)
 		return models.User{}, ErrAuthInvalidCreds
 	}
 	if err := ValidateSupportedWebUser(&user); err != nil {
@@ -381,6 +387,13 @@ func (service *AuthService) FindUserByEmailRecoveryCodeAndPassword(ctx context.C
 	recoveryCodeMatches := bcrypt.CompareHashAndPassword([]byte(hash), []byte(NormalizeRecoveryCode(code))) == nil
 	passwordMatches := bcrypt.CompareHashAndPassword([]byte(passwordHash), []byte(password)) == nil
 	if !recoveryCodeMatches || !passwordMatches {
+		// Both comparisons ran, but each spent only the work ITS stored hash
+		// carries, while equalizeRecoveryCodeLookupTiming above always spends
+		// two passwordHashCost comparisons. An account holding hashes minted
+		// before the current cost would answer faster than "no such address" —
+		// and unlike passwords, a recovery-code hash is never re-minted on a
+		// successful use, so a stale cost stays stale. Buy the difference.
+		topUpRecoveryLookupTiming(hash, code, passwordHash, password)
 		return nil, ErrRecoveryCodeNotFound
 	}
 	if err := ValidateSupportedWebUser(&user); err != nil {
@@ -530,6 +543,116 @@ var equalizeAuthCredentialsTiming = func(password string) {
 var equalizeRegistrationTiming = func(password string) {
 	_ = bcrypt.CompareHashAndPassword([]byte(credentialsTimingEqualizationHash), []byte(password))
 	_ = bcrypt.CompareHashAndPassword([]byte(recoveryCodeTimingEqualizationHash), []byte(password))
+}
+
+// timingTopUpPlaceholderInput is the value the top-up placeholder hashes below
+// are minted from. It is not a credential and cannot become one: the hashes it
+// produces are only ever compared with the result discarded, and every real
+// verification in this package compares against a hash read from the row.
+const timingTopUpPlaceholderInput = "ovumcy timing equalization placeholder"
+
+// timingTopUpHashesByCost holds one placeholder bcrypt hash per cost below
+// passwordHashCost. A comparison against a hash at cost k spends ~2^k units of
+// bcrypt work, so this table is what lets a rejection buy exactly the work a
+// legacy stored hash did not spend (see bcryptCostTopUpSchedule).
+//
+// The hashes are MINTED, never pasted in as constants: hand-written literals
+// would stay pinned to today's passwordHashCost, so raising the constant would
+// silently leave the new top cost unpaid and reopen the gap this table closes.
+// The one-time price is the sum of 2^k for k = bcrypt.MinCost ..
+// passwordHashCost-1, which is just under a single passwordHashCost hash —
+// roughly one login's work, paid once at startup and never per request.
+var timingTopUpHashesByCost = mintTimingTopUpHashes()
+
+func mintTimingTopUpHashes() map[int][]byte {
+	minted := make(map[int][]byte, passwordHashCost-bcrypt.MinCost)
+	for cost := bcrypt.MinCost; cost < passwordHashCost; cost++ {
+		hash, err := bcrypt.GenerateFromPassword([]byte(timingTopUpPlaceholderInput), cost)
+		if err != nil {
+			continue // codecov:ignore -- bcrypt only errors on an out-of-range cost; spendBcryptCostTopUp overpays a missing entry rather than under-paying it
+		}
+		minted[cost] = hash
+	}
+	return minted
+}
+
+// bcryptCostTopUpSchedule names the costs at which dummy bcrypt work has to be
+// spent so that a comparison already made against a hash at storedCost adds up
+// to the work of a comparison at passwordHashCost.
+//
+// bcrypt work is exponential in the cost — a comparison at cost c spends ~2^c
+// units — and the deficit 2^passwordHashCost - 2^c is exactly the sum of 2^k
+// for k = c .. passwordHashCost-1. One dummy comparison at each of those costs
+// therefore pays the deficit precisely. The schedule is derived from
+// passwordHashCost and the observed stored cost, never from a fixed pair, so
+// raising the constant widens it without a second edit.
+//
+// A stored cost at or above passwordHashCost owes nothing. A cost below
+// bcrypt.MinCost cannot come out of bcrypt.Cost (it rejects such a hash
+// outright); it is clamped so the schedule stays finite either way.
+func bcryptCostTopUpSchedule(storedCost int) []int {
+	if storedCost < bcrypt.MinCost {
+		storedCost = bcrypt.MinCost
+	}
+	if storedCost >= passwordHashCost {
+		return nil
+	}
+
+	schedule := make([]int, 0, passwordHashCost-storedCost)
+	for cost := storedCost; cost < passwordHashCost; cost++ {
+		schedule = append(schedule, cost)
+	}
+	return schedule
+}
+
+// spendBcryptCostTopUp pays, against placeholder hashes, the bcrypt work a real
+// comparison against storedHash left unspent relative to passwordHashCost. Like
+// the equalize* helpers it never authenticates anyone: every result is
+// discarded, and the placeholders are minted from a fixed non-credential input.
+//
+// fullCostPlaceholder is the caller's own passwordHashCost placeholder, spent
+// whole when the stored hash is unparseable — there bcrypt.CompareHashAndPassword
+// rejected the hash without running the KDF at all, so the entire cost is owed
+// rather than a deficit, and a zero-work rejection would be the loudest signal
+// of the three.
+func spendBcryptCostTopUp(storedHash string, operand string, fullCostPlaceholder string) {
+	storedCost, err := bcrypt.Cost([]byte(storedHash))
+	if err != nil {
+		_ = bcrypt.CompareHashAndPassword([]byte(fullCostPlaceholder), []byte(operand))
+		return
+	}
+
+	for _, topUpCost := range bcryptCostTopUpSchedule(storedCost) {
+		placeholder, ok := timingTopUpHashesByCost[topUpCost]
+		if !ok {
+			// Unreachable: the table covers every cost a schedule can name.
+			// If it ever does not, overpay by a full comparison instead of
+			// silently skipping the work.
+			_ = bcrypt.CompareHashAndPassword([]byte(fullCostPlaceholder), []byte(operand)) // codecov:ignore -- unreachable while the table covers bcrypt.MinCost..passwordHashCost-1
+			return
+		}
+		_ = bcrypt.CompareHashAndPassword(placeholder, []byte(operand))
+	}
+}
+
+// topUpAuthCredentialsTiming closes the login half of the same gap the
+// equalize* helpers close: the early-return branches of AuthenticateCredentials
+// always spend a passwordHashCost comparison, while the real comparison spends
+// only what the stored hash carries. Declared as a var for the same
+// test-substitution reason as equalizeAuthCredentialsTiming — production code
+// never reassigns it.
+var topUpAuthCredentialsTiming = func(storedHash string, password string) {
+	spendBcryptCostTopUp(storedHash, password, credentialsTimingEqualizationHash)
+}
+
+// topUpRecoveryLookupTiming is the recovery-lookup counterpart: it tops up both
+// operands equalizeRecoveryCodeLookupTiming spends at full cost, each against
+// its own placeholder, so a rejection costs the same whether the address has no
+// account or the account's stored hashes predate the current cost. The code is
+// normalized exactly as the real comparison normalizes it.
+var topUpRecoveryLookupTiming = func(recoveryHash string, code string, passwordHash string, password string) {
+	spendBcryptCostTopUp(recoveryHash, NormalizeRecoveryCode(code), recoveryCodeTimingEqualizationHash)
+	spendBcryptCostTopUp(passwordHash, password, credentialsTimingEqualizationHash)
 }
 
 // ResetPasswordAndRotateRecoveryCodeCAS is the single-use variant of

--- a/internal/services/auth_service.go
+++ b/internal/services/auth_service.go
@@ -356,8 +356,15 @@ func (service *AuthService) rehashPasswordIfStale(ctx context.Context, user *mod
 // captured secret can no longer rewrite the password and mint a session.
 //
 // Every rejection returns the one ErrRecoveryCodeNotFound, and every rejection
-// spends the SAME bcrypt work as a success — two cost-12 comparisons. The
-// operands are therefore never short-circuited against each other: when the row
+// spends the same bcrypt work as every OTHER rejection — two comparisons at
+// passwordHashCost. Where the row exists and its stored hashes were minted
+// below that cost, topUpRecoveryLookupTiming buys the shortfall back, so a
+// wrong code costs what an address with no account at all costs. A SUCCESS is
+// deliberately not held to that total: it runs no top-up, so an account still
+// carrying pre-raise hashes verifies more cheaply than it is rejected. Nothing
+// leaks by that — reaching the success path already requires both secrets.
+//
+// The operands are therefore never short-circuited against each other: when the row
 // exists, both comparisons run and only their combined result decides, and when
 // it does not, equalizeRecoveryCodeLookupTiming spends both against the fixed
 // placeholders. A password compare skipped after a failed code compare (or the
@@ -605,6 +612,17 @@ func bcryptCostTopUpSchedule(storedCost int) []int {
 	return schedule
 }
 
+// timingTopUpCompare is the single point at which the top-up spends bcrypt
+// work. Declared as a var for the same test-substitution reason as the
+// equalize* helpers, but used differently: a guard WRAPS it to account the work
+// spendBcryptCostTopUp actually spends, rather than recomputing that work from
+// bcryptCostTopUpSchedule. Recomputing it would only prove the schedule is
+// consistent with itself, and would stay green if the loop below stopped
+// comparing altogether. Production code never reassigns it.
+var timingTopUpCompare = func(hash []byte, operand []byte) {
+	_ = bcrypt.CompareHashAndPassword(hash, operand)
+}
+
 // spendBcryptCostTopUp pays, against placeholder hashes, the bcrypt work a real
 // comparison against storedHash left unspent relative to passwordHashCost. Like
 // the equalize* helpers it never authenticates anyone: every result is
@@ -618,7 +636,7 @@ func bcryptCostTopUpSchedule(storedCost int) []int {
 func spendBcryptCostTopUp(storedHash string, operand string, fullCostPlaceholder string) {
 	storedCost, err := bcrypt.Cost([]byte(storedHash))
 	if err != nil {
-		_ = bcrypt.CompareHashAndPassword([]byte(fullCostPlaceholder), []byte(operand))
+		timingTopUpCompare([]byte(fullCostPlaceholder), []byte(operand))
 		return
 	}
 
@@ -628,10 +646,10 @@ func spendBcryptCostTopUp(storedHash string, operand string, fullCostPlaceholder
 			// Unreachable: the table covers every cost a schedule can name.
 			// If it ever does not, overpay by a full comparison instead of
 			// silently skipping the work.
-			_ = bcrypt.CompareHashAndPassword([]byte(fullCostPlaceholder), []byte(operand)) // codecov:ignore -- unreachable while the table covers bcrypt.MinCost..passwordHashCost-1
+			timingTopUpCompare([]byte(fullCostPlaceholder), []byte(operand)) // codecov:ignore -- unreachable while the table covers bcrypt.MinCost..passwordHashCost-1
 			return
 		}
-		_ = bcrypt.CompareHashAndPassword(placeholder, []byte(operand))
+		timingTopUpCompare(placeholder, []byte(operand))
 	}
 }
 

--- a/internal/services/auth_service_recovery_lookup_timing_barrier_test.go
+++ b/internal/services/auth_service_recovery_lookup_timing_barrier_test.go
@@ -26,8 +26,10 @@ import (
 // the early-return equalizer, which must spend BOTH operands' compute.
 //
 // What it cannot see: a `return` inserted between the two assignments, or a
-// compare hidden behind a helper call. Neither is invisible to the enumeration
-// guards in internal/api, which compare the answers themselves.
+// compare hidden behind a helper it does not name. Neither is invisible to the
+// enumeration guards in internal/api, which compare the answers themselves. The
+// two helpers this route DOES spend bcrypt work through are named and counted
+// at the end of the test.
 func TestRecoveryLookupSpendsBothCredentialComparesWithoutShortCircuit(t *testing.T) {
 	fileSet := token.NewFileSet()
 	file, err := parser.ParseFile(fileSet, "auth_service.go", nil, parser.ParseComments)
@@ -86,6 +88,40 @@ func TestRecoveryLookupSpendsBothCredentialComparesWithoutShortCircuit(t *testin
 		}
 		return true
 	})
+
+	// The inline comparisons above are only half the story: two rejection paths
+	// spend their bcrypt work through a helper instead, and deleting either call
+	// is invisible both to a compare count and to the work ledgers in
+	// auth_service_timing_cost_topup_test.go, which read the unknown-address
+	// baseline off the placeholder constants rather than measuring it. Pin the
+	// calls themselves. Two equalizer calls: the unknown-address branch and the
+	// no-local-auth/empty-hash branch. One top-up call: the branch where both
+	// comparisons ran, against stored hashes that may predate passwordHashCost.
+	helperCalls := map[string]int{}
+	ast.Inspect(bodies["FindUserByEmailRecoveryCodeAndPassword"], func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if ident, ok := call.Fun.(*ast.Ident); ok {
+			helperCalls[ident.Name]++
+		}
+		return true
+	})
+
+	for _, want := range []struct {
+		helper string
+		calls  int
+		why    string
+	}{
+		{"equalizeRecoveryCodeLookupTiming", 2, "an unknown address would then be refused with no bcrypt work at all — the loudest account-enumeration signal this route can emit"},
+		{"topUpRecoveryLookupTiming", 1, "a row whose stored hashes predate passwordHashCost would then be refused more cheaply than an unknown address"},
+	} {
+		if got := helperCalls[want.helper]; got != want.calls {
+			t.Fatalf("FindUserByEmailRecoveryCodeAndPassword calls %s %d times, want %d: %s",
+				want.helper, got, want.calls, want.why)
+		}
+	}
 }
 
 func isBcryptCompareCall(call *ast.CallExpr) bool {

--- a/internal/services/auth_service_timing_cost_topup_test.go
+++ b/internal/services/auth_service_timing_cost_topup_test.go
@@ -42,21 +42,23 @@ func mintBcryptHashAtCost(t *testing.T, value string, cost int) string {
 	return string(hash)
 }
 
-// topUpWorkUnits is the work the top-up owes for storedHash: the scheduled
-// dummy comparisons, or one whole passwordHashCost comparison when the stored
-// hash is unparseable and the real comparison therefore ran no KDF at all.
-func topUpWorkUnits(t *testing.T, storedHash string, fullCostPlaceholder string) int64 {
+// withTopUpCompareLedger wraps the single seam through which the shipped
+// spendBcryptCostTopUp spends its bcrypt work, so a test accounts the
+// comparisons the code ACTUALLY makes and reads each one's cost off the hash it
+// was handed.
+//
+// This guard used to recompute the same total from bcryptCostTopUpSchedule
+// instead. That proved only that the schedule agreed with itself: replacing the
+// body of spendBcryptCostTopUp with a bare return left the oracle wide open and
+// every assertion in this file green.
+func withTopUpCompareLedger(t *testing.T, ledger *bcryptWorkLedger) {
 	t.Helper()
-	storedCost, err := bcrypt.Cost([]byte(storedHash))
-	if err != nil {
-		return bcryptWorkUnits(mustBcryptCost(t, fullCostPlaceholder))
+	original := timingTopUpCompare
+	timingTopUpCompare = func(hash []byte, operand []byte) {
+		ledger.units += bcryptWorkUnits(mustBcryptCost(t, string(hash)))
+		original(hash, operand)
 	}
-
-	var units int64
-	for _, cost := range bcryptCostTopUpSchedule(storedCost) {
-		units += bcryptWorkUnits(cost)
-	}
-	return units
+	t.Cleanup(func() { timingTopUpCompare = original })
 }
 
 // bcryptWorkLedger accumulates the work the equalizing helpers spend on a
@@ -92,7 +94,6 @@ func withLoginWorkLedger(t *testing.T) *bcryptWorkLedger {
 	topUpAuthCredentialsTiming = func(storedHash string, password string) {
 		ledger.topUpHashes = append(ledger.topUpHashes, storedHash)
 		ledger.topUpOperands = append(ledger.topUpOperands, password)
-		ledger.units += topUpWorkUnits(t, storedHash, credentialsTimingEqualizationHash)
 		originalTopUp(storedHash, password)
 	}
 
@@ -100,6 +101,8 @@ func withLoginWorkLedger(t *testing.T) *bcryptWorkLedger {
 		equalizeAuthCredentialsTiming = originalEqualize
 		topUpAuthCredentialsTiming = originalTopUp
 	})
+
+	withTopUpCompareLedger(t, ledger)
 	return ledger
 }
 
@@ -217,8 +220,9 @@ func TestAuthenticateCredentialsAccountsFullWorkForAnUnparseableStoredHash(t *te
 		t.Fatalf("expected ErrAuthInvalidCreds for an unparseable stored hash, got %v", err)
 	}
 
-	if want := bcryptWorkUnits(passwordHashCost); ledger.drain() != want {
-		t.Fatalf("unparseable stored hash accounts to %d work units, want %d (2^passwordHashCost)", ledger.units, want)
+	spent := ledger.drain()
+	if want := bcryptWorkUnits(passwordHashCost); spent != want {
+		t.Fatalf("unparseable stored hash accounts to %d work units, want %d (2^passwordHashCost)", spent, want)
 	}
 }
 
@@ -266,17 +270,22 @@ func TestRecoveryLookupAccountsEqualWorkForMissingAccountAndStaleHashes(t *testi
 	originalTopUp := topUpRecoveryLookupTiming
 	topUpRecoveryLookupTiming = func(recoveryHash string, code string, passwordHash string, password string) {
 		ledger.topUpHashes = append(ledger.topUpHashes, recoveryHash, passwordHash)
-		ledger.units += topUpWorkUnits(t, recoveryHash, recoveryCodeTimingEqualizationHash)
-		ledger.units += topUpWorkUnits(t, passwordHash, credentialsTimingEqualizationHash)
 		originalTopUp(recoveryHash, code, passwordHash, password)
 	}
 	t.Cleanup(func() { topUpRecoveryLookupTiming = originalTopUp })
+	withTopUpCompareLedger(t, ledger)
 
-	// The unknown-address branch runs equalizeRecoveryCodeLookupTiming, whose
-	// two placeholder comparisons are pinned to passwordHashCost by
-	// TestTimingEqualizationHashesMatchTargetCost and pinned to both running by
-	// TestRecoveryLookupSpendsBothCredentialComparesWithoutShortCircuit; its
-	// work is read off those same constants here.
+	// The unknown-address baseline is read off the two placeholder constants
+	// rather than measured, because equalizeRecoveryCodeLookupTiming compares
+	// against them with a literal bcrypt call the barrier test requires it to
+	// keep. Three guards make that reading safe, and none of them is this test:
+	// TestTimingEqualizationHashesMatchTargetCost pins both placeholders to
+	// passwordHashCost, and
+	// TestRecoveryLookupSpendsBothCredentialComparesWithoutShortCircuit pins
+	// both comparisons to running unconditionally AND pins both early-return
+	// branches to actually calling the equalizer — without that last check,
+	// deleting the call here would leave an unknown address costing nothing and
+	// this test still green.
 	missing := NewAuthService(&stubAuthUserRepo{})
 	if _, err := missing.FindUserByEmailRecoveryCodeAndPassword(context.Background(), "nobody@example.com", submittedCode, submittedPassword); !errors.Is(err, ErrRecoveryCodeNotFound) {
 		t.Fatalf("expected ErrRecoveryCodeNotFound for an unknown address, got %v", err)

--- a/internal/services/auth_service_timing_cost_topup_test.go
+++ b/internal/services/auth_service_timing_cost_topup_test.go
@@ -129,6 +129,35 @@ func TestBcryptCostTopUpScheduleClosesTheDeficitExactly(t *testing.T) {
 	}
 }
 
+// TestBcryptCostTopUpScheduleClampsACostBelowTheBcryptMinimum pins the defensive
+// clamp. `bcrypt.Cost` rejects a hash below `bcrypt.MinCost` outright, so nothing
+// in production reaches this branch — but the schedule still has to stay FINITE
+// for whatever does, which is the whole reason the clamp is there.
+//
+// It does not close the deficit exactly, and the assertion below deliberately
+// does not claim it does: clamping storedCost UP shortens the schedule, so a
+// hypothetical cost-2 row would be underpaid by 2^4-2^2 = 12 units against
+// 2^passwordHashCost = 4096. Unreachable, and a rounding error if it were not.
+func TestBcryptCostTopUpScheduleClampsACostBelowTheBcryptMinimum(t *testing.T) {
+	atMinimum := bcryptCostTopUpSchedule(bcrypt.MinCost)
+	if len(atMinimum) == 0 {
+		t.Fatal("the schedule at bcrypt.MinCost is empty — this test would assert nothing")
+	}
+
+	for storedCost := 0; storedCost < bcrypt.MinCost; storedCost++ {
+		got := bcryptCostTopUpSchedule(storedCost)
+		if len(got) != len(atMinimum) {
+			t.Fatalf("stored cost %d: schedule has %d steps, want the %d of bcrypt.MinCost — the clamp did not hold and the schedule is not finite",
+				storedCost, len(got), len(atMinimum))
+		}
+		for step := range got {
+			if got[step] != atMinimum[step] {
+				t.Fatalf("stored cost %d: schedule step %d names cost %d, want %d", storedCost, step, got[step], atMinimum[step])
+			}
+		}
+	}
+}
+
 // TestTimingTopUpPlaceholdersCoverEveryScheduledCost proves the schedule can
 // actually be paid: a named cost with no minted placeholder, or one minted at
 // the wrong cost, would leave the arithmetic above true and the shipped path

--- a/internal/services/auth_service_timing_cost_topup_test.go
+++ b/internal/services/auth_service_timing_cost_topup_test.go
@@ -1,0 +1,316 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// Guards for the legacy-cost half of the auth timing-equalization story.
+//
+// The equalize* helpers make every early-return branch spend a full
+// passwordHashCost bcrypt comparison, so "no such address" costs the same as a
+// wrong password. That holds only while the REAL comparison also costs
+// passwordHashCost. A stored hash minted before the cost was raised carries its
+// own, lower cost, and bcrypt work doubles per cost step — so a wrong password
+// against such an account answers ~4x faster than an unknown address, which is
+// the account-enumeration oracle (CWE-208 / CWE-204) read backwards.
+//
+// These tests account WORK, not wall-clock time: a latency budget is flake-prone
+// on shared CI runners (the reason the older login timing guard was rewritten as
+// a call counter), while the property at stake — "every rejection adds up to
+// 2^passwordHashCost units" — is arithmetic and settles exactly.
+
+// bcryptWorkUnits states bcrypt's own work model: the KDF runs 2^cost rounds, so
+// a comparison against a hash at cost c is worth 2^c units and the work of
+// several comparisons adds.
+func bcryptWorkUnits(cost int) int64 {
+	return int64(1) << cost
+}
+
+// mintBcryptHashAtCost produces a stored-hash fixture at an arbitrary cost —
+// how a row written before the cost raise looks today.
+func mintBcryptHashAtCost(t *testing.T, value string, cost int) string {
+	t.Helper()
+	hash, err := bcrypt.GenerateFromPassword([]byte(value), cost)
+	if err != nil {
+		t.Fatalf("mint bcrypt hash at cost %d: %v", cost, err)
+	}
+	return string(hash)
+}
+
+// topUpWorkUnits is the work the top-up owes for storedHash: the scheduled
+// dummy comparisons, or one whole passwordHashCost comparison when the stored
+// hash is unparseable and the real comparison therefore ran no KDF at all.
+func topUpWorkUnits(t *testing.T, storedHash string, fullCostPlaceholder string) int64 {
+	t.Helper()
+	storedCost, err := bcrypt.Cost([]byte(storedHash))
+	if err != nil {
+		return bcryptWorkUnits(mustBcryptCost(t, fullCostPlaceholder))
+	}
+
+	var units int64
+	for _, cost := range bcryptCostTopUpSchedule(storedCost) {
+		units += bcryptWorkUnits(cost)
+	}
+	return units
+}
+
+// bcryptWorkLedger accumulates the work the equalizing helpers spend on a
+// request, so two rejection paths can be compared as totals.
+type bcryptWorkLedger struct {
+	units          int64
+	topUpHashes    []string
+	topUpOperands  []string
+	equalizerCalls int
+}
+
+func (ledger *bcryptWorkLedger) drain() int64 {
+	units := ledger.units
+	ledger.units = 0
+	return units
+}
+
+// withLoginWorkLedger wraps both login-side helpers so the test can account
+// their work. Each wrapper still calls the production helper, so the real
+// bcrypt work is spent exactly as it ships and only the accounting is added.
+func withLoginWorkLedger(t *testing.T) *bcryptWorkLedger {
+	t.Helper()
+	ledger := &bcryptWorkLedger{}
+
+	originalEqualize := equalizeAuthCredentialsTiming
+	equalizeAuthCredentialsTiming = func(password string) {
+		ledger.equalizerCalls++
+		ledger.units += bcryptWorkUnits(mustBcryptCost(t, credentialsTimingEqualizationHash))
+		originalEqualize(password)
+	}
+
+	originalTopUp := topUpAuthCredentialsTiming
+	topUpAuthCredentialsTiming = func(storedHash string, password string) {
+		ledger.topUpHashes = append(ledger.topUpHashes, storedHash)
+		ledger.topUpOperands = append(ledger.topUpOperands, password)
+		ledger.units += topUpWorkUnits(t, storedHash, credentialsTimingEqualizationHash)
+		originalTopUp(storedHash, password)
+	}
+
+	t.Cleanup(func() {
+		equalizeAuthCredentialsTiming = originalEqualize
+		topUpAuthCredentialsTiming = originalTopUp
+	})
+	return ledger
+}
+
+// TestBcryptCostTopUpScheduleClosesTheDeficitExactly is the arithmetic leg: for
+// every cost a stored hash can carry, the real comparison plus the scheduled
+// top-up must add up to one comparison at passwordHashCost — no more (wasted
+// CPU on every wrong password) and no less (the oracle stays open). The
+// expectation is derived from passwordHashCost, so raising the constant keeps
+// the assertion honest instead of pinning the (10, 12) pair of the day.
+func TestBcryptCostTopUpScheduleClosesTheDeficitExactly(t *testing.T) {
+	for storedCost := bcrypt.MinCost; storedCost <= passwordHashCost; storedCost++ {
+		total := bcryptWorkUnits(storedCost)
+		for _, topUpCost := range bcryptCostTopUpSchedule(storedCost) {
+			if topUpCost < storedCost || topUpCost >= passwordHashCost {
+				t.Fatalf("stored cost %d: schedule names cost %d, outside [%d, %d)", storedCost, topUpCost, storedCost, passwordHashCost)
+			}
+			total += bcryptWorkUnits(topUpCost)
+		}
+
+		if want := bcryptWorkUnits(passwordHashCost); total != want {
+			t.Fatalf("stored cost %d: real comparison plus top-up accounts to %d work units, want %d (2^passwordHashCost) — the deficit is not closed",
+				storedCost, total, want)
+		}
+	}
+}
+
+// TestTimingTopUpPlaceholdersCoverEveryScheduledCost proves the schedule can
+// actually be paid: a named cost with no minted placeholder, or one minted at
+// the wrong cost, would leave the arithmetic above true and the shipped path
+// still cheap.
+func TestTimingTopUpPlaceholdersCoverEveryScheduledCost(t *testing.T) {
+	for _, topUpCost := range bcryptCostTopUpSchedule(bcrypt.MinCost) {
+		placeholder, ok := timingTopUpHashesByCost[topUpCost]
+		if !ok {
+			t.Fatalf("no top-up placeholder minted for cost %d — that step of the deficit cannot be paid", topUpCost)
+		}
+		if got := mustBcryptCost(t, string(placeholder)); got != topUpCost {
+			t.Fatalf("top-up placeholder for cost %d is minted at cost %d — it buys the wrong amount of work", topUpCost, got)
+		}
+		if err := bcrypt.CompareHashAndPassword(placeholder, []byte("any")); !errors.Is(err, bcrypt.ErrMismatchedHashAndPassword) {
+			t.Fatalf("top-up placeholder for cost %d is not a usable bcrypt hash (%v) — the comparison would short-circuit", topUpCost, err)
+		}
+	}
+}
+
+// TestAuthenticateCredentialsAccountsEqualWorkForMissingAccountAndStaleHash is
+// the leg that matters: it drives the shipped AuthenticateCredentials and
+// compares the total work of the two rejection paths an enumerator can reach.
+func TestAuthenticateCredentialsAccountsEqualWorkForMissingAccountAndStaleHash(t *testing.T) {
+	const submittedPassword = "WrongGuess1!"
+	staleHash := mintBcryptHashAtCost(t, "CorrectHorse1!", bcrypt.DefaultCost)
+	staleCost := mustBcryptCost(t, staleHash)
+	if staleCost >= passwordHashCost {
+		t.Fatalf("fixture stored hash is at cost %d, want below passwordHashCost (%d)", staleCost, passwordHashCost)
+	}
+
+	ledger := withLoginWorkLedger(t)
+
+	missing := NewAuthService(&stubAuthUserRepo{findByEmailErr: errors.New("not found")})
+	if _, err := missing.AuthenticateCredentials(context.Background(), "nobody@example.com", submittedPassword); !errors.Is(err, ErrAuthInvalidCreds) {
+		t.Fatalf("expected ErrAuthInvalidCreds for an unknown address, got %v", err)
+	}
+	missingUnits := ledger.drain()
+	if ledger.equalizerCalls != 1 {
+		t.Fatalf("expected the unknown-address branch to equalize exactly once, got %d calls", ledger.equalizerCalls)
+	}
+	if want := bcryptWorkUnits(passwordHashCost); missingUnits != want {
+		t.Fatalf("unknown-address branch accounts to %d work units, want %d (2^passwordHashCost)", missingUnits, want)
+	}
+
+	stale := NewAuthService(&stubAuthUserRepo{findByEmailUser: models.User{
+		ID:               7,
+		Email:            "owner@example.com",
+		Role:             models.RoleOwner,
+		LocalAuthEnabled: true,
+		PasswordHash:     staleHash,
+	}})
+	if _, err := stale.AuthenticateCredentials(context.Background(), "owner@example.com", submittedPassword); !errors.Is(err, ErrAuthInvalidCreds) {
+		t.Fatalf("expected ErrAuthInvalidCreds for a wrong password, got %v", err)
+	}
+	// The real comparison ran against the stored hash and spent its cost; the
+	// ledger only sees what the helpers added on top.
+	staleUnits := ledger.drain() + bcryptWorkUnits(staleCost)
+
+	if staleUnits != missingUnits {
+		t.Fatalf("a wrong password against a cost-%d stored hash accounts to %d bcrypt work units while an unknown address accounts to %d: "+
+			"the cheaper branch tells an attacker the account exists (CWE-208 / CWE-204)", staleCost, staleUnits, missingUnits)
+	}
+	if len(ledger.topUpHashes) != 1 {
+		t.Fatalf("expected exactly 1 top-up on the failed-compare path, got %d", len(ledger.topUpHashes))
+	}
+	if ledger.topUpHashes[0] != staleHash {
+		t.Fatal("the top-up ran against a hash other than the one the real comparison used — its cost would be read from the wrong operand")
+	}
+	if ledger.topUpOperands[0] != submittedPassword {
+		t.Fatalf("expected the top-up to run against the submitted password, got %q", ledger.topUpOperands[0])
+	}
+}
+
+// TestAuthenticateCredentialsAccountsFullWorkForAnUnparseableStoredHash covers
+// the branch where bcrypt.Cost has no answer: the real comparison rejects the
+// row without running the KDF at all, so the whole passwordHashCost is owed —
+// a zero-work rejection would be the loudest of the three signals.
+func TestAuthenticateCredentialsAccountsFullWorkForAnUnparseableStoredHash(t *testing.T) {
+	ledger := withLoginWorkLedger(t)
+
+	service := NewAuthService(&stubAuthUserRepo{findByEmailUser: models.User{
+		ID:               9,
+		Email:            "owner@example.com",
+		Role:             models.RoleOwner,
+		LocalAuthEnabled: true,
+		PasswordHash:     "not-a-bcrypt-hash",
+	}})
+	if _, err := service.AuthenticateCredentials(context.Background(), "owner@example.com", "WrongGuess1!"); !errors.Is(err, ErrAuthInvalidCreds) {
+		t.Fatalf("expected ErrAuthInvalidCreds for an unparseable stored hash, got %v", err)
+	}
+
+	if want := bcryptWorkUnits(passwordHashCost); ledger.drain() != want {
+		t.Fatalf("unparseable stored hash accounts to %d work units, want %d (2^passwordHashCost)", ledger.units, want)
+	}
+}
+
+// TestAuthenticateCredentialsAddsNoWorkForACurrentCostHash is the other side of
+// "exactly": an account already at passwordHashCost owes nothing, and paying a
+// top-up there would both waste CPU on every wrong password and make the
+// current-cost account the slow one.
+func TestAuthenticateCredentialsAddsNoWorkForACurrentCostHash(t *testing.T) {
+	currentHash := mintBcryptHashAtCost(t, "CorrectHorse1!", passwordHashCost)
+	ledger := withLoginWorkLedger(t)
+
+	service := NewAuthService(&stubAuthUserRepo{findByEmailUser: models.User{
+		ID:               11,
+		Email:            "owner@example.com",
+		Role:             models.RoleOwner,
+		LocalAuthEnabled: true,
+		PasswordHash:     currentHash,
+	}})
+	if _, err := service.AuthenticateCredentials(context.Background(), "owner@example.com", "WrongGuess1!"); !errors.Is(err, ErrAuthInvalidCreds) {
+		t.Fatalf("expected ErrAuthInvalidCreds for a wrong password, got %v", err)
+	}
+
+	toppedUp := ledger.drain()
+	if toppedUp != 0 {
+		t.Fatalf("a stored hash already at passwordHashCost was topped up by %d work units, want 0", toppedUp)
+	}
+	if total := bcryptWorkUnits(mustBcryptCost(t, currentHash)) + toppedUp; total != bcryptWorkUnits(passwordHashCost) {
+		t.Fatalf("current-cost rejection accounts to %d work units, want %d (2^passwordHashCost)", total, bcryptWorkUnits(passwordHashCost))
+	}
+}
+
+// TestRecoveryLookupAccountsEqualWorkForMissingAccountAndStaleHashes is the
+// same guard for the recovery reset, which verifies two stored hashes and
+// equalizes both on its early returns. Recovery-code hashes are never re-minted
+// on use — there is no rehash-if-stale for them — so a cost written before the
+// raise stays below passwordHashCost for the life of the code.
+func TestRecoveryLookupAccountsEqualWorkForMissingAccountAndStaleHashes(t *testing.T) {
+	const submittedCode = "OVM-ABCD-EFGH-JKLM"
+	const submittedPassword = "WrongGuess1!"
+
+	staleRecoveryHash := mintBcryptHashAtCost(t, NormalizeRecoveryCode("OVM-ZZZZ-YYYY-XXXX"), bcrypt.DefaultCost)
+	stalePasswordHash := mintBcryptHashAtCost(t, "CorrectHorse1!", bcrypt.DefaultCost)
+
+	ledger := &bcryptWorkLedger{}
+	originalTopUp := topUpRecoveryLookupTiming
+	topUpRecoveryLookupTiming = func(recoveryHash string, code string, passwordHash string, password string) {
+		ledger.topUpHashes = append(ledger.topUpHashes, recoveryHash, passwordHash)
+		ledger.units += topUpWorkUnits(t, recoveryHash, recoveryCodeTimingEqualizationHash)
+		ledger.units += topUpWorkUnits(t, passwordHash, credentialsTimingEqualizationHash)
+		originalTopUp(recoveryHash, code, passwordHash, password)
+	}
+	t.Cleanup(func() { topUpRecoveryLookupTiming = originalTopUp })
+
+	// The unknown-address branch runs equalizeRecoveryCodeLookupTiming, whose
+	// two placeholder comparisons are pinned to passwordHashCost by
+	// TestTimingEqualizationHashesMatchTargetCost and pinned to both running by
+	// TestRecoveryLookupSpendsBothCredentialComparesWithoutShortCircuit; its
+	// work is read off those same constants here.
+	missing := NewAuthService(&stubAuthUserRepo{})
+	if _, err := missing.FindUserByEmailRecoveryCodeAndPassword(context.Background(), "nobody@example.com", submittedCode, submittedPassword); !errors.Is(err, ErrRecoveryCodeNotFound) {
+		t.Fatalf("expected ErrRecoveryCodeNotFound for an unknown address, got %v", err)
+	}
+	missingUnits := bcryptWorkUnits(mustBcryptCost(t, recoveryCodeTimingEqualizationHash)) +
+		bcryptWorkUnits(mustBcryptCost(t, credentialsTimingEqualizationHash))
+
+	stale := NewAuthService(&stubAuthUserRepo{
+		findByEmailOptionalFound: true,
+		findByEmailOptionalUser: models.User{
+			ID:               13,
+			Email:            "owner@example.com",
+			Role:             models.RoleOwner,
+			LocalAuthEnabled: true,
+			PasswordHash:     stalePasswordHash,
+			RecoveryCodeHash: staleRecoveryHash,
+		},
+	})
+	if _, err := stale.FindUserByEmailRecoveryCodeAndPassword(context.Background(), "owner@example.com", submittedCode, submittedPassword); !errors.Is(err, ErrRecoveryCodeNotFound) {
+		t.Fatalf("expected ErrRecoveryCodeNotFound for a wrong code, got %v", err)
+	}
+	staleUnits := ledger.drain() +
+		bcryptWorkUnits(mustBcryptCost(t, staleRecoveryHash)) +
+		bcryptWorkUnits(mustBcryptCost(t, stalePasswordHash))
+
+	if staleUnits != missingUnits {
+		t.Fatalf("a rejected recovery reset against stored hashes at cost %d/%d accounts to %d bcrypt work units while an unknown address accounts to %d: "+
+			"the cheaper branch tells an attacker the account exists (CWE-208 / CWE-204)",
+			mustBcryptCost(t, staleRecoveryHash), mustBcryptCost(t, stalePasswordHash), staleUnits, missingUnits)
+	}
+	if len(ledger.topUpHashes) != 2 {
+		t.Fatalf("expected the rejection to top up both stored operands, got %d", len(ledger.topUpHashes))
+	}
+	if ledger.topUpHashes[0] != staleRecoveryHash || ledger.topUpHashes[1] != stalePasswordHash {
+		t.Fatal("the recovery top-up ran against hashes other than the ones the real comparisons used")
+	}
+}

--- a/internal/services/auth_service_timing_cost_topup_test.go
+++ b/internal/services/auth_service_timing_cost_topup_test.go
@@ -144,7 +144,7 @@ func TestBcryptCostTopUpScheduleClampsACostBelowTheBcryptMinimum(t *testing.T) {
 		t.Fatal("the schedule at bcrypt.MinCost is empty — this test would assert nothing")
 	}
 
-	for storedCost := 0; storedCost < bcrypt.MinCost; storedCost++ {
+	for storedCost := range bcrypt.MinCost {
 		got := bcryptCostTopUpSchedule(storedCost)
 		if len(got) != len(atMinimum) {
 			t.Fatalf("stored cost %d: schedule has %d steps, want the %d of bcrypt.MinCost — the clamp did not hold and the schedule is not finite",


### PR DESCRIPTION
## Why

The `equalize*` helpers in `internal/services/auth_service.go` spend one `passwordHashCost` bcrypt
comparison on every early-return branch of `AuthenticateCredentials` and of the recovery lookup, so
that "no such address" costs what "wrong password" costs — the enumeration-safety invariant in
`docs/SECURITY_INVARIANTS.md`.

That equality holds only while the **real** comparison also costs `passwordHashCost`. It does not,
for a row written before the cost was raised to 12: `bcrypt.CompareHashAndPassword` spends the cost
embedded in the stored hash, and bcrypt work doubles per cost step. A wrong password against an
account still at cost 10 therefore spent 2^10 units where an unknown address spent 2^12 — refused
roughly 4x faster, which is the account-enumeration timing oracle (CWE-208 / CWE-204) read backwards.
`rehashPasswordIfStale` does not close it: it runs only **after** a successful comparison, and a
prober never supplies a correct password.

Neither existing guard could go red on this. `auth_service_hash_cost_test.go:44` compares the
placeholder's cost with `passwordHashCost` — a constant against a constant, saying nothing about the
cost the real branch meets — and `auth_service_credentials_timing_test.go` only counts invocations.

## What changed

`internal/services/auth_service.go`

- `bcryptCostTopUpSchedule(storedCost)` — the deficit `2^P - 2^c` is exactly the sum of `2^k` for
  `k = c .. P-1`, so one dummy comparison at each of those costs closes it precisely. The schedule is
  derived from `passwordHashCost` and the observed stored cost, never from the (10, 12) pair.
- `timingTopUpHashesByCost` — one placeholder hash per cost below `passwordHashCost`, **minted** at
  package initialization rather than pasted in as constants: literals would stay pinned to today's
  cost, so raising the constant would silently leave the new top step unpaid. Minting them costs the
  sum of `2^k` for `k = bcrypt.MinCost .. passwordHashCost-1`, just under a single
  `passwordHashCost` hash — measured 0.23 s here, paid once per process, never per request.
- `spendBcryptCostTopUp` — spends the schedule against those placeholders, discarding every result
  exactly as the `equalize*` helpers do. An **unparseable** stored hash is the one case where the
  real comparison ran no KDF at all, so it spends a whole `passwordHashCost` equalization instead of
  a deficit; a missing table entry (unreachable) overpays a full comparison rather than skipping the
  work.
- `AuthenticateCredentials`, failed-compare branch: `topUpAuthCredentialsTiming(user.PasswordHash,
  password)`.
- `FindUserByEmailRecoveryCodeAndPassword`, failed-compare branch:
  `topUpRecoveryLookupTiming(...)` for **both** stored operands. This is the second site of the same
  class, and the one that cannot heal itself — unlike passwords, a recovery-code hash is never
  re-minted on a successful use, so a cost written before the raise stays where it is forever.

Both new helpers are `var`-declared functions, the same test-substitution idiom as
`equalizeAuthCredentialsTiming`; production never reassigns them. The early-return branches are
untouched and still call the equalizers — losing that would restore a far louder oracle (no bcrypt at
all versus bcrypt). No real comparison or generation cost is lowered; `passwordHashCost` stays 12.

## Blast radius

The top-up runs only on the **failure** path of two routes that already carry an
`AuthAttemptPolicy`, and it can never exceed what a current-cost account already costs: a refused
sign-in against a legacy hash now costs 2^12 units, the same as a refused sign-in against a
current-cost one, which is today's worst case. No new maximum, no new reachable surface. Startup
pays the one-time minting described above.

## Regression guard — `internal/services/auth_service_timing_cost_topup_test.go`

Work accounting, not wall clock: a latency budget is flake-prone on shared runners (the reason the
older login timing guard was rewritten as a call counter), while "every refusal adds up to
2^passwordHashCost units" settles exactly. `bcryptWorkUnits(cost) = 2^cost` is bcrypt's own model.

1. `TestBcryptCostTopUpScheduleClosesTheDeficitExactly` — for every stored cost from
   `bcrypt.MinCost` to `passwordHashCost`, real comparison plus schedule equals
   `2^passwordHashCost`, no more and no less.
2. `TestTimingTopUpPlaceholdersCoverEveryScheduledCost` — every scheduled cost has a minted
   placeholder, at that cost, that bcrypt can actually compare (a pure schedule can be right while
   nothing can pay it).
3. `TestAuthenticateCredentialsAccountsEqualWorkForMissingAccountAndStaleHash` — the leg that
   matters: it drives the shipped `AuthenticateCredentials` and asserts the unknown-address branch
   and the stale-hash wrong-password branch account to the **same** total, so dropping either one
   reddens it. It also pins that the top-up ran against the same stored hash and the submitted
   password.
4. `TestAuthenticateCredentialsAccountsFullWorkForAnUnparseableStoredHash` and
   `TestAuthenticateCredentialsAddsNoWorkForACurrentCostHash` — the two ends: full cost when no KDF
   ran, zero top-up when nothing is owed.
5. `TestRecoveryLookupAccountsEqualWorkForMissingAccountAndStaleHashes` — the same comparison for
   the recovery reset's two operands.

The accounting wrappers call through to the production helpers, so the real bcrypt work is still
spent as it ships; only the bookkeeping is added.

### Red before, green after

With the two call sites unwired (helpers present, nothing calling them):

```
=== RUN   TestBcryptCostTopUpScheduleClosesTheDeficitExactly
--- PASS: TestBcryptCostTopUpScheduleClosesTheDeficitExactly (0.00s)
=== RUN   TestTimingTopUpPlaceholdersCoverEveryScheduledCost
--- PASS: TestTimingTopUpPlaceholdersCoverEveryScheduledCost (0.23s)
=== RUN   TestAuthenticateCredentialsAccountsEqualWorkForMissingAccountAndStaleHash
    auth_service_timing_cost_topup_test.go:188: a wrong password against a cost-10 stored hash accounts to 1024 bcrypt work units while an unknown address accounts to 4096: the cheaper branch tells an attacker the account exists (CWE-208 / CWE-204)
--- FAIL: TestAuthenticateCredentialsAccountsEqualWorkForMissingAccountAndStaleHash (0.35s)
=== RUN   TestAuthenticateCredentialsAccountsFullWorkForAnUnparseableStoredHash
    auth_service_timing_cost_topup_test.go:221: unparseable stored hash accounts to 0 work units, want 4096 (2^passwordHashCost)
--- FAIL: TestAuthenticateCredentialsAccountsFullWorkForAnUnparseableStoredHash (0.00s)
=== RUN   TestAuthenticateCredentialsAddsNoWorkForACurrentCostHash
--- PASS: TestAuthenticateCredentialsAddsNoWorkForACurrentCostHash (0.48s)
=== RUN   TestRecoveryLookupAccountsEqualWorkForMissingAccountAndStaleHashes
    auth_service_timing_cost_topup_test.go:306: a rejected recovery reset against stored hashes at cost 10/10 accounts to 2048 bcrypt work units while an unknown address accounts to 8192: the cheaper branch tells an attacker the account exists (CWE-208 / CWE-204)
--- FAIL: TestRecoveryLookupAccountsEqualWorkForMissingAccountAndStaleHashes (1.11s)
FAIL
FAIL	github.com/ovumcy/ovumcy-web/internal/services	5.682s
```

With the fix wired in:

```
--- PASS: TestBcryptCostTopUpScheduleClosesTheDeficitExactly (0.00s)
--- PASS: TestTimingTopUpPlaceholdersCoverEveryScheduledCost (0.23s)
--- PASS: TestAuthenticateCredentialsAccountsEqualWorkForMissingAccountAndStaleHash (0.53s)
--- PASS: TestAuthenticateCredentialsAccountsFullWorkForAnUnparseableStoredHash (0.24s)
--- PASS: TestAuthenticateCredentialsAddsNoWorkForACurrentCostHash (0.81s)
--- PASS: TestRecoveryLookupAccountsEqualWorkForMissingAccountAndStaleHashes (1.95s)
PASS
ok  	github.com/ovumcy/ovumcy-web/internal/services	7.281s
```

## Everything else that was run

- `go test ./internal/services/` — `ok ... 143.447s`.
- The existing guards over the same placeholders needed **no change** and stay green:
  `TestTimingEqualizationHashesMatchTargetCost`, `TestNewPasswordHashesUseConfiguredCost`,
  `TestCredentialsTimingEqualizationHashIsBcryptCompatible`,
  `TestRecoveryCodeTimingEqualizationHashIsBcryptCompatible`,
  `TestAuthenticateCredentialsEqualizesTimingForMissingUser`,
  `TestAuthenticateCredentialsEqualizesTimingForDisabledLocalAuth`,
  `TestRegisterOwnerEqualizesTimingForDuplicateEmail`. So does the AST barrier
  `TestRecoveryLookupSpendsBothCredentialComparesWithoutShortCircuit` — the top-up enters the
  recovery lookup as a helper call, so that function still contains exactly its two
  `bcrypt.CompareHashAndPassword` calls, neither in an `if` condition.
- `go test ./internal/api/` — `ok ... 594.369s`, run because that package drives the login and
  recovery routes end to end and holds fixtures with unparseable stored hashes, which now spend a
  full equalization on refusal.
- `go vet ./internal/services/...`, `golangci-lint run ./internal/services/...` (0 issues),
  `gofmt -l` on both touched files (clean; the five unrelated files this repo is known to diverge on
  were not touched), `gosec -include=G101 ./internal/services/...` (no findings — the minted
  placeholders are runtime values, so no `#nosec` annotation is needed for them).
- `go run ./scripts/changelogd check` — OK.

## Confidence and evidence

The finding behind this carries **0.55** confidence, and **no timing harness was run**: the gap is
derived from the cost arithmetic (2^12 / 2^10 = 4x, and 0 versus 2^12 for an unparseable hash), not
measured on a running instance. What the tests above prove is the accounting identity, not a latency
claim. The change is cheap and one-directional — it can only add work to a failure path, capped at
what a current-cost account already pays — so it is worth landing at that confidence.

## Rollback

Single-commit revert. No persisted data, no schema, no migration, no public contract change; no
stored hash is rewritten by this change, and reverting restores the previous timing behaviour
exactly.

## Notes

- The cross-layer sentinel identity this area also flagged is already fixed on `main` — both
  `internal/db` and `internal/services` alias the single `internal/models` value — so this pull
  request carries only the timing half.
- `VerifyStoredRecoveryCode` was read and deliberately left alone: it is not the same site. It has no
  equalized sibling branch to diverge from, and its only caller consumes a sealed one-time pickup
  cookie and resolves the account by id first, so there is no address probe whose timing it could be
  compared against; the hash it meets was minted at `passwordHashCost` seconds earlier by
  registration.
- The Test Enforcement Matrix row for the timing equalizers could name the new guards; left out of
  this pull request's scope.
