### PR TITLE
fix(config): refuse a mistyped security toggle or trusted-proxy entry at boot

### DIFF
--- a/changelog.d/fix-boot-refuses-malformed-security-env.md
+++ b/changelog.d/fix-boot-refuses-malformed-security-env.md
@@ -5,7 +5,8 @@
   `WEBHOOK_BLOCK_PRIVATE_ADDRESSES` (`COOKIE_SECURE=ture`) used to log a line and start on the
   fallback, so what an instance actually ran with could not be read from the env file. With
   `TRUST_PROXY_ENABLED=true`, a `TRUSTED_PROXIES` entry the trust boundary cannot use — a broken CIDR,
-  a non-IP string, or an IP not written in canonical form — was likewise dropped, leaving the proxy
+  a non-IP string, an IP not written in canonical form, or an IP listed twice — was likewise dropped
+  or collapsed, leaving the proxy
   untrusted so every client behind it shared one rate-limit bucket while the startup banner counted
   the raw list and reported the typo as configured. Both now stop the process with an error naming
   the key and the rejected value. Unset keys still mean their documented defaults, and every other

--- a/changelog.d/fix-boot-refuses-malformed-security-env.md
+++ b/changelog.d/fix-boot-refuses-malformed-security-env.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- **A mistyped security setting now refuses the boot instead of running on the default.** A value the
+  app cannot parse for `COOKIE_SECURE`, `HSTS_ENABLED`, `TRUST_PROXY_ENABLED` or
+  `WEBHOOK_BLOCK_PRIVATE_ADDRESSES` (`COOKIE_SECURE=ture`) used to log a line and start on the
+  fallback, so what an instance actually ran with could not be read from the env file. With
+  `TRUST_PROXY_ENABLED=true`, a `TRUSTED_PROXIES` entry the trust boundary cannot use — a broken CIDR,
+  a non-IP string, or an IP not written in canonical form — was likewise dropped, leaving the proxy
+  untrusted so every client behind it shared one rate-limit bucket while the startup banner counted
+  the raw list and reported the typo as configured. Both now stop the process with an error naming
+  the key and the rejected value. Unset keys still mean their documented defaults, and every other
+  env var keeps its fallback behaviour.

--- a/cmd/ovumcy/boot_config_validation_guard_test.go
+++ b/cmd/ovumcy/boot_config_validation_guard_test.go
@@ -37,6 +37,10 @@ func TestResolveProxySettingsRejectsAMalformedTrustedProxyEntry(t *testing.T) {
 		// an entry contains() can never match — the same silent miss as "bogus".
 		{"non-canonical ipv6", "2001:DB8::1", "2001:DB8::1"},
 		{"ipv4-mapped ipv6", "::ffff:10.0.0.1", "::ffff:10.0.0.1"},
+		// Both spellings are well formed, so only the repetition itself is the
+		// defect: the matcher's exact set collapses them and the banner counts
+		// a trusted proxy the matcher does not hold.
+		{"repeated ip", "203.0.113.7,203.0.113.7", "203.0.113.7"},
 	}
 
 	for _, tc := range cases {
@@ -85,6 +89,14 @@ func TestTrustedProxyCountTheBannerPrintsMatchesTheMatcher(t *testing.T) {
 		"127.0.0.1,::1",
 		"10.0.0.0/8x,192.168.0.0/16,bogus",
 		"203.0.113.7,10.0.0.0/8",
+		// A repeated entry is well-formed twice over, so nothing above refuses
+		// it — yet the matcher keys its exact set by the entry and collapses the
+		// pair into one, which is the same banner-vs-matcher lie as a typo.
+		"203.0.113.7,203.0.113.7",
+		// Scoping anchor for the duplicate check: ranges are appended to a
+		// slice rather than keyed, so a repeated CIDR keeps both copies and the
+		// two counts already agree — it must still boot.
+		"10.0.0.0/8,10.0.0.0/8",
 	}
 
 	accepted := 0
@@ -107,10 +119,12 @@ func TestTrustedProxyCountTheBannerPrintsMatchesTheMatcher(t *testing.T) {
 		}
 	}
 
-	// Anti-vacuity: the two well-formed lists must have been accepted, so the
-	// comparison above actually ran.
-	if accepted < 2 {
-		t.Fatalf("expected at least the two well-formed lists to be accepted, got %d", accepted)
+	// Anti-vacuity: the two well-formed lists and the repeated-CIDR list must
+	// have been accepted, so the comparison above actually ran — and a blanket
+	// duplicate check that also refused the CIDR pair would fail here rather
+	// than pass by refusing everything.
+	if accepted < 3 {
+		t.Fatalf("expected the two well-formed lists and the repeated-CIDR list to be accepted, got %d", accepted)
 	}
 }
 

