### PR TITLE
refactor(services): retire dead declarations and unify the date tables

### DIFF
--- a/changelog.d/refactor-services-dead-code-and-date-tables.md
+++ b/changelog.d/refactor-services-dead-code-and-date-tables.md
@@ -1,0 +1,13 @@
+### Internal
+
+- **Localized date names moved to one table per language.** The five parallel month/weekday maps in
+  the services layer became a single fixed-size entry per language, and a new sweep requires a
+  complete entry for every locale the i18n manager reports — a seventh locale can no longer be added
+  and silently render English dates on the calendar header, the day label and the dashboard. Every
+  rendered date is byte-identical to before.
+- **Dead code retired in the services layer.** The unused singular `AttemptLimiter` methods are gone
+  and the lockout tests now drive the plural methods production actually calls; the Russian plural
+  rule has one home again (`i18n.PluralCategory`); the unreachable nil-user guards in the day-feedback
+  policy and a French count-word branch with identical arms were removed. `User.LongPeriodWarnedAt`
+  is now `User.LongPeriodWarningCycleStart`, the name its column and its date-only type always had.
+  No stored data, API payload or rendered string changes.

--- a/internal/api/handlers_days_upsert_validation_test.go
+++ b/internal/api/handlers_days_upsert_validation_test.go
@@ -214,7 +214,7 @@ func TestUpsertDayPersistsPregnancyTest(t *testing.T) {
 // which guards persisting the long-period-warning acknowledgement. Seeding an
 // 8-day period streak and upserting the ninth consecutive period day makes
 // ResolveDayFeedback return ShowLongPeriodWarning=true with a non-zero cycle start,
-// so the handler must persist LongPeriodWarnedAt (column
+// so the handler must persist LongPeriodWarningCycleStart (column
 // long_period_warning_cycle_start) to suppress the warning on later saves. The
 // CONDITIONALS_NEGATION mutant (`feedbackErr != nil`) skips the ack block on the
 // happy path, leaving the column NULL and re-showing the warning on every save.
@@ -276,10 +276,10 @@ func TestUpsertDayPersistsLongPeriodWarningAcknowledgement(t *testing.T) {
 	if err := database.Select("long_period_warning_cycle_start").First(&persisted, user.ID).Error; err != nil {
 		t.Fatalf("reload user: %v", err)
 	}
-	if persisted.LongPeriodWarnedAt == nil {
+	if persisted.LongPeriodWarningCycleStart == nil {
 		t.Fatal("expected long-period-warning acknowledgement to be persisted after a nine-day period streak upsert (feedbackErr==nil guard must run the ack)")
 	}
-	if got := services.CalendarDayKey(*persisted.LongPeriodWarnedAt); got != "2026-03-01" {
+	if got := services.CalendarDayKey(*persisted.LongPeriodWarningCycleStart); got != "2026-03-01" {
 		t.Fatalf("expected acknowledged cycle start 2026-03-01, got %s", got)
 	}
 }

--- a/internal/api/handlers_days_write.go
+++ b/internal/api/handlers_days_write.go
@@ -121,8 +121,8 @@ func (handler *Handler) applyUpsertDayAcknowledgements(c fiber.Ctx, request upse
 	feedback, feedbackErr := handler.dayService.ResolveDayFeedback(c.Context(), request.user, request.day, time.Now().In(request.location), request.location)
 	if feedbackErr == nil && feedback.ShowLongPeriodWarning && !feedback.LongPeriodCycleStart.IsZero() {
 		if err := handler.dayService.AcknowledgeLongPeriodWarning(c.Context(), request.user.ID, feedback.LongPeriodCycleStart, request.location); err == nil { // codecov:ignore -- best-effort long-period-warning ack; error intentionally swallowed
-			warnedAt := feedback.LongPeriodCycleStart
-			request.user.LongPeriodWarnedAt = &warnedAt
+			acknowledgedCycleStart := feedback.LongPeriodCycleStart
+			request.user.LongPeriodWarningCycleStart = &acknowledgedCycleStart
 		}
 	}
 	return feedback, feedbackErr

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -48,39 +48,44 @@ const (
 )
 
 type User struct {
-	ID                   uint       `gorm:"primaryKey"`
-	DisplayName          string     `gorm:"size:80"`
-	Email                string     `gorm:"uniqueIndex;not null"`
-	PasswordHash         string     `gorm:"not null"`
-	RecoveryCodeHash     string     `gorm:"column:recovery_code_hash"`
-	LocalAuthEnabled     bool       `gorm:"column:local_auth_enabled;not null"`
-	AuthSessionVersion   int        `gorm:"column:auth_session_version;not null;default:1"`
-	MustChangePassword   bool       `gorm:"column:must_change_password;not null;default:false"`
-	Role                 string     `gorm:"not null;default:owner"`
-	OnboardingCompleted  bool       `gorm:"not null;default:false"`
-	CycleLength          int        `gorm:"not null;default:28"`
-	PeriodLength         int        `gorm:"not null;default:5"`
-	LutealPhase          int        `gorm:"column:luteal_phase;not null;default:14"`
-	AutoPeriodFill       bool       `gorm:"column:auto_period_fill;not null;default:false"`
-	IrregularCycle       bool       `gorm:"column:irregular_cycle;not null;default:false"`
-	TrackBBT             bool       `gorm:"column:track_bbt;not null;default:false"`
-	TemperatureUnit      string     `gorm:"column:temperature_unit;not null;default:c"`
-	TrackCervicalMucus   bool       `gorm:"column:track_cervical_mucus;not null;default:false"`
-	HideSexChip          bool       `gorm:"column:hide_sex_chip;not null;default:false"`
-	HideCycleFactors     bool       `gorm:"column:hide_cycle_factors;not null;default:false"`
-	HideNotesField       bool       `gorm:"column:hide_notes_field;not null;default:false"`
-	ShowHistoricalPhases bool       `gorm:"column:show_historical_phases;not null;default:false"`
-	WeekStartsOn         string     `gorm:"column:week_starts_on;not null;default:sunday"`
-	ShownPeriodTip       bool       `gorm:"column:shown_period_tip;not null;default:false"`
-	AgeGroup             string     `gorm:"column:age_group;not null;default:''"`
-	UsageGoal            string     `gorm:"column:usage_goal;not null;default:health"`
-	UnpredictableCycle   bool       `gorm:"column:unpredictable_cycle;not null;default:false"`
-	LongPeriodWarnedAt   *time.Time `gorm:"column:long_period_warning_cycle_start;type:date"`
-	LastPeriodStart      *time.Time `gorm:"type:date"`
-	CreatedAt            time.Time  `gorm:"not null"`
-	TOTPSecret           string     `gorm:"column:totp_secret"`
-	TOTPEnabled          bool       `gorm:"column:totp_enabled;not null;default:false"`
-	TOTPLastUsedStep     int64      `gorm:"column:totp_last_used_step;not null;default:0"`
+	ID                   uint   `gorm:"primaryKey"`
+	DisplayName          string `gorm:"size:80"`
+	Email                string `gorm:"uniqueIndex;not null"`
+	PasswordHash         string `gorm:"not null"`
+	RecoveryCodeHash     string `gorm:"column:recovery_code_hash"`
+	LocalAuthEnabled     bool   `gorm:"column:local_auth_enabled;not null"`
+	AuthSessionVersion   int    `gorm:"column:auth_session_version;not null;default:1"`
+	MustChangePassword   bool   `gorm:"column:must_change_password;not null;default:false"`
+	Role                 string `gorm:"not null;default:owner"`
+	OnboardingCompleted  bool   `gorm:"not null;default:false"`
+	CycleLength          int    `gorm:"not null;default:28"`
+	PeriodLength         int    `gorm:"not null;default:5"`
+	LutealPhase          int    `gorm:"column:luteal_phase;not null;default:14"`
+	AutoPeriodFill       bool   `gorm:"column:auto_period_fill;not null;default:false"`
+	IrregularCycle       bool   `gorm:"column:irregular_cycle;not null;default:false"`
+	TrackBBT             bool   `gorm:"column:track_bbt;not null;default:false"`
+	TemperatureUnit      string `gorm:"column:temperature_unit;not null;default:c"`
+	TrackCervicalMucus   bool   `gorm:"column:track_cervical_mucus;not null;default:false"`
+	HideSexChip          bool   `gorm:"column:hide_sex_chip;not null;default:false"`
+	HideCycleFactors     bool   `gorm:"column:hide_cycle_factors;not null;default:false"`
+	HideNotesField       bool   `gorm:"column:hide_notes_field;not null;default:false"`
+	ShowHistoricalPhases bool   `gorm:"column:show_historical_phases;not null;default:false"`
+	WeekStartsOn         string `gorm:"column:week_starts_on;not null;default:sunday"`
+	ShownPeriodTip       bool   `gorm:"column:shown_period_tip;not null;default:false"`
+	AgeGroup             string `gorm:"column:age_group;not null;default:''"`
+	UsageGoal            string `gorm:"column:usage_goal;not null;default:health"`
+	UnpredictableCycle   bool   `gorm:"column:unpredictable_cycle;not null;default:false"`
+	// LongPeriodWarningCycleStart is the cycle START the long-period warning was
+	// last acknowledged for — a date-only value (`type:date`, UTC-midnight), not
+	// the instant the warning was shown. The name follows the column and the
+	// type so no reader reaches for DateAtLocation, the instant-only helper
+	// (day_utils.go, issue #48/#64 class).
+	LongPeriodWarningCycleStart *time.Time `gorm:"column:long_period_warning_cycle_start;type:date"`
+	LastPeriodStart             *time.Time `gorm:"type:date"`
+	CreatedAt                   time.Time  `gorm:"not null"`
+	TOTPSecret                  string     `gorm:"column:totp_secret"`
+	TOTPEnabled                 bool       `gorm:"column:totp_enabled;not null;default:false"`
+	TOTPLastUsedStep            int64      `gorm:"column:totp_last_used_step;not null;default:0"`
 	// Timezone is the owner's last known IANA timezone name (e.g.
 	// "Europe/Belgrade"), persisted from the request so request-free batch
 	// passes (webhook reminders, issue #124) can resolve "today" without a

--- a/internal/services/attempt_limiter.go
+++ b/internal/services/attempt_limiter.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	// evictEveryN triggers a full-map stale-key sweep every N AddFailure calls.
+	// evictEveryN triggers a full-map stale-key sweep every N AddFailureAll calls.
 	// Keys are partly attacker-influenced (identity:<hmac>), so without periodic
 	// eviction the map grows unboundedly until process restart. N=128 keeps the
 	// sweep rare enough to be O(1) amortised while bounding residual memory.
@@ -27,7 +27,7 @@ const (
 type AttemptLimiter struct {
 	mu        sync.Mutex
 	attempts  map[string][]time.Time
-	addCallsN int // counts AddFailure/AddFailureAll invocations for eviction pacing
+	addCallsN int // counts AddFailureAll invocations for eviction pacing
 }
 
 func NewAttemptLimiter() *AttemptLimiter {
@@ -44,14 +44,6 @@ func NormalizeLimiterKey(raw string) string {
 	return key
 }
 
-func (limiter *AttemptLimiter) TooManyRecent(key string, now time.Time, limit int, window time.Duration) bool {
-	limiter.mu.Lock()
-	defer limiter.mu.Unlock()
-
-	pruned := limiter.pruneLocked(key, now, window)
-	return len(pruned) >= limit
-}
-
 func (limiter *AttemptLimiter) TooManyRecentAny(keys []string, now time.Time, limit int, window time.Duration) bool {
 	limiter.mu.Lock()
 	defer limiter.mu.Unlock()
@@ -62,18 +54,6 @@ func (limiter *AttemptLimiter) TooManyRecentAny(keys []string, now time.Time, li
 		}
 	}
 	return false
-}
-
-func (limiter *AttemptLimiter) AddFailure(key string, now time.Time, window time.Duration) {
-	limiter.mu.Lock()
-	defer limiter.mu.Unlock()
-
-	pruned := limiter.pruneLocked(key, now, window)
-	pruned = append(pruned, now)
-	limiter.attempts[key] = pruned
-
-	limiter.addCallsN++
-	limiter.maybeEvictStaleLocked(now, window)
 }
 
 func (limiter *AttemptLimiter) AddFailureAll(keys []string, now time.Time, window time.Duration) {
@@ -143,12 +123,6 @@ func (limiter *AttemptLimiter) enforceSizeCapLocked() {
 	for _, entry := range ages[:excess] {
 		delete(limiter.attempts, entry.key)
 	}
-}
-
-func (limiter *AttemptLimiter) Reset(key string) {
-	limiter.mu.Lock()
-	defer limiter.mu.Unlock()
-	delete(limiter.attempts, key)
 }
 
 func (limiter *AttemptLimiter) ResetAll(keys []string) {

--- a/internal/services/attempt_limiter_test.go
+++ b/internal/services/attempt_limiter_test.go
@@ -14,18 +14,18 @@ func TestAttemptLimiterWindowAndReset(t *testing.T) {
 	window := time.Hour
 	now := time.Now().UTC()
 
-	limiter.AddFailure(key, now.Add(-2*time.Hour), window)
-	if limiter.TooManyRecent(key, now, 1, window) {
+	limiter.AddFailureAll([]string{key}, now.Add(-2*time.Hour), window)
+	if limiter.TooManyRecentAny([]string{key}, now, 1, window) {
 		t.Fatal("expected old attempt to be pruned from active window")
 	}
 
-	limiter.AddFailure(key, now.Add(-30*time.Minute), window)
-	if !limiter.TooManyRecent(key, now, 1, window) {
+	limiter.AddFailureAll([]string{key}, now.Add(-30*time.Minute), window)
+	if !limiter.TooManyRecentAny([]string{key}, now, 1, window) {
 		t.Fatal("expected one recent attempt to hit limit 1")
 	}
 
-	limiter.Reset(key)
-	if limiter.TooManyRecent(key, now, 1, window) {
+	limiter.ResetAll([]string{key})
+	if limiter.TooManyRecentAny([]string{key}, now, 1, window) {
 		t.Fatal("expected no attempts after reset")
 	}
 }
@@ -53,7 +53,7 @@ func TestAttemptLimiterMultiKeyOperations(t *testing.T) {
 }
 
 // TestAttemptLimiterStaleKeyEviction is a regression test for F7 (opportunistic
-// global eviction). After the window elapses, AddFailure on a live key should
+// global eviction). After the window elapses, AddFailureAll on a live key should
 // trigger a sweep that removes all stale keys, leaving only the live one.
 func TestAttemptLimiterStaleKeyEviction(t *testing.T) {
 	t.Parallel()
@@ -65,7 +65,7 @@ func TestAttemptLimiterStaleKeyEviction(t *testing.T) {
 	limiter := NewAttemptLimiter()
 
 	// Force addCallsN to just below the sweep threshold so the next
-	// AddFailure call crosses it and triggers the sweep.
+	// AddFailureAll call crosses it and triggers the sweep.
 	limiter.addCallsN = evictEveryN - 1
 
 	// Populate evictEveryN-1 stale keys (failures recorded at 'past').
@@ -82,7 +82,7 @@ func TestAttemptLimiterStaleKeyEviction(t *testing.T) {
 	// Add a live key via the normal path — this increments addCallsN to
 	// evictEveryN and triggers the sweep.
 	liveKey := "live-key"
-	limiter.AddFailure(liveKey, live, window)
+	limiter.AddFailureAll([]string{liveKey}, live, window)
 
 	// All stale keys should be gone.
 	limiter.mu.Lock()
@@ -98,7 +98,7 @@ func TestAttemptLimiterStaleKeyEviction(t *testing.T) {
 	}
 
 	// Confirm the live key is still recognized as having a recent failure.
-	if !limiter.TooManyRecent(liveKey, live, 1, window) {
+	if !limiter.TooManyRecentAny([]string{liveKey}, live, 1, window) {
 		t.Fatal("live key should still register as having a recent failure after eviction sweep")
 	}
 }
@@ -141,7 +141,7 @@ func TestAttemptLimiterSizeCapUnderFreshKeyFlood(t *testing.T) {
 	// the window so the stale sweep removes none of them.
 	total := evictAboveSize * 2
 	for index := range total {
-		limiter.AddFailure(fmt.Sprintf("identity:flood-%05d", index), now.Add(time.Duration(index)*time.Millisecond), window)
+		limiter.AddFailureAll([]string{fmt.Sprintf("identity:flood-%05d", index)}, now.Add(time.Duration(index)*time.Millisecond), window)
 	}
 
 	limiter.mu.Lock()
@@ -161,13 +161,13 @@ func TestAttemptLimiterSizeCapEvictsColdestKeysFirst(t *testing.T) {
 	window := time.Hour
 
 	// The victim key is the oldest entry but stays inside the window…
-	limiter.AddFailure("identity:victim-hot", base, window)
+	limiter.AddFailureAll([]string{"identity:victim-hot"}, base, window)
 	// …and is refreshed continuously while the flood runs, making it one of
 	// the newest entries by last-failure time.
 	for index := range evictAboveSize + 200 {
-		limiter.AddFailure(fmt.Sprintf("identity:cold-%05d", index), base.Add(time.Duration(index)*time.Millisecond), window)
+		limiter.AddFailureAll([]string{fmt.Sprintf("identity:cold-%05d", index)}, base.Add(time.Duration(index)*time.Millisecond), window)
 		if index%100 == 0 {
-			limiter.AddFailure("identity:victim-hot", base.Add(time.Duration(index)*time.Millisecond+time.Second), window)
+			limiter.AddFailureAll([]string{"identity:victim-hot"}, base.Add(time.Duration(index)*time.Millisecond+time.Second), window)
 		}
 	}
 

--- a/internal/services/cycle_start_policy.go
+++ b/internal/services/cycle_start_policy.go
@@ -80,12 +80,22 @@ func potentialImplantationGapDays(user *models.User, logs []models.DailyLog, tar
 	filtered := filterLogsNotAfter(logs, targetDay.AddDate(0, 0, -1))
 	stats := BuildCycleStats(filtered, targetDay.Add(-time.Second))
 	cycleLength := predictedCycleLength(stats.MedianCycleLength, stats.AverageCycleLength)
+	// codecov:ignore:start -- unreachable from this caller, kept as a floor for
+	// a future statistic that can report "unknown". stats are computed HERE by
+	// BuildCycleStats, so either there are fewer than two detected cycle starts
+	// (median and average both 0 -> predictedCycleLength returns
+	// models.DefaultCycleLength) or the starts are distinct sorted calendar days
+	// (every observed length >= 1 -> median > 0). Callers that pass CALLER-BUILT
+	// CycleStats can still drive predictedCycleLength to 0 with a fractional
+	// average in (0, 0.5) — applyProjectedBaseline is that shape and its guards
+	// are live — which is why these two are left in place rather than removed.
 	if cycleLength <= 0 {
 		cycleLength = DashboardCycleReferenceLength(user, stats)
 	}
 	if cycleLength <= 0 {
 		return 0, false
 	}
+	// codecov:ignore:end
 
 	window := PredictCycleWindow(previousStart, cycleLength, stats.LutealPhase)
 	if !window.Calculable || window.OvulationDate.IsZero() {

--- a/internal/services/cycle_start_policy_coverage_test.go
+++ b/internal/services/cycle_start_policy_coverage_test.go
@@ -8,9 +8,10 @@ package services
 //   61            – AddDate(0,0,-1) offset: anchor search must stop *before* targetDay
 //   80            – filterLogsNotAfter(logs, targetDay.AddDate(0,0,-1)): targetDay log excluded from stats
 //   81            – BuildCycleStats(filtered, targetDay.Add(-time.Second)): equivalent, no test needed
-//   83, 86        – cycleLength <= 0 guards after predictedCycleLength / DashboardCycleReferenceLength:
-//                   equivalent (both callees always return > 0), no test needed
-//   103           – nil-location guard in LatestCycleStartAnchorBeforeOrOn
+//   92, 95        – cycleLength <= 0 guards after predictedCycleLength / DashboardCycleReferenceLength:
+//                   equivalent (unreachable from this caller — the reason is
+//                   recorded at the codecov:ignore block there), no test needed
+//   118           – nil-location guard in LatestCycleStartAnchorBeforeOrOn
 
 import (
 	"testing"

--- a/internal/services/cycle_start_policy_mutation_round3_test.go
+++ b/internal/services/cycle_start_policy_mutation_round3_test.go
@@ -7,20 +7,19 @@ import (
 	"github.com/ovumcy/ovumcy-web/internal/models"
 )
 
-// TestMR3Cycles_PotentialImplantationZeroCycleLengthFallback pins
-// implantation detection for the no-observed-data path. NOTE on
-// cycle_start_policy.go:83 BOUNDARY `if cycleLength <= 0` (-> `< 0`): that
-// mutant is EQUIVALENT because the guard is effectively dead.
-// predictedCycleLength never returns <= 0 — its final fallback returns
-// models.DefaultCycleLength (28) — so cycleLength is always positive here and
-// the DashboardCycleReferenceLength branch is unreachable in practice. The
-// `<= 0` vs `< 0` distinction therefore has no observable effect. This test
-// still pins the real behavior: implantation detection fires on the no-data
-// path (using the default 28-day cycle that predictedCycleLength supplies).
-func TestMR3Cycles_PotentialImplantationZeroCycleLengthFallback(t *testing.T) {
+// TestMR3Cycles_PotentialImplantationUsesTheDefaultCycleLengthWithoutLogs pins
+// implantation detection for the no-observed-data path: with no daily logs
+// predictedCycleLength falls through to models.DefaultCycleLength (28) and the
+// detection runs on that default. It does NOT cover the
+// cycleLength <= 0 fallback at cycle_start_policy.go:83-88 — nothing this
+// caller can build reaches it (the reason is recorded there), which is why the
+// `<= 0` -> `< 0` mutant on those two lines is equivalent and why the name no
+// longer advertises a zero-cycle-length fallback.
+func TestMR3Cycles_PotentialImplantationUsesTheDefaultCycleLengthWithoutLogs(t *testing.T) {
 	location := time.UTC
 	// Owner with a configured 28-day cycle and an explicit last period start,
-	// but NO daily logs -> no observed cycle lengths -> predictedCycleLength==0.
+	// but NO daily logs -> no observed cycle lengths -> predictedCycleLength
+	// returns its models.DefaultCycleLength (28) fallback.
 	lastPeriod := mr3cycDay(2026, time.March, 1)
 	user := &models.User{
 		Role:            models.RoleOwner,
@@ -38,7 +37,7 @@ func TestMR3Cycles_PotentialImplantationZeroCycleLengthFallback(t *testing.T) {
 
 	policy := ResolveManualCycleStartPolicy(user, nil, target, now, location)
 	if !policy.PotentialImplantation {
-		t.Fatalf("expected implantation detection via cycle-length fallback, got none (gap=%d)",
+		t.Fatalf("expected implantation detection on the default 28-day cycle, got none (gap=%d)",
 			policy.ImplantationGapDays)
 	}
 }

--- a/internal/services/date_i18n_policy.go
+++ b/internal/services/date_i18n_policy.go
@@ -6,124 +6,120 @@ import (
 	"time"
 )
 
-var monthNames = map[string][]string{
-	"de": {"Januar", "Februar", "März", "April", "Mai", "Juni", "Juli", "August", "September", "Oktober", "November", "Dezember"},
-	"en": {"January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"},
-	"es": {"Enero", "Febrero", "Marzo", "Abril", "Mayo", "Junio", "Julio", "Agosto", "Septiembre", "Octubre", "Noviembre", "Diciembre"},
-	"fr": {"Janvier", "Février", "Mars", "Avril", "Mai", "Juin", "Juillet", "Août", "Septembre", "Octobre", "Novembre", "Décembre"},
-	"ru": {"Январь", "Февраль", "Март", "Апрель", "Май", "Июнь", "Июль", "Август", "Сентябрь", "Октябрь", "Ноябрь", "Декабрь"},
-	"it": {"Gennaio", "Febbraio", "Marzo", "Aprile", "Maggio", "Giugno", "Luglio", "Agosto", "Settembre", "Ottobre", "Novembre", "Dicembre"},
+// localizedDateNames carries every calendar form one language needs. One entry
+// per language replaces the five parallel maps this file used to keep: adding
+// a language is a single literal in a single place instead of five coordinated
+// edits that nothing forces you to finish, and a missing form shows up as an
+// empty string in one table rather than as an English date on one surface.
+// TestLocalizedDateFormsCoverEveryRequiredLocale is what fails when an entry is
+// incomplete or absent.
+//
+// The three month forms are genuinely different words, not a duplication:
+//   - months is the standalone heading form, title-cased where the UI wants a
+//     capital (es "Enero", fr "Janvier", it "Gennaio") even though the language
+//     writes months lowercase in running text;
+//   - monthsLong is that running-text form, which for Russian is also the
+//     required genitive ("января", not "Январь");
+//   - monthsShort is the abbreviation.
+//
+// The arrays are fixed-size on purpose: time.Month() is always 1-12 and
+// time.Weekday() always 0-6, so every index below is in range by construction
+// and no length check stands between the lookup and the rendered string.
+type localizedDateNames struct {
+	months        [12]string
+	monthsLong    [12]string
+	monthsShort   [12]string
+	weekdaysShort [7]string
+	weekdaysLong  [7]string
 }
 
-var monthLongNames = map[string][]string{
-	"de": {"Januar", "Februar", "März", "April", "Mai", "Juni", "Juli", "August", "September", "Oktober", "November", "Dezember"},
-	"en": {"January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"},
-	"es": {"enero", "febrero", "marzo", "abril", "mayo", "junio", "julio", "agosto", "septiembre", "octubre", "noviembre", "diciembre"},
-	"fr": {"janvier", "février", "mars", "avril", "mai", "juin", "juillet", "août", "septembre", "octobre", "novembre", "décembre"},
-	"ru": {"января", "февраля", "марта", "апреля", "мая", "июня", "июля", "августа", "сентября", "октября", "ноября", "декабря"},
-	"it": {"gennaio", "febbraio", "marzo", "aprile", "maggio", "giugno", "luglio", "agosto", "settembre", "ottobre", "novembre", "dicembre"},
-}
-
-var weekdayShortNames = map[string][]string{
-	"de": {"So.", "Mo.", "Di.", "Mi.", "Do.", "Fr.", "Sa."},
-	"en": {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"},
-	"es": {"dom", "lun", "mar", "mié", "jue", "vie", "sáb"},
-	"fr": {"dim", "lun", "mar", "mer", "jeu", "ven", "sam"},
-	"ru": {"Вс", "Пн", "Вт", "Ср", "Чт", "Пт", "Сб"},
-	"it": {"dom", "lun", "mar", "mer", "gio", "ven", "sab"},
-}
-
-var weekdayLongNames = map[string][]string{
-	"de": {"Sonntag", "Montag", "Dienstag", "Mittwoch", "Donnerstag", "Freitag", "Samstag"},
-	"en": {"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"},
-	"es": {"domingo", "lunes", "martes", "miércoles", "jueves", "viernes", "sábado"},
-	"fr": {"dimanche", "lundi", "mardi", "mercredi", "jeudi", "vendredi", "samedi"},
-	"ru": {"воскресенье", "понедельник", "вторник", "среда", "четверг", "пятница", "суббота"},
-	"it": {"domenica", "lunedì", "martedì", "mercoledì", "giovedì", "venerdì", "sabato"},
-}
-
-var monthShortNames = map[string][]string{
-	"de": {"Jan.", "Feb.", "Mär.", "Apr.", "Mai", "Juni", "Juli", "Aug.", "Sep.", "Okt.", "Nov.", "Dez."},
-	"en": {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"},
-	"es": {"ene", "feb", "mar", "abr", "may", "jun", "jul", "ago", "sep", "oct", "nov", "dic"},
-	"fr": {"jan", "fév", "mar", "avr", "mai", "jun", "jul", "aoû", "sep", "oct", "nov", "déc"},
-	"ru": {"Янв", "Фев", "Мар", "Апр", "Май", "Июн", "Июл", "Авг", "Сен", "Окт", "Ноя", "Дек"},
-	"it": {"gen", "feb", "mar", "apr", "mag", "giu", "lug", "ago", "set", "ott", "nov", "dic"},
+var dateNames = map[string]localizedDateNames{
+	"de": {
+		months:        [12]string{"Januar", "Februar", "März", "April", "Mai", "Juni", "Juli", "August", "September", "Oktober", "November", "Dezember"},
+		monthsLong:    [12]string{"Januar", "Februar", "März", "April", "Mai", "Juni", "Juli", "August", "September", "Oktober", "November", "Dezember"},
+		monthsShort:   [12]string{"Jan.", "Feb.", "Mär.", "Apr.", "Mai", "Juni", "Juli", "Aug.", "Sep.", "Okt.", "Nov.", "Dez."},
+		weekdaysShort: [7]string{"So.", "Mo.", "Di.", "Mi.", "Do.", "Fr.", "Sa."},
+		weekdaysLong:  [7]string{"Sonntag", "Montag", "Dienstag", "Mittwoch", "Donnerstag", "Freitag", "Samstag"},
+	},
+	"en": {
+		months:        [12]string{"January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"},
+		monthsLong:    [12]string{"January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"},
+		monthsShort:   [12]string{"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"},
+		weekdaysShort: [7]string{"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"},
+		weekdaysLong:  [7]string{"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"},
+	},
+	"es": {
+		months:        [12]string{"Enero", "Febrero", "Marzo", "Abril", "Mayo", "Junio", "Julio", "Agosto", "Septiembre", "Octubre", "Noviembre", "Diciembre"},
+		monthsLong:    [12]string{"enero", "febrero", "marzo", "abril", "mayo", "junio", "julio", "agosto", "septiembre", "octubre", "noviembre", "diciembre"},
+		monthsShort:   [12]string{"ene", "feb", "mar", "abr", "may", "jun", "jul", "ago", "sep", "oct", "nov", "dic"},
+		weekdaysShort: [7]string{"dom", "lun", "mar", "mié", "jue", "vie", "sáb"},
+		weekdaysLong:  [7]string{"domingo", "lunes", "martes", "miércoles", "jueves", "viernes", "sábado"},
+	},
+	"fr": {
+		months:        [12]string{"Janvier", "Février", "Mars", "Avril", "Mai", "Juin", "Juillet", "Août", "Septembre", "Octobre", "Novembre", "Décembre"},
+		monthsLong:    [12]string{"janvier", "février", "mars", "avril", "mai", "juin", "juillet", "août", "septembre", "octobre", "novembre", "décembre"},
+		monthsShort:   [12]string{"jan", "fév", "mar", "avr", "mai", "jun", "jul", "aoû", "sep", "oct", "nov", "déc"},
+		weekdaysShort: [7]string{"dim", "lun", "mar", "mer", "jeu", "ven", "sam"},
+		weekdaysLong:  [7]string{"dimanche", "lundi", "mardi", "mercredi", "jeudi", "vendredi", "samedi"},
+	},
+	"ru": {
+		months:        [12]string{"Январь", "Февраль", "Март", "Апрель", "Май", "Июнь", "Июль", "Август", "Сентябрь", "Октябрь", "Ноябрь", "Декабрь"},
+		monthsLong:    [12]string{"января", "февраля", "марта", "апреля", "мая", "июня", "июля", "августа", "сентября", "октября", "ноября", "декабря"},
+		monthsShort:   [12]string{"Янв", "Фев", "Мар", "Апр", "Май", "Июн", "Июл", "Авг", "Сен", "Окт", "Ноя", "Дек"},
+		weekdaysShort: [7]string{"Вс", "Пн", "Вт", "Ср", "Чт", "Пт", "Сб"},
+		weekdaysLong:  [7]string{"воскресенье", "понедельник", "вторник", "среда", "четверг", "пятница", "суббота"},
+	},
+	"it": {
+		months:        [12]string{"Gennaio", "Febbraio", "Marzo", "Aprile", "Maggio", "Giugno", "Luglio", "Agosto", "Settembre", "Ottobre", "Novembre", "Dicembre"},
+		monthsLong:    [12]string{"gennaio", "febbraio", "marzo", "aprile", "maggio", "giugno", "luglio", "agosto", "settembre", "ottobre", "novembre", "dicembre"},
+		monthsShort:   [12]string{"gen", "feb", "mar", "apr", "mag", "giu", "lug", "ago", "set", "ott", "nov", "dic"},
+		weekdaysShort: [7]string{"dom", "lun", "mar", "mer", "gio", "ven", "sab"},
+		weekdaysLong:  [7]string{"domenica", "lunedì", "martedì", "mercoledì", "giovedì", "venerdì", "sabato"},
+	},
 }
 
 func LocalizedMonthYear(language string, value time.Time) string {
-	names, ok := monthNames[dateLanguageOrDefault(language)]
-	if !ok || len(names) < 12 {
-		return value.Format("January 2006")
-	}
-	monthIndex := int(value.Month()) - 1
-	if monthIndex < 0 || monthIndex >= len(names) {
-		return value.Format("January 2006")
-	}
-	return fmt.Sprintf("%s %d", names[monthIndex], value.Year())
+	_, names := dateNamesFor(language)
+	return fmt.Sprintf("%s %d", names.months[monthIndex(value)], value.Year())
 }
 
 func LocalizedDateLabel(language string, value time.Time) string {
-	lang := dateLanguageOrDefault(language)
-	weekdays, weekdaysOK := weekdayShortNames[lang]
-	months, monthsOK := monthShortNames[lang]
-	if !weekdaysOK || !monthsOK {
-		return value.Format("Mon, Jan 2")
-	}
-	monthIndex := int(value.Month()) - 1
-	if monthIndex < 0 || monthIndex >= len(months) {
-		return value.Format("Mon, Jan 2")
-	}
+	lang, names := dateNamesFor(language)
+	weekday := names.weekdaysShort[int(value.Weekday())]
+	month := names.monthsShort[monthIndex(value)]
 
-	weekday := weekdays[int(value.Weekday())]
-	month := months[monthIndex]
-	if lang == "ru" {
-		longMonths := monthLongNames[lang]
-		if monthIndex < 0 || monthIndex >= len(longMonths) {
-			return value.Format("Mon, Jan 2")
-		}
-		return fmt.Sprintf("%s, %d %s", weekday, value.Day(), longMonths[monthIndex])
-	}
-	if lang == "es" {
+	switch lang {
+	case "ru":
+		return fmt.Sprintf("%s, %d %s", weekday, value.Day(), names.monthsLong[monthIndex(value)])
+	case "es":
 		return fmt.Sprintf("%s, %d %s", weekday, value.Day(), month)
-	}
-	if lang == "de" {
+	case "de":
 		return fmt.Sprintf("%s, %d. %s", weekday, value.Day(), month)
-	}
-	if lang == "fr" || lang == "it" {
+	case "fr", "it":
 		return fmt.Sprintf("%s %d %s", weekday, value.Day(), month)
+	default:
+		return fmt.Sprintf("%s, %s %d", weekday, month, value.Day())
 	}
-	return fmt.Sprintf("%s, %s %d", weekday, month, value.Day())
 }
 
 func LocalizedDashboardDate(language string, value time.Time) string {
-	lang := dateLanguageOrDefault(language)
-	weekdays, weekdaysOK := weekdayLongNames[lang]
-	months, monthsOK := monthLongNames[lang]
-	if !weekdaysOK || !monthsOK {
-		return value.Format("January 2, 2006, Monday")
-	}
-	monthIndex := int(value.Month()) - 1
-	if monthIndex < 0 || monthIndex >= len(months) {
-		return value.Format("January 2, 2006, Monday")
-	}
+	lang, names := dateNamesFor(language)
+	weekday := names.weekdaysLong[int(value.Weekday())]
+	month := names.monthsLong[monthIndex(value)]
 
-	weekday := weekdays[int(value.Weekday())]
-	month := months[monthIndex]
-	if lang == "ru" {
+	switch lang {
+	case "ru":
 		return fmt.Sprintf("%d %s %d, %s", value.Day(), month, value.Year(), weekday)
-	}
-	if lang == "es" {
+	case "es":
 		return fmt.Sprintf("%d de %s de %d, %s", value.Day(), month, value.Year(), weekday)
-	}
-	if lang == "de" {
+	case "de":
 		return fmt.Sprintf("%s, %d. %s %d", weekday, value.Day(), month, value.Year())
-	}
-	if lang == "fr" || lang == "it" {
+	case "fr", "it":
 		// French and Italian: "lundi 21 mars 2026" / "lunedì 21 luglio 2026"
 		return fmt.Sprintf("%s %d %s %d", weekday, value.Day(), month, value.Year())
+	default:
+		return fmt.Sprintf("%s %d, %d, %s", month, value.Day(), value.Year(), weekday)
 	}
-	return fmt.Sprintf("%s %d, %d, %s", month, value.Day(), value.Year(), weekday)
 }
 
 func LocalizedDateDisplay(language string, value time.Time) string {
@@ -136,14 +132,14 @@ func LocalizedDateShort(language string, value time.Time) string {
 
 // localizedDayMonth renders the compact day-month form shared by
 // LocalizedDateDisplay and LocalizedDateShort — the two differ only by the
-// year suffix, so the per-language ladder lives here once. Adding a sixth
+// year suffix, so the per-language ladder lives here once. Adding a seventh
 // language means one new case, not two.
 func localizedDayMonth(language string, value time.Time, withYear bool) string {
 	if value.IsZero() {
 		return ""
 	}
 
-	lang := dateLanguageOrDefault(language)
+	lang, names := dateNamesFor(language)
 	if lang == "ru" {
 		if withYear {
 			return value.Format("02.01.2006")
@@ -151,28 +147,7 @@ func localizedDayMonth(language string, value time.Time, withYear bool) string {
 		return value.Format("02.01")
 	}
 
-	months := monthShortNames[lang]
-	monthIndex := int(value.Month()) - 1
-	if monthIndex < 0 || monthIndex >= len(months) {
-		// codecov:ignore:start -- defensive fallback: time.Month() is always
-		// 1-12 for any time.Time (time.Date normalizes out-of-range months)
-		// and every monthShortNames table has 12 entries, so this branch is
-		// unreachable. Kept so a future table edit degrades to a stdlib
-		// format instead of an index panic.
-		switch {
-		case lang == "en" && withYear:
-			return value.Format("Jan 2, 2006")
-		case lang == "en":
-			return value.Format("Jan 2")
-		case withYear:
-			return value.Format("2 Jan 2006")
-		default:
-			return value.Format("2 Jan")
-		}
-		// codecov:ignore:end
-	}
-	month := months[monthIndex]
-
+	month := names.monthsShort[monthIndex(value)]
 	switch lang {
 	case "es", "fr", "it":
 		if withYear {
@@ -192,10 +167,21 @@ func localizedDayMonth(language string, value time.Time, withYear bool) string {
 	}
 }
 
-func dateLanguageOrDefault(language string) string {
+// dateNamesFor resolves language to a table this file actually carries — the
+// language itself when it has one, English otherwise — and returns the
+// normalized language alongside it, because the ladders above still switch on
+// the language for word order and separators.
+func dateNamesFor(language string) (string, localizedDateNames) {
 	normalized := strings.ToLower(strings.TrimSpace(language))
-	if _, ok := monthNames[normalized]; ok {
-		return normalized
+	if names, ok := dateNames[normalized]; ok {
+		return normalized, names
 	}
-	return "en"
+	return "en", dateNames["en"]
+}
+
+// monthIndex converts a time to a 0-based month index. time.Month() is 1-12 for
+// every time.Time (time.Date normalizes an out-of-range month into the year),
+// so the result is always a valid index into a [12]string.
+func monthIndex(value time.Time) int {
+	return int(value.Month()) - 1
 }

--- a/internal/services/date_i18n_policy_coverage_test.go
+++ b/internal/services/date_i18n_policy_coverage_test.go
@@ -2,47 +2,35 @@ package services
 
 // date_i18n_policy_coverage_test.go
 //
-// Targets surviving mutants at lines 55, 69, 77, 102, 136, 144, 152, 161,
-// 179, 187, 195, 204 of internal/services/date_i18n_policy.go.
+// Per-locale January assertions for LocalizedMonthYear, LocalizedDateLabel and
+// LocalizedDashboardDate in internal/services/date_i18n_policy.go.
 //
-// The monthIndex bounds guards in LocalizedDateDisplay and LocalizedDateShort
-// (the shared localizedDayMonth) have a fallback BODY that is unreachable dead
-// code: time.Month is always 1-12 and every locale slice has 12 entries, so the
-// UPPER-bound term (monthIndex >= len(...)) never trips and its boundary/`||→&&`
-// mutations are equivalent. The LOWER-bound term (monthIndex < 0) is NOT
-// equivalent: a `< 0 → <= 0` (or its negation) redirects January onto the
-// stdlib fallback, and at a 3-digit year that fallback's 4-digit zero-padded
-// year differs from the locale path's %d year — observable, and already killed
-// by date_i18n_policy_mutation_test.go
-// (TestLocalizedDateDisplayEnglishJanuaryThreeDigitYear /
-// ...AlwaysLocalePathThreeDigitYear).
-//
-// Lines 55, 69, 77, 102 guard LocalizedMonthYear, LocalizedDateLabel, and
-// LocalizedDashboardDate. The existing tests only use February (monthIndex=1).
-// A relational-operator mutation of "< 0" to "<= 0" would silently redirect
-// January (monthIndex=0) to the English fallback path, which produces a
-// different string for non-English locales. Tests below use January to close
-// that gap.
+// These were written against monthIndex bounds guards that no longer exist:
+// the five parallel name maps became one fixed-size table per language
+// (localizedDateNames), and with [12]string / [7]string fields every index is
+// in range by construction — time.Month() is 1-12 and time.Weekday() is 0-6 —
+// so there is no lower-bound term to mutate and no stdlib fallback to be
+// redirected onto. What survives here is what was always worth keeping: each
+// locale renders January in its own words, which fails if a language's forms
+// go missing or the language dispatch is mutated. Table completeness for a
+// newly added locale is TestLocalizedDateFormsCoverEveryRequiredLocale's job.
 
 import (
 	"testing"
 	"time"
 )
 
-// datei18npolicyCovJanuary is the date used across all coverage tests below.
-// January (monthIndex=0) is the specific value needed to catch mutations that
-// change the lower-bound check from "< 0" to "<= 0".
+// datei18npolicyCovJanuary is the date used across all coverage tests below:
+// the first month and a weekday whose name differs in every supported language.
 var datei18npolicyCovJanuary = time.Date(2026, time.January, 5, 0, 0, 0, 0, time.UTC) // Monday
 
 // ---------------------------------------------------------------------------
-// LocalizedMonthYear – line 55 guard
+// LocalizedMonthYear
 // ---------------------------------------------------------------------------
 
-// TestDateI18nPolicyMonthYearJanuary ensures that January is formatted with
-// the locale-specific name, not the English fallback.  A mutation of
-// "monthIndex < 0" to "monthIndex <= 0" would redirect index 0 (January) to
-// value.Format("January 2006"), producing "January 2026" for every locale
-// instead of the expected translated month name.
+// TestDateI18nPolicyMonthYearJanuary ensures that January is formatted with the
+// locale-specific standalone month name — the heading form, title-cased where
+// the language's running-text form is not.
 func TestDateI18nPolicyMonthYearJanuary(t *testing.T) {
 	tests := []struct {
 		lang string
@@ -66,22 +54,20 @@ func TestDateI18nPolicyMonthYearJanuary(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// LocalizedDateLabel – line 69 guard (all locales) and line 77 guard (ru)
+// LocalizedDateLabel (all locales, and the Russian long-month path)
 // ---------------------------------------------------------------------------
 
 // TestDateI18nPolicyDateLabelJanuary ensures that January is formatted with
-// locale-specific month names.  The mutations guarded at lines 69 and 77 would
-// cause January to fall through to the English fallback "Mon, Jan 5" instead
-// of the correct translated representation.
+// locale-specific month names, including the Russian arm that reaches for the
+// genitive long form instead of the abbreviation the others use.
 func TestDateI18nPolicyDateLabelJanuary(t *testing.T) {
 	// Jan 5, 2026 is a Monday.
 	tests := []struct {
 		lang string
 		want string
 	}{
-		// Line 69 guard (general) + line 77 guard (ru long-month lookup)
+		// The Russian arm renders the genitive long month, not the abbreviation.
 		{"ru", "Пн, 5 января"},
-		// Line 69 guard for other locales
 		{"de", "Mo., 5. Jan."},
 		{"es", "lun, 5 ene"},
 		{"fr", "lun 5 jan"},
@@ -99,13 +85,12 @@ func TestDateI18nPolicyDateLabelJanuary(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// LocalizedDashboardDate – line 102 guard
+// LocalizedDashboardDate
 // ---------------------------------------------------------------------------
 
-// TestDateI18nPolicyDashboardDateJanuary ensures that January is formatted
-// with locale-specific month names rather than the English fallback.  A
-// "monthIndex <= 0" mutation on line 102 would redirect January to
-// value.Format("January 2, 2006, Monday") for every locale.
+// TestDateI18nPolicyDashboardDateJanuary ensures that January is formatted with
+// locale-specific long month and weekday names, in each language's own word
+// order.
 func TestDateI18nPolicyDashboardDateJanuary(t *testing.T) {
 	// Jan 5, 2026 is a Monday.
 	tests := []struct {

--- a/internal/services/date_i18n_policy_locale_test.go
+++ b/internal/services/date_i18n_policy_locale_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -71,6 +72,39 @@ func TestLocalizedDateFormsCoverEveryRequiredLocale(t *testing.T) {
 			english := render(i18n.LangEN, value)
 			if got := render(language, value); got == english {
 				t.Errorf("%s: locale %q renders the English form %q", name, language, english)
+			}
+		}
+	}
+}
+
+// TestLocalizedDateFormsFallBackToEnglishForAnUnknownLanguage pins the arm the
+// sweep above cannot reach: every language it walks has a table entry, so the
+// lookup's miss branch is only taken by a language that is not in the table at
+// all. The tables replaced per-form length checks and stdlib fallbacks, so this
+// one branch is now the whole safety net — a language string that reaches these
+// renderers from outside the supported set must render English words, never the
+// zero value of a fixed-size array.
+func TestLocalizedDateFormsFallBackToEnglishForAnUnknownLanguage(t *testing.T) {
+	value := time.Date(2026, time.January, 5, 0, 0, 0, 0, time.UTC)
+	renderers := map[string]func(string, time.Time) string{
+		"LocalizedMonthYear":     LocalizedMonthYear,
+		"LocalizedDateLabel":     LocalizedDateLabel,
+		"LocalizedDashboardDate": LocalizedDashboardDate,
+		"LocalizedDateDisplay":   LocalizedDateDisplay,
+		"LocalizedDateShort":     LocalizedDateShort,
+	}
+
+	// "" is the unset language every request-free surface can carry; "zz" is a
+	// well-formed code no catalogue defines.
+	for _, language := range []string{"", "zz", "en-GB"} {
+		for name, render := range renderers {
+			want := render(i18n.LangEN, value)
+			got := render(language, value)
+			if got != want {
+				t.Errorf("%s(%q) = %q, want the English rendering %q", name, language, got, want)
+			}
+			if strings.TrimSpace(got) == "" {
+				t.Errorf("%s(%q) rendered blank: the lookup returned a zero-valued table", name, language)
 			}
 		}
 	}

--- a/internal/services/date_i18n_policy_locale_test.go
+++ b/internal/services/date_i18n_policy_locale_test.go
@@ -1,0 +1,77 @@
+package services
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/i18n"
+)
+
+// TestLocalizedDateFormsCoverEveryRequiredLocale is the sweep mechanism for the
+// dateNames table, the same shape as
+// TestLocalizedSymptomFrequencySummaryCoversEveryRequiredLocale one file over.
+// Month and weekday names live in Go source rather than under a locale JSON
+// key, so TestLocaleKeysParity and the rest of the six-file parity machinery
+// cannot see them: a seventh locale is added by dropping a JSON file in, which
+// extends SupportedLanguages automatically, and every date on the calendar
+// header, the day label and the dashboard would silently render in English
+// while every keyed string switched. Nothing would fail.
+//
+// This walks every locale the i18n manager reports and requires (a) a complete
+// dateNames entry for it and (b) each rendered date to diverge from the English
+// one. It deliberately does not pin translated wording — date_i18n_policy_test.go
+// and the coverage tests do that — so it fails when a locale's forms are
+// missing, not when copy changes.
+func TestLocalizedDateFormsCoverEveryRequiredLocale(t *testing.T) {
+	manager, err := i18n.NewManager(i18n.LangEN)
+	if err != nil {
+		t.Fatalf("init i18n manager: %v", err)
+	}
+
+	languages := manager.SupportedLanguages()
+	if len(languages) == 0 {
+		t.Fatal("expected the i18n manager to report supported languages")
+	}
+
+	// Monday, 5 January 2026: a month and a weekday whose names differ in every
+	// currently supported language.
+	value := time.Date(2026, time.January, 5, 0, 0, 0, 0, time.UTC)
+
+	renderers := map[string]func(string, time.Time) string{
+		"LocalizedMonthYear":     LocalizedMonthYear,
+		"LocalizedDateLabel":     LocalizedDateLabel,
+		"LocalizedDashboardDate": LocalizedDashboardDate,
+		"LocalizedDateDisplay":   LocalizedDateDisplay,
+		"LocalizedDateShort":     LocalizedDateShort,
+	}
+
+	for _, language := range languages {
+		names, ok := dateNames[language]
+		if !ok {
+			t.Errorf("locale %q has no dateNames entry: every date surface renders it in English", language)
+			continue
+		}
+		for index, month := range names.months {
+			if month == "" || names.monthsLong[index] == "" || names.monthsShort[index] == "" {
+				t.Errorf("locale %q is missing a month form at index %d (standalone=%q long=%q short=%q)",
+					language, index, month, names.monthsLong[index], names.monthsShort[index])
+			}
+		}
+		for index, weekday := range names.weekdaysShort {
+			if weekday == "" || names.weekdaysLong[index] == "" {
+				t.Errorf("locale %q is missing a weekday form at index %d (short=%q long=%q)",
+					language, index, weekday, names.weekdaysLong[index])
+			}
+		}
+
+		if language == i18n.LangEN {
+			continue
+		}
+		for name, render := range renderers {
+			english := render(i18n.LangEN, value)
+			if got := render(language, value); got == english {
+				t.Errorf("%s: locale %q renders the English form %q", name, language, english)
+			}
+		}
+	}
+}

--- a/internal/services/date_i18n_policy_mutation_round3_test.go
+++ b/internal/services/date_i18n_policy_mutation_round3_test.go
@@ -9,8 +9,9 @@ func mr3i18nDate(year int, month time.Month, day int) time.Time {
 	return time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
 }
 
-// date_i18n_policy.go:55:34 BOUNDARY `monthIndex < 0`->`<= 0`.
-// January -> monthIndex 0; with `<= 0` the guard fires and returns English.
+// LocalizedMonthYear renders the Russian standalone (nominative) month name,
+// not the genitive running-text form and not the English default. January is
+// the first index into the table, so it also pins the 0-based conversion.
 func TestMR3I18n_LocalizedMonthYearRuJanuary(t *testing.T) {
 	got := LocalizedMonthYear("ru", mr3i18nDate(2026, time.January, 1))
 	if want := "Январь 2026"; got != want {
@@ -18,9 +19,8 @@ func TestMR3I18n_LocalizedMonthYearRuJanuary(t *testing.T) {
 	}
 }
 
-// date_i18n_policy.go:69:34 BOUNDARY in LocalizedDateLabel.
-// date_i18n_policy.go:77:35 BOUNDARY (ru long-month guard) -- January keeps both
-// guards on the in-range side; mutating either to `<= 0` flips January's branch.
+// LocalizedDateLabel's Russian arm pairs the short weekday with the genitive
+// long month — the one language where the label does not use the abbreviation.
 func TestMR3I18n_LocalizedDateLabelRuJanuary(t *testing.T) {
 	// 2026-01-05 is a Monday.
 	got := LocalizedDateLabel("ru", mr3i18nDate(2026, time.January, 5))
@@ -29,7 +29,8 @@ func TestMR3I18n_LocalizedDateLabelRuJanuary(t *testing.T) {
 	}
 }
 
-// date_i18n_policy.go:102:34 BOUNDARY in LocalizedDashboardDate.
+// LocalizedDashboardDate's Russian arm: day, genitive month, year, then the
+// long weekday last.
 func TestMR3I18n_LocalizedDashboardDateRuJanuary(t *testing.T) {
 	// 2026-01-05 is a Monday -> понедельник.
 	got := LocalizedDashboardDate("ru", mr3i18nDate(2026, time.January, 5))

--- a/internal/services/date_i18n_policy_mutation_test.go
+++ b/internal/services/date_i18n_policy_mutation_test.go
@@ -5,31 +5,29 @@ import (
 	"time"
 )
 
-func TestLocalizedDateDisplayEnglishJanuaryThreeDigitYear(t *testing.T) {
-	// monthIndex==0 (January) is the only index where `monthIndex < 0` differs
-	// from the mutated `monthIndex <= 0`. A 3-digit year makes the locale path
-	// (year via %d) differ from the bounds-fallback value.Format("Jan 2, 2006")
-	// (year zero-padded to 4 digits), so taking the fallback is observable.
-	value := time.Date(999, time.January, 5, 0, 0, 0, 0, time.UTC)
-
-	got := LocalizedDateDisplay("en", value)
-	want := "Jan 5, 999"
-	if got != want {
-		t.Fatalf("expected %q, got %q", want, got)
+// TestLocalizedDateDisplayRendersAnUnpaddedYear pins the year rendering of the
+// compact day-month form. Both cases used to exist to kill boundary mutants on
+// the `monthIndex < 0` terms in localizedDayMonth: a 3-digit year was the way
+// to observe the stdlib fallback, whose "2006" layout zero-pads the year while
+// the locale path prints it with %d. The fixed-size [12]string tables removed
+// both the bounds terms and the fallback, so what is left is the assertion that
+// was always about behaviour — the year is printed as written, in January as in
+// any other month.
+func TestLocalizedDateDisplayRendersAnUnpaddedYear(t *testing.T) {
+	tests := []struct {
+		name  string
+		value time.Time
+		want  string
+	}{
+		{name: "january", value: time.Date(999, time.January, 5, 0, 0, 0, 0, time.UTC), want: "Jan 5, 999"},
+		{name: "february", value: time.Date(999, time.February, 5, 0, 0, 0, 0, time.UTC), want: "Feb 5, 999"},
 	}
-}
 
-func TestLocalizedDateDisplayEnglishAlwaysLocalePathThreeDigitYear(t *testing.T) {
-	// Negating `monthIndex < 0` to `monthIndex >= 0` makes the bounds guard
-	// always true, forcing every month onto the fallback value.Format("Jan 2, 2006").
-	// February (monthIndex==1) is unaffected by the January-only boundary flip,
-	// so it specifically pins the always-locale-path behavior. A 3-digit year
-	// exposes the fallback via year zero-padding.
-	value := time.Date(999, time.February, 5, 0, 0, 0, 0, time.UTC)
-
-	got := LocalizedDateDisplay("en", value)
-	want := "Feb 5, 999"
-	if got != want {
-		t.Fatalf("expected %q, got %q", want, got)
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := LocalizedDateDisplay("en", testCase.value); got != testCase.want {
+				t.Fatalf("LocalizedDateDisplay(en, %s) = %q, want %q", testCase.name, got, testCase.want)
+			}
+		})
 	}
 }

--- a/internal/services/day_feedback_dst_walk_test.go
+++ b/internal/services/day_feedback_dst_walk_test.go
@@ -173,7 +173,7 @@ func TestResolveDayFeedbackDoesNotMergeTwoPeriodsAcrossTheDSTMidnightGap(t *test
 			t.Fatalf("AcknowledgeLongPeriodWarning() unexpected error: %v", err)
 		}
 	}
-	if stored := users.settings.LongPeriodWarnedAt; stored != nil {
+	if stored := users.settings.LongPeriodWarningCycleStart; stored != nil {
 		t.Fatalf("long_period_warning_cycle_start = %s, want no write at all", stored.Format("2006-01-02"))
 	}
 }

--- a/internal/services/day_feedback_policy.go
+++ b/internal/services/day_feedback_policy.go
@@ -54,7 +54,7 @@ func (service *DayService) ResolveDayFeedback(ctx context.Context, user *models.
 	}
 
 	streakLength, cycleStart, ok := currentPeriodStreakAtDay(logs, day, location)
-	if ok && streakLength > 8 && (user == nil || user.LongPeriodWarnedAt == nil || !sameCalendarDay(CalendarDay(*user.LongPeriodWarnedAt, location), cycleStart)) {
+	if ok && streakLength > 8 && (user.LongPeriodWarningCycleStart == nil || !sameCalendarDay(CalendarDay(*user.LongPeriodWarningCycleStart, location), cycleStart)) {
 		state.ShowLongPeriodWarning = true
 		state.LongPeriodCycleStart = cycleStart
 	}
@@ -79,6 +79,9 @@ func (service *DayService) AcknowledgeLongPeriodWarning(ctx context.Context, use
 	})
 }
 
+// resolveDaySaveMessageKey requires a non-nil user: its only caller,
+// ResolveDayFeedback, dereferences user.ID before it gets here, so a nil user
+// panics there rather than reaching a guard in this package.
 func resolveDaySaveMessageKey(user *models.User, day time.Time, stats CycleStats) string {
 	// A positive pregnancy test pauses predictions (ResolvePregnancyPause);
 	// explain the pause right at save time instead of a routine
@@ -86,7 +89,7 @@ func resolveDaySaveMessageKey(user *models.User, day time.Time, stats CycleStats
 	if stats.PregnancyPaused {
 		return daySaveMessagePregnancyPaused
 	}
-	if user != nil && user.UnpredictableCycle {
+	if user.UnpredictableCycle {
 		return daySaveMessageNeutral
 	}
 	// `day` arrives as a location-midnight working value while the stats

--- a/internal/services/day_feedback_policy_mutation_test.go
+++ b/internal/services/day_feedback_policy_mutation_test.go
@@ -18,10 +18,10 @@ func TestAcknowledgeLongPeriodWarningNormalizesCycleStartToMidnight(t *testing.T
 	if err := service.AcknowledgeLongPeriodWarning(context.Background(), 10, cycleStart, time.UTC); err != nil {
 		t.Fatalf("AcknowledgeLongPeriodWarning() unexpected error: %v", err)
 	}
-	if users.settings.LongPeriodWarnedAt == nil {
+	if users.settings.LongPeriodWarningCycleStart == nil {
 		t.Fatal("expected long-period warning date to be persisted")
 	}
-	persisted := *users.settings.LongPeriodWarnedAt
+	persisted := *users.settings.LongPeriodWarningCycleStart
 	if persisted.Hour() != 0 || persisted.Minute() != 0 || persisted.Second() != 0 || persisted.Nanosecond() != 0 {
 		t.Fatalf("expected persisted cycle start normalized to midnight, got %s", persisted.Format("2006-01-02T15:04:05"))
 	}

--- a/internal/services/day_feedback_policy_test.go
+++ b/internal/services/day_feedback_policy_test.go
@@ -209,7 +209,7 @@ func TestResolveDayFeedbackShowsLongPeriodWarningOnlyOncePerCycle(t *testing.T) 
 		t.Fatalf("expected long-period cycle start 2026-03-01, got %s", got)
 	}
 
-	warnedState, err := service.ResolveDayFeedback(context.Background(), &models.User{ID: 10, LongPeriodWarnedAt: ptrDayFeedbackTime(cycleStart)}, mustParseDayFeedbackDate(t, "2026-03-09"), mustParseDayFeedbackDate(t, "2026-03-09"), time.UTC)
+	warnedState, err := service.ResolveDayFeedback(context.Background(), &models.User{ID: 10, LongPeriodWarningCycleStart: ptrDayFeedbackTime(cycleStart)}, mustParseDayFeedbackDate(t, "2026-03-09"), mustParseDayFeedbackDate(t, "2026-03-09"), time.UTC)
 	if err != nil {
 		t.Fatalf("ResolveDayFeedback() unexpected error after warning acknowledgement: %v", err)
 	}
@@ -226,10 +226,10 @@ func TestAcknowledgeLongPeriodWarningPersistsCycleStart(t *testing.T) {
 	if err := service.AcknowledgeLongPeriodWarning(context.Background(), 10, cycleStart, time.UTC); err != nil {
 		t.Fatalf("AcknowledgeLongPeriodWarning() unexpected error: %v", err)
 	}
-	if users.settings.LongPeriodWarnedAt == nil {
+	if users.settings.LongPeriodWarningCycleStart == nil {
 		t.Fatal("expected long-period warning date to be persisted")
 	}
-	if got := users.settings.LongPeriodWarnedAt.Format("2006-01-02"); got != "2026-03-01" {
+	if got := users.settings.LongPeriodWarningCycleStart.Format("2006-01-02"); got != "2026-03-01" {
 		t.Fatalf("expected persisted warning date 2026-03-01, got %s", got)
 	}
 	// The written map is only half of the claim: the acknowledgement must land

--- a/internal/services/day_feedback_utc_regression_test.go
+++ b/internal/services/day_feedback_utc_regression_test.go
@@ -10,7 +10,7 @@ package services
 // (issue #48/#64 bug class).
 //
 // The fix rebuilds the value at time.UTC before the update.  These tests
-// assert the persisted LongPeriodWarnedAt is always UTC-midnight regardless of
+// assert the persisted LongPeriodWarningCycleStart is always UTC-midnight regardless of
 // the request timezone.
 
 import (
@@ -30,7 +30,7 @@ func TestAcknowledgeLongPeriodWarningPersistsUTCMidnightInUTCZone(t *testing.T) 
 		t.Fatalf("AcknowledgeLongPeriodWarning() unexpected error: %v", err)
 	}
 
-	stored := users.settings.LongPeriodWarnedAt
+	stored := users.settings.LongPeriodWarningCycleStart
 	if stored == nil {
 		t.Fatal("expected long_period_warning_cycle_start to be persisted, got nil")
 	}
@@ -64,7 +64,7 @@ func TestAcknowledgeLongPeriodWarningPersistsUTCMidnightFromEastZone(t *testing.
 		t.Fatalf("AcknowledgeLongPeriodWarning() unexpected error: %v", err)
 	}
 
-	stored := users.settings.LongPeriodWarnedAt
+	stored := users.settings.LongPeriodWarningCycleStart
 	if stored == nil {
 		t.Fatal("expected long_period_warning_cycle_start to be persisted, got nil")
 	}
@@ -95,7 +95,7 @@ func TestAcknowledgeLongPeriodWarningPersistsUTCMidnightFromWestZone(t *testing.
 		t.Fatalf("AcknowledgeLongPeriodWarning() unexpected error: %v", err)
 	}
 
-	stored := users.settings.LongPeriodWarnedAt
+	stored := users.settings.LongPeriodWarningCycleStart
 	if stored == nil {
 		t.Fatal("expected long_period_warning_cycle_start to be persisted, got nil")
 	}

--- a/internal/services/day_service_workflow_test.go
+++ b/internal/services/day_service_workflow_test.go
@@ -220,9 +220,9 @@ func (stub *dayUserRepositoryStub) UpdateByID(ctx context.Context, userID uint, 
 		}
 	}
 	if value, exists := updates["long_period_warning_cycle_start"]; exists {
-		if warnedAt, ok := value.(time.Time); ok {
-			copyValue := warnedAt
-			stub.settings.LongPeriodWarnedAt = &copyValue
+		if cycleStart, ok := value.(time.Time); ok {
+			copyValue := cycleStart
+			stub.settings.LongPeriodWarningCycleStart = &copyValue
 		}
 	}
 	return nil

--- a/internal/services/i18n_policy.go
+++ b/internal/services/i18n_policy.go
@@ -3,6 +3,8 @@ package services
 import (
 	"fmt"
 	"strings"
+
+	"github.com/ovumcy/ovumcy-web/internal/i18n"
 )
 
 var authErrorTranslationKeys = map[string]string{
@@ -198,10 +200,9 @@ func LocalizedSymptomFrequencySummary(language string, count int, days int) stri
 		return fmt.Sprintf("%d Mal (an %d %s)", count, days, dayWord)
 	}
 	if lang == "fr" {
+		// "fois" is invariant in French — the same word for one and many — so
+		// there is no singular form to select here, unlike the es/it/en arms.
 		countWord := "fois"
-		if count == 1 {
-			countWord = "fois"
-		}
 		dayWord := "jours"
 		if days == 1 {
 			dayWord = "jour"
@@ -232,21 +233,15 @@ func LocalizedSymptomFrequencySummary(language string, count int, days int) stri
 	return fmt.Sprintf("%d %s (in %d %s)", count, countWord, days, dayWord)
 }
 
+// russianPluralForm picks the Russian one/few/many wording for value. The CLDR
+// rule itself lives once, in i18n.PluralCategory — this is only the mapping
+// from a category to the caller's three literals, so a correction to Russian
+// pluralization has a single home and cannot be made on one copy alone.
 func russianPluralForm(value int, one string, few string, many string) string {
-	absolute := value
-	if absolute < 0 {
-		absolute = -absolute
-	}
-	lastTwoDigits := absolute % 100
-	if lastTwoDigits >= 11 && lastTwoDigits <= 14 {
-		return many
-	}
-
-	lastDigit := absolute % 10
-	switch {
-	case lastDigit == 1:
+	switch i18n.PluralCategory(i18n.LangRU, value) {
+	case "one":
 		return one
-	case lastDigit >= 2 && lastDigit <= 4:
+	case "few":
 		return few
 	default:
 		return many

--- a/internal/services/i18n_policy_coverage_test.go
+++ b/internal/services/i18n_policy_coverage_test.go
@@ -91,12 +91,11 @@ func TestI18nPolicyRussianPluralSwitchCases(t *testing.T) {
 	}
 }
 
-// TestI18nPolicyFrenchCountSingular covers line 137 (`if count == 1` in the
-// French branch). French does not change the word for "fois" between singular
-// and plural — both are "fois" — so the branch is equivalent for count-word
-// purposes. However the branch IS executed for count==1, and the test below
-// verifies the full output is correct so that any mutation to the surrounding
-// logic (e.g. flipping to lang=="de") is caught.
+// TestI18nPolicyFrenchCountSingular pins the French summary output across the
+// count/day combinations. French does not change the word for "fois" between
+// singular and plural, so there is no count-word branch to cover here — the
+// day word is the only form that varies, and the assertions below also catch a
+// mutation to the surrounding language dispatch (e.g. flipping to lang=="de").
 func TestI18nPolicyFrenchCountSingular(t *testing.T) {
 	// count==1, days==1 → singular day form
 	got := LocalizedSymptomFrequencySummary("fr", 1, 1)


### PR DESCRIPTION

Technical-debt group **T0006** (dead-code / `internal/services`, cluster split by file).
Nine records covered, four skipped with reasons. No behaviour changes: every rendered string,
stored value and API payload is identical.

## Medical safety (§10.6)

Nothing here touches whether a prediction may render. The change set is name-level and
table-level: the localized date tables produce byte-identical output (proved below), the day-save
message keys are untouched, and the zero-completed-cycle suppression floor in
`day_feedback_policy.go:106-129` — including its FOLLOW-UP note about the shared suppression
predicate — is carried over verbatim. `dashboard_view_service.go` is not modified at all, so the
hand-recombined suppression at `dashboard_view_service.go:271` and
`DashboardCycleContext.FertilitySuppressed` stay exactly as they are; collapsing them is not
equivalent (`dashboard_cycle.go:411-416` returns `estimatePaused=false` for `IrregularCycle` with
`<3` cycles when overdue), and the two records that would have led there are skipped below.
Display confidence still follows data confidence at every site this PR passes through.

## Records covered

### R2-0006 — dead `AttemptLimiter` singular methods (P2, dead-code)

`AttemptLimiter.TooManyRecent/AddFailure/Reset` were called only from `attempt_limiter_test.go`;
production runs the plural forms through `AuthAttemptPolicy` (`auth_attempt_policy.go:48,52,56`).
Proof of unreachability, before the removal:

```
$ grep -rn "TooManyRecent\b|AddFailure\b|limiter\.Reset(" --include=*.go internal/ \
    | grep -v "TooManyRecentAny|AddFailureAll"
internal/services/attempt_limiter.go:47,67,148   # the three declarations
internal/services/attempt_limiter_test.go:17,18,22,23,27,28,85,101,144,164,168,170
internal/services/auth_attempt_policy.go:48,52,56  # different receiver (*AuthAttemptPolicy)
… (remaining hits are *AuthAttemptPolicy call sites in login/auth/totp/settings/reset services)
```

The record's cost is that "the tests pin the singular and production runs the plural", so the fix
is the test conversion, not only the deletion. Anti-vacuity proof that the converted tests now
exercise the production path — gut `AddFailureAll`'s body (signature kept):

```
$ go test -count=1 -run TestAttemptLimiter ./internal/services/
--- FAIL: TestAttemptLimiterSizeCapEvictsColdestKeysFirst
    attempt_limiter_test.go:181: actively refreshed key must survive the size-cap eviction
--- FAIL: TestAttemptLimiterWindowAndReset
    attempt_limiter_test.go:24: expected one recent attempt to hit limit 1
--- FAIL: TestAttemptLimiterStaleKeyEviction
    attempt_limiter_test.go:94: expected 1 key after stale eviction, got 127
--- FAIL: TestAttemptLimiterMultiKeyOperations
    attempt_limiter_test.go:43: expected client limiter entry to be recorded
FAIL
```

Body restored, singular methods deleted → `go build ./...` OK,
`go test -count=1 -run 'TestAttemptLimiter|TestNormalizeLimiterKey' ./internal/services/` → `ok`.
Three of those four tests would have stayed green on the gutted production method before this PR.

### R2-0050 + R2-0051 + R2-0052 + R2-0934 — one date table per language

`date_i18n_policy.go` kept five parallel `map[string][]string` tables (300 strings) that no test
named and that the six-file locale parity machinery cannot see. They are now one
`localizedDateNames` entry per language with fixed-size `[12]string` / `[7]string` fields:

- **R2-0051**: adding a language is one literal in one place instead of five coordinated edits.
  The `months` / `monthsLong` split is preserved and documented — it is not duplication for
  es/fr/it (heading form vs running text) or ru (nominative vs genitive), only de/en coincide.
- **R2-0052**: the weekday index was guarded differently from the month index in the same
  expression. With `[7]string` there is nothing left to guard — `time.Weekday()` is 0-6 by
  construction — and a shortened row is no longer an index panic inside a page render.
- **R2-0934**: the impossible `monthIndex < 0` terms, the `len(names) < 12` checks and the stdlib
  fallbacks they protected are gone, together with the mutation-only cases written for them
  (`date_i18n_policy_mutation_test.go`); the ordinary January locale assertions are kept.
- **R2-0050**: `TestLocalizedDateFormsCoverEveryRequiredLocale` (new) walks
  `manager.SupportedLanguages()` and requires a complete `dateNames` entry plus a non-English
  rendering from all five exported functions.

Guard red, by gutting the fix's data — dropping the `"it"` entry and shortening ru's
`weekdaysShort` to six:

```
$ go test -count=1 -run TestLocalizedDateFormsCoverEveryRequiredLocale ./internal/services/
--- FAIL: TestLocalizedDateFormsCoverEveryRequiredLocale
    date_i18n_policy_locale_test.go:51: locale "it" has no dateNames entry: every date surface renders it in English
    date_i18n_policy_locale_test.go:62: locale "ru" is missing a weekday form at index 6 (short="" long="суббота")
FAIL
```

Restored → green. Refactor fidelity: a throwaway dump of
`LocalizedMonthYear/DateLabel/DashboardDate/DateDisplay/DateShort` over 366 days × 9 language
inputs (the six supported ones plus an unknown locale, an empty string and `"EN "`) was captured
before and after; `diff` reports **0** differing rendering lines out of 3296 (only the two
`go test` timing lines differ).

### R2-0062 — Russian plural rule had two homes

`russianPluralForm` re-implemented the CLDR rule that `i18n.PluralCategory` already owns; it now
maps that category onto its three literals. No import cycle: `internal/i18n` imports nothing from
this repository. Anti-vacuity proof that the services surface now runs the shared rule — gut
`PluralCategory`'s `LangRU` arm to `return "many"`:

```
$ go test -count=1 -run 'TestI18nPolicyRussianPluralForm|Russian' ./internal/services/
--- FAIL: TestI18nPolicyRussianPluralNegativeValue
    i18n_policy_coverage_test.go:13: russianPluralForm(-1): expected "один" (one form), got "много"
--- FAIL: TestI18nPolicyRussianPluralTeenBoundary
    i18n_policy_coverage_test.go:49: russianPluralForm(24): expected "раза" (few, lastDigit==4), got "раз"
--- FAIL: TestI18nPolicyRussianPluralSwitchCases  (8 values)
--- FAIL: TestI18nPolicyRussianPluralTeenLowerBoundary / TestMR3I18n_RussianPluralFormOne21 / …Few2 / …Few4
FAIL
```

`plural.go` restored byte-identically (`git diff internal/i18n/plural.go` → empty), suite green.

### R2-0064 + R2-0942 — French count word with identical arms

`if count == 1 { countWord = "fois" }` could not change the result. Deleted, with a comment
stating that "fois" is invariant in French, and the coverage test's stale rationale replaced by
what it actually pins. Both records state the assertions hold with the branch gone; confirmed:
`go test -count=1 -run 'French|SymptomFrequency' ./internal/services/` → `ok`.

### R2-0501 — unreachable nil-user guards

`day_feedback_policy.go:57` tested `user == nil` and `:89` tested `user != nil` although `:29`
dereferences `user.ID` first. Proof, from a throwaway probe passing `nil` (not committed):

```
$ go test -count=1 -run TestT0006ProbeNilUserPanicsBeforeTheNilGuards ./internal/services/
panic: runtime error: invalid memory address or nil pointer dereference
	…/internal/services/day_feedback_policy.go:29 +0xa2
```

Both guards dropped; `resolveDaySaveMessageKey` now documents the non-nil precondition its single
caller establishes.

### R2-0053 — `LongPeriodWarnedAt` says instant, column says cycle start

Renamed to `LongPeriodWarningCycleStart` across 17 sites (compiler-enforced; the column,
`long_period_warning_cycle_start`, and the `type:date` tag are unchanged, so no migration and no
stored-data change). `grep -rn LongPeriodWarnedAt --include=*.go internal/ | wc -l` → `0`.
`internal/models/user.go` is re-aligned by gofmt as a consequence of the longer field name.

### R2-0465 — a test named for a fallback it never reaches

`TestMR3Cycles_PotentialImplantationZeroCycleLengthFallback`'s own header said
`predictedCycleLength` never returns `<= 0`, while its body comment claimed the opposite. Renamed
to `TestMR3Cycles_PotentialImplantationUsesTheDefaultCycleLengthWithoutLogs`, body comment
corrected, and `cycle_start_policy.go:83-98` carries a `codecov:ignore` block recording why the
two `cycleLength <= 0` guards are unreachable **from that caller** (stats are built there by
`BuildCycleStats`: fewer than two starts → both statistics 0 → `models.DefaultCycleLength`;
otherwise distinct sorted starts → every observed length ≥ 1 → median > 0). The line references in
`cycle_start_policy_coverage_test.go`'s header are updated with it.

## Records skipped

- **R2-0041** — its evidence is false on the current tree. `predictedCycleLength` *can* return 0:
  with `median == 0` and a caller-supplied `average` in `(0, 0.5)`, `int(average+0.5) == 0`, and
  `ApplyUserCycleBaseline` consumes caller-built `CycleStats`. Both guards at
  `cycle_baseline.go:75-81` are live and pinned by
  `TestCycleBaseline_FractionalAverageTriggersCycleLengthFallback` and
  `TestCycleBaseline_NoProjectionWhenResolvedCycleLengthIsZero`
  (`cycle_baseline_mutation_round2_test.go:74-160`). Deleting them would have deleted two green
  tests. The distinction is now written down at the `codecov:ignore` block added for R2-0465, so
  the two call sites cannot be conflated again.
- **R2-0046** and **R2-0482** — the pair only makes sense together (the tests fabricate
  `Role: "viewer"` precisely to reach the branches R2-0046 wants removed), and R2-0046's own
  minimal guard is a `CHECK` narrowed to `{owner}`, i.e. a migration — outside this group's file
  boundary and a schema change on its own. Both are `reclassified` at confidence 0.7 with open
  reachability. Removing only the fixtures would strip the sole coverage of branches that stay in
  the tree.
- **R2-0063** — moving `LocalizedSymptomFrequencySummary`'s six inline language branches into the
  locale files requires threading the merged messages map into `stats_cycle_insights.go:116` and
  `stats_page_view_service.go:230` (a signature change in callers this group does not own) and two
  plural families per locale, since the pattern carries two independent counts. Its own PR.

## Verification

```
go build ./...                                                        # OK
go test -count=1 ./internal/services/                                  # ok  215.6s
go test -count=1 ./internal/i18n/ ./internal/models/ ./internal/db/    # ok
go test -count=1 -timeout 20m ./internal/api/                          # ok  840.8s
golangci-lint run ./internal/services/... ./internal/api/... ./internal/models/... ./internal/i18n/...
                                                                       # 0 issues
go run ./scripts/changelogd check                                      # changelog fragment check OK
```

## Rollback

Single-commit revert; every change is local code, a test or a doc comment. Nothing alters
persisted data (the `long_period_warning_cycle_start` column is untouched), a migration, or a
public contract, so no dialect-parity or OpenAPI re-run is needed after a revert.
