### PR TITLE
test(csrf): pin the fiber v3 CSRF token idle timeout to one hour

### DIFF
--- a/changelog.d/test-csrf-idle-timeout-pin.md
+++ b/changelog.d/test-csrf-idle-timeout-pin.md
@@ -1,0 +1,5 @@
+none
+
+Test-only: pins the CSRF middleware's token idle timeout to the one hour the server
+already configures, so a silent revert to fiber v3's 30-minute default cannot pass
+green. No behaviour changes.

--- a/cmd/ovumcy/csrf_token_lifetime_pin_test.go
+++ b/cmd/ovumcy/csrf_token_lifetime_pin_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// The CSRF token's idle timeout is a BEHAVIOR-PRESERVING pin, not a security
+// floor: fiber v2 expressed the same window as Expiration=1h, v3 renamed the
+// field to IdleTimeout and defaults it to 30m. Until this file nothing read the
+// value back, so a silent revert to the v3 default would have halved every
+// form's validity window — the failure csrfMiddlewareConfig's own comment names
+// — with the whole suite still green.
+//
+// The assert reads the REAL csrfMiddlewareConfig rather than a copy: the api
+// package's test app carries its own hand-written csrf.Config
+// (internal/api/test_onboarding_app_setup_helpers_test.go), and asserting
+// against that one would pin the double instead of the server.
+//
+// handler is only closed over by the config's ErrorHandler, which this test
+// never drives, so a nil handler is safe here.
+func TestCSRFConfigPinsTheTokenIdleTimeoutToOneHour(t *testing.T) {
+	for _, cookieSecure := range []bool{false, true} {
+		config := csrfMiddlewareConfig(cookieSecure, nil)
+		if config.IdleTimeout != time.Hour {
+			t.Fatalf("csrfMiddlewareConfig(cookieSecure=%t).IdleTimeout = %s, want %s (fiber v3 defaults it to 30m)",
+				cookieSecure, config.IdleTimeout, time.Hour)
+		}
+	}
+}


### PR DESCRIPTION
## What

Adds `TestCSRFConfigPinsTheTokenIdleTimeoutToOneHour` (`cmd/ovumcy/csrf_token_lifetime_pin_test.go`). Test-only; no production file changes.

## Why

`csrfMiddlewareConfig` pins `IdleTimeout` to `time.Hour` with a comment naming the failure it prevents — fiber v3 renamed v2's `Expiration` and defaults it to 30m. Nothing read the value back. The only other `IdleTimeout: time.Hour` in a tracked file is inside `testCSRFMiddlewareConfig`, a hand-written copy of the config in the api package's test app, so it pins the copy rather than the server.

## Measured, not argued

With `cmd/ovumcy/server.go:325` flipped to `30 * time.Minute`:

| suite | before this PR |
| --- | --- |
| `go test ./cmd/ovumcy/ -count=1` | ok |
| `go test ./internal/api/ -count=1 -run 'CSRF\|Csrf'` | ok |

The mutant survived both. With this PR's test in place the same mutation fails with `IdleTimeout = 30m0s, want 1h0m0s`, and the pin restored passes. The test reads the real `csrfMiddlewareConfig` in both transport postures (`cookieSecure` false and true), so a pin that became conditional fails too.

## Not touched

`SECURITY.md` — its matrix never claimed this value, and the pin preserves behaviour across a framework upgrade rather than setting a security floor. 30 minutes is the stricter CSRF window; the cost of a silent revert lands on how long a form stays submittable, not on the strength of the check.
