### PR TITLE
test(services): close three holes in the symptom-id dedup sweep

### DIFF
--- a/changelog.d/test-services-dedup-sweep-holes.md
+++ b/changelog.d/test-services-dedup-sweep-holes.md
@@ -1,0 +1,24 @@
+none
+
+Test-only. The symptom-id dedup sweep that shipped alongside the dedup fix
+passed in three situations it was written to fail in, and this closes all three.
+No production code changes; the dedup itself is unaffected and still closed at
+every read site.
+
+The exemption that clears the export flag builder's loop was keyed on the
+function and skipped that function's whole body, so a counting loop added beside
+the cleared one was never examined — and the export path is the one site with no
+behavioural guard behind the sweep. An exemption now names the loop it clears,
+must match exactly one, and fails if the loop it cleared starts incrementing
+anything, which was previously only a comment.
+
+The sweep matched a range expression by its source text, so an ordinary
+`ids := logEntry.SymptomIDs` walked past it. A local assigned exactly once is
+now resolved back to the expression it was assigned from; one assigned twice, or
+bound by the `range` clause itself, is left alone.
+
+Its refusal to report success on an empty sweep counted compliant and violating
+loops together, so the six compliant sites kept the count above zero and a
+broken matcher could have detected nothing while passing. The sweep is now
+anchored on fixture sources the test owns: two that must be flagged, two that
+must not, and both sides of the exemption rule.

