### PR TITLE
chore(lint): stop the linter walking node_modules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,6 +37,16 @@ linters:
     - intrange
     - misspell
     - unconvert
+  exclusions:
+    # `npm ci` installs at least one package that ships Go sources of its own
+    # (`flatted`, a Go port beside its JavaScript), and a bare `golangci-lint
+    # run` walks straight into it: five findings — 2 govet, 3 intrange — in a
+    # file nothing here calls, that is untracked, and that the next install
+    # overwrites. Scoping the run by hand hides them and hides nothing else,
+    # but only for whoever remembers to; the config is where it belongs, so
+    # the plain command is the correct command.
+    paths:
+      - node_modules
   settings:
     misspell:
       # Localized copy asserted by backend regressions is not English prose:

--- a/changelog.d/chore-lint-excludes-node-modules.md
+++ b/changelog.d/chore-lint-excludes-node-modules.md
@@ -1,0 +1,12 @@
+none
+
+Lint configuration only, with no effect on the shipped application. `npm ci` installs at least one
+package that ships Go sources of its own — `flatted`, whose Go port sits beside its JavaScript — and
+a bare `golangci-lint run` walked into it and reported five findings (2 govet, 3 intrange) in a file
+nothing in this repository calls, that is untracked, and that the next install overwrites. Anyone
+running the linter without scoping it by hand read a verdict that was partly about someone else's
+code, and the findings invited a fix that could not survive an install.
+
+`linters.exclusions.paths` now names `node_modules`, so the plain command is the correct command.
+CI was never affected and its step is unchanged: it names the module's package trees explicitly, in
+a job that does not run `npm ci` at all.


### PR DESCRIPTION
A bare `golangci-lint run` was reporting five findings that had nothing to do with this repository.

`npm ci` installs at least one package that ships **Go sources of its own** — `flatted`, whose Go
port sits in the package beside its JavaScript — and the linter walked straight into it:

```
$ golangci-lint run
.../node_modules/flatted/golang/pkg/flatted/flatted.go:100:4: for loop can be changed to use an integer range (Go 1.22+) (intrange)
.../node_modules/flatted/golang/pkg/flatted/flatted.go:119:2: for loop can be changed to use an integer range (Go 1.22+) (intrange)
5 issues:
* govet: 2
* intrange: 3
```

The file is untracked, nothing here calls it, and the next `npm ci` overwrites it — so the verdict
was partly about someone else's code, and the findings invited a fix that could not survive an
install. Scoping the invocation by hand (`./internal/... ./cmd/... ./scripts/...`) hid exactly the
same five and hid nothing else, but only for whoever remembered to do it. The config is where that
rule belongs, so the plain command is now the correct command.

## The change

`linters.exclusions.paths` naming `node_modules`, with the reason beside it. That is the v2 spelling
of the old `issues.exclude-dirs`; `golangci-lint config verify` accepts it on the pinned v2.12.2.

The exclusion names `node_modules` and nothing else. It matches wherever the directory appears,
including under a git worktree, which is where these findings actually surfaced — a worktree that
had run `npm ci` to rebuild the CSS.

## Verified both directions, on a tree that HAS node_modules

Before — the five findings above. After:

```
$ golangci-lint run
0 issues.
```

A green run after adding an exclusion proves nothing on its own, so the linter was also made to say
**no**. A throwaway file in `internal/i18n` carrying a three-clause counting loop and an unused
function:

```
$ golangci-lint run
internal\i18n\zz_scratch_lintprobe.go:5:6: func scratchLintProbe is unused (unused)
2 issues:
* intrange: 1
* unused: 1
```

Both linters still reach the module's own tree; the probe was deleted and `git status` shows only
`.golangci.yml` and the changelog fragment. The exclusion narrows the walk without blinding it.

## CI is untouched, and was never affected

The lint step names the module's package trees explicitly —
`golangci-lint run ./cmd/... ./internal/... ./migrations/... ./scripts/... ./web/...`
(`.github/workflows/ci.yml:531`) — in a job that does not run `npm ci` at all, which the job's own
comment states at `:449`. This change alters no workflow.

## Rollback

Single-commit revert. Configuration only: no Go source, no persisted data, no schema, no route, no
public interface. Reverting restores the five third-party findings on any tree that has installed
node modules, and changes nothing about CI.