--- a/cmd/ovumcy/boot_config_validation_guard_test.go
+++ b/cmd/ovumcy/boot_config_validation_guard_test.go
@@ -1,0 +1,212 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/db"
+)
+
+// Boot-time refusal guards for the two runtime-config values an operator can
+// mistype into a silently degraded security posture.
+//
+// Deliberately narrow: only TRUSTED_PROXIES and the four security-relevant
+// booleans (COOKIE_SECURE, HSTS_ENABLED, TRUST_PROXY_ENABLED,
+// WEBHOOK_BLOCK_PRIVATE_ADDRESSES) refuse the boot. The lenient getEnvBool /
+// getEnvInt / getEnvDuration fallback still governs every other key, so nothing
+// here may be read as "every invalid env value stops the process".
+
+// TestResolveProxySettingsRejectsAMalformedTrustedProxyEntry pins that a
+// TRUSTED_PROXIES entry the trusted-proxy matcher could never use refuses the
+// boot instead of being dropped. An unparseable CIDR was discarded and a non-IP
+// literal was stored as an exact match nothing can equal, so the proxy stayed
+// untrusted and every client behind it shared one rate-limit bucket.
+func TestResolveProxySettingsRejectsAMalformedTrustedProxyEntry(t *testing.T) {
+	cases := []struct {
+		name     string
+		value    string
+		rejected string
+	}{
+		{"cidr typo", "10.0.0.0/8x", "10.0.0.0/8x"},
+		{"non-ip literal", "192.168.0.0/16,bogus", "bogus"},
+		{"out-of-range octet", "127.0.0.256", "127.0.0.256"},
+		{"host bits without a mask width", "10.0.0.1/", "10.0.0.1/"},
+		// Parses as an IP, but the matcher keys its exact set on the entry as
+		// written and looks up net.IP.String(), so a non-canonical spelling is
+		// an entry contains() can never match — the same silent miss as "bogus".
+		{"non-canonical ipv6", "2001:DB8::1", "2001:DB8::1"},
+		{"ipv4-mapped ipv6", "::ffff:10.0.0.1", "::ffff:10.0.0.1"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("TRUST_PROXY_ENABLED", "true")
+			t.Setenv("PROXY_HEADER", "X-Real-IP")
+			t.Setenv("TRUSTED_PROXIES", tc.value)
+
+			_, err := resolveProxySettings()
+			if err == nil {
+				t.Fatalf("expected TRUSTED_PROXIES=%q to refuse the boot", tc.value)
+			}
+			if !strings.Contains(err.Error(), "TRUSTED_PROXIES") || !strings.Contains(err.Error(), tc.rejected) {
+				t.Fatalf("expected the error to name TRUSTED_PROXIES and the rejected entry %q, got: %v", tc.rejected, err)
+			}
+		})
+	}
+
+	// Positive anchor: a well-formed list of both shapes still boots, so the
+	// cases above fail on the malformed entry and not on the check itself.
+	t.Run("well-formed list still boots", func(t *testing.T) {
+		t.Setenv("TRUST_PROXY_ENABLED", "true")
+		t.Setenv("PROXY_HEADER", "X-Real-IP")
+		t.Setenv("TRUSTED_PROXIES", "127.0.0.1, ::1 ,10.0.0.0/8,2001:db8::/32")
+
+		settings, err := resolveProxySettings()
+		if err != nil {
+			t.Fatalf("expected a well-formed TRUSTED_PROXIES list to be accepted, got: %v", err)
+		}
+		if len(settings.TrustedProxies) != 4 {
+			t.Fatalf("expected 4 trusted proxy entries, got %#v", settings.TrustedProxies)
+		}
+	})
+}
+
+// TestTrustedProxyCountTheBannerPrintsMatchesTheMatcher pins the disagreement
+// R2-0009 rests on: logStartup reports trusted_proxy_count=len(TrustedProxies)
+// — the raw CSV — while the rate-limit key generator only ever consults what
+// newTrustedProxyMatcher managed to parse. With "10.0.0.0/8x,192.168.0.0/16,
+// bogus" the banner said 3 and the matcher held 2, so the startup line that
+// exists to confirm the setting agreed with the operator that the typo was
+// fine. Either the boot is refused (the banner never prints) or the two counts
+// agree; nothing in between.
+func TestTrustedProxyCountTheBannerPrintsMatchesTheMatcher(t *testing.T) {
+	values := []string{
+		"127.0.0.1,::1",
+		"10.0.0.0/8x,192.168.0.0/16,bogus",
+		"203.0.113.7,10.0.0.0/8",
+	}
+
+	accepted := 0
+	for _, value := range values {
+		t.Setenv("TRUST_PROXY_ENABLED", "true")
+		t.Setenv("PROXY_HEADER", "X-Real-IP")
+		t.Setenv("TRUSTED_PROXIES", value)
+
+		settings, err := resolveProxySettings()
+		if err != nil {
+			continue // refused at boot: logStartup never runs, so no count is printed
+		}
+		accepted++
+
+		matcher := newTrustedProxyMatcher(settings.TrustedProxies)
+		banner := len(settings.TrustedProxies)
+		usable := len(matcher.exact) + len(matcher.ranges)
+		if banner != usable {
+			t.Fatalf("TRUSTED_PROXIES=%q: banner would print trusted_proxy_count=%d while the matcher holds %d usable entries", value, banner, usable)
+		}
+	}
+
+	// Anti-vacuity: the two well-formed lists must have been accepted, so the
+	// comparison above actually ran.
+	if accepted < 2 {
+		t.Fatalf("expected at least the two well-formed lists to be accepted, got %d", accepted)
+	}
+}
+
+// TestBootRefusesAnUnparseableSecurityBoolean pins that a typo in one of the
+// four security-relevant booleans stops the process with an error naming the
+// key and the rejected value, instead of silently running on the fallback:
+// COOKIE_SECURE=ture used to yield cookies without the Secure flag and a boot
+// that looked normal.
+func TestBootRefusesAnUnparseableSecurityBoolean(t *testing.T) {
+	cases := []struct {
+		key   string
+		value string
+	}{
+		{"COOKIE_SECURE", "ture"},
+		{"HSTS_ENABLED", "yess"},
+		{"TRUST_PROXY_ENABLED", "tru"},
+		{"WEBHOOK_BLOCK_PRIVATE_ADDRESSES", "onn"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.key, func(t *testing.T) {
+			setValidBootEnv(t)
+			t.Setenv(tc.key, tc.value)
+
+			_, err := loadRuntimeConfig(time.UTC)
+			if err == nil {
+				t.Fatalf("expected boot to refuse %s=%q", tc.key, tc.value)
+			}
+			if !strings.Contains(err.Error(), tc.key) || !strings.Contains(err.Error(), tc.value) {
+				t.Fatalf("expected the error to name %s and the rejected value %q, got: %v", tc.key, tc.value, err)
+			}
+		})
+	}
+
+	// WEBHOOK_BLOCK_PRIVATE_ADDRESSES is read twice — once at server boot and
+	// once by the `notify` CLI pass that actually makes the outbound calls. The
+	// two must refuse the same value, or the egress gate is strict where it is
+	// only recorded and lenient where it is enforced.
+	t.Run("notify CLI refuses the same unparseable egress gate", func(t *testing.T) {
+		setValidBootEnv(t)
+		t.Setenv("WEBHOOK_BLOCK_PRIVATE_ADDRESSES", "onn")
+
+		called := false
+		handled, err := tryRunCLICommandWithHandlers([]string{"notify"}, cliCommandHandlers{
+			runNotify: func(db.Config, string, string, *time.Location, bool, []string) error {
+				called = true
+				return nil
+			},
+		})
+		if !handled || err == nil {
+			t.Fatalf("expected notify to refuse WEBHOOK_BLOCK_PRIVATE_ADDRESSES=%q, got (%t, %v)", "onn", handled, err)
+		}
+		if called {
+			t.Fatal("expected notify to refuse before running a delivery pass")
+		}
+		if !strings.Contains(err.Error(), "WEBHOOK_BLOCK_PRIVATE_ADDRESSES") || !strings.Contains(err.Error(), "onn") {
+			t.Fatalf("expected the error to name the key and the rejected value, got: %v", err)
+		}
+	})
+
+	t.Run("notify CLI still runs on a well-formed egress gate", func(t *testing.T) {
+		setValidBootEnv(t)
+		t.Setenv("WEBHOOK_BLOCK_PRIVATE_ADDRESSES", "on")
+
+		blocked := false
+		handled, err := tryRunCLICommandWithHandlers([]string{"notify"}, cliCommandHandlers{
+			runNotify: func(_ db.Config, _ string, _ string, _ *time.Location, blockPrivate bool, _ []string) error {
+				blocked = blockPrivate
+				return nil
+			},
+		})
+		if !handled || err != nil {
+			t.Fatalf("expected notify to run, got (%t, %v)", handled, err)
+		}
+		if !blocked {
+			t.Fatal("expected WEBHOOK_BLOCK_PRIVATE_ADDRESSES=on to reach the delivery pass as true")
+		}
+	})
+
+	// Positive anchor: the same keys spelled correctly boot and land on the
+	// values the operator asked for.
+	t.Run("correctly spelled values still boot", func(t *testing.T) {
+		setValidBootEnv(t)
+		t.Setenv("COOKIE_SECURE", "true")
+		t.Setenv("HSTS_ENABLED", "off")
+		t.Setenv("TRUST_PROXY_ENABLED", "yes")
+		t.Setenv("TRUSTED_PROXIES", "127.0.0.1")
+		t.Setenv("WEBHOOK_BLOCK_PRIVATE_ADDRESSES", "1")
+
+		config, err := loadRuntimeConfig(time.UTC)
+		if err != nil {
+			t.Fatalf("expected well-formed booleans to be accepted, got: %v", err)
+		}
+		if !config.CookieSecure || config.HSTSEnabled || !config.Proxy.Enabled || !config.WebhookBlockPrivate {
+			t.Fatalf("unexpected parsed booleans: cookie_secure=%t hsts=%t trust_proxy=%t webhook_block_private=%t",
+				config.CookieSecure, config.HSTSEnabled, config.Proxy.Enabled, config.WebhookBlockPrivate)
+		}
+	})
+}