--- a/internal/services/symptom_id_dedup_barrier_test.go
+++ b/internal/services/symptom_id_dedup_barrier_test.go
@@ -35,26 +35,72 @@ import (
 // source to keep it closed: a new loop over a day's symptom ids that does not
 // route through one of the two helpers fails here the moment it is written.
 //
-// What it cannot see, stated here and repeated in the failure text: it matches
-// a range expression whose source ends in `symptomids`, case-insensitively. A
-// slice first assigned to a differently named local, or counted with an index
-// loop rather than `range`, is invisible to it.
+// Three properties keep the sweep honest, and each was added after the sweep
+// was measured passing without it:
+//
+//   - an exemption clears ONE loop, not a whole function, and an exempted loop
+//     that increments anything is itself an error — a counting loop added
+//     beside the cleared one used to be unexamined;
+//   - a single-assignment local is resolved back to the expression it was
+//     assigned from, because `ids := logEntry.SymptomIDs` followed by
+//     `range ids` is an everyday refactor and used to walk straight past;
+//   - the violation matcher is anchored on fixture sources this test owns, one
+//     that must be flagged and one that must not, because the real tree's six
+//     compliant sites keep the "found something" counter above zero on their
+//     own and would hide a matcher that had stopped matching.
+//
+// What it still cannot see, stated here and repeated in the failure text: a
+// local assigned more than once, a slice handed to a helper of this package's
+// own before being counted, an index loop rather than `range`, and any field
+// not named SymptomIDs. Those are why the three SurvivesARepeatedID guards
+// below exist beside it — the sweep is the barrier for sites added tomorrow,
+// and it is not the only one for the sites that exist today.
 var symptomIDDedupHelpers = map[string]struct{}{
 	"uniqueSymptomIDs":      {},
 	"uniqueKnownSymptomIDs": {},
 }
 
-// symptomIDLoopExemptions are the functions whose loop over a day's symptom ids
-// is provably idempotent under a repeat, so routing it through a helper would
-// buy nothing. Each entry carries the reason it is not a counting site; a loop
-// that increments anything does not belong here.
-var symptomIDLoopExemptions = map[string]string{
-	"buildExportSymptomFlags": "sets booleans and collects names into a set, so a repeated id changes no output",
+// symptomIDLoopExemption clears exactly one loop: the one in `function` whose
+// range expression reads `rangeExpr` after alias resolution. Naming the
+// expression rather than the function is what stops the exemption from
+// spreading to a second loop somebody adds later.
+type symptomIDLoopExemption struct {
+	function  string
+	rangeExpr string
+	reason    string
+}
+
+// symptomIDLoopExemptions are the loops whose walk over a day's symptom ids is
+// provably idempotent under a repeat, so routing them through a helper would
+// buy nothing. A loop that increments anything does not belong here, and the
+// sweep enforces that rather than trusting this comment.
+var symptomIDLoopExemptions = []symptomIDLoopExemption{
+	{
+		function:  "buildExportSymptomFlags",
+		rangeExpr: "symptomIDs",
+		reason:    "sets booleans and collects names into a set, so a repeated id changes no output",
+	},
+}
+
+// Verdicts the sweep can reach for one loop over a day's symptom ids.
+const (
+	symptomLoopRouted          = "routed"
+	symptomLoopViolation       = "violation"
+	symptomLoopExempt          = "exempt"
+	symptomLoopExemptButCounts = "exempt-but-counts"
+)
+
+type symptomIDLoopFinding struct {
+	verdict   string
+	function  string
+	line      int
+	source    string // range expression, after alias resolution
+	written   string // range expression as written, when resolution changed it
+	exemption int    // index into the exemption slice, for exempt verdicts
 }
 
 // TestEverySymptomIDLoopDedupes fails when a production loop in this package
-// walks a day's symptom ids without routing them through a dedup helper. The
-// helpers' own bodies are exempt — one of them is where the deduping happens.
+// walks a day's symptom ids without routing them through a dedup helper.
 func TestEverySymptomIDLoopDedupes(t *testing.T) {
 	root := servicesSourceBarrierRoot(t)
 	dir := filepath.Join(root, "internal", "services")
@@ -64,7 +110,9 @@ func TestEverySymptomIDLoopDedupes(t *testing.T) {
 		t.Fatalf("reading %s: %v", dir, err)
 	}
 
-	inspected, found, exempted := 0, 0, 0
+	inspected, found := 0, 0
+	exemptionUses := make([]int, len(symptomIDLoopExemptions))
+
 	for _, entry := range entries {
 		name := entry.Name()
 		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
@@ -78,34 +126,19 @@ func TestEverySymptomIDLoopDedupes(t *testing.T) {
 			t.Fatalf("parsing %s: %v", name, parseErr)
 		}
 
-		for _, decl := range parsed.Decls {
-			fn, ok := decl.(*ast.FuncDecl)
-			if !ok || fn.Body == nil {
-				continue
+		for _, finding := range symptomIDLoopFindings(t, fset, parsed, symptomIDLoopExemptions) {
+			found++
+			switch finding.verdict {
+			case symptomLoopViolation:
+				t.Errorf("%s:%d ranges over %s%s without deduping: a repeated id counts its day twice, which renders a phase percentage above 100 and skews both the frequency list and the picker's usage ranking. Route it through %v",
+					name, finding.line, finding.source, symptomLoopAliasNote(finding), sortedKeys(symptomIDDedupHelpers))
+			case symptomLoopExemptButCounts:
+				t.Errorf("%s:%d is exempted as %q, and its body increments a counter: an exemption clears a loop whose output a repeat cannot change, which this loop's no longer is",
+					name, finding.line, symptomIDLoopExemptions[finding.exemption].reason)
+				exemptionUses[finding.exemption]++
+			case symptomLoopExempt:
+				exemptionUses[finding.exemption]++
 			}
-			if _, helper := symptomIDDedupHelpers[fn.Name.Name]; helper {
-				continue
-			}
-			if _, exempt := symptomIDLoopExemptions[fn.Name.Name]; exempt {
-				exempted++
-				continue
-			}
-			ast.Inspect(fn.Body, func(node ast.Node) bool {
-				loop, ok := node.(*ast.RangeStmt)
-				if !ok {
-					return true
-				}
-				source := symptomLoopSource(t, fset, loop.X)
-				switch {
-				case symptomLoopRoutesThroughADedupHelper(loop.X):
-					found++
-				case strings.HasSuffix(strings.ToLower(source), "symptomids"):
-					found++
-					t.Errorf("%s:%d ranges over %s without deduping: a repeated id counts its day twice, which renders a phase percentage above 100 and skews both the frequency list and the picker's usage ranking. Route it through %v",
-						name, fset.Position(loop.Pos()).Line, source, sortedKeys(symptomIDDedupHelpers))
-				}
-				return true
-			})
 		}
 	}
 
@@ -115,13 +148,142 @@ func TestEverySymptomIDLoopDedupes(t *testing.T) {
 	if found == 0 {
 		t.Fatalf("no loop over a day's symptom ids was found in %s — the barrier's matcher no longer recognises the shape it judges", dir)
 	}
-	if exempted != len(symptomIDLoopExemptions) {
-		t.Errorf("%d of the %d exempted functions were swept: an exemption for a function this package no longer declares hides nothing and should be dropped", exempted, len(symptomIDLoopExemptions))
+	for index, uses := range exemptionUses {
+		if uses != 1 {
+			t.Errorf("the exemption for %s over %q matched %d loops, want exactly 1: an exemption that matches nothing hides nothing and should be dropped, and one that matches twice is clearing a loop nobody cleared",
+				symptomIDLoopExemptions[index].function, symptomIDLoopExemptions[index].rangeExpr, uses)
+		}
 	}
 }
 
-// TestSymptomDedupHelpersAgreeOnARepeatedID anchors the sweep on fixtures this
-// test owns, so it cannot pass by pointing every loop at a helper that dedupes
+// TestSymptomIDSweepMatcherFlagsAKnownViolation anchors the sweep on fixture
+// sources this test owns. The real tree's compliant sites keep the sweep's
+// "found something" counter above zero by themselves, so without a fixture that
+// MUST be flagged, a matcher that had stopped matching would report success
+// while detecting nothing.
+func TestSymptomIDSweepMatcherFlagsAKnownViolation(t *testing.T) {
+	exemptions := []symptomIDLoopExemption{
+		{function: "exemptedFixture", rangeExpr: "logEntry.SymptomIDs", reason: "fixture"},
+	}
+
+	tests := []struct {
+		name        string
+		source      string
+		wantVerdict string
+		wantSource  string
+	}{
+		{
+			name: "a bare loop is a violation",
+			source: `package p
+func f(logEntry L, counts map[uint]int) {
+	for _, id := range logEntry.SymptomIDs {
+		counts[id]++
+	}
+}`,
+			wantVerdict: symptomLoopViolation,
+			wantSource:  "logEntry.SymptomIDs",
+		},
+		{
+			name: "a helper-routed loop is compliant",
+			source: `package p
+func f(logEntry L, counts map[uint]int) {
+	for _, id := range uniqueSymptomIDs(logEntry.SymptomIDs) {
+		counts[id]++
+	}
+}`,
+			wantVerdict: symptomLoopRouted,
+			wantSource:  "uniqueSymptomIDs(logEntry.SymptomIDs)",
+		},
+		{
+			name: "a single-assignment alias is resolved and still a violation",
+			source: `package p
+func f(logEntry L, counts map[uint]int) {
+	ids := logEntry.SymptomIDs
+	for _, id := range ids {
+		counts[id]++
+	}
+}`,
+			wantVerdict: symptomLoopViolation,
+			wantSource:  "logEntry.SymptomIDs",
+		},
+		{
+			name: "an alias of a helper call is resolved and compliant",
+			source: `package p
+func f(logEntry L, counts map[uint]int) {
+	ids := uniqueSymptomIDs(logEntry.SymptomIDs)
+	for _, id := range ids {
+		counts[id]++
+	}
+}`,
+			wantVerdict: symptomLoopRouted,
+			wantSource:  "uniqueSymptomIDs(logEntry.SymptomIDs)",
+		},
+		{
+			name: "an exempted loop that counts nothing stays exempt",
+			source: `package p
+func exemptedFixture(logEntry L, flags map[uint]bool) {
+	for _, id := range logEntry.SymptomIDs {
+		flags[id] = true
+	}
+}`,
+			wantVerdict: symptomLoopExempt,
+			wantSource:  "logEntry.SymptomIDs",
+		},
+		{
+			name: "an exempted loop that increments is an error in its own right",
+			source: `package p
+func exemptedFixture(logEntry L, counts map[uint]int) {
+	for _, id := range logEntry.SymptomIDs {
+		counts[id]++
+	}
+}`,
+			wantVerdict: symptomLoopExemptButCounts,
+			wantSource:  "logEntry.SymptomIDs",
+		},
+		{
+			name: "a second loop beside an exempted one is still swept",
+			source: `package p
+func exemptedFixture(logEntry L, counts map[uint]int) {
+	for _, id := range logEntry.SymptomIDs {
+		_ = id
+	}
+	for _, id := range logEntry.OtherSymptomIDs {
+		counts[id]++
+	}
+}`,
+			wantVerdict: symptomLoopViolation,
+			wantSource:  "logEntry.OtherSymptomIDs",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fset := token.NewFileSet()
+			parsed, err := parser.ParseFile(fset, "fixture.go", tc.source, 0)
+			if err != nil {
+				t.Fatalf("parsing the fixture: %v", err)
+			}
+
+			findings := symptomIDLoopFindings(t, fset, parsed, exemptions)
+			matched := 0
+			for _, finding := range findings {
+				if finding.source != tc.wantSource {
+					continue
+				}
+				matched++
+				if finding.verdict != tc.wantVerdict {
+					t.Errorf("the sweep called %s %q, want %q", tc.wantSource, finding.verdict, tc.wantVerdict)
+				}
+			}
+			if matched != 1 {
+				t.Fatalf("the sweep returned %d findings for %s, want exactly 1 — the matcher no longer recognises the shape it judges (all findings: %+v)", matched, tc.wantSource, findings)
+			}
+		})
+	}
+}
+
+// TestSymptomDedupHelpersAgreeOnARepeatedID anchors the helpers themselves, so
+// the sweep cannot pass by pointing every loop at a helper that dedupes
 // nothing.
 func TestSymptomDedupHelpersAgreeOnARepeatedID(t *testing.T) {
 	known := map[uint]models.SymptomType{1: {ID: 1}, 2: {ID: 2}}
@@ -201,6 +363,157 @@ func TestPickerRankingSurvivesARepeatedID(t *testing.T) {
 	if ranked[0].ID != 2 {
 		t.Errorf("one day repeating id 1 outranked the two days that logged id 2: got id %d first", ranked[0].ID)
 	}
+}
+
+// symptomIDLoopFindings classifies every `range` over a day's symptom ids in
+// one parsed file. The helpers' own bodies are skipped — one of them is where
+// the deduping happens — and everything else is judged loop by loop.
+func symptomIDLoopFindings(t *testing.T, fset *token.FileSet, file *ast.File, exemptions []symptomIDLoopExemption) []symptomIDLoopFinding {
+	t.Helper()
+
+	var findings []symptomIDLoopFinding
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			continue
+		}
+		if _, helper := symptomIDDedupHelpers[fn.Name.Name]; helper {
+			continue
+		}
+
+		aliases := singleAssignmentLocals(fn.Body)
+		ast.Inspect(fn.Body, func(node ast.Node) bool {
+			loop, ok := node.(*ast.RangeStmt)
+			if !ok {
+				return true
+			}
+
+			written := symptomLoopSource(t, fset, loop.X)
+			expr := loop.X
+			if ident, isIdent := loop.X.(*ast.Ident); isIdent {
+				if resolved, known := aliases[ident.Name]; known {
+					expr = resolved
+				}
+			}
+			source := symptomLoopSource(t, fset, expr)
+
+			routed := symptomLoopRoutesThroughADedupHelper(expr)
+			if !routed && !strings.HasSuffix(strings.ToLower(source), "symptomids") {
+				return true
+			}
+
+			finding := symptomIDLoopFinding{
+				function:  fn.Name.Name,
+				line:      fset.Position(loop.Pos()).Line,
+				source:    source,
+				exemption: -1,
+			}
+			if source != written {
+				finding.written = written
+			}
+
+			switch {
+			case routed:
+				finding.verdict = symptomLoopRouted
+			default:
+				finding.verdict = symptomLoopViolation
+				for index, exemption := range exemptions {
+					if exemption.function != fn.Name.Name || exemption.rangeExpr != source {
+						continue
+					}
+					finding.exemption = index
+					finding.verdict = symptomLoopExempt
+					if loopBodyIncrements(loop.Body) {
+						finding.verdict = symptomLoopExemptButCounts
+					}
+					break
+				}
+			}
+
+			findings = append(findings, finding)
+			return true
+		})
+	}
+	return findings
+}
+
+// singleAssignmentLocals maps each local that is assigned exactly once in the
+// body to the expression it was assigned from. Assigned twice, or assigned by a
+// `range` clause, and it is left unresolved: this is one dataflow step, enough
+// for the extract-a-local refactor and deliberately not more.
+func singleAssignmentLocals(body *ast.BlockStmt) map[string]ast.Expr {
+	assignments := map[string]int{}
+	candidates := map[string]ast.Expr{}
+
+	note := func(expr ast.Expr) string {
+		ident, ok := expr.(*ast.Ident)
+		if !ok || ident.Name == "_" {
+			return ""
+		}
+		assignments[ident.Name]++
+		return ident.Name
+	}
+
+	ast.Inspect(body, func(node ast.Node) bool {
+		switch stmt := node.(type) {
+		case *ast.AssignStmt:
+			for _, lhs := range stmt.Lhs {
+				name := note(lhs)
+				if name != "" && stmt.Tok == token.DEFINE && len(stmt.Lhs) == 1 && len(stmt.Rhs) == 1 {
+					candidates[name] = stmt.Rhs[0]
+				}
+			}
+		case *ast.RangeStmt:
+			if stmt.Tok == token.DEFINE {
+				note(stmt.Key)
+				note(stmt.Value)
+			}
+		case *ast.IncDecStmt:
+			note(stmt.X)
+		case *ast.ValueSpec:
+			for index, name := range stmt.Names {
+				assignments[name.Name]++
+				if len(stmt.Names) == 1 && len(stmt.Values) == 1 {
+					candidates[name.Name] = stmt.Values[index]
+				}
+			}
+		}
+		return true
+	})
+
+	resolved := map[string]ast.Expr{}
+	for name, expr := range candidates {
+		if assignments[name] == 1 {
+			resolved[name] = expr
+		}
+	}
+	return resolved
+}
+
+// loopBodyIncrements reports whether the loop counts anything — `x++`, `x--` or
+// a `+=`/`-=`. An exemption is a statement that a repeated id changes no
+// output, and a counter is the one construct that always makes that false.
+func loopBodyIncrements(body *ast.BlockStmt) bool {
+	counts := false
+	ast.Inspect(body, func(node ast.Node) bool {
+		switch stmt := node.(type) {
+		case *ast.IncDecStmt:
+			counts = true
+		case *ast.AssignStmt:
+			if stmt.Tok == token.ADD_ASSIGN || stmt.Tok == token.SUB_ASSIGN {
+				counts = true
+			}
+		}
+		return !counts
+	})
+	return counts
+}
+
+func symptomLoopAliasNote(finding symptomIDLoopFinding) string {
+	if finding.written == "" {
+		return ""
+	}
+	return " (written as " + finding.written + ")"
 }
 
 func symptomLoopSource(t *testing.T, fset *token.FileSet, expr ast.Expr) string {


### PR DESCRIPTION
# What this is

A follow-up to the symptom-id dedup sweep that landed with `cfa1d27f`. Review of that branch found
`internal/services/symptom_id_dedup_barrier_test.go` passing in three situations it was written to
fail in. All three are in the barrier, not in the fix it guards: **no production code changes**, and
the dedup itself stays closed at every read site.

Each hole was measured green on this tree first. The sweep is the subject, so its defects are latent
and the red is induced by putting the situation in front of it.

## 1. The exemption skipped the whole function, not the one loop

The exemption `continue`d before `ast.Inspect` ran, so every loop in `buildExportSymptomFlags` was
unexamined — and no `SurvivesARepeatedID` guard covers the export path either, so the one site
deliberately left unconverted was the one site with no defence at all.

**Hole, measured** — a `counts[symptomID]++` tally added beside the cleared loop:

```
$ go test ./internal/services/ -run 'TestEverySymptomIDLoopDedupes'
ok      github.com/ovumcy/ovumcy-web/internal/services   8.716s     <-- GREEN with a real counting loop
```

**After the fix**, same induction, two independent signals:

```
--- FAIL: TestEverySymptomIDLoopDedupes
    export_service.go:399 is exempted as "sets booleans and collects names into a set, so a repeated
    id changes no output", and its body increments a counter: an exemption clears a loop whose output
    a repeat cannot change, which this loop's no longer is
    the exemption for buildExportSymptomFlags over "symptomIDs" matched 2 loops, want exactly 1
```

An exemption is now `{function, rangeExpr, reason}` and clears exactly one loop; every other loop in
that function is swept; and `loopBodyIncrements` turns "a loop that increments anything does not
belong here" from a comment into an assertion. Each exemption must match exactly one loop, so a
stale entry that matches nothing fails too.

## 2. An ordinary local alias walked past the sweep

**Hole, measured** — `CalculateFrequencies` rewritten as `ids := logEntry.SymptomIDs` then
`for _, id := range ids`, no helper:

```
$ go test ./internal/services/ -run 'TestEverySymptomIDLoopDedupes'
ok      github.com/ovumcy/ovumcy-web/internal/services   8.689s     <-- sweep GREEN

$ go test ./internal/services/ -run 'TestSymptomFrequencySurvivesARepeatedID'
    symptom_id_dedup_barrier_test.go:180: a repeated id counted 2 times across 1 days
FAIL                                                               <-- behavioural guard holds
```

The class held even so, through defence in depth. The residual was a site added tomorrow, which has
no behavioural guard of its own — leaving the sweep as the only barrier for exactly the case it
could not see.

**After the fix**, same induction:

```
--- FAIL: TestEverySymptomIDLoopDedupes
    symptom_service.go:175 ranges over logEntry.SymptomIDs (written as ids) without deduping: ...
```

`singleAssignmentLocals` resolves a local assigned exactly once back to its source expression — one
dataflow step, deliberately not more. Assigned twice, or bound by a `range` clause, and it stays
unresolved. The failure names both the resolved expression and what was written.

## 3. The "found nothing" refusal could not notice a broken matcher

`found++` fired for compliant loops too, so the six routed sites held it above zero forever.

**Hole, measured** — suffix test broken to `"symptomidsXX"`:

```
$ go test ./internal/services/ -run 'TestEverySymptomIDLoopDedupes|TestSymptomDedupHelpersAgreeOnARepeatedID'
ok      github.com/ovumcy/ovumcy-web/internal/services   6.046s     <-- GREEN, detecting nothing
```

**After the fix**, same mutant:

```
--- FAIL: TestSymptomIDSweepMatcherFlagsAKnownViolation/a_bare_loop_is_a_violation
    the sweep returned 0 findings for logEntry.SymptomIDs, want exactly 1 — the matcher no longer
    recognises the shape it judges (all findings: [])
--- FAIL: .../a_single-assignment_alias_is_resolved_and_still_a_violation
--- FAIL: .../an_exempted_loop_that_counts_nothing_stays_exempt
--- FAIL: .../an_exempted_loop_that_increments_is_an_error_in_its_own_right
--- FAIL: .../a_second_loop_beside_an_exempted_one_is_still_swept
--- FAIL: TestEverySymptomIDLoopDedupes
    the exemption for buildExportSymptomFlags over "symptomIDs" matched 0 loops, want exactly 1
```

The classifier is now one function, `symptomIDLoopFindings`, driven both by the real tree and by
seven fixture sources the test owns — a bare loop and an aliased one that must be flagged, a routed
loop and an aliased routed loop that must not, and both sides of the exemption rule. Same shape as
the fuzz-parity normaliser anchor. The per-loop exemption accounting catches this mutant as a
second, independent signal.

All three inductions reverted.

## Limits, restated

The file's own "what it cannot see" paragraph is rewritten to what is true after this: a local
assigned more than once, a slice handed to another helper before being counted, an index loop rather
than `range`, and any field not named `SymptomIDs`. It now also states that the three
`SurvivesARepeatedID` guards stand **beside** the sweep rather than behind it — the sweep is the
barrier for sites added tomorrow, and documentation is not the only thing covering them.

## Validation

```
$ go build ./...
(no output)

$ go vet ./...
(no output)

$ golangci-lint run
0 issues.

$ go test ./internal/services/... -timeout 20m
ok  	github.com/ovumcy/ovumcy-web/internal/services	239.944s

$ go test ./internal/i18n/...
ok  	github.com/ovumcy/ovumcy-web/internal/i18n	1.487s

$ go build -tags gofuzz ./internal/services/...
(no output)

$ go run ./scripts/changelogd check
changelog fragment check OK.
```

`gofmt -l internal/services` reports the same three pre-existing files this branch does not touch:
`day_service.go`, `settings_view_service.go`, `webhook_reminder.go`.

The changelog fragment is this branch's own. The entry that shipped with the dedup fix is left
exactly as it merged — an edit to a fragment another branch already landed is not this branch's
entry, and the fragment gate enforces that.
