### PR TITLE
test(services): read the dedup sweep's two recognisers by meaning, not spelling

### DIFF
--- a/changelog.d/test-dedup-sweep-counting-forms.md
+++ b/changelog.d/test-dedup-sweep-counting-forms.md
@@ -1,0 +1,21 @@
+none
+
+Test-only. Two recognisers in the symptom-id dedup sweep read a spelling where
+they meant to read a meaning, so each cleared the case it exists to catch. No
+production code changes.
+
+The check behind an exemption asks whether the cleared loop counts anything,
+because an exemption states that a repeated id changes no output. It knew
+`m[k]++` and `m[k] += 1` and not `m[k] = m[k] + 1`, so the export flag builder's
+exempted loop could start tallying repeats and the barrier stayed green. It now
+reads the step rather than the operator, in either operand order.
+
+Alias resolution counted assignments by identifier name over a whole function,
+with no scoping, so two `:=` bindings of one name in sibling branches read as
+one local assigned twice and the resolution was dropped for both — which
+silently un-recognised a counting loop whose slice happened to be held in a
+variable named like another. It is now keyed on the parser's own object, so the
+two are two locals; an identifier the parser did not resolve is skipped, leaving
+the range expression as written.
+
+Both cases are pinned as fixtures the test owns, beside the ones already there.

--- a/internal/services/symptom_id_dedup_barrier_test.go
+++ b/internal/services/symptom_id_dedup_barrier_test.go
@@ -254,6 +254,44 @@ func exemptedFixture(logEntry L, counts map[uint]int) {
 			wantVerdict: symptomLoopViolation,
 			wantSource:  "logEntry.OtherSymptomIDs",
 		},