--- a/cmd/ovumcy/commands.go
+++ b/cmd/ovumcy/commands.go
@@ -124,7 +124,13 @@ func handleNotifyCommand(args []string, handlers cliCommandHandlers) (bool, erro
 	}
 	location := mustLoadLocation(getEnv("TZ", "Local"))
 	defaultLanguage := getEnv("DEFAULT_LANGUAGE", "en")
-	blockPrivateAddresses := getEnvBool("WEBHOOK_BLOCK_PRIVATE_ADDRESSES", false)
+	// Strict, exactly as at server boot: this pass is where the egress gate is
+	// enforced, so a value the server would refuse to start on must not be
+	// reinterpreted here into an unguarded delivery run.
+	blockPrivateAddresses, err := getEnvBoolStrict("WEBHOOK_BLOCK_PRIVATE_ADDRESSES", false)
+	if err != nil {
+		return true, err
+	}
 	return true, handlers.runNotify(databaseConfig, secretKey, defaultLanguage, location, blockPrivateAddresses, args[1:])
 }
 

--- a/cmd/ovumcy/config.go
+++ b/cmd/ovumcy/config.go
@@ -242,7 +242,15 @@ func resolveProxySettings() (proxySettings, error) {
 // stayed untrusted, every client behind it fell back to the socket peer and
 // shared one rate-limit bucket, while the startup banner counted the raw CSV
 // and reported the typo as configured.
+//
+// A repeated IP is refused for the same reason though both spellings are well
+// formed: the matcher keys its exact set by the entry and collapses the pair
+// into one, so the banner would count a trusted proxy the matcher does not
+// hold — the same lie the typo told, minted by a copy-paste instead. A repeated
+// CIDR is left alone: ranges are appended to a slice, so both copies survive
+// and the two counts still agree.
 func validateTrustedProxies(entries []string) error {
+	seen := make(map[string]struct{}, len(entries))
 	for _, entry := range entries {
 		if strings.Contains(entry, "/") {
 			if _, _, err := net.ParseCIDR(entry); err != nil {
@@ -257,6 +265,10 @@ func validateTrustedProxies(entries []string) error {
 		if canonical := parsed.String(); canonical != entry {
 			return fmt.Errorf("invalid TRUSTED_PROXIES entry %q: an IP is matched literally, so it must be written in canonical form (%q)", entry, canonical)
 		}
+		if _, duplicate := seen[entry]; duplicate {
+			return fmt.Errorf("invalid TRUSTED_PROXIES entry %q: listed more than once", entry)
+		}
+		seen[entry] = struct{}{}
 	}
 	return nil
 }

--- a/cmd/ovumcy/config.go
+++ b/cmd/ovumcy/config.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"net"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -115,12 +116,22 @@ func loadRuntimeConfig(location *time.Location) (runtimeConfig, error) {
 		return runtimeConfig{}, err
 	}
 
-	cookieSecure := getEnvBool("COOKIE_SECURE", false)
+	cookieSecure, err := getEnvBoolStrict("COOKIE_SECURE", false)
+	if err != nil {
+		return runtimeConfig{}, err
+	}
 	// HSTS defaults to COOKIE_SECURE (preserving the historical coupling where
 	// enabling secure cookies also pinned HTTPS) but is an independent switch:
 	// HSTS_ENABLED=false lets an operator run secure cookies without pinning
 	// browsers to HTTPS for a year, and HSTS_ENABLED=true opts in explicitly.
-	hstsEnabled := getEnvBool("HSTS_ENABLED", cookieSecure)
+	hstsEnabled, err := getEnvBoolStrict("HSTS_ENABLED", cookieSecure)
+	if err != nil {
+		return runtimeConfig{}, err
+	}
+	webhookBlockPrivate, err := getEnvBoolStrict("WEBHOOK_BLOCK_PRIVATE_ADDRESSES", false)
+	if err != nil {
+		return runtimeConfig{}, err
+	}
 	oidcConfig, err := resolveOIDCConfig(cookieSecure, registrationMode)
 	if err != nil {
 		return runtimeConfig{}, err
@@ -152,7 +163,7 @@ func loadRuntimeConfig(location *time.Location) (runtimeConfig, error) {
 		},
 		Proxy:               proxy,
 		AuditLogEnabled:     getEnvBool("AUDIT_LOG_ENABLED", false),
-		WebhookBlockPrivate: getEnvBool("WEBHOOK_BLOCK_PRIVATE_ADDRESSES", false),
+		WebhookBlockPrivate: webhookBlockPrivate,
 		ReminderScheduler: reminderSchedulerSettings{
 			Enabled: getEnvBool("REMINDER_SCHEDULER_ENABLED", false),
 			// getEnvInt rejects values <1, so hour 0 (valid) would be lost; use a
@@ -192,8 +203,13 @@ func resolveOIDCConfig(cookieSecure bool, registrationMode services.Registration
 }
 
 func resolveProxySettings() (proxySettings, error) {
+	enabled, err := getEnvBoolStrict("TRUST_PROXY_ENABLED", false)
+	if err != nil {
+		return proxySettings{}, err
+	}
+
 	settings := proxySettings{
-		Enabled:        getEnvBool("TRUST_PROXY_ENABLED", false),
+		Enabled:        enabled,
 		Header:         strings.TrimSpace(getEnv("PROXY_HEADER", fiber.HeaderXForwardedFor)),
 		TrustedProxies: parseCSV(getEnv("TRUSTED_PROXIES", "127.0.0.1,::1")),
 	}
@@ -207,7 +223,42 @@ func resolveProxySettings() (proxySettings, error) {
 	if len(settings.TrustedProxies) == 0 {
 		return proxySettings{}, fmt.Errorf("TRUST_PROXY_ENABLED=true requires at least one TRUSTED_PROXIES entry")
 	}
+	if err := validateTrustedProxies(settings.TrustedProxies); err != nil {
+		return proxySettings{}, err
+	}
 	return settings, nil
+}
+
+// validateTrustedProxies refuses a TRUSTED_PROXIES entry the trust boundary
+// could never use, so the boot fails loudly instead of running on a smaller
+// trusted set than the operator wrote.
+//
+// The rules are the ones newTrustedProxyMatcher (and fiber's own
+// handleTrustedProxy) apply: an entry containing "/" is a CIDR range, anything
+// else is matched by exact net.IP string — hence the canonical-spelling check,
+// since "2001:DB8::1" parses fine yet never equals the "2001:db8::1" the
+// matcher looks up. An entry that fails either rule used to be dropped (bad
+// CIDR) or stored where nothing can match it (everything else): the proxy then
+// stayed untrusted, every client behind it fell back to the socket peer and
+// shared one rate-limit bucket, while the startup banner counted the raw CSV
+// and reported the typo as configured.
+func validateTrustedProxies(entries []string) error {
+	for _, entry := range entries {
+		if strings.Contains(entry, "/") {
+			if _, _, err := net.ParseCIDR(entry); err != nil {
+				return fmt.Errorf("invalid TRUSTED_PROXIES entry %q: not a CIDR range (for example 10.0.0.0/8)", entry)
+			}
+			continue
+		}
+		parsed := net.ParseIP(entry)
+		if parsed == nil {
+			return fmt.Errorf("invalid TRUSTED_PROXIES entry %q: not an IP address or CIDR range", entry)
+		}
+		if canonical := parsed.String(); canonical != entry {
+			return fmt.Errorf("invalid TRUSTED_PROXIES entry %q: an IP is matched literally, so it must be written in canonical form (%q)", entry, canonical)
+		}
+	}
+	return nil
 }
 
 func resolveDatabaseConfig() (db.Config, error) {

--- a/cmd/ovumcy/env.go
+++ b/cmd/ovumcy/env.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"strconv"
@@ -62,21 +63,55 @@ func getEnvDuration(key string, fallback time.Duration) time.Duration {
 	return parsed
 }
 
+// parseBoolEnvValue holds the accepted vocabulary for every boolean env var. Both
+// getEnvBool and getEnvBoolStrict route through it so the lenient and the
+// refusing getter can never accept different spellings of the same value.
+func parseBoolEnvValue(value string) (bool, bool) {
+	switch strings.ToLower(value) {
+	case "1", "true", "yes", "on":
+		return true, true
+	case "0", "false", "no", "off":
+		return false, true
+	default:
+		return false, false
+	}
+}
+
 func getEnvBool(key string, fallback bool) bool {
 	value := strings.TrimSpace(os.Getenv(key))
 	if value == "" {
 		return fallback
 	}
 
-	switch strings.ToLower(value) {
-	case "1", "true", "yes", "on":
-		return true
-	case "0", "false", "no", "off":
-		return false
-	default:
+	parsed, ok := parseBoolEnvValue(value)
+	if !ok {
 		log.Printf("invalid %s=%q, using fallback %t", key, value, fallback)
 		return fallback
 	}
+	return parsed
+}
+
+// getEnvBoolStrict reads a boolean env var like getEnvBool but refuses an
+// unparseable value instead of falling back to the default.
+//
+// It is used for the toggles whose fallback IS the insecure posture —
+// COOKIE_SECURE, HSTS_ENABLED, TRUST_PROXY_ENABLED,
+// WEBHOOK_BLOCK_PRIVATE_ADDRESSES. There a typo (COOKIE_SECURE=ture) used to
+// start the process on the default, so what the instance ran with could not be
+// answered from the operator's env file, only from the boot log. An unset
+// value is still the documented default; only a value the operator wrote and
+// this process cannot read stops the boot, naming the key and the value.
+func getEnvBoolStrict(key string, fallback bool) (bool, error) {
+	value := strings.TrimSpace(os.Getenv(key))
+	if value == "" {
+		return fallback, nil
+	}
+
+	parsed, ok := parseBoolEnvValue(value)
+	if !ok {
+		return false, fmt.Errorf("invalid %s=%q: expected one of 1/true/yes/on or 0/false/no/off", key, value)
+	}
+	return parsed, nil
 }
 
 func parseCSV(value string) []string {

--- a/docs/self-hosted.md
+++ b/docs/self-hosted.md
@@ -157,6 +157,11 @@ The supported reverse proxy path is intentionally narrow:
 - Ovumcy continues to listen on plain HTTP at `:8080` inside that private network.
 - `COOKIE_SECURE=true` is mandatory once the public site is HTTPS-only.
 - `TRUST_PROXY_ENABLED=true` is valid only when every trusted proxy IP or internal proxy subnet is explicitly listed in `TRUSTED_PROXIES`.
+  Each entry must be a literal IP in canonical form (`10.0.0.1`, `2001:db8::1`) or a CIDR range (`10.0.0.0/8`); with trust-proxy enabled,
+  an entry the app cannot use refuses the boot, naming the rejected entry, rather than being dropped from the trusted set.
+- A value this app cannot parse for `COOKIE_SECURE`, `HSTS_ENABLED`, `TRUST_PROXY_ENABLED` or `WEBHOOK_BLOCK_PRIVATE_ADDRESSES` also
+  refuses the boot, naming the key and the value — a typo in one of these no longer starts the instance on the insecure default.
+  Accepted spellings are `1`/`true`/`yes`/`on` and `0`/`false`/`no`/`off`; leaving a key unset still means its documented default.
 - Keep `PROXY_HEADER=X-Real-IP`; the example proxies set it to the real client IP. Do not use `X-Forwarded-For` for per-IP rate limiting — the proxy appends the client value and the app keys on the leftmost (spoofable) entry.
 
 The example stacks below use dedicated internal subnets and set `TRUSTED_PROXIES` to those exact ranges. If you adapt the stacks, keep the trusted proxy range as small as the network design allows. If the sample subnet collides with your environment, change both the Docker subnet and `TRUSTED_PROXIES` together.
@@ -509,7 +514,9 @@ curl -fsS http://127.0.0.1:8080/healthz
 Typical failure split:
 
 - App issue: container exits, the container healthcheck fails, or `/healthz` fails inside the intended deployment path.
-- Config issue: container runs but startup logs show invalid env values or trusted-proxy configuration errors.
+- Config issue: startup logs show invalid env values or trusted-proxy configuration errors. Most invalid values fall back to the
+  documented default and the container keeps running; an unparseable security toggle or `TRUSTED_PROXIES` entry exits instead, with
+  the last log line naming the key and the rejected value.
 - Proxy issue: `ovumcy` is healthy, but public requests fail, loop, or lose the real client IP.
 
 ### `431 Request Header Fields Too Large`

--- a/scripts/webhookdocs/main_test.go
+++ b/scripts/webhookdocs/main_test.go
@@ -373,9 +373,11 @@ func TestOperatorDocsStateTheGateAndTheCodeDefault(t *testing.T) {
 	}
 }
 
-// gateDefaultFromCode reads the default out of every getEnvBool call for the
-// gate and fails when they disagree — the server path and the CLI path parse
-// it separately, and a default that drifts between them is its own defect.
+// gateDefaultFromCode reads the default out of every getEnvBool /
+// getEnvBoolStrict call for the gate and fails when they disagree — the server
+// path and the CLI path parse it separately, and a default that drifts between
+// them is its own defect. Both getters count: they differ in what they do with
+// an unparseable value, not in the default an unset value falls back to.
 func gateDefaultFromCode(t *testing.T, root string) bool {
 	t.Helper()
 
@@ -384,7 +386,7 @@ func gateDefaultFromCode(t *testing.T, root string) bool {
 		t.Fatalf("glob %s: %v", gateParseGlob, err)
 	}
 
-	call := regexp.MustCompile(`getEnvBool\("` + gateEnv + `", (true|false)\)`)
+	call := regexp.MustCompile(`getEnvBool(?:Strict)?\("` + gateEnv + `", (true|false)\)`)
 	defaults := map[string]string{}
 	for _, path := range paths {
 		if strings.HasSuffix(path, "_test.go") {
@@ -405,7 +407,7 @@ func gateDefaultFromCode(t *testing.T, root string) bool {
 			return value == "true"
 		}
 	case 0:
-		t.Fatalf("no getEnvBool(%q, …) call found in %s: this guard reads the documented default out of the code and now reads nothing", gateEnv, gateParseGlob)
+		t.Fatalf("no getEnvBool/getEnvBoolStrict(%q, …) call found in %s: this guard reads the documented default out of the code and now reads nothing", gateEnv, gateParseGlob)
 	}
 	t.Fatalf("%s is parsed with more than one default (%v): the server and CLI paths must agree before any document can state one", gateEnv, defaults)
 	return false


### PR DESCRIPTION

Tail-board group **T0009** (config-ops / `cmd/ovumcy`), records **R2-0009** and **R2-0797**. Both are
the same shape: a value the operator wrote, silently reinterpreted into a weaker posture, with the
boot log agreeing that the config is fine.

## The trade-off, stated

This changes boot behaviour for a self-hosted operator. A value that was previously tolerated now
**refuses to start**. The scope is deliberately narrow:

- Strict: `COOKIE_SECURE`, `HSTS_ENABLED`, `TRUST_PROXY_ENABLED`,
  `WEBHOOK_BLOCK_PRIVATE_ADDRESSES` — the toggles whose fallback *is* the insecure posture — and
  `TRUSTED_PROXIES` entries, only while `TRUST_PROXY_ENABLED=true` (where the list has any effect).
- Unchanged: every other env var. `getEnvBool`, `getEnvInt`, `getEnvIntInRange` and
  `getEnvDuration` keep logging and falling back, so an unparseable `RATE_LIMIT_*` or
  `REMINDER_SCHEDULER_HOUR` still starts the instance. That sibling smell has its own finding.
- An **unset** key still means its documented default; only a value this process cannot read stops
  the boot. Every refusal names the key and the rejected value.

Availability cost: an operator who mistypes one of the four toggles now gets a container that exits
instead of one that runs insecurely. That is the intended direction for a privacy-critical app — the
old behaviour meant "what is this instance running with" could not be answered from the env file,
only from the boot log.

## R2-0009 — `TRUSTED_PROXIES` silently drops malformed entries

`resolveProxySettings` accepted any string; `newTrustedProxyMatcher` then dropped an unparseable CIDR
and stored everything else as an exact `net.IP` string match. `10.0.0.0/8x` disappeared, `bogus`
landed where `contains` can never match it — so the peer was untrusted, the rate-limit key fell back
to the socket address, and every client behind the proxy shared one bucket. Meanwhile `logStartup`
printed `trusted_proxy_count=3` from the raw CSV while the matcher held 2.

`validateTrustedProxies` (`cmd/ovumcy/config.go:245`) now parses each entry exactly as the trust
boundary does: `/` means `net.ParseCIDR`, anything else `net.ParseIP` **plus** a canonical-form check
— `2001:DB8::1` parses fine yet never equals the `2001:db8::1` the matcher looks up, which is the
same silent miss as `bogus` wearing a valid-looking value. `ratelimit.go` is unchanged: its defensive
drop is now unreachable from the config path.

### Evidence — red before, green after

```
$ go test ./cmd/ovumcy/ -run 'TestResolveProxySettingsRejectsAMalformedTrustedProxyEntry|TestTrustedProxyCountTheBannerPrintsMatchesTheMatcher' -count=1     # unfixed tree
--- FAIL: TestResolveProxySettingsRejectsAMalformedTrustedProxyEntry/cidr_typo
        expected TRUSTED_PROXIES="10.0.0.0/8x" to refuse the boot
--- FAIL: .../non-ip_literal, .../out-of-range_octet, .../host_bits_without_a_mask_width,
    .../non-canonical_ipv6, .../ipv4-mapped_ipv6
--- FAIL: TestTrustedProxyCountTheBannerPrintsMatchesTheMatcher
        TRUSTED_PROXIES="10.0.0.0/8x,192.168.0.0/16,bogus": banner would print
        trusted_proxy_count=3 while the matcher holds 2 usable entries
FAIL
```

The banner-vs-matcher disagreement the record describes is asserted directly, and reproduced the
record's own numbers (3 vs 2). After the fix both pass, with the well-formed-list subtest as the
positive anchor.

Per-rule mutants (gut the body, not the call site):

- `validateTrustedProxies` body replaced by `return nil` → both guards red, all six malformed cases
  plus the count guard.
- Only the canonical-spelling clause disabled → exactly `non-canonical_ipv6` and `ipv4-mapped_ipv6`
  red, the other four green. The rules are independently necessary.

## R2-0797 — `getEnvBool` silently falls back on a typo

`COOKIE_SECURE=ture` logged one line and served cookies without the `Secure` flag. New
`getEnvBoolStrict` (`cmd/ovumcy/env.go:104`) refuses instead; both getters share
`parseBoolEnvValue`, so the lenient and the strict path can never accept different spellings of the
same value.

`WEBHOOK_BLOCK_PRIVATE_ADDRESSES` is read **twice** — at server boot and by the `notify` CLI pass
that actually performs the outbound calls (`cmd/ovumcy/commands.go:130`). Converting only the first
would have left the egress gate strict where it is recorded and lenient where it is enforced, so both
sites moved.

### Evidence — red before, green after

```
$ go test ./cmd/ovumcy/ -run TestBootRefusesAnUnparseableSecurityBoolean -count=1     # unfixed tree
2026/08/24 16:19:26 invalid COOKIE_SECURE="ture", using fallback false
2026/08/24 16:19:26 invalid HSTS_ENABLED="yess", using fallback false
2026/08/24 16:19:26 invalid TRUST_PROXY_ENABLED="tru", using fallback false
2026/08/24 16:19:26 invalid WEBHOOK_BLOCK_PRIVATE_ADDRESSES="onn", using fallback false
--- FAIL: TestBootRefusesAnUnparseableSecurityBoolean/COOKIE_SECURE
        expected boot to refuse COOKIE_SECURE="ture"
--- FAIL: .../HSTS_ENABLED, .../TRUST_PROXY_ENABLED, .../WEBHOOK_BLOCK_PRIVATE_ADDRESSES
FAIL
```

The `notify` subtest was observed red on its own after the boot half was already fixed —
`expected notify to refuse WEBHOOK_BLOCK_PRIVATE_ADDRESSES="onn", got (true, <nil>)` — which is the
N-of-N+1 divergence the conversion closes.

Mutant: `getEnvBoolStrict`'s `!ok` arm replaced by `return fallback, nil` → all four keys red again;
the proxy guards stayed green, so the two records' guards are independent.

## Verification

- `go build ./...` — clean.
- `go test ./cmd/ovumcy/... -count=1` → `ok 53.4s`.
- `golangci-lint run ./cmd/ovumcy/...` and `./scripts/webhookdocs/...` → `0 issues.`
- `go test ./scripts/... -count=1` — caught a real coupling: `webhookdocs`'
  `TestOperatorDocsStateTheGateAndTheCodeDefault` reads the gate's documented default out of every
  `getEnvBool("WEBHOOK_BLOCK_PRIVATE_ADDRESSES", …)` call and found none once both call sites moved
  to the strict getter. Its regex
  now accepts both getters (`getEnvBool(?:Strict)?`) and still fails closed on zero matches; it reads
  two call sites agreeing on `false`. All `./scripts/...` green afterwards.
- `go run ./scripts/changelogd check` → `changelog fragment check OK.`
- Not run: the full `./internal/...` suite. No `internal` package changed, and the four test files
  naming `docs/self-hosted.md` there do so in comments, not assertions.

## Operator-facing docs

`docs/self-hosted.md` gains two lines in the reverse-proxy contract (the accepted `TRUSTED_PROXIES`
spellings and that a bad entry or toggle refuses the boot, naming the value) and its
Troubleshooting failure-split bullet now distinguishes "falls back and keeps running" from "exits".
`SECURITY.md` / `docs/SECURITY_INVARIANTS.md` are untouched: this adds no new test-enforced security
claim, it makes an existing configuration contract fail loudly.

## Rollback

Single-commit revert; no persisted data, schema or public contract is touched. Reverting restores the
previous lenient parse, and an instance running a malformed value would boot again on the fallback.
