### PR TITLE
fix(services): keep cycle, day and export surfaces to what the data says

### DIFF
--- a/changelog.d/fix-services-cycle-stats-and-export-contracts.md
+++ b/changelog.d/fix-services-cycle-stats-and-export-contracts.md
@@ -1,0 +1,37 @@
+### Changed
+
+- **The settings page reads the owner's entries once per render.** The export panel's figures — the
+  selectable date range and the default window's totals — were two separate reads of every
+  `daily_logs` row, each walked in Go. They now come from one read, so the slowest page in a long
+  history costs half of what it did.
+
+### Fixed
+
+- **The Insights cycle stack no longer marks a fertile window it cannot locate.** A completed cycle
+  shorter than 19 days has no room for a full luteal phase, so the ovulation day behind its fertile
+  shading, its peak band and its ovulation cell was a clamped fallback rather than an estimate from
+  the account's own data. Those rows now show what was recorded — their length and their period
+  days — and nothing inferred; the marks stay on every cycle whose window fits.
+- **A day in the cycle stack can no longer be both a period day and the fertile peak.** On a short
+  cycle the two landed together and the row said both at once, leaving the display to decide. The
+  peak is now the ovulation cell itself, so one day carries one claim.
+- **A cycle drawn past the stack's axis says so.** Two cycles longer than the axis were drawn as two
+  identical full-width rows while the numbers beside them differed; such a row is now flagged as
+  truncated rather than reading as a complete comparison.
+- **A temperature entered in Fahrenheit comes back exactly as it was typed.** Readings are stored in
+  Celsius, and the stored value was rounded to two Celsius decimals — a step too coarse to represent
+  a two-decimal Fahrenheit entry, so 98.61 °F redisplayed as 98.62 °F after every save. Stored
+  readings now keep enough precision for the owner's own unit; nothing already stored changes.
+- **A cycle start in the previous December can be entered in settings.** The form accepted only
+  dates from 1 January of the current year, so in early January the anchor every prediction is
+  measured from could not be recorded truthfully. The accepted window is now the last year, measured
+  from today; every date the old bound accepted is still accepted.
+- **A custom symptom named "Mood" exports as itself.** It was written into the built-in "Mood
+  swings" column and left out of the other-symptoms list, so an export carried the wrong symptom and
+  a re-import restored it. Export columns are now keyed on the built-in catalog, one column per
+  built-in symptom.
+
+### Internal
+
+- The CSV header row is handed out as a copy instead of as a shared package-level slice, and the
+  export panel's date comparison reads the same operands in both of its arms.

