### PR TITLE
fix(egress): write both egress surfaces in the owner's language

### DIFF
--- a/changelog.d/refactor-webhook-notify-locale-and-pass-hygiene.md
+++ b/changelog.d/refactor-webhook-notify-locale-and-pass-hygiene.md
@@ -1,0 +1,23 @@
+### Fixed
+
+- **Webhook reminders and the calendar feed now speak the owner's language.** Both surfaces that
+  carry predictions off the instance resolved the mandatory "estimates, not medical advice or a
+  method of contraception" disclaimer at the server default, and the webhook headline and sentence
+  were English literals with no catalogue entry at all — so an owner on one of the five non-default
+  locales received a notification written in two languages, neither of them necessarily theirs. The
+  notify pass and the `.ics` feed now resolve every localized field at the owner's chosen interface
+  language, and the reminder copy lives in all six locale catalogues.
+
+### Internal
+
+- **One URL-hostname redaction helper, not two.** The settings display carried its own byte-identical
+  copy of the "hostname and nothing else" rule that the notify pass and the CLI print through; a
+  hardening of what is safe to show now reaches every surface at once.
+- **The notify pass decides once per owner.** Its idempotency counter was derived by re-running the
+  whole reminder decision with the watermarks cleared, which rebuilt the owner's cycle statistics
+  from their entire logged history a second time; one traversal now yields both the due set and the
+  count.
+- **A locale sweep for the day-field label functions.** Every value of every day-field enum is fed
+  through its translation-key function and required to resolve in all six catalogues, closing the
+  gap the existing map-based sweep could not cover: those keys come from `switch` statements, so a
+  typo reached every language as a raw key on screen.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -367,7 +367,8 @@ Operator-relevant summary (the full, test-backed claim list lives in
 - **Disclaimer in every payload.** Every delivered JSON body includes a
   `disclaimer` field carrying the exact medical-safety string shown elsewhere
   in the app: *"Predictions are estimates, not medical advice or a method of
-  contraception."*
+  contraception."* — in the owner's own interface language, the same one the
+  title and message are written in.
 - **URL encrypted at rest.** The stored webhook URL is AES-256-GCM ciphertext,
   bound to the owning user's id, exactly like a TOTP secret. If `SECRET_KEY`
   is rotated, existing stored URLs can no longer be decrypted; delivery fails
@@ -399,6 +400,15 @@ Operator-relevant summary (the full, test-backed claim list lives in
 consumer (an ntfy topic rule, a Gotify filter, a home-automation flow) can
 route on it without parsing `message`. `disclaimer` is present on every
 payload, unconditionally.
+
+The three text fields — `title`, `message` and `disclaimer` — are written in the
+**interface language the owner chose in settings**, all three in the same one
+(the example above is an owner on English). A pass runs without a browser, so
+the stored language is the only thing that knows which one to use, exactly as
+the stored timezone is the only thing that knows which calendar day the owner is
+on. An owner who never picked a language gets the server default
+(`DEFAULT_LANGUAGE`). `type`, `event_date` and `lead_days` never change with the
+language — route on those, not on the prose.
 
 ## 3. Calendar (.ics) subscription
 

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -45,14 +45,15 @@ type Options struct {
 	AuditLogEnabled bool
 }
 
-// i18nDisclaimerProvider adapts the i18n Manager to services.DisclaimerProvider:
-// it returns the localized medical-safety disclaimer (i18n key
-// medical.disclaimer — the single catalogue entry every predictive surface
-// renders) for a language, falling back to the manager's
-// default language (Messages merges the default over the target). It is the seam
-// the request-free webhook notify pass uses so every payload carries the
-// owner-localized "estimates, not medical advice or a method of contraception"
-// string without importing the whole Manager into internal/services.
+// i18nDisclaimerProvider adapts the i18n Manager to services.NotifyCopyProvider:
+// it answers any catalogue key for a language, and names the medical-safety
+// disclaimer (i18n key medical.disclaimer — the single catalogue entry every
+// predictive surface renders) through its own method, falling back to the
+// manager's default language (Messages merges the default over the target). It
+// is the seam the request-free egress passes use so every payload carries
+// owner-localized copy — the reminder headline and sentence as well as the
+// "estimates, not medical advice or a method of contraception" string — without
+// importing the whole Manager into internal/services.
 type i18nDisclaimerProvider struct {
 	manager *i18n.Manager
 }
@@ -60,10 +61,17 @@ type i18nDisclaimerProvider struct {
 const disclaimerMessageKey = "medical.disclaimer"
 
 func (provider i18nDisclaimerProvider) Disclaimer(language string) string {
+	return provider.Message(language, disclaimerMessageKey)
+}
+
+// Message returns the catalogue entry for key at language. A nil manager (never
+// production, only a partially wired test) yields the empty string rather than
+// panicking, matching Disclaimer's original behavior.
+func (provider i18nDisclaimerProvider) Message(language string, key string) string {
 	if provider.manager == nil {
 		return ""
 	}
-	return provider.manager.Messages(language)[disclaimerMessageKey]
+	return provider.manager.Messages(language)[key]
 }
 
 // BuildNotifyService assembles the request-free webhook notify pass (issue #124,

--- a/internal/db/user_repository.go
+++ b/internal/db/user_repository.go
@@ -238,8 +238,11 @@ func (repo *UserRepository) SaveWebhookSettings(ctx context.Context, userID uint
 // ListAllForNotify returns the per-owner projection a future request-free batch
 // pass needs to decide and send webhook reminders (issue #124). It selects a
 // deliberately narrow column whitelist — cycle-prediction inputs, the webhook
-// settings, the per-kind watermarks, the encrypted URL, and the timezone — and
-// nothing else, so the batch query never over-reads sensitive per-account data.
+// settings, the per-kind watermarks, the encrypted URL, the timezone, and the
+// chosen interface language — and nothing else, so the batch query never
+// over-reads sensitive per-account data. The last two are what a request-free
+// pass has instead of a browser: they decide which calendar day the owner is on
+// and which language the payload is written in.
 // This is a dedicated method, NOT an overload of LoadSettingsByID (which stays
 // the single settings whitelist). webhook_url is returned as CIPHERTEXT;
 // decrypt via WebhookSettingsService.DecryptWebhookURL.
@@ -256,6 +259,7 @@ func (repo *UserRepository) ListAllForNotify(ctx context.Context) ([]models.Webh
 			"unpredictable_cycle",
 			"last_period_start",
 			"timezone",
+			"interface_language",
 			"webhook_enabled",
 			"webhook_url",
 			"webhook_notify_period",

--- a/internal/i18n/locales/de.json
+++ b/internal/i18n/locales/de.json
@@ -655,6 +655,11 @@
   "settings.webhook.notify_ovulation": "Vor dem Eisprung benachrichtigen",
   "settings.webhook.remove_url": "Gespeicherte URL entfernen",
   "settings.webhook.save": "Webhook speichern",
+
+  "webhook.reminder.period.title": "Erinnerung an die Periode",
+  "webhook.reminder.period.message": "Nächste Periode voraussichtlich um den %s.",
+  "webhook.reminder.ovulation.title": "Erinnerung an den Eisprung",
+  "webhook.reminder.ovulation.message": "Eisprung voraussichtlich um den %s.",
   "settings.success.calendar_feed_generated": "Kalender-Feed aktiviert. Kopiere jetzt deinen Abo-Link — er wird nur einmal angezeigt.",
   "settings.success.calendar_feed_rotated": "Kalender-Feed-Link erneuert. Der alte Link funktioniert nicht mehr; kopiere jetzt den neuen.",
   "settings.success.calendar_feed_revoked": "Kalender-Feed deaktiviert. Ein vorhandener Abo-Link funktioniert nicht mehr.",

--- a/internal/i18n/locales/en.json
+++ b/internal/i18n/locales/en.json
@@ -655,6 +655,11 @@
   "settings.webhook.notify_ovulation": "Notify before ovulation",
   "settings.webhook.remove_url": "Remove saved URL",
   "settings.webhook.save": "Save webhook",
+
+  "webhook.reminder.period.title": "Period reminder",
+  "webhook.reminder.period.message": "Estimated next period around %s.",
+  "webhook.reminder.ovulation.title": "Ovulation reminder",
+  "webhook.reminder.ovulation.message": "Estimated ovulation around %s.",
   "settings.success.calendar_feed_generated": "Calendar feed enabled. Copy your subscribe link now — it is shown only once.",
   "settings.success.calendar_feed_rotated": "Calendar feed link rotated. The old link stopped working; copy the new one now.",
   "settings.success.calendar_feed_revoked": "Calendar feed turned off. Any existing subscribe link no longer works.",

--- a/internal/i18n/locales/es.json
+++ b/internal/i18n/locales/es.json
@@ -655,6 +655,11 @@
   "settings.webhook.notify_ovulation": "Avisar antes de la ovulación",
   "settings.webhook.remove_url": "Eliminar la URL guardada",
   "settings.webhook.save": "Guardar webhook",
+
+  "webhook.reminder.period.title": "Recordatorio del periodo",
+  "webhook.reminder.period.message": "Próximo periodo estimado alrededor del %s.",
+  "webhook.reminder.ovulation.title": "Recordatorio de ovulación",
+  "webhook.reminder.ovulation.message": "Ovulación estimada alrededor del %s.",
   "settings.success.calendar_feed_generated": "Feed de calendario activado. Copia tu enlace de suscripción ahora: solo se muestra una vez.",
   "settings.success.calendar_feed_rotated": "Enlace del feed de calendario rotado. El enlace anterior dejó de funcionar; copia el nuevo ahora.",
   "settings.success.calendar_feed_revoked": "Feed de calendario desactivado. Cualquier enlace de suscripción existente ya no funciona.",

--- a/internal/i18n/locales/fr.json
+++ b/internal/i18n/locales/fr.json
@@ -395,6 +395,11 @@
   "settings.webhook.notify_ovulation": "Prévenir avant l'ovulation",
   "settings.webhook.remove_url": "Supprimer l'URL enregistrée",
   "settings.webhook.save": "Enregistrer le webhook",
+
+  "webhook.reminder.period.title": "Rappel de règles",
+  "webhook.reminder.period.message": "Prochaines règles estimées autour du %s.",
+  "webhook.reminder.ovulation.title": "Rappel d'ovulation",
+  "webhook.reminder.ovulation.message": "Ovulation estimée autour du %s.",
   "settings.success.calendar_feed_generated": "Flux de calendrier activé. Copiez votre lien d'abonnement maintenant : il ne s'affiche qu'une seule fois.",
   "settings.success.calendar_feed_rotated": "Lien du flux de calendrier renouvelé. L'ancien lien ne fonctionne plus ; copiez le nouveau maintenant.",
   "settings.success.calendar_feed_revoked": "Flux de calendrier désactivé. Tout lien d'abonnement existant ne fonctionne plus.",

--- a/internal/i18n/locales/it.json
+++ b/internal/i18n/locales/it.json
@@ -655,6 +655,11 @@
   "settings.webhook.notify_ovulation": "Avvisa prima dell'ovulazione",
   "settings.webhook.remove_url": "Rimuovi l'URL salvato",
   "settings.webhook.save": "Salva webhook",
+
+  "webhook.reminder.period.title": "Promemoria del ciclo",
+  "webhook.reminder.period.message": "Prossimo ciclo stimato intorno al %s.",
+  "webhook.reminder.ovulation.title": "Promemoria dell'ovulazione",
+  "webhook.reminder.ovulation.message": "Ovulazione stimata intorno al %s.",
   "settings.success.calendar_feed_generated": "Feed del calendario attivato. Copia subito il tuo link di iscrizione: viene mostrato solo una volta.",
   "settings.success.calendar_feed_rotated": "Link del feed del calendario ruotato. Il link precedente ha smesso di funzionare; copia ora quello nuovo.",
   "settings.success.calendar_feed_revoked": "Feed del calendario disattivato. Qualsiasi link di iscrizione esistente non funziona più.",

--- a/internal/i18n/locales/ru.json
+++ b/internal/i18n/locales/ru.json
@@ -671,6 +671,11 @@
   "settings.webhook.notify_ovulation": "Уведомлять перед овуляцией",
   "settings.webhook.remove_url": "Удалить сохранённый URL",
   "settings.webhook.save": "Сохранить веб-хук",
+
+  "webhook.reminder.period.title": "Напоминание о месячных",
+  "webhook.reminder.period.message": "Следующие месячные ожидаются около %s.",
+  "webhook.reminder.ovulation.title": "Напоминание об овуляции",
+  "webhook.reminder.ovulation.message": "Овуляция ожидается около %s.",
   "settings.success.calendar_feed_generated": "Календарная лента включена. Скопируйте ссылку сейчас — она показывается только один раз.",
   "settings.success.calendar_feed_rotated": "Ссылка календарной ленты обновлена. Старая ссылка больше не работает; скопируйте новую сейчас.",
   "settings.success.calendar_feed_revoked": "Календарная лента отключена. Любая существующая ссылка больше не работает.",

--- a/internal/models/webhook.go
+++ b/internal/models/webhook.go
@@ -31,7 +31,9 @@ type WebhookSettingsColumns struct {
 // webhook reminders, and nothing else. EncryptedURL is CIPHERTEXT (decrypt via
 // WebhookSettingsService.DecryptWebhookURL, aad-bound to ID). The two
 // *LastSentCycleStart watermarks gate at most one reminder of each kind per
-// cycle. Timezone lets the pass resolve "today" without a browser request.
+// cycle. Timezone lets the pass resolve "today" without a browser request, and
+// InterfaceLanguage lets it render the payload in the language the owner chose
+// — both are the request-free pass's substitute for a browser it never sees.
 //
 // It is intentionally NOT models.User: LoadSettingsByID stays the single
 // settings whitelist, and this projection is scoped to the notify use case so
@@ -47,6 +49,13 @@ type WebhookNotifyRecord struct {
 	UnpredictableCycle bool       `gorm:"column:unpredictable_cycle"`
 	LastPeriodStart    *time.Time `gorm:"column:last_period_start;type:date"`
 	Timezone           string     `gorm:"column:timezone"`
+
+	// InterfaceLanguage is the UI language the owner chose (users.interface_language,
+	// empty when they never chose one). It is the durable carrier of that choice,
+	// so the notify pass resolves every localized payload field at it instead of
+	// at the server default. Not a credential and not a health specific: it names
+	// a language, nothing about the account.
+	InterfaceLanguage string `gorm:"column:interface_language"`
 
 	// Webhook settings.
 	WebhookEnabled         bool   `gorm:"column:webhook_enabled"`

--- a/internal/reminders/idempotency_layering_test.go
+++ b/internal/reminders/idempotency_layering_test.go
@@ -149,10 +149,28 @@ func (echoDecryptor) DecryptWebhookURL(_ uint, encryptedURL string) (string, err
 	return encryptedURL, nil
 }
 
+// fixedDisclaimer is the notify pass's localized-copy seam, answered with fixed
+// English text. These cases are about idempotency, not language, so the entries
+// are returned regardless of the language asked for.
 type fixedDisclaimer struct{}
 
 func (fixedDisclaimer) Disclaimer(string) string {
 	return "Predictions are estimates, not medical advice or a method of contraception."
+}
+
+func (fixedDisclaimer) Message(_ string, key string) string {
+	switch key {
+	case "webhook.reminder.period.title":
+		return "Period reminder"
+	case "webhook.reminder.period.message":
+		return "Estimated next period around %s."
+	case "webhook.reminder.ovulation.title":
+		return "Ovulation reminder"
+	case "webhook.reminder.ovulation.message":
+		return "Estimated ovulation around %s."
+	default:
+		return ""
+	}
 }
 
 // dueRecord builds a period-due record for a regular 28-day owner whose last

--- a/internal/services/calendar_feed_service.go
+++ b/internal/services/calendar_feed_service.go
@@ -173,10 +173,15 @@ func (service *CalendarFeedService) ResolveFeed(ctx context.Context, token strin
 
 	disclaimer := ""
 	if service.disclaimer != nil {
-		// No per-owner language is persisted (mirrors the webhook notify pass):
-		// resolve the disclaimer at the server-default language. Messages merges
-		// the default over an empty/unknown target, so "" yields the default copy.
-		disclaimer = service.disclaimer.Disclaimer("")
+		// Resolve at the OWNER's chosen language (users.interface_language, the
+		// durable carrier of that choice), not at the server default: a calendar
+		// client sends no Accept-Language and no cookie, so the stored column is the
+		// only thing that knows which language this owner reads — exactly as
+		// users.timezone is the only thing that knows their calendar day. The
+		// webhook notify pass resolves the same field the same way. An owner who
+		// never chose a language stores "", and Messages merges the default over an
+		// empty or unknown target, so "" still yields the server-default copy.
+		disclaimer = service.disclaimer.Disclaimer(user.InterfaceLanguage)
 	}
 
 	feedUser := user

--- a/internal/services/domain_label_policy_test.go
+++ b/internal/services/domain_label_policy_test.go
@@ -1,6 +1,11 @@
 package services
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+)
 
 func TestDomainLabelPolicy(t *testing.T) {
 	cases := []struct {
@@ -27,4 +32,57 @@ func TestDomainLabelPolicy(t *testing.T) {
 			t.Fatalf("%s: got %q, want %q", tc.name, tc.got, tc.want)
 		}
 	}
+}
+
+// domainLabelTranslationKeys feeds every enum value the day-entry validator
+// accepts through its label function and returns the resulting catalogue keys,
+// spec-labelled so a failure names the value that produced the key.
+//
+// The switch-based key functions sit OUTSIDE the map sweep in i18n_policy_test.go
+// — that helper was written as "the guard for the defect CLASS", but it takes a
+// map[string]string, and these keys are produced by switch statements — so a key
+// added with a typo, or renamed in the catalogue alone, passes both the switch
+// test above and the map sweep while rendering as the raw key
+// ("dashboard.mood.very_low") on the dashboard and the calendar in all six
+// languages: the #287 failure the sweep exists to stop.
+func domainLabelTranslationKeys(t *testing.T) map[string]string {
+	t.Helper()
+
+	keys := map[string]string{}
+	add := func(spec string, key string) {
+		if key == "" {
+			t.Fatalf("%s resolved to no key at all", spec)
+		}
+		keys[spec] = key
+	}
+
+	for _, phase := range []string{"menstrual", "follicular", "ovulation", "luteal", "unrecognized"} {
+		add("phase "+phase, PhaseTranslationKey(phase))
+	}
+	for _, flow := range []string{models.FlowNone, models.FlowSpotting, models.FlowLight, models.FlowMedium, models.FlowHeavy, "unrecognized"} {
+		add("flow "+flow, FlowTranslationKey(flow))
+	}
+	for _, activity := range []string{models.SexActivityNone, models.SexActivityProtected, models.SexActivityUnprotected, "unrecognized"} {
+		add("sex activity "+activity, SexActivityTranslationKey(activity))
+	}
+	for _, mucus := range []string{models.CervicalMucusNone, models.CervicalMucusDry, models.CervicalMucusMoist, models.CervicalMucusCreamy, models.CervicalMucusEggWhite, "unrecognized"} {
+		add("cervical mucus "+mucus, CervicalMucusTranslationKey(mucus))
+	}
+	for _, result := range []string{models.PregnancyTestNone, models.PregnancyTestNegative, models.PregnancyTestPositive, "unrecognized"} {
+		add("pregnancy test "+result, PregnancyTestTranslationKey(result))
+	}
+	for _, step := range DayMoodScale().Steps {
+		add(fmt.Sprintf("mood step %d", step), MoodTranslationKey(step))
+	}
+	return keys
+}
+
+// TestDomainLabelTranslationKeysResolveInEveryLocale is the switch-statement
+// sibling of the authErrorTranslationKeys / settingsStatusTranslationKeys
+// sweeps: every key a day-field label function can produce must exist in every
+// SupportedLanguages() catalogue. A locale-parity test in internal/i18n catches
+// a key missing from ONE locale; only this sweep catches a key present in NO
+// locale, which is exactly what a typo in a switch arm produces.
+func TestDomainLabelTranslationKeysResolveInEveryLocale(t *testing.T) {
+	assertMappedTranslationKeysResolveInEveryLocale(t, "domain label switch functions", domainLabelTranslationKeys(t))
 }

--- a/internal/services/egress_owner_language_test.go
+++ b/internal/services/egress_owner_language_test.go
@@ -126,8 +126,12 @@ func TestNotifyPayloadCopyResolvesInEveryLocale(t *testing.T) {
 				t.Errorf("locale %q has no entry for %q: the reminder would go out empty", language, key)
 				continue
 			}
-			if strings.HasSuffix(key, ".message") && !strings.Contains(value, "%s") {
-				t.Errorf("locale %q entry %q = %q: the reminder sentence must keep its %%s date placeholder", language, key, value)
+			// Exactly one verb, not merely one present: reminderCopy passes a
+			// single date, so a second %%s renders as %%!s(MISSING) in a payload
+			// that has already left the instance. Both directions are one
+			// translator edit away and neither is visible from the catalogue.
+			if verbs := strings.Count(value, "%s"); strings.HasSuffix(key, ".message") && verbs != 1 {
+				t.Errorf("locale %q entry %q = %q: the reminder sentence must carry exactly one %%s date placeholder, found %d", language, key, value, verbs)
 			}
 		}
 	}

--- a/internal/services/egress_owner_language_test.go
+++ b/internal/services/egress_owner_language_test.go
@@ -1,0 +1,170 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/i18n"
+	"github.com/ovumcy/ovumcy-web/internal/models"
+)
+
+// localeCopyProvider is the test twin of the production i18n adapter
+// (internal/bootstrap): it answers both seams — the medical-safety disclaimer
+// and any catalogue key — out of the REAL locale files, so these guards fail
+// both when a surface resolves at the wrong language and when the key it names
+// is missing from a catalogue.
+//
+// internal/i18n is imported by this TEST only; the services layer keeps no
+// dependency on it (the same arrangement i18n_policy_test.go documents).
+type localeCopyProvider struct{ manager *i18n.Manager }
+
+func newLocaleCopyProvider(t *testing.T) localeCopyProvider {
+	t.Helper()
+	manager, err := i18n.NewManager(i18n.LangEN)
+	if err != nil {
+		t.Fatalf("init i18n manager: %v", err)
+	}
+	return localeCopyProvider{manager: manager}
+}
+
+func (provider localeCopyProvider) Disclaimer(language string) string {
+	return provider.Message(language, "medical.disclaimer")
+}
+
+func (provider localeCopyProvider) Message(language string, key string) string {
+	return provider.manager.Messages(language)[key]
+}
+
+func (provider localeCopyProvider) messages(t *testing.T, language string) map[string]string {
+	t.Helper()
+	messages := provider.manager.Messages(language)
+	if len(messages) == 0 {
+		t.Fatalf("locale %q carries no messages", language)
+	}
+	return messages
+}
+
+// TestNotifyPayloadIsLocalizedToTheOwnersInterfaceLanguage is the R2-0135 /
+// R2-0109 regression on the webhook half: the owner's persisted
+// users.interface_language is the durable carrier of the language they chose, so
+// the notify pass must resolve BOTH payload fields at it — the disclaimer AND
+// the reminder headline/sentence, which live in the locale catalogue rather than
+// as English literals in Go. Resolving the disclaimer at the server default (the
+// empty language) hands an owner on a non-default locale a mandatory safety
+// string in a language they never chose, next to an English body.
+func TestNotifyPayloadIsLocalizedToTheOwnersInterfaceLanguage(t *testing.T) {
+	now := time.Date(2026, 3, 12, 9, 0, 0, 0, time.UTC)
+	record := ovulationDueRecord(1, "https://a.example/hook", now)
+	record.InterfaceLanguage = i18n.LangRU
+
+	repo := &stubNotifyRepo{records: []models.WebhookNotifyRecord{record}}
+	logs := stubLogReader{byUser: map[uint][]models.DailyLog{1: completedCycleStartLogs(1, *record.LastPeriodStart)}}
+	deliverer := &stubDeliverer{}
+	provider := newLocaleCopyProvider(t)
+	service := NewWebhookNotifyService(repo, logs, stubDecryptor{}, deliverer, provider)
+
+	report, err := service.RunOnce(context.Background(), now, time.UTC, false)
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	deliveries := deliverer.deliveries()
+	if len(deliveries) == 0 {
+		t.Fatalf("expected at least one delivery (sent=%d, due=%d)", report.Sent, report.Due)
+	}
+
+	russian := provider.messages(t, i18n.LangRU)
+	english := provider.messages(t, i18n.LangEN)
+
+	for _, delivery := range deliveries {
+		payload := delivery.payload
+
+		if payload.Disclaimer != russian["medical.disclaimer"] {
+			t.Errorf("disclaimer for a ru owner = %q, want the ru catalogue entry %q", payload.Disclaimer, russian["medical.disclaimer"])
+		}
+		if payload.Disclaimer == english["medical.disclaimer"] {
+			t.Errorf("disclaimer for a ru owner resolved at the server default language: %q", payload.Disclaimer)
+		}
+
+		titleKey, messageKey := "webhook.reminder.period.title", "webhook.reminder.period.message"
+		if payload.Type == DueReminderTypeOvulation {
+			titleKey, messageKey = "webhook.reminder.ovulation.title", "webhook.reminder.ovulation.message"
+		}
+		wantTitle := russian[titleKey]
+		if wantTitle == "" {
+			t.Fatalf("locale ru has no entry for %q: the reminder copy is not in the catalogue", titleKey)
+		}
+		wantMessage := fmt.Sprintf(russian[messageKey], payload.EventDate)
+		if payload.Title != wantTitle {
+			t.Errorf("%s title = %q, want the ru catalogue entry %q", payload.Type, payload.Title, wantTitle)
+		}
+		if payload.Message != wantMessage {
+			t.Errorf("%s message = %q, want the ru catalogue entry %q", payload.Type, payload.Message, wantMessage)
+		}
+	}
+}
+
+// TestNotifyPayloadCopyResolvesInEveryLocale keeps the four reminder-copy keys
+// inside the six-file locale contract: the notify pass renders them for whatever
+// language the owner chose, so a key present in one catalogue and absent from
+// another would send that owner an empty title or an unrendered sentence.
+func TestNotifyPayloadCopyResolvesInEveryLocale(t *testing.T) {
+	provider := newLocaleCopyProvider(t)
+	keys := []string{
+		"webhook.reminder.period.title",
+		"webhook.reminder.period.message",
+		"webhook.reminder.ovulation.title",
+		"webhook.reminder.ovulation.message",
+	}
+	for _, language := range provider.manager.SupportedLanguages() {
+		messages := provider.messages(t, language)
+		for _, key := range keys {
+			value := messages[key]
+			if value == "" {
+				t.Errorf("locale %q has no entry for %q: the reminder would go out empty", language, key)
+				continue
+			}
+			if strings.HasSuffix(key, ".message") && !strings.Contains(value, "%s") {
+				t.Errorf("locale %q entry %q = %q: the reminder sentence must keep its %%s date placeholder", language, key, value)
+			}
+		}
+	}
+}
+
+// TestCalendarFeedDisclaimerIsLocalizedToTheOwnersInterfaceLanguage is the
+// R2-0135 regression on the .ics half. The feed is the second surface that
+// carries predictions off the instance, and it repeated the webhook pass's stale
+// justification verbatim ("no per-owner language is persisted"), so the fix has
+// to reach both or the next egress surface inherits the wrong reason.
+func TestCalendarFeedDisclaimerIsLocalizedToTheOwnersInterfaceLanguage(t *testing.T) {
+	user, token := armedFeedUser(t, 42, "2026-03-02")
+	user.InterfaceLanguage = i18n.LangRU
+
+	users := &stubFeedUserStore{selector: user.CalendarFeedSelector, user: user}
+	days := &stubFeedDayReader{logs: predictableFeedLogs(t)}
+	provider := newLocaleCopyProvider(t)
+	service := NewCalendarFeedService(users, days, provider, []byte(calendarFeedTestSecretKey))
+
+	body, ok, err := service.ResolveFeed(context.Background(), token, mustParseDashboardDay(t, "2026-03-20"), time.UTC)
+	if err != nil {
+		t.Fatalf("ResolveFeed: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected the armed feed to resolve")
+	}
+
+	// RFC 5545 folds a content line at 75 octets; unfold before matching so a
+	// long localized sentence is compared as one string.
+	text := strings.ReplaceAll(string(body), "\r\n ", "")
+
+	// Comma-free fragments: escapeICSText backslash-escapes a comma, so the
+	// assertion stays on the part of each sentence the escaping never touches.
+	if !strings.Contains(text, "медицинский совет") {
+		t.Errorf("the .ics body does not carry the ru medical disclaimer:\n%s", text)
+	}
+	if strings.Contains(text, "not medical advice") {
+		t.Errorf("the .ics body carries the server-default (English) disclaimer for a ru owner:\n%s", text)
+	}
+}

--- a/internal/services/egress_owner_language_test.go
+++ b/internal/services/egress_owner_language_test.go
@@ -38,6 +38,42 @@ func (provider localeCopyProvider) Message(language string, key string) string {
 	return provider.manager.Messages(language)[key]
 }
 
+// titleOnlyCopyProvider answers the reminder TITLE keys and nothing else, which
+// is the shape of a provider whose catalogue lost the sentence entry. It exists
+// because reminderCopy's empty-template arm is otherwise unreachable from a
+// catalogue-backed provider: the sweep above forbids a blank sentence in any
+// shipped locale, so the branch that keeps a missing one from rendering as
+// formatting residue has no locale that can exercise it.
+type titleOnlyCopyProvider struct{}
+
+func (titleOnlyCopyProvider) Disclaimer(string) string { return "" }
+
+func (titleOnlyCopyProvider) Message(_ string, key string) string {
+	if strings.HasSuffix(key, ".title") {
+		return "Reminder"
+	}
+	return ""
+}
+
+// TestReminderCopyWithoutASentenceSendsTheHeadlineAlone pins the arm that keeps
+// a missing catalogue sentence from reaching a webhook consumer as Sprintf
+// residue. Without it, reminderCopy would format the empty template and the
+// payload body would read "%!(EXTRA string=2026-02-10)".
+func TestReminderCopyWithoutASentenceSendsTheHeadlineAlone(t *testing.T) {
+	service := NewWebhookNotifyService(nil, nil, nil, nil, titleOnlyCopyProvider{})
+	eventDate := time.Date(2026, time.February, 10, 0, 0, 0, 0, time.UTC)
+
+	for _, reminderType := range []string{DueReminderTypePeriod, DueReminderTypeOvulation} {
+		title, message := service.reminderCopy(DueReminder{Type: reminderType, EventDate: eventDate}, "en")
+		if title != "Reminder" {
+			t.Errorf("%s title = %q, want the headline the provider does carry", reminderType, title)
+		}
+		if message != "" {
+			t.Errorf("%s message = %q, want it empty rather than formatted from a missing template", reminderType, message)
+		}
+	}
+}
+
 func (provider localeCopyProvider) messages(t *testing.T, language string) map[string]string {
 	t.Helper()
 	messages := provider.manager.Messages(language)

--- a/internal/services/webhook_delivery.go
+++ b/internal/services/webhook_delivery.go
@@ -92,13 +92,18 @@ type ipResolver interface {
 // recovery code) and no health specifics beyond the reminder type, estimated
 // date, and lead days already summarized into Title/Message.
 type WebhookPayload struct {
-	// Title is a short reminder headline (e.g. "Period reminder").
+	// Title is a short reminder headline, owner-localized from the catalogue
+	// (i18n keys webhook.reminder.{period,ovulation}.title).
 	Title string `json:"title"`
-	// Message is the human-readable reminder line (type + estimated date + lead).
+	// Message is the human-readable reminder line (type + estimated date),
+	// owner-localized from the catalogue (i18n keys
+	// webhook.reminder.{period,ovulation}.message).
 	Message string `json:"message"`
 	// Disclaimer is the medical-safety qualifier, MANDATORY in every payload. It
 	// is the owner-localized "estimates, not medical advice or a method of
-	// contraception" string (i18n key medical.disclaimer).
+	// contraception" string (i18n key medical.disclaimer). All three localized
+	// fields resolve at ONE language — the owner's users.interface_language — so a
+	// payload is never half in the owner's language and half in the server's.
 	Disclaimer string `json:"disclaimer"`
 	// Type is the machine-readable reminder kind (DueReminderType*), so a webhook
 	// consumer can route on it without parsing Message.

--- a/internal/services/webhook_notify_service.go
+++ b/internal/services/webhook_notify_service.go
@@ -91,12 +91,37 @@ type WebhookURLDecryptor interface {
 }
 
 // DisclaimerProvider yields the medical-safety disclaimer for a language. It is
-// satisfied by an i18n adapter; the notify pass uses it so every payload carries
-// the owner-localized (or server-default) "estimates, not medical advice"
-// string without importing the whole i18n Manager.
+// satisfied by an i18n adapter; the egress surfaces use it so every payload
+// carries the owner-localized "estimates, not medical advice" string without
+// importing the whole i18n Manager.
 type DisclaimerProvider interface {
 	Disclaimer(language string) string
 }
+
+// NotifyCopyProvider is the whole localized-copy seam of the notify pass: the
+// medical-safety disclaimer plus any catalogue entry by key. The reminder
+// headline and sentence are catalogue entries rather than Go literals precisely
+// so they follow the same language the disclaimer does — a payload written half
+// in the owner's language and half in the server's is what the split produced.
+// Both halves resolve at the owner's users.interface_language.
+type NotifyCopyProvider interface {
+	DisclaimerProvider
+	// Message returns the catalogue entry for key at language, or "" when the key
+	// is unknown. An empty or unsupported language yields the server default (the
+	// i18n Manager merges the default over the target).
+	Message(language string, key string) string
+}
+
+// The reminder copy keys. They are whole literals on purpose: the locale
+// reachability sweep recognises a key only by the literal that names it, so a
+// key assembled from parts would read as unreachable and be deleted by the next
+// catalogue cleanup.
+const (
+	reminderPeriodTitleKey      = "webhook.reminder.period.title"
+	reminderPeriodMessageKey    = "webhook.reminder.period.message"
+	reminderOvulationTitleKey   = "webhook.reminder.ovulation.title"
+	reminderOvulationMessageKey = "webhook.reminder.ovulation.message"
+)
 
 // NotifyReport is the transport-free result of one notify pass. It never carries
 // a URL, token, or payload — a destination appears as a HOST at most.
@@ -154,11 +179,11 @@ type NotifyPreviewLine struct {
 // WebhookNotifyService runs the notify pass. It holds only narrow seams so it is
 // fully unit-testable with stubs and never reaches for a real socket or clock.
 type WebhookNotifyService struct {
-	users      NotifyUserRepository
-	logs       NotifyLogReader
-	decryptor  WebhookURLDecryptor
-	deliverer  WebhookDeliverer
-	disclaimer DisclaimerProvider
+	users     NotifyUserRepository
+	logs      NotifyLogReader
+	decryptor WebhookURLDecryptor
+	deliverer WebhookDeliverer
+	localized NotifyCopyProvider
 }
 
 // NewWebhookNotifyService assembles the notify service from its collaborators.
@@ -167,14 +192,14 @@ func NewWebhookNotifyService(
 	logs NotifyLogReader,
 	decryptor WebhookURLDecryptor,
 	deliverer WebhookDeliverer,
-	disclaimer DisclaimerProvider,
+	localized NotifyCopyProvider,
 ) *WebhookNotifyService {
 	return &WebhookNotifyService{
-		users:      users,
-		logs:       logs,
-		decryptor:  decryptor,
-		deliverer:  deliverer,
-		disclaimer: disclaimer,
+		users:     users,
+		logs:      logs,
+		decryptor: decryptor,
+		deliverer: deliverer,
+		localized: localized,
 	}
 }
 
@@ -242,16 +267,14 @@ func (service *WebhookNotifyService) processOwner(
 
 	user := userFromNotifyRecord(record)
 	settings := WebhookReminderSettingsFromNotifyRecord(record)
-	due := DecideDueReminders(&user, settings, dayLogs, now, ownerLocation)
-
-	// Idempotency observability: the pure decision already hides reminders whose
-	// watermark covers them, so re-run the SAME decision with the watermarks
-	// cleared to learn how many candidates existed, and attribute the difference
-	// (candidates that were suppressed purely by an existing watermark) to
-	// SkippedIdempotent. This is a second pure, I/O-free decision call — no store,
-	// no clock — kept so the Report can prove "sent once, then skipped" without
-	// changing the authoritative (watermarked) decision above.
-	report.SkippedIdempotent += countWatermarkSuppressed(&user, settings, dayLogs, now, ownerLocation, due)
+	// One traversal yields both the authoritative due set and the idempotency
+	// counter: the decision already knows which reminders its own watermark
+	// withheld, so the Report can prove "sent once, then skipped" without the pass
+	// deciding a second time. That second decision was pure and I/O-free but not
+	// cheap — it rebuilt the owner's cycle statistics from their whole logged
+	// history, so the counter cost as much as the work it counted.
+	due, watermarkSuppressed := decideDueReminders(&user, settings, dayLogs, now, ownerLocation)
+	report.SkippedIdempotent += watermarkSuppressed
 
 	// Destination HOST only, for the dry-run preview and any host-scoped logging.
 	// Never keep or print more of the URL than this.
@@ -259,7 +282,7 @@ func (service *WebhookNotifyService) processOwner(
 
 	for _, reminder := range due {
 		report.Due++
-		payload := service.buildPayload(reminder)
+		payload := service.buildPayload(reminder, record.InterfaceLanguage)
 
 		if dryRun {
 			// Compute-only: no outbound request, no watermark. Record what WOULD be
@@ -330,12 +353,15 @@ func watermarkForReminderType(settings WebhookReminderSettings, reminderType str
 }
 
 // buildPayload turns a due reminder into the transport-free notification body.
-// It resolves the disclaimer at the server-default language (no per-owner
-// language is persisted) and minimizes health specifics to type + estimated date
-// + lead days.
-func (service *WebhookNotifyService) buildPayload(reminder DueReminder) WebhookPayload {
-	disclaimer := service.disclaimer.Disclaimer("")
-	title, message := reminderCopy(reminder)
+// Every localized field — the headline, the sentence, and the medical-safety
+// disclaimer — resolves at ONE language: the owner's persisted
+// users.interface_language, which the projection carries because a request-free
+// pass has no browser to ask. An owner who never chose a language stores "",
+// which the provider answers at the server default. Health specifics stay
+// minimized to type + estimated date + lead days.
+func (service *WebhookNotifyService) buildPayload(reminder DueReminder, language string) WebhookPayload {
+	disclaimer := service.localized.Disclaimer(language)
+	title, message := service.reminderCopy(reminder, language)
 	return WebhookPayload{
 		Title:      title,
 		Message:    message,
@@ -346,62 +372,38 @@ func (service *WebhookNotifyService) buildPayload(reminder DueReminder) WebhookP
 	}
 }
 
-// reminderCopy returns a neutral, secret-free title and message for a reminder.
-// The copy is intentionally minimal and English-neutral machine text; the
-// disclaimer field carries the localized medical-safety string.
-func reminderCopy(reminder DueReminder) (string, string) {
-	date := reminder.EventDate.Format("2006-01-02")
-	switch reminder.Type {
-	case DueReminderTypeOvulation:
-		return "Ovulation reminder", fmt.Sprintf("Estimated ovulation around %s.", date)
-	default:
-		return "Period reminder", fmt.Sprintf("Estimated next period around %s.", date)
+// reminderCopy returns the minimal, secret-free title and message for a
+// reminder, resolved at language. Both come from the locale catalogue: the copy
+// used to be English literals here, which put the reminder body outside the
+// six-file locale contract (no translator ever saw a key for it) and sent an
+// owner a headline in one language beside a disclaimer in another. The sentence
+// template carries a single %s for the ISO event date.
+func (service *WebhookNotifyService) reminderCopy(reminder DueReminder, language string) (string, string) {
+	titleKey, messageKey := reminderPeriodTitleKey, reminderPeriodMessageKey
+	if reminder.Type == DueReminderTypeOvulation {
+		titleKey, messageKey = reminderOvulationTitleKey, reminderOvulationMessageKey
 	}
+	title := service.localized.Message(language, titleKey)
+	template := service.localized.Message(language, messageKey)
+	if template == "" {
+		// No catalogue entry (a provider without the key): send the headline alone
+		// rather than a body of formatting-verb residue.
+		return title, ""
+	}
+	return title, fmt.Sprintf(template, reminder.EventDate.Format("2006-01-02"))
 }
 
-// countWatermarkSuppressed reports how many reminders WOULD be due for this
-// owner if no watermark existed but are absent from due (i.e. were suppressed
-// purely because an incoming watermark already covered them). It re-runs the
-// pure decision with both watermarks cleared and subtracts, by type, the
-// reminders that actually surfaced. It performs no I/O.
-func countWatermarkSuppressed(
-	user *models.User,
-	settings WebhookReminderSettings,
-	logs []models.DailyLog,
-	now time.Time,
-	location *time.Location,
-	due []DueReminder,
-) int {
-	unwatermarked := settings
-	unwatermarked.PeriodWatermark = nil
-	unwatermarked.OvulationWatermark = nil
-	candidates := DecideDueReminders(user, unwatermarked, logs, now, location)
-
-	dueTypes := make(map[string]bool, len(due))
-	for _, reminder := range due {
-		dueTypes[reminder.Type] = true
-	}
-
-	suppressed := 0
-	for _, candidate := range candidates {
-		if !dueTypes[candidate.Type] {
-			suppressed++
-		}
-	}
-	return suppressed
-}
-
-// hostOnly returns the hostname of a URL and nothing else — no scheme, path,
-// query, or userinfo (which may carry a notification token). It is the only form
-// of a webhook URL that may appear in a preview or log. Returns "" when the URL
-// cannot be parsed.
+// hostOnly returns the hostname of a URL and nothing else — no scheme, port,
+// path, query, or userinfo (which may carry a notification token). It is the
+// only form of a webhook URL that may appear in a preview, a settings page, or a
+// log, and it is the package's ONLY implementation of that rule: the notify
+// pass, the CLI status view, and BuildWebhookURLDisplay all print through it, so
+// a hardening of "what is safe to show" reaches every surface at once. Returns
+// "" when the URL cannot be parsed, which the settings display renders as
+// configured-but-hostless rather than as an error.
 func hostOnly(rawURL string) string {
 	parsed, err := url.Parse(strings.TrimSpace(rawURL))
 	if err != nil {
-		// codecov:ignore -- unreachable from the notify path: processOwner only
-		// reaches here for a URL the decryptor returned, which slice-1 save-time
-		// validation already parsed; kept as a fail-safe so a malformed value yields
-		// an empty host rather than leaking anything.
 		return ""
 	}
 	return parsed.Hostname()

--- a/internal/services/webhook_notify_service_test.go
+++ b/internal/services/webhook_notify_service_test.go
@@ -61,10 +61,29 @@ func (stub stubDecryptor) DecryptWebhookURL(userID uint, encryptedURL string) (s
 	return encryptedURL, nil
 }
 
-// stubDisclaimer returns a fixed disclaimer, standing in for the i18n adapter.
+// stubDisclaimer stands in for the i18n adapter: a fixed disclaimer plus the
+// English reminder copy for the four catalogue keys the payload names. Language
+// is ignored on purpose — that the pass resolves at the OWNER's language is
+// guarded against the real catalogue in egress_owner_language_test.go, which
+// keeps every other test of the pass free of the locale files.
 type stubDisclaimer struct{ text string }
 
 func (stub stubDisclaimer) Disclaimer(string) string { return stub.text }
+
+func (stub stubDisclaimer) Message(_ string, key string) string {
+	switch key {
+	case reminderPeriodTitleKey:
+		return "Period reminder"
+	case reminderPeriodMessageKey:
+		return "Estimated next period around %s."
+	case reminderOvulationTitleKey:
+		return "Ovulation reminder"
+	case reminderOvulationMessageKey:
+		return "Estimated ovulation around %s."
+	default:
+		return ""
+	}
+}
 
 // watermarkWrite records one watermark advance.
 type watermarkWrite struct {

--- a/internal/services/webhook_notify_source_policy_test.go
+++ b/internal/services/webhook_notify_source_policy_test.go
@@ -1,0 +1,150 @@
+package services
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// packageFunctionDecls parses every non-test .go file of this package and hands
+// each top-level function declaration to visit, named as the reader sees it.
+// Both guards below are about the SHAPE of the package's own source — "there is
+// one of these, not two" — which no behavioral assertion can express, so they
+// read the source the same way a reviewer would.
+func packageFunctionDecls(t *testing.T, visit func(name string, decl *ast.FuncDecl)) {
+	t.Helper()
+
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read the services package directory: %v", err)
+	}
+
+	fileSet := token.NewFileSet()
+	seen := 0
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, parseErr := parser.ParseFile(fileSet, name, nil, 0)
+		if parseErr != nil {
+			t.Fatalf("parse %s: %v", name, parseErr)
+		}
+		for _, decl := range file.Decls {
+			function, isFunction := decl.(*ast.FuncDecl)
+			if !isFunction || function.Body == nil {
+				continue
+			}
+			seen++
+			visit(function.Name.Name, function)
+		}
+	}
+	if seen == 0 {
+		t.Fatal("no function declarations found; the guards below would pass vacuously")
+	}
+}
+
+// TestOneURLHostRedactionHelper is the R2-0103 regression. A webhook URL may
+// embed a notification token, so "the hostname and nothing else" is the single
+// redaction rule that decides what may reach an operator's screen or log. The
+// package had TWO byte-identical implementations of it under different names —
+// hostOnly (notify pass + CLI) and webhookURLHost (the settings display) — which
+// means the next hardening of that rule has two places to reach and only one
+// obvious one. Detected by shape, not by name: any function that parses a URL
+// and returns its Hostname() is that helper, whatever it is called.
+func TestOneURLHostRedactionHelper(t *testing.T) {
+	helpers := []string{}
+	packageFunctionDecls(t, func(name string, decl *ast.FuncDecl) {
+		if returnsParsedHostname(decl) {
+			helpers = append(helpers, name)
+		}
+	})
+	sort.Strings(helpers)
+
+	if len(helpers) != 1 || helpers[0] != "hostOnly" {
+		t.Fatalf("URL-hostname redaction helpers in package services = %v, want exactly [hostOnly]: "+
+			"a second copy of the rule means a hardening applied to one leaves the other", helpers)
+	}
+}
+
+// returnsParsedHostname reports whether a function's body returns the hostname
+// of a parsed URL directly (`return parsed.Hostname()`) — the redaction helper's
+// signature move. A Hostname() call fed to a log line or an error message is a
+// USE of the rule, not another copy of it, so only a bare return counts.
+func returnsParsedHostname(decl *ast.FuncDecl) bool {
+	found := false
+	ast.Inspect(decl.Body, func(node ast.Node) bool {
+		result, isReturn := node.(*ast.ReturnStmt)
+		if !isReturn || len(result.Results) != 1 {
+			return true
+		}
+		call, isCall := result.Results[0].(*ast.CallExpr)
+		if !isCall {
+			return true
+		}
+		selector, isSelector := call.Fun.(*ast.SelectorExpr)
+		if isSelector && selector.Sel.Name == "Hostname" {
+			found = true
+		}
+		return true
+	})
+	return found
+}
+
+// TestNotifyPassRunsTheDecisionOncePerOwner is the R2-0110 regression. The
+// decision is not cheap: every call rebuilds the owner's cycle statistics from
+// their entire logged history, which the pass reads unbounded. The pass used to
+// run it TWICE per owner — once for the authoritative due set and once more,
+// with the watermarks cleared, purely to populate report.SkippedIdempotent — so
+// the cost of the observability counter equalled the cost of the work it
+// reports. One traversal now yields both, and this guard keeps it that way by
+// naming every non-test function that enters the decision.
+func TestNotifyPassRunsTheDecisionOncePerOwner(t *testing.T) {
+	callers := map[string]int{}
+	packageFunctionDecls(t, func(name string, decl *ast.FuncDecl) {
+		// The exported wrapper exists to call the traversal; it is not a second
+		// traversal of its own.
+		if name == "DecideDueReminders" {
+			return
+		}
+		if calls := countDecisionCalls(decl); calls > 0 {
+			callers[name] = calls
+		}
+	})
+
+	if len(callers) != 1 || callers["processOwner"] != 1 {
+		names := make([]string, 0, len(callers))
+		for name, calls := range callers {
+			names = append(names, name)
+			if calls > 1 {
+				t.Errorf("%s enters the reminder decision %d times; one traversal must yield both the due set and the suppressed count", name, calls)
+			}
+		}
+		sort.Strings(names)
+		t.Fatalf("functions entering the reminder decision = %v, want exactly [processOwner]", names)
+	}
+}
+
+// countDecisionCalls counts the calls a function makes into the reminder
+// decision under either of its names — the exported entry point and the
+// single-traversal form the notify pass consumes.
+func countDecisionCalls(decl *ast.FuncDecl) int {
+	calls := 0
+	ast.Inspect(decl.Body, func(node ast.Node) bool {
+		call, isCall := node.(*ast.CallExpr)
+		if !isCall {
+			return true
+		}
+		if identifier, isIdentifier := call.Fun.(*ast.Ident); isIdentifier {
+			if identifier.Name == "DecideDueReminders" || identifier.Name == "decideDueReminders" {
+				calls++
+			}
+		}
+		return true
+	})
+	return calls
+}

--- a/internal/services/webhook_reminder.go
+++ b/internal/services/webhook_reminder.go
@@ -152,8 +152,25 @@ func WebhookReminderSettingsFromNotifyRecord(record models.WebhookNotifyRecord) 
 // banner): a webhook consumer can act on each independently. Period precedes
 // ovulation in the returned slice.
 func DecideDueReminders(user *models.User, settings WebhookReminderSettings, logs []models.DailyLog, now time.Time, location *time.Location) []DueReminder {
+	reminders, _ := decideDueReminders(user, settings, logs, now, location)
+	return reminders
+}
+
+// decideDueReminders is the single traversal behind DecideDueReminders. It
+// returns the due set AND watermarkSuppressed: how many reminders this owner
+// would have received but for a watermark that already covers them — the count
+// the notify pass reports as SkippedIdempotent.
+//
+// The count comes from the same pass that builds the due set because the
+// traversal is not cheap: it rebuilds the owner's cycle statistics from their
+// whole logged history, so deriving the counter by deciding a second time with
+// the watermarks cleared made the observability cost equal the cost of the work
+// it observes. Nothing about the authoritative decision changes: a kind is
+// counted exactly when its own watermark is what withheld it, which is the
+// definition the second decision approximated by subtraction.
+func decideDueReminders(user *models.User, settings WebhookReminderSettings, logs []models.DailyLog, now time.Time, location *time.Location) ([]DueReminder, int) {
 	if !settings.Enabled {
-		return nil
+		return nil, 0
 	}
 
 	// Reuse the exact dashboard prediction path. BuildCycleStatsFromLogs is a
@@ -165,7 +182,7 @@ func DecideDueReminders(user *models.User, settings WebhookReminderSettings, log
 	// Medical-safety gate: if the app suppresses predictions, emit nothing. The
 	// three signals are read through the predicate every surface shares.
 	if PredictionsSuppressed(user, stats) {
-		return nil
+		return nil, 0
 	}
 
 	today := DateAtLocation(now, location)
@@ -174,9 +191,14 @@ func DecideDueReminders(user *models.User, settings WebhookReminderSettings, log
 	prediction := DashboardUpcomingPredictions(stats, user, today, cycleLength)
 
 	reminders := make([]DueReminder, 0, 2)
+	watermarkSuppressed := 0
 
-	if due, ok := decidePeriodReminder(settings, prediction, today, leadDays); ok {
+	due, ok, watermarked := decidePeriodReminder(settings, prediction, today, leadDays)
+	if ok {
 		reminders = append(reminders, due)
+	}
+	if watermarked {
+		watermarkSuppressed++
 	}
 	// The ovulation reminder carries the extra first-cycle floor: before one
 	// cycle has been observed its date comes from the onboarding slider alone,
@@ -184,31 +206,40 @@ func DecideDueReminders(user *models.User, settings WebhookReminderSettings, log
 	// (FertilityProjectionSuppressed). The period reminder keeps its own path —
 	// it is anchored on a recorded cycle start and rides the estimate flag.
 	if !FertilityProjectionSuppressed(user, stats) {
-		if due, ok := decideOvulationReminder(stats, settings, prediction, today, cycleLength, leadDays); ok {
+		due, ok, watermarked := decideOvulationReminder(stats, settings, prediction, today, cycleLength, leadDays)
+		if ok {
 			reminders = append(reminders, due)
+		}
+		if watermarked {
+			watermarkSuppressed++
 		}
 	}
 
 	if len(reminders) == 0 {
-		return nil
+		return nil, watermarkSuppressed
 	}
-	return reminders
+	return reminders, watermarkSuppressed
 }
 
 // decidePeriodReminder applies the period-soon rule. The next period start is
 // the anchor of the upcoming cycle, so it doubles as the event date and the
 // watermark key.
-func decidePeriodReminder(settings WebhookReminderSettings, prediction DashboardUpcomingPrediction, today time.Time, leadDays int) (DueReminder, bool) {
+//
+// The second result says the reminder is due; the third says it was withheld by
+// its OWN watermark — an already-sent reminder, not an absent one. Only that
+// case is idempotency: a reminder outside the lead window, or of a kind the
+// owner turned off, is simply not due and must never be reported as skipped.
+func decidePeriodReminder(settings WebhookReminderSettings, prediction DashboardUpcomingPrediction, today time.Time, leadDays int) (reminder DueReminder, due bool, watermarkSuppressed bool) {
 	if !settings.NotifyPeriod {
-		return DueReminder{}, false
+		return DueReminder{}, false, false
 	}
 	eventDate := prediction.NextPeriodStart
 	if !reminderWithinWindow(today, eventDate, leadDays) {
-		return DueReminder{}, false
+		return DueReminder{}, false, false
 	}
 	anchor := CalendarDay(eventDate, today.Location())
 	if watermarkCoversAnchor(settings.PeriodWatermark, anchor) {
-		return DueReminder{}, false
+		return DueReminder{}, false, true
 	}
 	return DueReminder{
 		Type:        DueReminderTypePeriod,
@@ -216,19 +247,22 @@ func decidePeriodReminder(settings WebhookReminderSettings, prediction Dashboard
 		CycleAnchor: anchor,
 		LeadDays:    leadDays,
 		Estimate:    true,
-	}, true
+	}, true, false
 }
 
 // decideOvulationReminder applies the ovulation-soon rule. The ovulation's cycle
 // anchor is the start of the cycle it belongs to, derived with the same
 // projection helpers DashboardUpcomingPredictions uses so the two never drift.
-func decideOvulationReminder(stats CycleStats, settings WebhookReminderSettings, prediction DashboardUpcomingPrediction, today time.Time, cycleLength int, leadDays int) (DueReminder, bool) {
+//
+// Its three results carry the same meaning as decidePeriodReminder's: due, and
+// separately withheld by its own watermark.
+func decideOvulationReminder(stats CycleStats, settings WebhookReminderSettings, prediction DashboardUpcomingPrediction, today time.Time, cycleLength int, leadDays int) (reminder DueReminder, due bool, watermarkSuppressed bool) {
 	if !settings.NotifyOvulation || prediction.OvulationImpossible {
-		return DueReminder{}, false
+		return DueReminder{}, false, false
 	}
 	eventDate := prediction.OvulationDate
 	if !reminderWithinWindow(today, eventDate, leadDays) {
-		return DueReminder{}, false
+		return DueReminder{}, false, false
 	}
 	anchor := ovulationCycleAnchor(stats, today, cycleLength)
 	// codecov:ignore:start -- defensive and unreachable from this call path: an
@@ -238,11 +272,11 @@ func decideOvulationReminder(stats CycleStats, settings WebhookReminderSettings,
 	// ovulationCycleAnchor needs to return a non-zero anchor. Kept so a reminder
 	// is never emitted without a watermark key the delivery slice can dedupe on.
 	if anchor.IsZero() {
-		return DueReminder{}, false
+		return DueReminder{}, false, false
 	}
 	// codecov:ignore:end
 	if watermarkCoversAnchor(settings.OvulationWatermark, anchor) {
-		return DueReminder{}, false
+		return DueReminder{}, false, true
 	}
 	return DueReminder{
 		Type:        DueReminderTypeOvulation,
@@ -250,7 +284,7 @@ func decideOvulationReminder(stats CycleStats, settings WebhookReminderSettings,
 		CycleAnchor: anchor,
 		LeadDays:    leadDays,
 		Estimate:    true,
-	}, true
+	}, true, false
 }
 
 // reminderWithinWindow reports whether eventDate falls in the inclusive lead

--- a/internal/services/webhook_settings_service.go
+++ b/internal/services/webhook_settings_service.go
@@ -332,17 +332,9 @@ func (service *WebhookSettingsService) BuildWebhookURLDisplay(userID uint, encry
 	if err != nil {
 		return WebhookURLDisplay{Configured: true}
 	}
-	return WebhookURLDisplay{Configured: true, Host: webhookURLHost(plaintext)}
-}
-
-// webhookURLHost returns the hostname component of a stored webhook URL and
-// nothing else — no scheme, port, path, query, or userinfo — so a token embedded
-// anywhere but the host can never reach a render surface. An unparseable value
-// yields an empty host (the caller still shows "configured").
-func webhookURLHost(raw string) string {
-	parsed, err := url.Parse(strings.TrimSpace(raw))
-	if err != nil {
-		return ""
-	}
-	return parsed.Hostname()
+	// hostOnly is the package's single URL-hostname redaction rule — the same one
+	// the notify pass and the CLI print through. Keeping one implementation is
+	// what makes a hardening of "what is safe to show" reach every surface at
+	// once; this display used to carry its own byte-identical copy.
+	return WebhookURLDisplay{Configured: true, Host: hostOnly(plaintext)}
 }

--- a/internal/services/webhook_settings_service_test.go
+++ b/internal/services/webhook_settings_service_test.go
@@ -583,7 +583,7 @@ func TestBuildWebhookURLDisplay(t *testing.T) {
 }
 
 // TestBuildWebhookURLDisplayUnparseableStoredURLHasNoHost covers the
-// webhookURLHost parse-error branch: a stored (decryptable) value that url.Parse
+// hostOnly parse-error branch: a stored (decryptable) value that url.Parse
 // rejects yields configured-but-hostless rather than leaking or crashing. A
 // control character makes url.Parse fail.
 func TestBuildWebhookURLDisplayUnparseableStoredURLHasNoHost(t *testing.T) {


### PR DESCRIPTION

Tail-board group **T0102** (locale / `internal/services`). Five of the six records
implemented, one skipped as already fixed on the current tree. Every guard was written
first and observed red before the corresponding fix was wired in.

## R2-0135 + R2-0109 — the disclaimer and the reminder copy (locale, P1 + P2)

Both egress surfaces that carry predictions off the instance resolved the mandatory
"estimates, not medical advice or a method of contraception" string at the *server*
default, each under a comment stating that no per-owner language is persisted
(`webhook_notify_service.go`, `calendar_feed_service.go`). `users.interface_language`
has been that carrier all along — the notify projection simply never selected it. On
top of that the webhook headline and sentence were English literals in Go with no
catalogue entry at all, so an owner on one of the five non-default locales received a
notification written in two languages, neither of them necessarily theirs.

- `models.WebhookNotifyRecord` and `UserRepository.ListAllForNotify` now project
  `interface_language`.
- `buildPayload` resolves the disclaimer, title and message at that one language;
  `reminderCopy` reads the copy from the catalogue instead of returning literals.
- The notify pass's i18n seam widens from `DisclaimerProvider` to `NotifyCopyProvider`
  (disclaimer + any key); `internal/bootstrap`'s adapter gains `Message`.
- Four new keys in all six catalogues: `webhook.reminder.{period,ovulation}.{title,message}`.
- `calendar_feed_service.go` resolves at `user.InterfaceLanguage`.
- `docs/notifications.md` states which payload fields follow the owner's language and
  which never do.

Guards — `internal/services/egress_owner_language_test.go`, resolved against the REAL
catalogue through a test twin of the production adapter.

RED, before any code change (the projection did not carry the column at all — exactly
what the record's evidence says):

```
$ go test ./internal/services/ -run 'TestNotifyPayloadIsLocalized...' -count=1
internal\services\egress_owner_language_test.go:61:9: record.InterfaceLanguage undefined
    (type models.WebhookNotifyRecord has no field or method InterfaceLanguage)
FAIL github.com/ovumcy/ovumcy-web/internal/services [build failed]
```

RED again with the column projected but the resolution untouched:

```
--- FAIL: TestNotifyPayloadIsLocalizedToTheOwnersInterfaceLanguage
    disclaimer for a ru owner = "Predictions are estimates, not medical advice or a
      method of contraception.", want the ru catalogue entry "Прогнозы — это оценки, ..."
    disclaimer for a ru owner resolved at the server default language
    locale ru has no entry for "webhook.reminder.ovulation.title": the reminder copy is
      not in the catalogue
--- FAIL: TestNotifyPayloadCopyResolvesInEveryLocale
    locale "de".."ru" has no entry for "webhook.reminder.period.title" (24 lines)
--- FAIL: TestCalendarFeedDisclaimerIsLocalizedToTheOwnersInterfaceLanguage
    the .ics body does not carry the ru medical disclaimer:
      DESCRIPTION:Predictions are estimates\, not medical advice or a method of ...
```

Proof-on-defect after the fix — the fix's bodies gutted back to `Disclaimer("")` /
`reminderCopy(reminder, "")` in `buildPayload` and to `Disclaimer("")` in
`ResolveFeed`, call sites left wired:

```
--- FAIL: TestNotifyPayloadIsLocalizedToTheOwnersInterfaceLanguage
    ovulation-soon title = "Ovulation reminder", want "Напоминание об овуляции"
    ovulation-soon message = "Estimated ovulation around 2026-03-13.",
      want "Овуляция ожидается около 2026-03-13."
--- FAIL: TestCalendarFeedDisclaimerIsLocalizedToTheOwnersInterfaceLanguage
```

GREEN with the fix restored: all three pass.

## R2-0103 — two copies of the URL-hostname redaction rule (duplication, P2)

`hostOnly` (notify pass + CLI) and `webhookURLHost` (settings display) were byte-identical
implementations of the rule that decides what part of a webhook URL — which can embed an
ntfy bearer token — may reach an operator's screen. `webhookURLHost` is deleted and
`BuildWebhookURLDisplay` routes through `hostOnly`. `hostOnly`'s parse-error branch loses
its `codecov:ignore` because it is now genuinely reachable, and is covered by the existing
`TestBuildWebhookURLDisplayUnparseableStoredURLHasNoHost`.

Guard — `TestOneURLHostRedactionHelper` (`webhook_notify_source_policy_test.go`), which
finds the helper by SHAPE (a function returning `parsed.Hostname()` directly), not by name,
so a differently-named copy is caught too.

```
RED   --- FAIL: TestOneURLHostRedactionHelper
        URL-hostname redaction helpers in package services = [hostOnly webhookURLHost],
        want exactly [hostOnly]: a second copy of the rule means a hardening applied to
        one leaves the other
GREEN --- PASS: TestOneURLHostRedactionHelper
```

## R2-0110 — the pass decided twice per owner (performance, P3)

`processOwner` ran `DecideDueReminders` for the due set and then `countWatermarkSuppressed`
ran it a second time with the watermarks cleared, purely to populate
`report.SkippedIdempotent` — so an observability counter cost exactly as much as the work
it counted, and each traversal rebuilds the owner's cycle statistics from their entire
(unbounded) logged history. `decideDueReminders` now returns the due set and the
watermark-suppressed count from one traversal; `DecideDueReminders` stays as the exported
wrapper, so no existing caller or test changed. The suppression signal is now exact — a
kind is counted when its OWN watermark withheld it — rather than derived by subtracting
type sets.

Guard — `TestNotifyPassRunsTheDecisionOncePerOwner`, same file.

```
RED   --- FAIL: TestNotifyPassRunsTheDecisionOncePerOwner
        functions entering the reminder decision = [countWatermarkSuppressed processOwner],
        want exactly [processOwner]
GREEN --- PASS: TestNotifyPassRunsTheDecisionOncePerOwner
```

## R2-0510 — the switch-based key functions had no locale sweep (locale, P2)

`assertMappedTranslationKeysResolveInEveryLocale` was built as "the guard for the defect
CLASS" but takes a `map[string]string`, so the five `*TranslationKey` functions in
`domain_label_policy.go` — which are `switch` statements — sat outside it. A key present
in NO locale (the typo case) reached every language as a raw key on screen. A sibling
sweep now feeds every enum value the validator accepts through its key function and
requires the result to resolve in every `SupportedLanguages()` catalogue.

This record's fix IS the guard, so it is proved on the defect: the mood key was typo'd in
`domain_label_policy.go` (`dashboard.mood.very_low` → `dashboard.mood.verylow`) and the
sweep reddened naming the culprit, then the key was restored.

```
RED   --- FAIL: TestDomainLabelTranslationKeysResolveInEveryLocale
        domain label switch functions: locale "de".."ru" has no entry for
        "dashboard.mood.verylow" (mapped from spec "mood step 1"): the message would
        render as the raw key                                         (6 lines, one per locale)
GREEN --- PASS: TestDomainLabelTranslationKeysResolveInEveryLocale
```

## R2-0102 — skipped: already fixed on the current tree

The record describes an unconditional `UpdateWebhookWatermark` written AFTER delivery.
That function no longer exists anywhere in the tree. `NotifyUserRepository` now exposes
`ClaimWebhookWatermark` (compare-and-set against the snapshot's value) and
`ReleaseWebhookWatermark`, the claim is taken BEFORE the POST and handed back when it
fails, and the file header documents the at-most-once trade-off this buys. The concurrency
test the record names (`internal/reminders/idempotency_layering_test.go`) is present and
green. Nothing to do.

## Verification

- `go build ./...` — clean.
- `go vet ./...` — clean.
- `go test -count=1` green on every touched package: `internal/services`, `internal/db`,
  `internal/models`, `internal/bootstrap`, `internal/reminders`, `internal/i18n`, plus
  `internal/api`, `internal/cli` and `./scripts/...` (which include `scripts/webhookdocs`
  and the locale reachability/parity suites).
- `golangci-lint run` — `0 issues.` on `internal/{services,models,db,bootstrap,reminders}`.

## Rollback

Single-commit revert. Nothing here alters persisted data or a public contract: the added
column is a SELECT-list addition to an existing read projection (no migration), and the
four new locale keys and the widened i18n seam are internal. Reverting restores the
server-default resolution and the English literals; no data written under this change
needs undoing.