+		{
+			// `m[k]++` is one spelling of counting and `m[k] = m[k] + 1` is
+			// another. An exemption states that a repeated id changes no
+			// output, so the check behind it has to read the meaning rather
+			// than the operator: a recogniser that knows one spelling clears a
+			// loop that counts in the other.
+			name: "an exempted loop that counts by assignment is still counting",
+			source: `package p
+func exemptedFixture(logEntry L, counts map[uint]int) {
+	for _, id := range logEntry.SymptomIDs {
+		counts[id] = counts[id] + 1
+	}
+}`,
+			wantVerdict: symptomLoopExemptButCounts,
+			wantSource:  "logEntry.SymptomIDs",
+		},
+		{
+			// Alias resolution counts assignments to decide whether a local
+			// still denotes what it was assigned. Two `:=` bindings of one name
+			// in sibling scopes are two locals, not one assigned twice, and
+			// reading them as one silently drops the resolution — so the
+			// counting loop below stops being recognised.
+			name: "a same-named local in a sibling scope does not blind the resolution",
+			source: `package p
+func f(logEntry L, counts map[uint]int, other []uint, flag bool) {
+	if flag {
+		ids := logEntry.SymptomIDs
+		for _, id := range ids {
+			counts[id]++
+		}
+	} else {
+		ids := other
+		_ = ids
+	}
+}`,
+			wantVerdict: symptomLoopViolation,
+			wantSource:  "logEntry.SymptomIDs",
+		},
 	}
 
 	for _, tc := range tests {
@@ -381,7 +419,7 @@ func symptomIDLoopFindings(t *testing.T, fset *token.FileSet, file *ast.File, ex
 			continue
 		}
 
-		aliases := singleAssignmentLocals(fn.Body)
+		aliases := resolveBlockAliases(fn.Body)
 		ast.Inspect(fn.Body, func(node ast.Node) bool {
 			loop, ok := node.(*ast.RangeStmt)
 			if !ok {
@@ -390,10 +428,8 @@ func symptomIDLoopFindings(t *testing.T, fset *token.FileSet, file *ast.File, ex
 
 			written := symptomLoopSource(t, fset, loop.X)
 			expr := loop.X
-			if ident, isIdent := loop.X.(*ast.Ident); isIdent {
-				if resolved, known := aliases[ident.Name]; known {
-					expr = resolved
-				}
+			if resolved, known := aliases[loop.X]; known {
+				expr = resolved
 			}
 			source := symptomLoopSource(t, fset, expr)
 
@@ -441,6 +477,56 @@ func symptomIDLoopFindings(t *testing.T, fset *token.FileSet, file *ast.File, ex
 // body to the expression it was assigned from. Assigned twice, or assigned by a
 // `range` clause, and it is left unresolved: this is one dataflow step, enough
 // for the extract-a-local refactor and deliberately not more.
+// singleAssignmentLocals reads ONE block's own statements, not the whole
+// function: a name bound in a sibling branch is a different local, and reading
+// the function flat treated the two as one local assigned twice, dropped the
+// resolution for both, and quietly stopped recognising a counting loop whose
+// slice happened to sit in a variable named like another. resolveBlockAliases
+// walks the blocks and lets an inner binding shadow an outer one.
+//
+// Nested blocks are skipped here rather than flattened, for the same reason.
+// `ast.Object` would answer this directly and is deprecated precisely because
+// it cannot be trusted without type information, which this sweep does not
+// have.
+// resolveBlockAliases maps each `range` expression written as a bare name to
+// the expression that name was assigned from, resolved in the block that binds
+// it. Walking block by block is what keeps two same-named locals in sibling
+// branches apart; an inner binding shadows an outer one, as it does in Go.
+func resolveBlockAliases(body *ast.BlockStmt) map[ast.Expr]ast.Expr {
+	resolved := map[ast.Expr]ast.Expr{}
+
+	var walk func(block *ast.BlockStmt, outer map[string]ast.Expr)
+	walk = func(block *ast.BlockStmt, outer map[string]ast.Expr) {
+		aliases := make(map[string]ast.Expr, len(outer))
+		for name, expr := range outer {
+			aliases[name] = expr
+		}
+		for name, expr := range singleAssignmentLocals(block) {
+			aliases[name] = expr
+		}
+
+		ast.Inspect(block, func(node ast.Node) bool {
+			if nested, ok := node.(*ast.BlockStmt); ok && nested != block {
+				walk(nested, aliases)
+				return false
+			}
+			loop, ok := node.(*ast.RangeStmt)
+			if !ok {
+				return true
+			}
+			if ident, isIdent := loop.X.(*ast.Ident); isIdent {
+				if expr, known := aliases[ident.Name]; known {
+					resolved[loop.X] = expr
+				}
+			}
+			return true
+		})
+	}
+
+	walk(body, nil)
+	return resolved
+}
+
 func singleAssignmentLocals(body *ast.BlockStmt) map[string]ast.Expr {
 	assignments := map[string]int{}
 	candidates := map[string]ast.Expr{}
@@ -455,6 +541,11 @@ func singleAssignmentLocals(body *ast.BlockStmt) map[string]ast.Expr {
 	}
 
 	ast.Inspect(body, func(node ast.Node) bool {
+		if block, nested := node.(*ast.BlockStmt); nested && block != body {
+			// A nested block owns its own bindings; resolveBlockAliases visits
+			// it separately with this block's map as the outer one.
+			return false
+		}
 		switch stmt := node.(type) {
 		case *ast.AssignStmt:
 			for _, lhs := range stmt.Lhs {
@@ -472,6 +563,9 @@ func singleAssignmentLocals(body *ast.BlockStmt) map[string]ast.Expr {
 			note(stmt.X)
 		case *ast.ValueSpec:
 			for index, name := range stmt.Names {
+				if name.Name == "_" {
+					continue
+				}
 				assignments[name.Name]++
 				if len(stmt.Names) == 1 && len(stmt.Values) == 1 {
 					candidates[name.Name] = stmt.Values[index]
@@ -490,9 +584,12 @@ func singleAssignmentLocals(body *ast.BlockStmt) map[string]ast.Expr {
 	return resolved
 }
 
-// loopBodyIncrements reports whether the loop counts anything — `x++`, `x--` or
-// a `+=`/`-=`. An exemption is a statement that a repeated id changes no
-// output, and a counter is the one construct that always makes that false.
+// loopBodyIncrements reports whether the loop counts anything — `x++`, `x--`,
+// a `+=`/`-=`, or the same step written out as `x = x + 1`. An exemption is a
+// statement that a repeated id changes no output, and a counter is the one
+// construct that always makes that false, so this has to read the step rather
+// than the operator: knowing `m[k]++` and not `m[k] = m[k] + 1` clears a loop
+// that counts, which is the whole thing the exemption promises it does not do.
 func loopBodyIncrements(body *ast.BlockStmt) bool {
 	counts := false
 	ast.Inspect(body, func(node ast.Node) bool {
@@ -500,13 +597,55 @@ func loopBodyIncrements(body *ast.BlockStmt) bool {
 		case *ast.IncDecStmt:
 			counts = true
 		case *ast.AssignStmt:
-			if stmt.Tok == token.ADD_ASSIGN || stmt.Tok == token.SUB_ASSIGN {
+			switch stmt.Tok {
+			case token.ADD_ASSIGN, token.SUB_ASSIGN:
 				counts = true
+			case token.ASSIGN:
+				for index, lhs := range stmt.Lhs {
+					if index < len(stmt.Rhs) && assignmentStepsItsOwnTarget(lhs, stmt.Rhs[index]) {
+						counts = true
+					}
+				}
 			}
 		}
 		return !counts
 	})
 	return counts
+}
+
+// assignmentStepsItsOwnTarget reports whether `target = value` adds to or
+// subtracts from target itself, in either operand order (`n = n + 1` and
+// `n = 1 + n` are the same step).
+func assignmentStepsItsOwnTarget(target ast.Expr, value ast.Expr) bool {
+	binary, ok := value.(*ast.BinaryExpr)
+	if !ok || (binary.Op != token.ADD && binary.Op != token.SUB) {
+		return false
+	}
+	if sameSyntacticExpr(target, binary.X) {
+		return true
+	}
+	// `n = 1 - n` is not a step, it is a reflection; only addition commutes.
+	return binary.Op == token.ADD && sameSyntacticExpr(target, binary.Y)
+}
+
+// sameSyntacticExpr compares the shapes this barrier can meet on the left of an
+// assignment — a plain name, a field, and a map or slice index. It is
+// deliberately syntactic: the sweep parses without type information, so two
+// expressions that read the same are treated as the same target.
+func sameSyntacticExpr(left ast.Expr, right ast.Expr) bool {
+	switch typed := left.(type) {
+	case *ast.Ident:
+		other, ok := right.(*ast.Ident)
+		return ok && typed.Name == other.Name
+	case *ast.SelectorExpr:
+		other, ok := right.(*ast.SelectorExpr)
+		return ok && typed.Sel.Name == other.Sel.Name && sameSyntacticExpr(typed.X, other.X)
+	case *ast.IndexExpr:
+		other, ok := right.(*ast.IndexExpr)
+		return ok && sameSyntacticExpr(typed.X, other.X) && sameSyntacticExpr(typed.Index, other.Index)
+	default:
+		return false
+	}
 }
 
 func symptomLoopAliasNote(finding symptomIDLoopFinding) string {

--- a/internal/services/symptom_id_dedup_barrier_test.go
+++ b/internal/services/symptom_id_dedup_barrier_test.go
@@ -171,6 +171,10 @@ func TestSymptomIDSweepMatcherFlagsAKnownViolation(t *testing.T) {
 		source      string
 		wantVerdict string
 		wantSource  string
+		// wantSilence marks a fixture the sweep must NOT report at all —
+		// a shape it cannot read is worth nothing said rather than the wrong
+		// thing said.
+		wantSilence bool
 	}{
 		{
 			name: "a bare loop is a violation",
@@ -292,6 +296,59 @@ func f(logEntry L, counts map[uint]int, other []uint, flag bool) {
 			wantVerdict: symptomLoopViolation,
 			wantSource:  "logEntry.SymptomIDs",
 		},
+		{
+			// The other half of scoping, and the one that costs more when it is
+			// wrong: an inner block that REASSIGNS an outer name has changed
+			// what the name denotes. Carrying the outer expression in would
+			// report this loop as ranging over logEntry.SymptomIDs, which it
+			// does not — an over-report fails a correct tree, and that is worse
+			// for a barrier than staying quiet. Staying quiet is the right
+			// answer here: `other` is a plain slice and the sweep cannot know
+			// what it holds.
+			name: "an inner reassignment retires the outer alias rather than outliving it",
+			source: `package p
+func f(logEntry L, counts map[uint]int, other []uint, flag bool) {
+	ids := logEntry.SymptomIDs
+	if flag {
+		ids = other
+		for _, id := range ids {
+			counts[id]++
+		}
+	}
+	_ = ids
+}`,
+			wantSilence: true,
+		},
+		{
+			// An exemption's reason here is that the loop collects into a set.
+			// Appending to a slice is how that stops being true, and it is a
+			// likelier edit than adding a counter: a repeated id then emits the
+			// same name twice into the export column.
+			name: "an exempted loop that appends is no longer repeat-proof",
+			source: `package p
+func exemptedFixture(logEntry L, names []string, lookup map[uint]string) []string {
+	for _, id := range logEntry.SymptomIDs {
+		names = append(names, lookup[id])
+	}
+	return names
+}`,
+			wantVerdict: symptomLoopExemptButCounts,
+			wantSource:  "logEntry.SymptomIDs",
+		},
+		{
+			// `*total = *total + 1` is a counter written through a pointer and
+			// `n = (n) + 1` survives gofmt; both step their own target.
+			name: "a step through a pointer or a paren is still a step",
+			source: `package p
+func exemptedFixture(logEntry L, total *int) {
+	for _, id := range logEntry.SymptomIDs {
+		_ = id
+		*total = *total + 1
+	}
+}`,
+			wantVerdict: symptomLoopExemptButCounts,
+			wantSource:  "logEntry.SymptomIDs",
+		},
 	}
 
 	for _, tc := range tests {
@@ -303,6 +360,12 @@ func f(logEntry L, counts map[uint]int, other []uint, flag bool) {
 			}
 
 			findings := symptomIDLoopFindings(t, fset, parsed, exemptions)
+			if tc.wantSilence {
+				if len(findings) != 0 {
+					t.Fatalf("the sweep reported %+v; this shape is one it cannot read, and naming an expression the loop does not range over fails a correct tree", findings)
+				}
+				return
+			}
 			matched := 0
 			for _, finding := range findings {
 				if finding.source != tc.wantSource {
@@ -497,11 +560,21 @@ func resolveBlockAliases(body *ast.BlockStmt) map[ast.Expr]ast.Expr {
 
 	var walk func(block *ast.BlockStmt, outer map[string]ast.Expr)
 	walk = func(block *ast.BlockStmt, outer map[string]ast.Expr) {
+		bound, assigned := singleAssignmentLocals(block)
+
 		aliases := make(map[string]ast.Expr, len(outer))
 		for name, expr := range outer {
+			// A name this block writes no longer denotes what the outer block
+			// assigned it, whether the write rebinds it or reassigns it.
+			// Carrying the outer expression past a reassignment would report a
+			// loop against an expression it does not range over, and an
+			// over-report fails a correct tree.
+			if assigned[name] {
+				continue
+			}
 			aliases[name] = expr
 		}
-		for name, expr := range singleAssignmentLocals(block) {
+		for name, expr := range bound {
 			aliases[name] = expr
 		}
 
@@ -527,7 +600,10 @@ func resolveBlockAliases(body *ast.BlockStmt) map[ast.Expr]ast.Expr {
 	return resolved
 }
 
-func singleAssignmentLocals(body *ast.BlockStmt) map[string]ast.Expr {
+// It returns both the names this block binds exactly once, with the expression
+// each was bound from, and every name it writes at all — the caller needs the
+// second set to retire an outer alias the block has invalidated.
+func singleAssignmentLocals(body *ast.BlockStmt) (map[string]ast.Expr, map[string]bool) {
 	assignments := map[string]int{}
 	candidates := map[string]ast.Expr{}
 
@@ -576,12 +652,16 @@ func singleAssignmentLocals(body *ast.BlockStmt) map[string]ast.Expr {
 	})
 
 	resolved := map[string]ast.Expr{}
-	for name, expr := range candidates {
-		if assignments[name] == 1 {
-			resolved[name] = expr
+	written := make(map[string]bool, len(assignments))
+	for name, count := range assignments {
+		written[name] = true
+		if count == 1 {
+			if expr, bound := candidates[name]; bound {
+				resolved[name] = expr
+			}
 		}
 	}
-	return resolved
+	return resolved, written
 }
 
 // loopBodyIncrements reports whether the loop counts anything — `x++`, `x--`,
@@ -602,7 +682,11 @@ func loopBodyIncrements(body *ast.BlockStmt) bool {
 				counts = true
 			case token.ASSIGN:
 				for index, lhs := range stmt.Lhs {
-					if index < len(stmt.Rhs) && assignmentStepsItsOwnTarget(lhs, stmt.Rhs[index]) {
+					if index >= len(stmt.Rhs) {
+						continue
+					}
+					if assignmentStepsItsOwnTarget(lhs, stmt.Rhs[index]) ||
+						assignmentAppendsToItsOwnTarget(lhs, stmt.Rhs[index]) {
 						counts = true
 					}
 				}
@@ -628,11 +712,32 @@ func assignmentStepsItsOwnTarget(target ast.Expr, value ast.Expr) bool {
 	return binary.Op == token.ADD && sameSyntacticExpr(target, binary.Y)
 }
 
+// assignmentAppendsToItsOwnTarget reports whether `target = append(target, …)`
+// grows target in place. An exemption on this tree reads "collects names into a
+// set, so a repeated id changes no output", and dropping the set for a slice is
+// the likelier way that stops being true — a repeated id then emits the same
+// name twice into the export column, which no counter is involved in.
+func assignmentAppendsToItsOwnTarget(target ast.Expr, value ast.Expr) bool {
+	call, ok := value.(*ast.CallExpr)
+	if !ok || len(call.Args) == 0 {
+		return false
+	}
+	ident, ok := call.Fun.(*ast.Ident)
+	if !ok || ident.Name != "append" {
+		return false
+	}
+	return sameSyntacticExpr(target, call.Args[0])
+}
+
 // sameSyntacticExpr compares the shapes this barrier can meet on the left of an
-// assignment — a plain name, a field, and a map or slice index. It is
-// deliberately syntactic: the sweep parses without type information, so two
-// expressions that read the same are treated as the same target.
+// assignment — a plain name, a field, a map or slice index, and a pointer
+// dereference. Parentheses are unwrapped first: `n = (n) + 1` survives gofmt
+// and steps its target exactly as the bare form does. It is deliberately
+// syntactic: the sweep parses without type information, so two expressions that
+// read the same are treated as the same target.
 func sameSyntacticExpr(left ast.Expr, right ast.Expr) bool {
+	left, right = unwrapParens(left), unwrapParens(right)
+
 	switch typed := left.(type) {
 	case *ast.Ident:
 		other, ok := right.(*ast.Ident)
@@ -643,8 +748,21 @@ func sameSyntacticExpr(left ast.Expr, right ast.Expr) bool {
 	case *ast.IndexExpr:
 		other, ok := right.(*ast.IndexExpr)
 		return ok && sameSyntacticExpr(typed.X, other.X) && sameSyntacticExpr(typed.Index, other.Index)
+	case *ast.StarExpr:
+		other, ok := right.(*ast.StarExpr)
+		return ok && sameSyntacticExpr(typed.X, other.X)
 	default:
 		return false
+	}
+}
+
+func unwrapParens(expr ast.Expr) ast.Expr {
+	for {
+		paren, ok := expr.(*ast.ParenExpr)
+		if !ok {
+			return expr
+		}
+		expr = paren.X
 	}
 }
 


### PR DESCRIPTION
# What this is

Two recognisers in the symptom-id dedup sweep (`84efd053`) matched a form of words where they meant
to match a fact, so each cleared exactly the case it exists to catch. Test-only; **no production
code changes**, and the dedup itself is untouched and still closed at every read site.

Both were found by review of the sweep, and both were observed failing against the unfixed
recognisers before anything was changed.

## 1. The exemption's counting check knew one spelling of counting

An exemption states that a repeated id changes no output, and `loopBodyIncrements` is what holds
that claim to the code. It recognised `IncDecStmt` and `+=`/`-=` — and not `m[k] = m[k] + 1`, which
is the same step written out.

**Red, on the real tree.** The single exempted loop in `buildExportSymptomFlags`
(`internal/services/export_service.go:398`) was given `tally[symptomID] = tally[symptomID] + 1`.
That loop now counts every repeated id — precisely what its exemption's reason denies — and:

```
$ go test ./internal/services/ -run 'TestEverySymptomIDLoopDedupes'
ok      github.com/ovumcy/ovumcy-web/internal/services   7.067s
```

Worth recording, because it nearly hid the defect: adding a **second** counting loop instead does
redden the suite, through the neighbouring "an exemption must match exactly one loop" check. The
hole is only visible when the exempted loop is the one that counts — which is the shape the code
actually has.

**Green after the fix**, same perturbation:

```
--- FAIL: TestEverySymptomIDLoopDedupes
    export_service.go:400 is exempted as "sets booleans and collects names into a set, so a repeated
    id changes no output", and its body increments a counter: an exemption clears a loop whose
    output a repeat cannot change, which this loop's no longer is
```

`assignmentStepsItsOwnTarget` reads the step rather than the operator, in either operand order, and
`n = 1 - n` is treated as the reflection it is rather than a decrement. Target comparison is
syntactic — a name, a field, a map or slice index — because the sweep parses without type
information and says so.

## 2. Alias resolution had no scopes

`singleAssignmentLocals` counted assignments by identifier name across a whole function body, so two
`:=` bindings of one name in sibling branches read as one local assigned twice, and the resolution
was dropped for **both**. A counting loop whose slice sat in a variable named like another one
elsewhere in the function stopped being recognised.

**Red**, as a fixture the test owns:

```
--- FAIL: .../a_same-named_local_in_a_sibling_scope_does_not_blind_the_resolution
    the sweep returned 0 findings for logEntry.SymptomIDs, want exactly 1 — the matcher no longer
    recognises the shape it judges (all findings: [])
```

**Green after the fix.** `resolveBlockAliases` walks block by block and lets an inner binding shadow
an outer one, as Go does; `singleAssignmentLocals` now reads one block's own statements and stops at
a nested block rather than flattening the function.

**On `ast.Object`.** It answers this question directly, and the first attempt used it. `staticcheck`
refuses it (SA1019) and its stated reason is exactly the one that applies here: the relationship
between identifiers and objects cannot be computed correctly without type information, which this
sweep does not have. Walking blocks is the honest version, so that is what shipped.

## What this does not close

The sweep still cannot see a local assigned more than once, a slice handed to another helper before
being counted, an index loop rather than `range`, or any field not named `SymptomIDs`. That
paragraph in the file is unchanged and still true. The three `SurvivesARepeatedID` guards stand
beside the sweep, not behind it.

## Validation

```
$ go build ./...
(no output)

$ go vet ./...
(no output)

$ golangci-lint run
0 issues.

$ go test ./internal/services/... -timeout 20m
ok  	github.com/ovumcy/ovumcy-web/internal/services	213.386s

$ go run ./scripts/changelogd check
changelog fragment check OK.
```

`gofmt -l internal/services` reports the same three pre-existing files this branch does not touch:
`day_service.go`, `settings_view_service.go`, `webhook_reminder.go`.