--- a/internal/api/handlers_export_csv.go
+++ b/internal/api/handlers_export_csv.go
@@ -34,7 +34,7 @@ func (handler *Handler) ExportCSV(c fiber.Ctx) error {
 	writer := csv.NewWriter(&output)
 	// The three build branches below are defensive: this csv.Writer writes into a
 	// bytes.Buffer, whose Write never returns an error, so no request reaches them.
-	if err := writer.Write(services.ExportCSVHeaders); err != nil {
+	if err := writer.Write(services.ExportCSVHeaders()); err != nil {
 		return handler.failEgress(c, exportCSVEgress, exportBuildErrorSpec()) // codecov:ignore -- unreachable: bytes.Buffer writes cannot fail
 	}
 

--- a/internal/api/settings_cycle_regressions_test.go
+++ b/internal/api/settings_cycle_regressions_test.go
@@ -156,7 +156,11 @@ func TestSettingsPageRendersPersistedCycleValues(t *testing.T) {
 	if !exportInputPattern.MatchString(rendered) {
 		t.Fatalf("expected export date fields to render segmented controls with explicit calendar buttons")
 	}
-	lastPeriodInputAccessibilityPattern := regexp.MustCompile(`(?s)data-date-field-id="settings-last-period-start".*?id="settings-last-period-start".*?lang="en".*?min="\d{4}-01-01".*?aria-label="Day".*?aria-label="Month".*?aria-label="Year"`)
+	// The min attribute is the rolling floor SettingsCycleStartDateBounds
+	// returns — any calendar day, not January 1st: the floor used to be the
+	// start of the current year, which put a December cycle start out of reach
+	// through the whole of January.
+	lastPeriodInputAccessibilityPattern := regexp.MustCompile(`(?s)data-date-field-id="settings-last-period-start".*?id="settings-last-period-start".*?lang="en".*?min="\d{4}-\d{2}-\d{2}".*?aria-label="Day".*?aria-label="Month".*?aria-label="Year"`)
 	if !lastPeriodInputAccessibilityPattern.MatchString(rendered) {
 		t.Fatalf("expected settings last-period-start field to include localized segmented accessibility labels and range attributes")
 	}

--- a/internal/services/calendar_day_construction_barrier_test.go
+++ b/internal/services/calendar_day_construction_barrier_test.go
@@ -71,8 +71,6 @@ const calendarDayConstructionPoint = "internal/services/day_utils.go:StartOfCale
 // so a fixed site cannot leave a stale exemption behind.
 var calendarDayBarrierAllowlist = map[string]string{
 	"internal/reminders/next_run.go:fireOnCalendarDay:calendar day built in a location": "deliberate carve-out: a scheduling instant at a runtime hour, not a calendar day, and the two lines below it check the requested date survived and fall back to services.StartOfCalendarDay when it did not.",
-
-	"internal/services/settings_cycle_policy.go:SettingsCycleStartDateBounds:calendar day built in a location": "deliberate carve-out: January 1st of the CURRENT year as a form's lower bound. Measured over tzdata 2025c (598 zones, 1970-2040): January 1st has no midnight in 15 zone-years, the most recent of them 1996, and none of them in the future — so the year this expression can ask for is never one of them. Here it is not compared at all, only formatted into the date input's min attribute. OnboardingDateBounds carried the twin of this expression until its window became a rolling one built from today.",
 }
 
 // calendarDayBarrierBlindSpots is what this sweep provably cannot see. It is

--- a/internal/services/day_tracking.go
+++ b/internal/services/day_tracking.go
@@ -159,10 +159,27 @@ func normalizeStoredDayBBT(value *float64) *float64 {
 	if value == nil || *value <= 0 {
 		return nil
 	}
-	rounded := roundTemperatureValue(*value)
+	rounded := roundStoredTemperatureValue(*value)
 	return &rounded
 }
 
+// roundStoredTemperatureValue rounds a reading to its canonical STORED form.
+// Storage is always Celsius, and it keeps more decimals than either unit
+// displays on purpose: a reading entered in Fahrenheit is converted before it
+// is stored, and one step of 0.01 °F is 0.0056 °C, so a stored value rounded to
+// the two Celsius decimals the form shows cannot represent what the owner
+// typed. It came back one hundredth of a degree away after every save — a
+// recorded measurement altered without notice, far below the 0.1-0.5 °F shift a
+// BBT chart is read for and therefore invisible to every other check. Four
+// decimals keep every 0.01 °F step distinct and exactly recoverable, while
+// still collapsing the float noise the conversion produces.
+func roundStoredTemperatureValue(value float64) float64 {
+	return math.Round(value*10000) / 10000
+}
+
+// roundTemperatureValue rounds to the two decimals a temperature is DISPLAYED
+// with, in whichever unit it is being shown. It is a presentation rounding, not
+// the stored one.
 func roundTemperatureValue(value float64) float64 {
 	return math.Round(value*100) / 100
 }

--- a/internal/services/day_tracking_test.go
+++ b/internal/services/day_tracking_test.go
@@ -1,6 +1,10 @@
 package services
 
-import "testing"
+import (
+	"math"
+	"strconv"
+	"testing"
+)
 
 // bbtPtr builds a *float64 for BBT test inputs (nil means "not measured").
 func bbtPtr(value float64) *float64 {
@@ -61,6 +65,51 @@ func TestFormatDayBBTForInputFahrenheit(t *testing.T) {
 	got := FormatDayBBTForInput(bbtPtr(37.0), TemperatureUnitFahrenheit)
 	if got != "98.60" {
 		t.Fatalf("expected 98.60, got %q", got)
+	}
+}
+
+// TestDayBBTRoundTripsEveryStepOfTheOwnersUnit is the storage contract of a
+// recorded measurement: what an owner typed is what the form shows back. The
+// value is stored in Celsius whatever unit it was entered in, and the stored
+// form used to be rounded to two Celsius decimals — the precision of the form
+// itself. One step of 0.01 °C is 0.018 °F, so a two-decimal Fahrenheit entry
+// has no exact two-decimal Celsius form: 98.61 came back as 98.62 after every
+// save, silently altering a health measurement the owner recorded. The drift
+// is below anything a BBT chart is read for, which is exactly why nothing else
+// would ever report it.
+//
+// Both units are swept step by step across the form's own advertised range,
+// because the range ENDS round-tripped even while the interior did not (93.20
+// and 109.40 map onto 34.00 and 43.00 exactly), so a boundary-only check stays
+// green over the defect.
+func TestDayBBTRoundTripsEveryStepOfTheOwnersUnit(t *testing.T) {
+	t.Parallel()
+
+	for _, unit := range []string{TemperatureUnitFahrenheit, TemperatureUnitCelsius} {
+		minimum, maximum := TemperatureUnitRange(unit)
+		lowest := int(math.Round(minimum * 100))
+		highest := int(math.Round(maximum * 100))
+		if highest-lowest < 100 {
+			t.Fatalf("unit %q: expected a range of at least a hundred steps to sweep, got %.2f..%.2f", unit, minimum, maximum)
+		}
+
+		for hundredths := lowest; hundredths <= highest; hundredths++ {
+			typed := strconv.FormatFloat(float64(hundredths)/100, 'f', 2, 64)
+
+			stored, err := ParseDayBBTRawWithUnit(typed, unit)
+			if err != nil {
+				t.Fatalf("unit %q: %q is inside the form's own range and must parse, got %v", unit, typed, err)
+			}
+			if stored == nil {
+				t.Fatalf("unit %q: %q is a measurement, not an empty field", unit, typed)
+			}
+			if !IsValidDayBBT(stored) {
+				t.Fatalf("unit %q: %q stored as %v, outside the storable range", unit, typed, *stored)
+			}
+			if got := FormatDayBBTForInput(stored, unit); got != typed {
+				t.Fatalf("unit %q: an owner typed %s and the form redisplays %s (stored %.6f °C) — the reading was altered on save", unit, typed, got, *stored)
+			}
+		}
 	}
 }
 

--- a/internal/services/export_service.go
+++ b/internal/services/export_service.go
@@ -12,7 +12,18 @@ import (
 
 const exportDateLayout = "2006-01-02"
 
-var ExportCSVHeaders = []string{
+// ExportCSVHeaders returns the CSV header row as a fresh slice. It is a copy
+// on purpose: the header row is the export's schema, and it used to be an
+// exported package-level slice handed straight to the writer, so one consumer
+// writing into it would have relabelled or malformed every export in the
+// process — concurrent ones included — with no boundary to catch it.
+func ExportCSVHeaders() []string {
+	headers := make([]string, len(exportCSVHeaders))
+	copy(headers, exportCSVHeaders)
+	return headers
+}
+
+var exportCSVHeaders = []string{
 	"Date",
 	"Period",
 	"Flow",
@@ -44,26 +55,29 @@ var ExportCSVHeaders = []string{
 	"Uncertain",
 }
 
-var exportSymptomColumnsByName = map[string]string{
-	"cramps":            "cramps",
-	"headache":          "headache",
-	"acne":              "acne",
-	"mood":              "mood",
-	"mood swings":       "mood",
-	"bloating":          "bloating",
-	"fatigue":           "fatigue",
-	"breast tenderness": "breast_tenderness",
-	"back pain":         "back_pain",
-	"nausea":            "nausea",
-	"spotting":          "spotting",
-	"irritability":      "irritability",
-	"insomnia":          "insomnia",
-	"food cravings":     "food_cravings",
-	"diarrhea":          "diarrhea",
-	"constipation":      "constipation",
-	"swelling":          "swelling",
+// exportSymptomColumnsByName maps a symptom's name onto the built-in KEY whose
+// export column it fills. It is derived from the catalog rather than written
+// out beside it: the hand-written table had one name too many — both "Mood
+// swings" and "Mood" resolved to the built-in Mood column, though only the
+// first is a built-in name and "Mood" is a name an owner's own symptom may
+// carry, since it is not among BuiltinSymptomReservedNames. That symptom was
+// then exported as the built-in AND dropped from other_symptoms (a matched
+// name never reaches that set), so a re-import restored a different symptom
+// with nothing signalling the substitution.
+var exportSymptomColumnsByName = buildExportSymptomColumnIndex()
+
+func buildExportSymptomColumnIndex() map[string]string {
+	builtins := models.DefaultBuiltinSymptoms()
+	index := make(map[string]string, len(builtins))
+	for _, builtin := range builtins {
+		index[strings.ToLower(strings.TrimSpace(builtin.Name))] = builtin.Key
+	}
+	return index
 }
 
+// exportSymptomFlagSetters is keyed on the built-in catalog KEY, one entry per
+// built-in — the bijection TestExportSymptomColumnsAreABijectionOntoTheBuiltin
+// Catalog pins. Anything that is not a built-in key is an other symptom.
 var exportSymptomFlagSetters = map[string]func(*ExportSymptomFlags){
 	"cramps": func(flags *ExportSymptomFlags) {
 		flags.Cramps = true
@@ -74,7 +88,7 @@ var exportSymptomFlagSetters = map[string]func(*ExportSymptomFlags){
 	"acne": func(flags *ExportSymptomFlags) {
 		flags.Acne = true
 	},
-	"mood": func(flags *ExportSymptomFlags) {
+	"mood_swings": func(flags *ExportSymptomFlags) {
 		flags.Mood = true
 	},
 	"bloating": func(flags *ExportSymptomFlags) {
@@ -219,8 +233,42 @@ func (service *ExportService) BuildSummary(ctx context.Context, userID uint, fro
 	if err != nil {
 		return ExportSummary{}, err
 	}
+	return summarizeExportLogs(logs), nil
+}
+
+// BuildSummaryHistoryAndWindow returns two aggregates over ONE read of the
+// owner's entries: the whole history, and the part of it up to and including
+// the `through` calendar day. The settings page needs exactly that pair — the
+// export panel's selectable bounds come from everything the owner has, its
+// default window stops at today — and asking BuildSummary twice fetched and
+// materialized every daily_logs row twice on every settings render, on a page
+// that displays neither figure until the panel is opened. The narrowing is
+// applied here, over rows already in hand, instead of as a second query.
+func (service *ExportService) BuildSummaryHistoryAndWindow(ctx context.Context, userID uint, through time.Time, location *time.Location) (ExportSummary, ExportSummary, error) {
+	logs, err := service.days.FetchLogsForOptionalRange(ctx, userID, nil, nil, location)
+	if err != nil {
+		return ExportSummary{}, ExportSummary{}, err
+	}
+
+	window := make([]models.DailyLog, 0, len(logs))
+	for _, logEntry := range logs {
+		// DailyLog.Date is a UTC-midnight date-only value and `through` is a
+		// calendar day resolved in the request location, so the two are ordered
+		// as calendar days rather than as instants: compared directly, every
+		// non-UTC zone would move the boundary by a day (day_utils.go).
+		if CalendarDaysBetween(logEntry.Date, through) >= 0 {
+			window = append(window, logEntry)
+		}
+	}
+
+	return summarizeExportLogs(logs), summarizeExportLogs(window), nil
+}
+
+// summarizeExportLogs reduces a set of entries to the count and the calendar
+// range the export surfaces quote.
+func summarizeExportLogs(logs []models.DailyLog) ExportSummary {
 	if len(logs) == 0 {
-		return ExportSummary{}, nil
+		return ExportSummary{}
 	}
 
 	first := logs[0].Date
@@ -244,7 +292,7 @@ func (service *ExportService) BuildSummary(ctx context.Context, userID uint, fro
 		HasData:      true,
 		DateFrom:     CalendarDayKey(first),
 		DateTo:       CalendarDayKey(last),
-	}, nil
+	}
 }
 
 func (service *ExportService) BuildJSONEntries(ctx context.Context, userID uint, from *time.Time, to *time.Time, location *time.Location) ([]ExportJSONEntry, error) {

--- a/internal/services/export_service_test.go
+++ b/internal/services/export_service_test.go
@@ -142,6 +142,30 @@ func TestExportBuildSummaryReturnsEmptyForNoLogs(t *testing.T) {
 	}
 }
 
+// TestBuildSummaryHistoryAndWindowPropagatesTheReadFailure pins the one-read
+// pair's failure path. It reads the owner's entries once and derives both
+// aggregates from that slice, so a failed read must surface as an error rather
+// than as two empty-but-plausible summaries: the settings page would otherwise
+// render "no entries" to an owner whose data simply could not be loaded, and
+// the export bounds would silently narrow to nothing.
+func TestBuildSummaryHistoryAndWindowPropagatesTheReadFailure(t *testing.T) {
+	readErr := errors.New("daily_logs read failed")
+	service := NewExportService(&stubExportDayReader{err: readErr}, &stubExportSymptomReader{})
+
+	history, window, err := service.BuildSummaryHistoryAndWindow(
+		context.Background(), 42, mustParseExportDay(t, "2026-02-18"), time.UTC)
+	if !errors.Is(err, readErr) {
+		t.Fatalf("BuildSummaryHistoryAndWindow() error = %v, want the reader's own error", err)
+	}
+	if history.HasData || window.HasData {
+		t.Errorf("a failed read must not report data: history=%+v window=%+v", history, window)
+	}
+	if history.TotalEntries != 0 || window.TotalEntries != 0 {
+		t.Errorf("a failed read must not report entries: history=%d window=%d",
+			history.TotalEntries, window.TotalEntries)
+	}
+}
+
 // TestExportSymptomColumnsAreABijectionOntoTheBuiltinCatalog pins the export's
 // symptom columns to the catalog they exist for. The mapping used to be a
 // hand-written table keyed on the DISPLAY NAME, with one name too many: both

--- a/internal/services/export_service_test.go
+++ b/internal/services/export_service_test.go
@@ -142,6 +142,95 @@ func TestExportBuildSummaryReturnsEmptyForNoLogs(t *testing.T) {
 	}
 }
 
+// TestExportSymptomColumnsAreABijectionOntoTheBuiltinCatalog pins the export's
+// symptom columns to the catalog they exist for. The mapping used to be a
+// hand-written table keyed on the DISPLAY NAME, with one name too many: both
+// "Mood swings" and "Mood" resolved to the built-in Mood column, so it was not
+// a bijection and one of the two names was not a built-in at all.
+func TestExportSymptomColumnsAreABijectionOntoTheBuiltinCatalog(t *testing.T) {
+	builtins := models.DefaultBuiltinSymptoms()
+	if len(builtins) == 0 {
+		t.Fatal("anchor: the built-in catalog must not be empty")
+	}
+	if len(exportSymptomFlagSetters) != len(builtins) {
+		t.Fatalf("the export has %d symptom columns for %d built-in symptoms — the two must be one set", len(exportSymptomFlagSetters), len(builtins))
+	}
+
+	for _, builtin := range builtins {
+		if _, ok := exportSymptomFlagSetters[builtin.Key]; !ok {
+			t.Fatalf("built-in %q has no export column keyed on it; the columns are keyed on something other than the catalog key", builtin.Key)
+		}
+		if got := exportSymptomColumn(builtin.Name); got != builtin.Key {
+			t.Fatalf("the built-in named %q must fill its own column %q, got %q", builtin.Name, builtin.Key, got)
+		}
+	}
+
+	// The import direction reads the same vocabulary in reverse, so the two
+	// maps are one set or a re-import silently drops the column they disagree
+	// on — which is how this key was found.
+	if len(importSymptomFlagGetters) != len(exportSymptomFlagSetters) {
+		t.Fatalf("export has %d symptom columns, import reads %d", len(exportSymptomFlagSetters), len(importSymptomFlagGetters))
+	}
+	for column := range exportSymptomFlagSetters {
+		if _, ok := importSymptomFlagGetters[column]; !ok {
+			t.Fatalf("column %q is written by the export and unknown to the import", column)
+		}
+	}
+
+	// The extra alias: a name that is NOT a built-in name must not reach a
+	// built-in column, however close it reads.
+	if got := exportSymptomColumn("Mood"); got != "other" {
+		t.Fatalf(`"Mood" is not a built-in name — the catalog calls that symptom "Mood swings" — so it must export as an other symptom, got column %q`, got)
+	}
+}
+
+// TestBuildExportSymptomFlagsKeepsACustomNameOutOfABuiltinColumn is the owner-
+// facing half of the same defect: a custom symptom whose name collided with an
+// alias of a built-in column was exported AS that built-in, and — because a
+// matched name never reaches the other-symptoms set — vanished from the export
+// entirely. Re-importing restored the wrong symptom with nothing to signal it.
+func TestBuildExportSymptomFlagsKeepsACustomNameOutOfABuiltinColumn(t *testing.T) {
+	names := map[uint]string{
+		1: "Mood swings", // the built-in
+		2: "Mood",        // an owner's own symptom, allowed: not a reserved name
+	}
+
+	builtinFlags, builtinOther := buildExportSymptomFlags([]uint{1}, names)
+	if !builtinFlags.Mood {
+		t.Fatal("anchor: the built-in Mood swings must still fill its own column")
+	}
+	if len(builtinOther) != 0 {
+		t.Fatalf("a built-in belongs in its column, not in other symptoms: %v", builtinOther)
+	}
+
+	customFlags, customOther := buildExportSymptomFlags([]uint{2}, names)
+	if customFlags.Mood {
+		t.Fatal(`an owner's custom "Mood" was exported as the built-in "Mood swings" — a different symptom's data under a built-in's label`)
+	}
+	if len(customOther) != 1 || customOther[0] != "Mood" {
+		t.Fatalf(`expected the custom symptom to be carried in other symptoms, got %v`, customOther)
+	}
+}
+
+// TestExportCSVHeadersCannotBeMutatedByACaller pins the header row as a value,
+// not as shared state. It used to be an exported package-level slice handed
+// straight to the CSV writer, so any consumer — a test, a future caller —
+// could rewrite the schema of every export in the process, concurrent ones
+// included, with nothing to catch it.
+func TestExportCSVHeadersCannotBeMutatedByACaller(t *testing.T) {
+	headers := ExportCSVHeaders()
+	if len(headers) == 0 {
+		t.Fatal("anchor: the CSV export must carry a header row")
+	}
+
+	original := headers[0]
+	headers[0] = "Rewritten by a caller"
+
+	if got := ExportCSVHeaders()[0]; got != original {
+		t.Fatalf("a caller's write reached the next export's header row: expected %q, got %q", original, got)
+	}
+}
+
 func TestExportBuildJSONEntriesNormalizesFlowAndMapsSymptoms(t *testing.T) {
 	service := NewExportService(
 		&stubExportDayReader{
@@ -223,8 +312,8 @@ func TestExportBuildCSVRowsBuildsExpectedColumns(t *testing.T) {
 	}
 
 	columns := rows[0].Columns()
-	if len(columns) != len(ExportCSVHeaders) {
-		t.Fatalf("expected %d csv columns, got %d", len(ExportCSVHeaders), len(columns))
+	if headers := ExportCSVHeaders(); len(columns) != len(headers) {
+		t.Fatalf("expected %d csv columns, got %d", len(headers), len(columns))
 	}
 	assertExportCSVFixedColumns(t, columns)
 	indexByHeader := exportCSVIndexByHeader()
@@ -259,10 +348,7 @@ func TestExportBuildCSVRowsNeutralizesFormulaLikeCells(t *testing.T) {
 	}
 
 	columns := rows[0].Columns()
-	indexByHeader := make(map[string]int, len(ExportCSVHeaders))
-	for index, header := range ExportCSVHeaders {
-		indexByHeader[header] = index
-	}
+	indexByHeader := exportCSVIndexByHeader()
 
 	if columns[indexByHeader["Other"]] != "'@Doctor export" {
 		t.Fatalf("expected sanitized other symptom cell, got %q", columns[indexByHeader["Other"]])
@@ -408,10 +494,11 @@ func assertExportCSVTrackingColumns(t *testing.T, columns []string, indexByHeade
 	}
 	// Append-only stability contract: the two new tracking columns must remain the
 	// final two headers, after Pregnancy test (docs/export.md "Stability").
-	if got := ExportCSVHeaders[len(ExportCSVHeaders)-2]; got != "Cycle start" {
+	headers := ExportCSVHeaders()
+	if got := headers[len(headers)-2]; got != "Cycle start" {
 		t.Fatalf("expected second-to-last header to be Cycle start, got %q", got)
 	}
-	if got := ExportCSVHeaders[len(ExportCSVHeaders)-1]; got != "Uncertain" {
+	if got := headers[len(headers)-1]; got != "Uncertain" {
 		t.Fatalf("expected last header to be Uncertain, got %q", got)
 	}
 }
@@ -431,8 +518,9 @@ func assertExportCSVSymptomColumns(t *testing.T, columns []string, indexByHeader
 }
 
 func exportCSVIndexByHeader() map[string]int {
-	indexByHeader := make(map[string]int, len(ExportCSVHeaders))
-	for index, header := range ExportCSVHeaders {
+	headers := ExportCSVHeaders()
+	indexByHeader := make(map[string]int, len(headers))
+	for index, header := range headers {
 		indexByHeader[header] = index
 	}
 	return indexByHeader

--- a/internal/services/import_service.go
+++ b/internal/services/import_service.go
@@ -47,7 +47,7 @@ var importSymptomFlagGetters = map[string]func(ExportSymptomFlags) bool{
 	"cramps":            func(f ExportSymptomFlags) bool { return f.Cramps },
 	"headache":          func(f ExportSymptomFlags) bool { return f.Headache },
 	"acne":              func(f ExportSymptomFlags) bool { return f.Acne },
-	"mood":              func(f ExportSymptomFlags) bool { return f.Mood },
+	"mood_swings":       func(f ExportSymptomFlags) bool { return f.Mood },
 	"bloating":          func(f ExportSymptomFlags) bool { return f.Bloating },
 	"fatigue":           func(f ExportSymptomFlags) bool { return f.Fatigue },
 	"breast_tenderness": func(f ExportSymptomFlags) bool { return f.BreastTenderness },

--- a/internal/services/settings_cycle_policy.go
+++ b/internal/services/settings_cycle_policy.go
@@ -130,11 +130,29 @@ func AlternativeUsageGoals(current string) []string {
 	return alternatives
 }
 
+// SettingsCycleStartWindowDays is how far back the settings form accepts a
+// cycle start, in days before today. A year of history: correcting this value
+// is the one route an owner has to the anchor every prediction is measured
+// from, and a cycle that began months ago is exactly the case an irregular or
+// paused history produces.
+//
+// The floor used to be 1 January of the current year, which is a calendar
+// artefact and not a cycle one: on 2 January the form took two dates, and a
+// cycle that began in December — the normal case in early January — could only
+// be recorded as a later, wrong date. Onboarding's twin carried the same floor
+// and became a rolling window (OnboardingDateBounds, 60 days, the number its
+// copy states); this one is wider because it is a correction surface rather
+// than a first-run one, and rolling for the same reason. The window only ever
+// grew: every date the January floor accepted is inside it.
+const SettingsCycleStartWindowDays = 365
+
+// SettingsCycleStartDateBounds returns the window the settings form accepts for
+// the last cycle start, which is also the window its date picker offers: the
+// last SettingsCycleStartWindowDays days, ending today.
 func SettingsCycleStartDateBounds(now time.Time, location *time.Location) (time.Time, time.Time) {
 	if location == nil {
 		location = time.UTC
 	}
 	today := DateAtLocation(now.In(location), location)
-	minDate := time.Date(today.Year(), time.January, 1, 0, 0, 0, 0, location)
-	return minDate, today
+	return today.AddDate(0, 0, -SettingsCycleStartWindowDays), today
 }

--- a/internal/services/settings_cycle_policy_mutation_round2_test.go
+++ b/internal/services/settings_cycle_policy_mutation_round2_test.go
@@ -46,8 +46,10 @@ func TestSettingsCycleStartDateBoundsHonorsLocationNearLocalMidnight(t *testing.
 	if got := today.Format("2006-01-02"); got != "2026-02-15" {
 		t.Fatalf("expected today computed in request location (UTC+9) = 2026-02-15, got %s", got)
 	}
-	if got := minDate.Format("2006-01-02"); got != "2026-01-01" {
-		t.Fatalf("expected minDate = 2026-01-01, got %s", got)
+	// The floor is a rolling window measured from that same local today, not a
+	// calendar boundary: it has to move with the location too.
+	if got := minDate.Format("2006-01-02"); got != "2025-02-15" {
+		t.Fatalf("expected minDate = local today minus %d days = 2025-02-15, got %s", SettingsCycleStartWindowDays, got)
 	}
 
 	// nil location must default to UTC (no panic) and yield UTC-based bounds.
@@ -56,7 +58,7 @@ func TestSettingsCycleStartDateBoundsHonorsLocationNearLocalMidnight(t *testing.
 	if got := todayNil.Format("2006-01-02"); got != "2026-02-15" {
 		t.Fatalf("expected nil-location today defaulted to UTC = 2026-02-15, got %s", got)
 	}
-	if got := minDateNil.Format("2006-01-02"); got != "2026-01-01" {
-		t.Fatalf("expected nil-location minDate = 2026-01-01, got %s", got)
+	if got := minDateNil.Format("2006-01-02"); got != "2025-02-15" {
+		t.Fatalf("expected nil-location minDate = 2025-02-15, got %s", got)
 	}
 }

--- a/internal/services/settings_service_cycle_test.go
+++ b/internal/services/settings_service_cycle_test.go
@@ -52,11 +52,15 @@ func TestValidateCycleSettingsLastPeriodStartRules(t *testing.T) {
 		t.Fatalf("expected ErrSettingsCycleStartDateInvalid for parse, got %v", err)
 	}
 
+	// Past the far end of the rolling window. It used to read "2025-12-31",
+	// six weeks before this now — a date the January floor refused and the
+	// window accepts, since a cycle that began in December is the ordinary
+	// answer in the weeks after New Year.
 	_, err = service.ValidateCycleSettings(CycleSettingsValidationInput{
 		CycleLength:        28,
 		PeriodLength:       5,
 		LastPeriodStartSet: true,
-		LastPeriodStartRaw: "2025-12-31",
+		LastPeriodStartRaw: "2024-12-31",
 	}, now, time.UTC)
 	if !errors.Is(err, ErrSettingsCycleStartDateInvalid) {
 		t.Fatalf("expected ErrSettingsCycleStartDateInvalid for out-of-range old date, got %v", err)
@@ -109,6 +113,53 @@ func TestValidateCycleSettingsBuildsUpdate(t *testing.T) {
 	}
 	if cleared.LastPeriodStart != nil {
 		t.Fatalf("expected nil last_period_start, got %#v", cleared.LastPeriodStart)
+	}
+}
+
+// TestValidateCycleSettingsAcceptsAStartInThePrecedingDecember is the January
+// boundary. The accepted window used to start at 1 January of the CURRENT year,
+// so on 2 January the only two answers this form took were 1 and 2 January —
+// while the value it asks for, the cycle start, is the anchor every prediction
+// is measured from, and in early January it lies in December by definition. The
+// window is a rolling one for that reason, the same shape onboarding's twin
+// took (OnboardingDateBounds), and it is measured from today rather than from a
+// calendar boundary that means nothing to a cycle.
+//
+// Both ends are pinned: a date past the window's far end is still refused, so
+// the guard cannot pass by accepting everything.
+func TestValidateCycleSettingsAcceptsAStartInThePrecedingDecember(t *testing.T) {
+	service := NewSettingsService(nil)
+	now := time.Date(2026, time.January, 2, 9, 0, 0, 0, time.UTC)
+
+	update, err := service.ValidateCycleSettings(CycleSettingsValidationInput{
+		CycleLength:        28,
+		PeriodLength:       5,
+		LastPeriodStartSet: true,
+		LastPeriodStartRaw: "2025-12-28",
+	}, now, time.UTC)
+	if err != nil {
+		t.Fatalf("a cycle that began on 28 December is the real anchor on 2 January and must be accepted, got %v", err)
+	}
+	if update.LastPeriodStart == nil || update.LastPeriodStart.Format("2006-01-02") != "2025-12-28" {
+		t.Fatalf("expected the December start stored verbatim, got %#v", update.LastPeriodStart)
+	}
+
+	minDate, maxDate := SettingsCycleStartDateBounds(now, time.UTC)
+	if !minDate.Before(time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)) {
+		t.Fatalf("the date picker must offer the December days the validator accepts, min=%s", minDate.Format("2006-01-02"))
+	}
+	if maxDate.Format("2006-01-02") != "2026-01-02" {
+		t.Fatalf("the upper bound stays today, got %s", maxDate.Format("2006-01-02"))
+	}
+
+	_, err = service.ValidateCycleSettings(CycleSettingsValidationInput{
+		CycleLength:        28,
+		PeriodLength:       5,
+		LastPeriodStartSet: true,
+		LastPeriodStartRaw: minDate.AddDate(0, 0, -1).Format("2006-01-02"),
+	}, now, time.UTC)
+	if !errors.Is(err, ErrSettingsCycleStartDateInvalid) {
+		t.Fatalf("the day before the window's floor must still be refused, got %v", err)
 	}
 }
 

--- a/internal/services/settings_view_service.go
+++ b/internal/services/settings_view_service.go
@@ -20,8 +20,11 @@ type SettingsViewLoader interface {
 	LoadSettings(ctx context.Context, userID uint) (models.User, error)
 }
 
+// SettingsViewExportBuilder is the seam the settings page reads its export
+// figures through. It asks for the owner's whole history and the window ending
+// today in ONE call because the two used to be two reads of the same rows.
 type SettingsViewExportBuilder interface {
-	BuildSummary(ctx context.Context, userID uint, from *time.Time, to *time.Time, location *time.Location) (ExportSummary, error)
+	BuildSummaryHistoryAndWindow(ctx context.Context, userID uint, through time.Time, location *time.Location) (ExportSummary, ExportSummary, error)
 }
 
 type SettingsViewSymptomProvider interface {
@@ -310,7 +313,11 @@ func (service *SettingsViewService) populateOwnerCalendarFeedViewData(ctx contex
 }
 
 func (service *SettingsViewService) buildOwnerExportViewData(ctx context.Context, userID uint, language string, today time.Time, location *time.Location) (SettingsExportViewData, error) {
-	availableSummary, err := service.export.BuildSummary(ctx, userID, nil, nil, location)
+	// One read, two aggregates: the panel's selectable bounds come from
+	// everything the owner has, its default window ends today. The default
+	// window's lower bound is the owner's earliest entry, so the window IS the
+	// history up to today and needs no second query to describe it.
+	availableSummary, defaultSummary, err := service.export.BuildSummaryHistoryAndWindow(ctx, userID, today, location)
 	if err != nil {
 		return SettingsExportViewData{}, fmt.Errorf("%w: %v", ErrSettingsViewLoadExport, err)
 	}
@@ -319,16 +326,6 @@ func (service *SettingsViewService) buildOwnerExportViewData(ctx context.Context
 	}
 
 	defaultFrom, defaultTo, selectableMin, selectableMax := resolveOwnerExportDateBounds(availableSummary, today)
-	defaultSummary, err := service.export.BuildSummary(
-		ctx,
-		userID,
-		exportSummaryBound(defaultFrom, location),
-		exportSummaryBound(defaultTo, location),
-		location,
-	)
-	if err != nil {
-		return SettingsExportViewData{}, fmt.Errorf("%w: %v", ErrSettingsViewLoadExport, err)
-	}
 
 	return SettingsExportViewData{
 		SummaryTotalEntries:    defaultSummary.TotalEntries,
@@ -372,24 +369,18 @@ func localizedExportSummaryDate(language string, raw string, location *time.Loca
 	return LocalizedDateDisplay(language, parsed)
 }
 
-func exportSummaryBound(raw string, location *time.Location) *time.Time {
-	trimmed := strings.TrimSpace(raw)
-	if trimmed == "" {
-		return nil
-	}
-
-	parsed, err := ParseDayDate(trimmed, location)
-	if err != nil {
-		return nil
-	}
-	return &parsed
-}
-
+// compareISODate orders two date-only ISO strings. Both operands are trimmed
+// ONCE into locals and every arm reads those: the equality arm used to trim
+// while the ordering arm compared the raw strings, so a padded value was
+// "not equal" and then ordered by its leading space — 0x20 sorts below every
+// digit — and a later date reported as the earlier one.
 func compareISODate(left string, right string) int {
+	leftDate := strings.TrimSpace(left)
+	rightDate := strings.TrimSpace(right)
 	switch {
-	case strings.TrimSpace(left) == strings.TrimSpace(right):
+	case leftDate == rightDate:
 		return 0
-	case left < right:
+	case leftDate < rightDate:
 		return -1
 	default:
 		return 1

--- a/internal/services/settings_view_service_test.go
+++ b/internal/services/settings_view_service_test.go
@@ -30,7 +30,6 @@ type stubSettingsViewExportBuilder struct {
 	responses []ExportSummary
 	err       error
 	called    bool
-	callIndex int
 	calls     []settingsViewSummaryCall
 
 	// Captured userID arguments, one per call — used to prove every summary
@@ -38,40 +37,32 @@ type stubSettingsViewExportBuilder struct {
 	summaryUserIDs []uint
 }
 
-func (stub *stubSettingsViewExportBuilder) BuildSummary(ctx context.Context, userID uint, from *time.Time, to *time.Time, location *time.Location) (ExportSummary, error) {
+// The responses stay a pair — the whole history first, the window ending today
+// second — now returned by one call rather than by two.
+func (stub *stubSettingsViewExportBuilder) BuildSummaryHistoryAndWindow(ctx context.Context, userID uint, through time.Time, location *time.Location) (ExportSummary, ExportSummary, error) {
 	stub.called = true
 	stub.summaryUserIDs = append(stub.summaryUserIDs, userID)
-	stub.calls = append(stub.calls, newSettingsViewSummaryCall(from, to, location))
+	stub.calls = append(stub.calls, newSettingsViewSummaryCall(through, location))
 	if stub.err != nil {
-		return ExportSummary{}, stub.err
+		return ExportSummary{}, ExportSummary{}, stub.err
 	}
-	if stub.callIndex < len(stub.responses) {
-		response := stub.responses[stub.callIndex]
-		stub.callIndex++
-		return response, nil
+
+	history, window := stub.summary, stub.summary
+	if len(stub.responses) > 0 {
+		history = stub.responses[0]
 	}
-	return stub.summary, nil
+	if len(stub.responses) > 1 {
+		window = stub.responses[1]
+	}
+	return history, window, nil
 }
 
 type settingsViewSummaryCall struct {
-	HasFrom bool
-	HasTo   bool
-	From    string
-	To      string
+	Through string
 }
 
-func newSettingsViewSummaryCall(from *time.Time, to *time.Time, location *time.Location) settingsViewSummaryCall {
-	call := settingsViewSummaryCall{
-		HasFrom: from != nil,
-		HasTo:   to != nil,
-	}
-	if from != nil {
-		call.From = from.In(location).Format("2006-01-02")
-	}
-	if to != nil {
-		call.To = to.In(location).Format("2006-01-02")
-	}
-	return call
+func newSettingsViewSummaryCall(through time.Time, location *time.Location) settingsViewSummaryCall {
+	return settingsViewSummaryCall{Through: through.In(location).Format("2006-01-02")}
 }
 
 type stubSettingsViewSymptomProvider struct {
@@ -121,6 +112,93 @@ type stubSettingsViewCalendarFeedStatusBuilder struct {
 func (stub *stubSettingsViewCalendarFeedStatusBuilder) BuildFeedStatus(ctx context.Context, userID uint) CalendarFeedStatus {
 	stub.feedUserID = userID
 	return stub.status
+}
+
+// TestBuildSettingsPageViewDataReadsTheOwnersEntriesOnce pins the cost of the
+// settings render against the real ExportService rather than a summary stub.
+// The page needs two aggregates — everything the owner has, for the export
+// panel's selectable bounds, and everything up to today, for its default window
+// — and it used to ask for them with two calls that each fetched EVERY
+// daily_logs row and walked it in Go. Two full reads of the owner's whole
+// history, on every settings render, for three numbers, on a page that shows
+// none of them until the export panel is opened; the shape hid it, because the
+// second call reads as a cheap narrowing of the first.
+//
+// The figures are asserted beside the count: one read must not become one read
+// of the wrong thing.
+// TestCompareISODateComparesTheSameOperandsInBothArms pins one comparison to
+// one reading of its operands. The equality arm trimmed and the ordering arm
+// did not, so a padded value was "not equal" and then ordered by the space:
+// 0x20 sorts below every digit, which made a padded LATER date read as earlier.
+// Both callers pass canonical values today — the trim in front of the raw
+// comparison is exactly what made a padded one look safe to pass — and the
+// function decides the export panel's selectable bounds, so the wrong branch
+// would silently offer a range that excludes the owner's own data.
+func TestCompareISODateComparesTheSameOperandsInBothArms(t *testing.T) {
+	for _, testCase := range []struct {
+		name  string
+		left  string
+		right string
+		want  int
+	}{
+		{name: "canonical earlier", left: "2024-01-02", right: "2024-01-05", want: -1},
+		{name: "canonical later", left: "2024-01-05", right: "2024-01-02", want: 1},
+		{name: "canonical equal", left: "2024-01-05", right: "2024-01-05", want: 0},
+		{name: "padded later left", left: " 2024-01-05", right: "2024-01-02", want: 1},
+		{name: "padded earlier left", left: " 2024-01-02", right: "2024-01-05", want: -1},
+		{name: "padded right", left: "2024-01-05", right: "2024-01-02 ", want: 1},
+		{name: "padded equal", left: " 2024-01-05 ", right: "2024-01-05", want: 0},
+		{name: "empty against a date", left: "", right: "2024-01-05", want: -1},
+	} {
+		if got := compareISODate(testCase.left, testCase.right); got != testCase.want {
+			t.Fatalf("%s: compareISODate(%q, %q) = %d, want %d", testCase.name, testCase.left, testCase.right, got, testCase.want)
+		}
+	}
+}
+
+func TestBuildSettingsPageViewDataReadsTheOwnersEntriesOnce(t *testing.T) {
+	days := &stubExportDayReader{logs: []models.DailyLog{
+		{Date: mustParseSettingsViewDay(t, "2026-02-01"), Notes: "first"},
+		{Date: mustParseSettingsViewDay(t, "2026-02-21"), Notes: "today"},
+		// A future-dated entry: inside the owner's history, outside the
+		// default export window that stops at today.
+		{Date: mustParseSettingsViewDay(t, "2026-03-05"), Notes: "ahead"},
+	}}
+	exportService := NewExportService(days, &stubExportSymptomReader{})
+	settingsLoader := &stubSettingsViewLoader{user: models.User{CycleLength: 28, PeriodLength: 5}}
+	service := NewSettingsViewService(settingsLoader, exportService, nil, nil, nil)
+
+	owner := &models.User{ID: 77, Role: models.RoleOwner}
+	viewData, err := service.BuildSettingsPageViewData(
+		context.Background(), owner, "en", SettingsViewInput{},
+		mustParseSettingsViewDay(t, "2026-02-21"), time.UTC,
+	)
+	if err != nil {
+		t.Fatalf("BuildSettingsPageViewData() unexpected error: %v", err)
+	}
+
+	if len(days.ownerIDs) != 1 {
+		t.Fatalf("one settings render fetched the owner's entries %d times; the whole history is materialized on each", len(days.ownerIDs))
+	}
+	if days.ownerIDs[0] != owner.ID {
+		t.Fatalf("the read must stay scoped to the acting owner %d, got %d", owner.ID, days.ownerIDs[0])
+	}
+
+	if viewData.Export.SelectableDateMax != "2026-03-05" {
+		t.Fatalf("the selectable range covers everything the owner has, got max %q", viewData.Export.SelectableDateMax)
+	}
+	if viewData.Export.SelectableDateMin != "2026-02-01" {
+		t.Fatalf("the selectable range starts at the earliest entry, got min %q", viewData.Export.SelectableDateMin)
+	}
+	if viewData.Export.DefaultDateTo != "2026-02-21" {
+		t.Fatalf("the default window still ends today, got %q", viewData.Export.DefaultDateTo)
+	}
+	if viewData.Export.SummaryTotalEntries != 2 {
+		t.Fatalf("the default window summarizes the two entries up to today, got %d", viewData.Export.SummaryTotalEntries)
+	}
+	if viewData.Export.SummaryDateFrom != "2026-02-01" || viewData.Export.SummaryDateTo != "2026-02-21" {
+		t.Fatalf("expected the default window summary 2026-02-01..2026-02-21, got %q..%q", viewData.Export.SummaryDateFrom, viewData.Export.SummaryDateTo)
+	}
 }
 
 func TestBuildSettingsPageViewDataClassifiesChangePasswordError(t *testing.T) {
@@ -186,8 +264,7 @@ func TestBuildSettingsPageViewDataOwnerLoadsExportSummary(t *testing.T) {
 		t.Fatalf("expected FetchSymptoms to be called for owner")
 	}
 	assertSettingsViewOwnerSummaryCalls(t, exportBuilder.calls, []settingsViewSummaryCall{
-		{HasFrom: false, HasTo: false},
-		{HasFrom: true, HasTo: true, From: "2026-02-01", To: "2026-02-21"},
+		{Through: "2026-02-21"},
 	})
 	assertOwnerSymptomsViewData(t, viewData)
 	assertOwnerExportViewData(t, viewData, ownerExportViewExpectation{
@@ -283,9 +360,10 @@ func TestBuildSettingsPageViewDataOwnerClampsExportDefaultToRequestLocalToday(t 
 		t.Fatalf("BuildSettingsPageViewData() unexpected error: %v", err)
 	}
 
+	// The window the page asks for ends at request-local today, not at the
+	// server's day: that cutoff is the whole point of this case.
 	assertSettingsViewOwnerSummaryCalls(t, exportBuilder.calls, []settingsViewSummaryCall{
-		{HasFrom: false, HasTo: false},
-		{HasFrom: true, HasTo: true, From: "2026-03-12", To: "2026-03-12"},
+		{Through: "2026-03-12"},
 	})
 	if viewData.Export.DefaultDateTo != "2026-03-12" {
 		t.Fatalf("expected export default to date to use request-local today, got %q", viewData.Export.DefaultDateTo)

--- a/internal/services/stats_cycle_ribbon.go
+++ b/internal/services/stats_cycle_ribbon.go
@@ -23,6 +23,10 @@ const (
 	statsCycleRibbonRows        = 4
 	statsCycleRibbonMinCycles   = 2
 	statsCycleRibbonMaxAxisDays = 60
+	// statsCycleRibbonOvulationPhase is the one phase value that names the
+	// ovulation day; the fertile peak is the same claim in a second encoding
+	// and reads it rather than recomputing it.
+	statsCycleRibbonOvulationPhase = "ovulation"
 )
 
 type StatsCycleRibbon struct {
@@ -35,14 +39,22 @@ type StatsCycleRibbon struct {
 	// phases — and, above it, the medical-safety suppression gate every projected
 	// surface shares. Off, the stack draws only what was recorded.
 	ShowPhases bool
-	Rows       []StatsCycleRibbonRow
+	// AxisTruncated reports that at least one cycle is longer than the axis the
+	// DOM bound allows, so the stack is no longer a complete comparison.
+	AxisTruncated bool
+	Rows          []StatsCycleRibbonRow
 }
 
 type StatsCycleRibbonRow struct {
 	Start        time.Time
 	CycleLength  int
 	PeriodLength int
-	Days         []StatsCycleRibbonDay
+	// Truncated marks a row whose cycle outran the axis: its band stops at the
+	// cap rather than at the cycle's own end, so its length may not be read
+	// off the drawing — only off CycleLength beside it. Two such rows are the
+	// same width whatever their lengths, and without this flag nothing said so.
+	Truncated bool
+	Days      []StatsCycleRibbonDay
 }
 
 type StatsCycleRibbonDay struct {
@@ -94,15 +106,19 @@ func buildStatsCycleRibbon(user *models.User, stats CycleStats, logs []models.Da
 	loggedByDay := statsCycleRibbonLoggedDays(logs)
 
 	rows := make([]StatsCycleRibbonRow, 0, len(shown))
+	axisTruncated := false
 	for _, cycle := range shown {
-		rows = append(rows, statsCycleRibbonRow(cycle, axisDays, luteal, showPhases, loggedByDay))
+		row := statsCycleRibbonRow(cycle, axisDays, luteal, showPhases, loggedByDay)
+		axisTruncated = axisTruncated || row.Truncated
+		rows = append(rows, row)
 	}
 
 	return StatsCycleRibbon{
-		Visible:    true,
-		AxisDays:   axisDays,
-		ShowPhases: showPhases,
-		Rows:       rows,
+		Visible:       true,
+		AxisDays:      axisDays,
+		ShowPhases:    showPhases,
+		AxisTruncated: axisTruncated,
+		Rows:          rows,
 	}
 }
 
@@ -137,6 +153,17 @@ func statsCycleRibbonLoggedDays(logs []models.DailyLog) map[string]bool {
 
 func statsCycleRibbonRow(cycle completedCycleSpan, axisDays int, luteal int, showPhases bool, logged map[string]bool) StatsCycleRibbonRow {
 	window := PredictCycleWindow(cycle.Start, cycle.CycleLength, luteal)
+	// A clamped window is not an estimate of the ovulation day, it is the
+	// absence of one: CalcOvulationDay reports OvulationExact=false when the
+	// luteal phase had to be SHORTENED to fit the cycle at all, which it does
+	// for every completed cycle under 19 days. The day it returns is then the
+	// earliest one the arithmetic allows rather than anything the account's own
+	// data locates. Display confidence follows data confidence, and the cells
+	// here are colour with no wording to qualify them — the dashboard's
+	// "approximate" line has no counterpart on this surface — so suppression is
+	// the floor and every ovulation-derived mark comes off the row. The
+	// recorded length and the recorded period days are facts and stay.
+	locatedOvulation := window.Calculable && window.OvulationExact
 	days := make([]StatsCycleRibbonDay, 0, axisDays)
 
 	for day := 1; day <= axisDays; day++ {
@@ -156,7 +183,7 @@ func statsCycleRibbonRow(cycle completedCycleSpan, axisDays int, luteal int, sho
 
 		if showPhases {
 			cell.Phase = statsCycleRibbonPhase(day, cycle.PeriodLength, window, cycle.Start)
-			if window.Calculable {
+			if locatedOvulation {
 				// date is a location midnight (cycle.Start carries the row's own
 				// location) while the window bounds are UTC-midnight date-only
 				// values, so both ends are compared as calendar days — exactly as
@@ -166,7 +193,16 @@ func statsCycleRibbonRow(cycle completedCycleSpan, axisDays int, luteal int, sho
 				// is never true outside UTC at all (issue #48 class).
 				cell.IsFertile = CalendarDaysBetween(window.FertilityWindowStart, date) >= 0 &&
 					CalendarDaysBetween(date, window.FertilityWindowEnd) >= 0
-				cell.IsFertilePeak = CalendarDaysBetween(date, window.OvulationDate) == 0
+				// The peak and the ovulation phase are ONE claim in two
+				// encodings, so the peak is read off the phase the row has
+				// already resolved instead of recomputed beside it. Computed
+				// twice they disagreed: a fertile day may overlap the period —
+				// the two axes are orthogonal (#416) — but on a short cycle the
+				// ovulation day itself landed inside the recorded period days,
+				// where the phase taxonomy spends its one value on "menstrual",
+				// and the cell then carried a period mark and a peak mark at
+				// once with only CSS precedence deciding which an owner saw.
+				cell.IsFertilePeak = cell.Phase == statsCycleRibbonOvulationPhase
 			}
 		} else if isPeriod {
 			// With inferred phases off, the observed period days are still a
@@ -182,6 +218,7 @@ func statsCycleRibbonRow(cycle completedCycleSpan, axisDays int, luteal int, sho
 		Start:        cycle.Start,
 		CycleLength:  cycle.CycleLength,
 		PeriodLength: cycle.PeriodLength,
+		Truncated:    cycle.CycleLength > axisDays,
 		Days:         days,
 	}
 }
@@ -194,14 +231,19 @@ func statsCycleRibbonPhase(day int, periodLength int, window CycleWindowPredicti
 	if day <= periodLength {
 		return "menstrual"
 	}
-	if !window.Calculable {
+	// The same floor the fertility marks take: an ovulation day the luteal
+	// phase had to be clamped to produce is not located by this cycle's data,
+	// so the row paints neither the ovulation cell nor the luteal span, which
+	// is only positioned relative to it. What remains is the follicular
+	// fallback the no-window case already uses.
+	if !window.Calculable || !window.OvulationExact {
 		return "follicular"
 	}
 
 	ovulationDay := CalendarDaysBetween(cycleStart, window.OvulationDate) + 1
 	switch {
 	case day == ovulationDay:
-		return "ovulation"
+		return statsCycleRibbonOvulationPhase
 	case day > ovulationDay:
 		return "luteal"
 	default:

--- a/internal/services/stats_cycle_ribbon_test.go
+++ b/internal/services/stats_cycle_ribbon_test.go
@@ -415,3 +415,201 @@ func TestBuildStatsCycleRibbonSuppressesInferredFertilityInUnpredictableMode(t *
 		}
 	}
 }
+
+// statscycleribbonStack builds a stack from consecutive cycle starts: every
+// entry is one cycle's first day plus its period days, and the last start only
+// closes the cycle before it. Lengths therefore come out as the gaps between
+// the starts, which is what the ribbon draws.
+func statscycleribbonStack(t *testing.T, cycles []statscycleribbonSpec) []models.DailyLog {
+	t.Helper()
+	logs := []models.DailyLog{}
+	for _, cycle := range cycles {
+		logs = append(logs, statscycleribbonCycle(t, cycle.start, cycle.period)...)
+	}
+	return logs
+}
+
+type statscycleribbonSpec struct {
+	start  string
+	period int
+}
+
+// statscycleribbonRowFertility counts one row's three encodings of a fertility
+// claim, the same three the stack-wide helper counts.
+func statscycleribbonRowFertility(row StatsCycleRibbonRow) (fertile int, peak int, ovulation int) {
+	for _, day := range row.Days {
+		if day.IsFertile {
+			fertile++
+		}
+		if day.IsFertilePeak {
+			peak++
+		}
+		if day.Phase == "ovulation" {
+			ovulation++
+		}
+	}
+	return fertile, peak, ovulation
+}
+
+// TestBuildStatsCycleRibbonSuppressesAClampedOvulationEstimate is the medical-
+// safety floor on this surface. PredictCycleWindow reports OvulationExact=false
+// when the luteal phase had to be SHORTENED to fit the cycle at all — every
+// completed cycle under 19 days — so the ovulation day it returns is a fallback
+// the data does not carry rather than an estimate of it. Display confidence
+// follows data confidence: the row keeps its recorded length and its recorded
+// period days and drops every mark derived from that fallback. The dashboard
+// says "approximate" for the same value; here the cells are colour with no
+// wording to qualify them, so suppression is the floor.
+//
+// The stack is drawn with a cycle whose window IS exact beside it: that anchor
+// proves the marks can appear at all, so the negative half cannot pass against
+// an empty ribbon.
+func TestBuildStatsCycleRibbonSuppressesAClampedOvulationEstimate(t *testing.T) {
+	// 15 days (Jan 1 → Jan 16), then 30 (Jan 16 → Feb 15). A 15-day cycle with
+	// a 14-day luteal phase clamps the phase to 10, i.e. OvulationExact=false.
+	logs := statscycleribbonStack(t, []statscycleribbonSpec{
+		{"2026-01-01", 5},
+		{"2026-01-16", 5},
+		{"2026-02-15", 5},
+	})
+
+	if _, exact := CalcOvulationDay(15, 14); exact {
+		t.Fatal("premise: a 15-day cycle with a 14-day luteal phase must clamp, i.e. report exact=false")
+	}
+	if _, exact := CalcOvulationDay(30, 14); !exact {
+		t.Fatal("anchor premise: a 30-day cycle with a 14-day luteal phase must fit exactly")
+	}
+
+	ribbon := buildStatsCycleRibbon(
+		statscycleribbonOwner(true),
+		CycleStats{LutealPhase: 14},
+		logs,
+		buildCompletedCycleSpans(logs, time.UTC),
+	)
+	if !ribbon.ShowPhases || len(ribbon.Rows) != 2 {
+		t.Fatalf("expected two rows with inferred phases on, got rows=%d showPhases=%v", len(ribbon.Rows), ribbon.ShowPhases)
+	}
+
+	clamped, fitted := ribbon.Rows[0], ribbon.Rows[1]
+	if clamped.CycleLength != 15 || fitted.CycleLength != 30 {
+		t.Fatalf("expected a 15-day row then a 30-day row, got %d and %d", clamped.CycleLength, fitted.CycleLength)
+	}
+
+	anchorFertile, anchorPeak, anchorOvulation := statscycleribbonRowFertility(fitted)
+	if anchorFertile == 0 || anchorPeak != 1 || anchorOvulation != 1 {
+		t.Fatalf("anchor: the 30-day row's window is exact and must carry the marks; got fertile=%d peak=%d ovulation=%d", anchorFertile, anchorPeak, anchorOvulation)
+	}
+
+	fertile, peak, ovulation := statscycleribbonRowFertility(clamped)
+	if fertile != 0 || peak != 0 || ovulation != 0 {
+		t.Fatalf("a clamped ovulation day is a fallback, not an observation: the 15-day row must carry no fertility claim; got fertile=%d peak=%d ovulation=%d", fertile, peak, ovulation)
+	}
+
+	// What must survive the floor: the recorded length and the period days.
+	inCycle := 0
+	for _, day := range clamped.Days {
+		if day.InCycle {
+			inCycle++
+		}
+		if day.Day <= clamped.PeriodLength && (!day.IsPeriod || day.Phase != "menstrual") {
+			t.Fatalf("day %d is a recorded period day: period=%v phase=%q", day.Day, day.IsPeriod, day.Phase)
+		}
+	}
+	if inCycle != 15 {
+		t.Fatalf("the recorded 15-day length is a fact and must still be drawn, got %d cells in cycle", inCycle)
+	}
+}
+
+// TestBuildStatsCycleRibbonNeverMarksAPeakOutsideTheOvulationPhase pins the two
+// axes of one cell against each other. Phase and fertility are orthogonal by
+// design (#416) and a fertile day may legitimately overlap the period — but the
+// peak IS the ovulation day, and the phase taxonomy spends its "ovulation"
+// value on the menstrual branch whenever the two land on the same day. A
+// 21-day cycle with a 7-day period does exactly that: the window is exact and
+// puts ovulation on day 7, which is also the last recorded period day. The cell
+// then said "menstrual" and "fertile peak" at once, and which of the two an
+// owner saw was decided by CSS precedence rather than by this service.
+func TestBuildStatsCycleRibbonNeverMarksAPeakOutsideTheOvulationPhase(t *testing.T) {
+	logs := statscycleribbonStack(t, []statscycleribbonSpec{
+		{"2026-01-01", 7},
+		{"2026-01-22", 7},
+		{"2026-02-19", 7},
+	})
+
+	ovulationDay, exact := CalcOvulationDay(21, 14)
+	if !exact || ovulationDay != 7 {
+		t.Fatalf("premise: a 21-day cycle must place an EXACT ovulation on day 7, got day=%d exact=%v", ovulationDay, exact)
+	}
+
+	ribbon := buildStatsCycleRibbon(
+		statscycleribbonOwner(true),
+		CycleStats{LutealPhase: 14},
+		logs,
+		buildCompletedCycleSpans(logs, time.UTC),
+	)
+	if !ribbon.ShowPhases {
+		t.Fatal("expected inferred phases on")
+	}
+
+	peaks := 0
+	for rowIndex, row := range ribbon.Rows {
+		for _, day := range row.Days {
+			if !day.IsFertilePeak {
+				continue
+			}
+			peaks++
+			if day.Phase != "ovulation" {
+				t.Fatalf("row %d day %d is marked the fertile peak while its phase says %q — one cell making two contradicting claims", rowIndex, day.Day, day.Phase)
+			}
+		}
+	}
+	if peaks == 0 {
+		t.Fatal("anchor: the stack must still mark a peak somewhere, or this guard is green against an empty ribbon")
+	}
+}
+
+// TestBuildStatsCycleRibbonFlagsARowTheAxisCannotHold covers the silent half of
+// the axis cap. The cap is the DOM bound and stays; what must not stay is a row
+// claiming to end where it was merely cut off. Two cycles past the cap were
+// drawn as two identical full-width rows, so the comparison the stack exists
+// for reported them equal while the number beside each row said otherwise.
+func TestBuildStatsCycleRibbonFlagsARowTheAxisCannotHold(t *testing.T) {
+	within := buildStatsCycleRibbon(
+		statscycleribbonOwner(false),
+		CycleStats{LutealPhase: 14},
+		nil,
+		[]completedCycleSpan{
+			{Start: statscycleribbonDay(t, "2026-01-01"), CycleLength: 30, PeriodLength: 5},
+			{Start: statscycleribbonDay(t, "2026-01-31"), CycleLength: 34, PeriodLength: 5},
+		},
+	)
+	for index, row := range within.Rows {
+		if row.Truncated {
+			t.Fatalf("row %d fits the axis (%d of %d) and must not be flagged truncated", index, row.CycleLength, within.AxisDays)
+		}
+	}
+	if within.AxisTruncated {
+		t.Fatal("a stack inside the cap draws every cycle whole")
+	}
+
+	beyond := buildStatsCycleRibbon(
+		statscycleribbonOwner(false),
+		CycleStats{LutealPhase: 14},
+		nil,
+		[]completedCycleSpan{
+			{Start: statscycleribbonDay(t, "2026-01-01"), CycleLength: statsCycleRibbonMaxAxisDays + 15, PeriodLength: 5},
+			{Start: statscycleribbonDay(t, "2026-04-01"), CycleLength: statsCycleRibbonMaxAxisDays + 30, PeriodLength: 5},
+		},
+	)
+	if beyond.AxisDays != statsCycleRibbonMaxAxisDays {
+		t.Fatalf("the axis stays capped at %d, got %d", statsCycleRibbonMaxAxisDays, beyond.AxisDays)
+	}
+	if !beyond.AxisTruncated {
+		t.Fatal("the stack must report that the axis could not hold every cycle")
+	}
+	for index, row := range beyond.Rows {
+		if !row.Truncated {
+			t.Fatalf("row %d is %d days long against a %d-day axis and must say so", index, row.CycleLength, beyond.AxisDays)
+		}
+	}
+}


### PR DESCRIPTION

Eight findings in `internal/services`, one commit. Each fix landed guard-first: the regression test
was written against the unfixed tree, observed red with the message naming the culprit, then the fix
was wired in and the same test observed green. Commands and output per record below.

## Invariant §10.6 (display confidence follows data confidence)

Two of these records are prediction surfaces, and both are resolved by suppression rather than by a
qualifier, which is what §10.6 makes the floor:

- `PredictCycleWindow` reports `OvulationExact=false` whenever the luteal phase had to be **clamped**
  to fit the cycle at all (`cycles.go:102-118`), i.e. for every completed cycle under 19 days. The
  Insights cycle stack consumed the resulting ovulation date as if it were an exact one. The stack's
  cells are colour with no wording beside them — the dashboard's `dashboard.ovulation_approximate`
  line has no counterpart there — so a qualifier is not available and would not be enough. The row
  now drops **all three encodings** of that claim (fertile shading, peak band, ovulation phase cell)
  and keeps what was recorded: its observed length and its observed period days
  (`internal/services/stats_cycle_ribbon.go:166`, `:186-205`, `:233-241`).
- The peak band is no longer computed beside the phase axis but read off it, so one cell can only
  make one claim (`internal/services/stats_cycle_ribbon.go:205`).

Nothing here weakens an existing suppression: `PredictionsSuppressed` still gates the whole phase
axis above this (`stats_cycle_ribbon.go:92`), and
`TestBuildStatsCycleRibbonSuppressesInferredFertilityInUnpredictableMode` still passes unchanged.

## Records

### R2-0086 — clamped ovulation drawn as an exact one (P2, api-contract)

`internal/services/stats_cycle_ribbon.go:166` gates every ovulation-derived mark on
`window.Calculable && window.OvulationExact`; `statsCycleRibbonPhase` takes the same floor and falls
back to `follicular`, the branch a non-calculable window already used.

```
$ go test ./internal/services/ -run 'TestBuildStatsCycleRibbonSuppressesAClampedOvulationEstimate' -v
--- FAIL: TestBuildStatsCycleRibbonSuppressesAClampedOvulationEstimate
    stats_cycle_ribbon_test.go:505: a clamped ovulation day is a fallback, not an observation:
        the 15-day row must carry no fertility claim; got fertile=5 peak=1 ovulation=0
# after the fix
ok  	github.com/ovumcy/ovumcy-web/internal/services
```

The guard renders a 15-day cycle (clamped) beside a 30-day one (exact) and asserts the exact row
still carries its marks, so the negative half cannot pass against an empty ribbon.

### R2-0087 — one cell, two contradicting claims (P2, api-contract)

`cell.IsFertilePeak = cell.Phase == statsCycleRibbonOvulationPhase`
(`internal/services/stats_cycle_ribbon.go:205`). A fertile day overlapping the period stays legal
(#416, two orthogonal axes); the peak follows the phase taxonomy, which spends its `ovulation` value
on the menstrual branch when the two coincide — the same precedence `resolveCyclePhase` uses.

```
$ go test ./internal/services/ -run 'TestBuildStatsCycleRibbonNeverMarksAPeakOutsideTheOvulationPhase' -v
--- FAIL: ...
    stats_cycle_ribbon_test.go:562: row 0 day 7 is marked the fertile peak while its phase says
        "menstrual" — one cell making two contradicting claims
# after the fix: ok
```

### R2-0088 — the axis cap was silent (P2, api-contract)

The cap stays (it is the DOM bound, pinned by `TestStatsCycleRibbonAxisDaysClampsAWildCycle`); the
row now says when it was cut: `StatsCycleRibbonRow.Truncated` and `StatsCycleRibbon.AxisTruncated`
(`internal/services/stats_cycle_ribbon.go:42-56`, `:113-120`, `:221`).

```
$ go test ./internal/services/ -run 'TestBuildStatsCycleRibbonFlagsARowTheAxisCannotHold' -v
--- FAIL: ...
    stats_cycle_ribbon_test.go:608: the stack must report that the axis could not hold every cycle
# after the fix: ok
```

Taken at the record's second option ("the truncation is flagged on the row"). Painting the flag is a
template + CSS change: `web/src/css/input.css` is outside this change's scope, the bundle is
built and committed, and an unconsumed markup hook is itself debt here — so the flag stops at the
service and the numeric length beside the row remains the truth.

### R2-0061 — a Fahrenheit reading altered on every save (P2, api-contract)

Storage is Celsius and was rounded to the two decimals the form displays; one step of 0.01 °F is
0.0056 °C, so no two-decimal Fahrenheit entry had an exact stored form. `roundStoredTemperatureValue`
now keeps four decimals; the display rounding is unchanged and named for what it is
(`internal/services/day_tracking.go:154-184`). No stored value changes.

```
$ go test ./internal/services/ -run 'TestDayBBTRoundTripsEveryStepOfTheOwnersUnit' -v
--- FAIL: ...
    day_tracking_test.go:110: unit "f": an owner typed 93.21 and the form redisplays 93.22
        (stored 34.010000 °C) — the reading was altered on save
# after the fix: ok
```

The guard sweeps **every** 0.01 step of both units across the form's advertised range: the range ends
round-tripped even while the interior did not, which is why the boundary tests were green.

### R2-0547 + R2-0077 — the January floor (P1 + P3)

Both records name the same expression. `SettingsCycleStartDateBounds` is now a rolling window,
`SettingsCycleStartWindowDays = 365` (`internal/services/settings_cycle_policy.go:139-158`). The
window only ever grew — 1 January of the current year is at most 365 days back — so no date the old
bound accepted is now refused.

```
$ go test ./internal/services/ -run 'TestValidateCycleSettingsAcceptsAStartInThePrecedingDecember' -v
--- FAIL: ...
    settings_service_cycle_test.go:137: a cycle that began on 28 December is the real anchor on
        2 January and must be accepted, got settings cycle start date invalid
# after the fix: ok
```

Three consequences, all expected and all resolved in the same commit:
`settings_service_cycle_test.go:55-63` cemented `2025-12-31` as invalid against `now=2026-02-15` and
now uses a date past the window's far end; `TestSettingsCycleStartDateBoundsHonorsLocationNearLocal
Midnight` pins the floor moving with the location instead of a calendar boundary; and the
`calendarDayBarrierAllowlist` carve-out for this function was removed, since the barrier fails on a
stale exemption. `internal/api/settings_cycle_regressions_test.go` matched `min="\d{4}-01-01"` on the
rendered date input and now matches any calendar day.

R2-0077 also asked for one shared bounds helper across both surfaces. Not done: the onboarding twin
(`onboarding_service.go:215`) is outside this change's scope, and the two windows differ by
design (60 days, the number its copy states, versus a year on a correction surface). What the record
called the defect — the same unexplained year floor written out twice — is gone from both: each
surface now states its own window once, in one place, with the reason.

### R2-0067 — an export column keyed on a display name (P3, api-contract)

`exportSymptomColumnsByName` is derived from `models.DefaultBuiltinSymptoms()` and
`exportSymptomFlagSetters` is keyed on the catalog `Key`
(`internal/services/export_service.go:58-76`, `:78-81`).

```
$ go test ./internal/services/ -run 'TestExportSymptomColumnsAreABijectionOntoTheBuiltinCatalog|TestBuildExportSymptomFlagsKeepsACustomNameOutOfABuiltinColumn' -v
--- FAIL: TestExportSymptomColumnsAreABijectionOntoTheBuiltinCatalog
    export_service_test.go:161: built-in "mood_swings" has no export column keyed on it;
        the columns are keyed on something other than the catalog key
--- FAIL: TestBuildExportSymptomFlagsKeepsACustomNameOutOfABuiltinColumn
    export_service_test.go:196: an owner's custom "Mood" was exported as the built-in "Mood swings"
        — a different symptom's data under a built-in's label
# after the fix: ok
```

The import direction reads the same vocabulary in reverse (`import_service.go:46-62`), so its key
moved with the export's — a fix at one of the two sites drops the column on re-import, which
`TestImportServiceRoundTripPreservesEntries` caught. The guard now pins the two maps as one set.
The wire contract is untouched: the JSON key stays `mood` and the CSV header stays `Mood`.

### R2-0839 — an exported mutable header slice (P3, concurrency)

`ExportCSVHeaders()` returns a fresh copy (`internal/services/export_service.go:15-24`); the sole
production caller is `internal/api/handlers_export_csv.go:37`.

```
$ go test ./internal/services/ -run 'TestExportCSVHeadersCannotBeMutatedByACaller' -v
--- FAIL: ...
    export_service_test.go:218: a caller's write reached the next export's header row:
        expected "Date", got "Rewritten by a caller"
# after the fix: ok
```

The red run was taken with the accessor already in place and its **body** still returning the shared
slice, not by unwiring the caller — a guard that reddens only on an unwired call site would stay
green on exactly the defect that ships.

### R2-0080 — two full reads per settings render (P3, performance)

`BuildSummaryHistoryAndWindow` returns both aggregates from one read
(`internal/services/export_service.go:238-266`); the settings view asks for them once
(`internal/services/settings_view_service.go:316-325`). The default window's lower bound is the
owner's earliest entry, so that window *is* the history up to today and needs no second query.

```
$ go test ./internal/services/ -run 'TestBuildSettingsPageViewDataReadsTheOwnersEntriesOnce' -v
--- FAIL: ...
    settings_view_service_test.go:160: one settings render fetched the owner's entries 2 times;
        the whole history is materialized on each
# after the fix: ok
```

The guard drives the **real** `ExportService` over a counting day reader, asserts one read, that it
is scoped to the acting owner, and that the figures are unchanged (a future-dated entry stays inside
the selectable range and outside the default window). Half of the record's guard is deliberately not
done: pushing `(count, min, max)` into SQL is a repository change, and `internal/db` is outside this
group's file boundary. The read count the record asked to pin is pinned.

### R2-0081 — one comparison, two readings of its operands (P3, api-contract)

`compareISODate` trims both operands once into locals
(`internal/services/settings_view_service.go:371-388`).

```
$ go test ./internal/services/ -run 'TestCompareISODateComparesTheSameOperandsInBothArms' -v
--- FAIL: ...
    settings_view_service_test.go:163: padded later left: compareISODate(" 2024-01-05",
        "2024-01-02") = -1, want 1
# after the fix: ok
```

## Verification

```
go build ./...                                   # clean
go test ./internal/... ./cmd/... ./scripts/...   # all packages pass
golangci-lint run ./internal/services/... ./internal/api/...   # 0 issues
staticcheck ./internal/...                       # clean
```

`internal/api` was run with `-timeout 1800s`: the package needs ~360 s on this machine and the
default 10 m alarm fires on a slower run, independently of this change.

## Rollback

Single-commit revert. Two records are category `api-contract` with an owner-visible effect, so a
revert should re-run the OpenAPI contract suite alongside the unit lanes; nothing here touches
persisted data, a migration or a wire field — the export JSON keys, the CSV header row and its
column order are unchanged, and stored temperatures keep their existing values (only newly written
ones carry the extra precision).
