### PR TITLE
fix(db,services): make per-owner symptom names unique in the schema

### DIFF
--- a/changelog.d/fix-symptom-name-uniqueness.md
+++ b/changelog.d/fix-symptom-name-uniqueness.md
@@ -13,8 +13,10 @@
   `symptom_types` now carries a unique index on `(user_id, lower(name))`, so the second writer
   is refused by the database rather than by a check it had already passed. A refused create or
   rename answers with the same "symptom name already exists" conflict a duplicate has always
-  produced. A refused built-in seeding does not surface at all: the request that lost the race
-  only wanted to read, and it is answered with the catalogue the other one wrote.
+  produced. A refused built-in seeding does not surface at all — the request that lost the race
+  only wanted to read, and it is answered with the catalogue the other one wrote — but only once
+  a re-read confirms those built-ins are in fact there now. A refusal that leaves the catalogue
+  short is reported, rather than repeating in silence on every page load.
 
   The index is keyed per account, so two accounts on one instance each keep their own "Cramps",
   and it covers archived symptoms as well as active ones — an archived name has always stayed
@@ -54,6 +56,15 @@
 
   Rolling this migration back is `DROP INDEX idx_symptom_types_user_name_unique`. It writes no
   data at all, so dropping the index restores the previous state exactly.
+
+- **A migration can no longer cut its own prose in half.** The runner splits statements on every
+  `;` without stripping comments, so a semicolon in the middle of a comment line turns the rest
+  of that sentence into the next statement, and the engine answers with a syntax error naming
+  English. Every migration file opens with a long prose header, and the rule against it lived
+  only in the closing paragraph of the files that happened to repeat it. A sweep over both
+  dialect trees now enforces it, narrowed to the form that actually breaks: a semicolon that ends
+  a comment line is harmless and three shipped files rely on that, so only a semicolon with text
+  after it on the same line is refused.
 
 - **The duplicate-name class is held by a barrier test rather than by timing.** Two goroutines
   are released together and rendezvous on the return of the catalogue read, so both hold a

--- a/changelog.d/fix-symptom-name-uniqueness.md
+++ b/changelog.d/fix-symptom-name-uniqueness.md
@@ -1,0 +1,64 @@
+### Fixed
+
+- **Two requests can no longer give one account two symptoms with the same name.** The
+  per-owner name rule lived only in application code: the symptom service listed the owner's
+  catalogue, compared normalized names in memory, and then issued an unrelated `INSERT`, with
+  nothing joining the two. Two requests that both passed the check before either wrote both
+  wrote, and the account was left holding two symptoms the day-entry picker, the frequency
+  counts and the export cannot tell apart. The built-in seeding path had the same shape on a
+  read path — two page loads each list the catalogue, each compute the same missing built-ins
+  and each insert them — which is the half a normal session reaches, since it needs only two
+  overlapping page loads rather than two overlapping form submissions.
+
+  `symptom_types` now carries a unique index on `(user_id, lower(name))`, so the second writer
+  is refused by the database rather than by a check it had already passed. A refused create or
+  rename answers with the same "symptom name already exists" conflict a duplicate has always
+  produced. A refused built-in seeding does not surface at all: the request that lost the race
+  only wanted to read, and it is answered with the catalogue the other one wrote.
+
+  The index is keyed per account, so two accounts on one instance each keep their own "Cramps",
+  and it covers archived symptoms as well as active ones — an archived name has always stayed
+  taken for its owner, and restoring an archived symptom re-checks it, so leaving archived rows
+  out would have admitted a pair that can never be restored.
+
+  What the index does **not** do is stated in the migration and pinned by a test: it is a
+  backstop weaker than the application rule, which also collapses runs of internal whitespace
+  and drops invalid UTF-8. Portable SQL can do neither, so "Mood&nbsp;&nbsp;swings" and "Mood
+  swings" are one name to the application and two keys to the index, and the application check
+  stays in front of it. `lower()` differs between engines as well: PostgreSQL folds by locale,
+  SQLite folds ASCII only, so a case-only variant of a non-ASCII name is covered on one and not
+  the other.
+
+- **The day-entry picker hides the four built-ins it says it hides.** The set of built-ins kept
+  out of the picker was keyed on a spelling of the display name and looked up through a
+  normalizer that lowercases and collapses whitespace but never removes it, so the entry
+  `moodswings` matched nothing the product can create. Fatigue, Irritability and Insomnia were
+  kept out; Mood swings was not, and was merely pushed into the picker's overflow by a second,
+  unrelated rule. The set is now keyed on the catalogue's own identity for a built-in, so all
+  four are kept out of the list unless the day already carries them, and a key that names no
+  built-in fails a test instead of quietly hiding nothing.
+
+### Internal
+
+- **A migration that adds a unique index stops rather than making room.** On a database that
+  already holds rows the new index cannot cover, the migration refuses and names every
+  conflicting group — the key value and how many rows share it — instead of creating the index.
+  It never deletes, merges or rewrites a row: this instance stores one person's health history,
+  and a schema change is not consent to lose part of it. Nothing is executed, the migration's
+  transaction is rolled back, and the message says what to resolve through the application
+  before starting it again. The check reads the key expressions out of the `CREATE UNIQUE INDEX`
+  statement itself, so it covers the next unique index as well as this one, and it excludes
+  `NULL` keys because both engines treat those as distinct in a unique index. A statement it
+  cannot read — a partial index, or anything trailing the key list — is left to the engine,
+  which still refuses a genuine conflict with its own message.
+
+  Rolling this migration back is `DROP INDEX idx_symptom_types_user_name_unique`. It writes no
+  data at all, so dropping the index restores the previous state exactly.
+
+- **The duplicate-name class is held by a barrier test rather than by timing.** Two goroutines
+  are released together and rendezvous on the return of the catalogue read, so both hold a
+  decision made from the same snapshot before either writes — starting two goroutines together
+  is not enough, since one usually finishes its insert before the other reads, and the guard
+  then passes on a tree with no constraint at all. One case covers the create path and one the
+  built-in seeding path; a third pins what the index does and does not normalize, and a fourth
+  pins that the name stays per owner and stays taken across archival.

--- a/internal/api/handlers_days_symptoms_regression_test.go
+++ b/internal/api/handlers_days_symptoms_regression_test.go
@@ -250,9 +250,15 @@ func TestRestoreSymptomRejectsDuplicateActiveName(t *testing.T) {
 	user := createOnboardingTestUser(t, database, "restore-symptom-duplicate@example.com", "StrongPass1", true)
 	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
 
+	// The two rows differ by one space, which is exactly the gap between the
+	// two name rules: the service collapses runs of internal whitespace before
+	// it compares, so these are one name to it, while the per-owner unique
+	// index on (user_id, lower(name)) sees two keys and admits both. That gap
+	// is what still makes this collision constructible — the index alone would
+	// refuse an exact pair — and the restore path must answer it the same way.
 	activeSymptom := models.SymptomType{
 		UserID: user.ID,
-		Name:   "Joint stiffness",
+		Name:   "Joint  stiffness",
 		Icon:   "x",
 		Color:  "#123456",
 	}

--- a/internal/api/settings_symptoms_htmx_regression_test.go
+++ b/internal/api/settings_symptoms_htmx_regression_test.go
@@ -173,7 +173,11 @@ func TestSettingsSymptomsHTMXUpdateTooLongDoesNotEchoDraftName(t *testing.T) {
 	authCookie := loginAndExtractAuthCookieWithCSRF(t, app, user.Email, "StrongPass1")
 	csrfCookie, csrfToken := loadSettingsCSRFContext(t, app, authCookie)
 
-	existing := models.SymptomType{UserID: user.ID, Name: "Cramps", Icon: "✨", Color: "#334455"}
+	// A name of its own rather than a builtin's: registration seeds the builtin
+	// catalogue for this account, and the per-owner unique index on
+	// (user_id, lower(name)) refuses a second "Cramps" for the same owner. The
+	// fixture only needs a custom symptom to PATCH.
+	existing := models.SymptomType{UserID: user.ID, Name: "Knee stiffness", Icon: "✨", Color: "#334455"}
 	if err := database.Create(&existing).Error; err != nil {
 		t.Fatalf("create symptom: %v", err)
 	}

--- a/internal/api/settings_symptoms_htmx_regression_test.go
+++ b/internal/api/settings_symptoms_htmx_regression_test.go
@@ -220,7 +220,7 @@ func TestSettingsSymptomsHTMXUpdateTooLongDoesNotEchoDraftName(t *testing.T) {
 	if err := database.First(&stored, existing.ID).Error; err != nil {
 		t.Fatalf("reload symptom after too-long update: %v", err)
 	}
-	if stored.Name != "Cramps" {
+	if stored.Name != "Knee stiffness" {
 		t.Fatalf("expected persisted symptom name unchanged, got %q", stored.Name)
 	}
 }

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -33,6 +33,12 @@ var dropTableStatementPattern = regexp.MustCompile(`(?i)^DROP\s+TABLE\s+(?:IF\s+
 var dropColumnStatementPattern = regexp.MustCompile(`(?i)^ALTER\s+TABLE\s+([^\s]+)\s+DROP\s+(?:COLUMN\s+)?(?:IF\s+EXISTS\s+)?([^\s;]+)`)
 var renameColumnStatementPattern = regexp.MustCompile(`(?i)^ALTER\s+TABLE\s+([^\s]+)\s+RENAME\s+(?:COLUMN\s+)?([^\s;]+)\s+TO\s+([^\s;]+)`)
 var removedTableMarkerPattern = regexp.MustCompile(`(?im)^[ \t]*--[ \t]*` + regexp.QuoteMeta(removedTableMarker) + `[ \t]+([^\s;]+)[ \t]*$`)
+var createUniqueIndexStatementPattern = regexp.MustCompile(`(?i)^CREATE\s+UNIQUE\s+INDEX\s+(?:IF\s+NOT\s+EXISTS\s+)?(\S+)\s+ON\s+([^\s(]+)\s*\(`)
+
+// duplicateGroupReportLimit caps how many conflicting groups a refusal spells
+// out. An operator needs enough to see the shape of the problem and to start
+// fixing it, not a dump of the table.
+const duplicateGroupReportLimit = 5
 
 type embeddedMigration struct {
 	Version string
@@ -188,6 +194,10 @@ func applyMigration(database *gorm.DB, migration embeddedMigration) error {
 				continue
 			}
 
+			if err := refuseUniqueIndexOverExistingDuplicates(tx, migration, statement); err != nil {
+				return err
+			}
+
 			if err := tx.Exec(statement).Error; err != nil {
 				return fmt.Errorf("execute migration %s statement %q: %w", migration.Name, statement, err)
 			}
@@ -276,6 +286,207 @@ func highestAppliedVersionAfter(appliedVersions map[string]struct{}, order int) 
 		}
 	}
 	return highestVersion, highestVersion != ""
+}
+
+// uniqueIndexIntent is a `CREATE UNIQUE INDEX` statement read back as what it
+// asks the database for: an index name, a table, and the key expressions that
+// have to be unique together.
+type uniqueIndexIntent struct {
+	IndexName   string
+	Table       string
+	KeyExprs    []string
+	Recognized  bool
+	KeyExprList string
+}
+
+// duplicateGroup is one conflicting key, rendered as text by the engine, with
+// the number of rows that share it.
+type duplicateGroup struct {
+	ConflictKey string `gorm:"column:conflict_key"`
+	RowCount    int64  `gorm:"column:row_count"`
+}
+
+// refuseUniqueIndexOverExistingDuplicates stops a migration that adds a UNIQUE
+// index to a table that already holds rows the index cannot cover, and names
+// the conflicting groups.
+//
+// Left to the engine, the same situation is a bare `UNIQUE constraint failed`
+// (or `could not create unique index`) with nothing an operator can act on:
+// neither engine says which rows collided, and the application that wrote them
+// is the only thing that knows what the key means. The alternative — having the
+// migration delete or merge the extra rows itself — is not available here. This
+// instance stores one person's health history, and a schema change is not
+// consent to lose part of it. So the migration refuses, prints the groups, and
+// leaves every row exactly where it was for the owner to resolve.
+//
+// The check derives its query from the statement rather than from a list of
+// migrations, so it covers the next unique index as well as this one, and it
+// runs only for a statement that actually asks for one. NULL keys are excluded
+// because both engines treat NULLs as distinct in a unique index: grouping them
+// would report a conflict the index would have accepted.
+//
+// A statement it cannot read — a partial index, or anything trailing the key
+// list — is left alone rather than guessed at: the engine still refuses the
+// migration on a genuine conflict, only with its own opaque message.
+func refuseUniqueIndexOverExistingDuplicates(database *gorm.DB, migration embeddedMigration, statement string) error {
+	intent := parseCreateUniqueIndexStatement(statement)
+	if !intent.Recognized {
+		return nil
+	}
+	if !database.Migrator().HasTable(intent.Table) {
+		return nil
+	}
+
+	groups, err := loadDuplicateKeyGroups(database, intent)
+	if err != nil {
+		return fmt.Errorf("inspect migration %s: %w", migration.Name, err)
+	}
+	if len(groups) == 0 {
+		return nil
+	}
+
+	rendered := make([]string, 0, duplicateGroupReportLimit)
+	for _, group := range groups {
+		if len(rendered) == duplicateGroupReportLimit {
+			rendered = append(rendered, "and more")
+			break
+		}
+		rendered = append(rendered, fmt.Sprintf("%s -> %d rows", group.ConflictKey, group.RowCount))
+	}
+
+	return fmt.Errorf(
+		"refusing migration %s: table %s already holds rows that unique index %s on (%s) cannot cover, and this migration never deletes, merges or rewrites a row to make room for it. Conflicting group(s), keyed as (%s): %s. Nothing was written: the migration was rolled back and the database is unchanged. Resolve each group by renaming or removing the extra rows through the application, then start it again",
+		migration.Name,
+		intent.Table,
+		intent.IndexName,
+		intent.KeyExprList,
+		intent.KeyExprList,
+		strings.Join(rendered, "; "),
+	)
+}
+
+// loadDuplicateKeyGroups asks the database which key values already repeat,
+// building the query out of the index's own key expressions so the grouping and
+// the index agree by construction. The key is rendered as text by the engine —
+// `CAST(... AS TEXT)` and `||` are the two spellings both engines share — so
+// one reader serves both.
+func loadDuplicateKeyGroups(database *gorm.DB, intent uniqueIndexIntent) ([]duplicateGroup, error) {
+	renderedKeys := make([]string, 0, len(intent.KeyExprs))
+	notNullTerms := make([]string, 0, len(intent.KeyExprs))
+	for _, expression := range intent.KeyExprs {
+		renderedKeys = append(renderedKeys, "CAST("+expression+" AS TEXT)")
+		notNullTerms = append(notNullTerms, "("+expression+") IS NOT NULL")
+	}
+
+	query := fmt.Sprintf(
+		"SELECT %s AS conflict_key, COUNT(*) AS row_count FROM %s WHERE %s GROUP BY %s HAVING COUNT(*) > 1 ORDER BY conflict_key LIMIT %d",
+		strings.Join(renderedKeys, " || ' | ' || "),
+		intent.Table,
+		strings.Join(notNullTerms, " AND "),
+		intent.KeyExprList,
+		duplicateGroupReportLimit+1,
+	)
+
+	groups := make([]duplicateGroup, 0)
+	if err := database.Raw(query).Scan(&groups).Error; err != nil {
+		return nil, fmt.Errorf("check table %s for rows that would collide under unique index %s: %w", intent.Table, intent.IndexName, err)
+	}
+	return groups, nil
+}
+
+// parseCreateUniqueIndexStatement reads a statement chunk as a
+// `CREATE UNIQUE INDEX`. Like the ADD COLUMN and DROP TABLE detections it looks
+// past the prose header splitSQLStatements leaves attached to the first chunk
+// of a file. Recognized is false for anything else, and for a unique index
+// whose key list is followed by more SQL (a partial index's WHERE, an engine
+// option): the key list alone would not describe what the index covers, and a
+// guess there would refuse a migration the engine would have accepted.
+func parseCreateUniqueIndexStatement(statement string) uniqueIndexIntent {
+	body := stripLeadingSQLComments(statement)
+	match := createUniqueIndexStatementPattern.FindStringSubmatchIndex(body)
+	if match == nil {
+		return uniqueIndexIntent{}
+	}
+
+	openParen := match[1] - 1
+	closeParen := matchingCloseParenIndex(body, openParen)
+	if closeParen < 0 {
+		return uniqueIndexIntent{}
+	}
+	if strings.TrimSpace(body[closeParen+1:]) != "" {
+		return uniqueIndexIntent{}
+	}
+
+	keyExprs := splitTopLevelCommas(body[openParen+1 : closeParen])
+	if len(keyExprs) == 0 {
+		return uniqueIndexIntent{}
+	}
+
+	return uniqueIndexIntent{
+		IndexName:   normalizeSQLIdentifier(body[match[2]:match[3]]),
+		Table:       normalizeSQLIdentifier(body[match[4]:match[5]]),
+		KeyExprs:    keyExprs,
+		Recognized:  true,
+		KeyExprList: strings.Join(keyExprs, ", "),
+	}
+}
+
+// matchingCloseParenIndex returns the index of the parenthesis closing the one
+// at openParen, or -1 when it is never closed.
+func matchingCloseParenIndex(text string, openParen int) int {
+	depth := 0
+	for index := openParen; index < len(text); index++ {
+		switch text[index] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return index
+			}
+		}
+	}
+	return -1
+}
+
+// splitTopLevelCommas splits an index key list on the commas that separate its
+// entries, leaving the commas inside a function call where they are. An empty
+// entry makes the whole list unreadable and returns nothing, so the caller
+// leaves the statement to the engine rather than building a query around a hole.
+func splitTopLevelCommas(list string) []string {
+	parts := make([]string, 0)
+	depth := 0
+	start := 0
+
+	appendPart := func(end int) bool {
+		part := strings.TrimSpace(list[start:end])
+		if part == "" {
+			return false
+		}
+		parts = append(parts, part)
+		return true
+	}
+
+	for index := range len(list) {
+		switch list[index] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+		case ',':
+			if depth != 0 {
+				continue
+			}
+			if !appendPart(index) {
+				return nil
+			}
+			start = index + 1
+		}
+	}
+	if !appendPart(len(list)) {
+		return nil
+	}
+	return parts
 }
 
 // snapshotEveryTableColumns records the columns of EVERY table there is, read

--- a/internal/db/migrations_bootstrap_test.go
+++ b/internal/db/migrations_bootstrap_test.go
@@ -693,6 +693,137 @@ func sortedMigrationKeys(files map[string]string) []string {
 	return keys
 }
 
+// TestNoEmbeddedMigrationCutsItsOwnProseInHalf holds the one convention every
+// migration file in this tree depends on and nothing enforced.
+//
+// splitSQLStatements splits the raw SQL on `;` WITHOUT stripping comments, so a
+// semicolon inside comment text ends the chunk there. What happens next depends
+// on what follows it ON THAT LINE, and only one of the two outcomes is a defect:
+//
+//   - nothing follows it. The chunk that ends is comment-only, both engines
+//     accept a comment-only statement, and the next chunk starts on the next
+//     line — which is either more comment or the real SQL. Three shipped files
+//     already do this at the end of a `-- Rollback: …;` line and are correct.
+//   - text follows it. The `--` that opened the comment went with the previous
+//     chunk, so the remainder of the sentence starts the next one as bare SQL,
+//     and the engine answers `near "…": syntax error` naming words the author
+//     wrote as English, on a migration that read fine in review.
+//
+// The second is one ordinary compound sentence away in every file, now that
+// every file opens with a long prose header, and until this sweep the rule
+// lived only in the closing paragraph of the files that happened to repeat it.
+//
+// The fix belongs in the runner or in the file, and this guard deliberately
+// takes the file's side: making the splitter comment-aware changes how every
+// migration that has already run on every installation is parsed, which is a
+// larger blast radius than the convention it would replace. It is also why the
+// guard is written to the narrow rule rather than to "no semicolon in prose" —
+// applied migrations are immutable, so a sweep that condemned the three
+// harmless ones could never be made to pass.
+func TestNoEmbeddedMigrationCutsItsOwnProseInHalf(t *testing.T) {
+	assertCommentSemicolonScannerAnswersBothWays(t)
+
+	filesRead := 0
+	for _, driver := range []Driver{DriverSQLite, DriverPostgres} {
+		migrations, err := loadEmbeddedMigrations(driver)
+		if err != nil {
+			t.Fatalf("load embedded %s migrations: %v", driver, err)
+		}
+		for _, migration := range migrations {
+			filesRead++
+			lines := commentSemicolonLines(migration.SQL)
+			if len(lines) == 0 {
+				continue
+			}
+			t.Errorf("migration %s/%s cuts a comment line in half on line(s) %v: the runner splits statements on every `;` without stripping comments, so the words after that semicolon start the next chunk as bare SQL and the engine reports a syntax error naming prose — rewrite the sentence without the semicolon, or end the line there", driver, migration.Name, lines)
+		}
+	}
+	if filesRead == 0 {
+		t.Fatal("read no embedded migration files at all — the loader is broken, not the migrations")
+	}
+}
+
+// assertCommentSemicolonScannerAnswersBothWays anchors the scanner on fixtures
+// this test owns, before either live tree is read. The set it judges is
+// expected to be clean forever, so an anchor taken from the live files would
+// stop measuring anything the moment the sweep started passing — which is
+// immediately.
+func assertCommentSemicolonScannerAnswersBothWays(t *testing.T) {
+	t.Helper()
+
+	for _, fixture := range []struct {
+		Name    string
+		SQL     string
+		Flagged []int
+	}{
+		{
+			Name:    "a compound sentence in a prose header is found",
+			SQL:     "-- Adds the column; and explains why.\n\nSELECT 1;\n",
+			Flagged: []int{1},
+		},
+		{
+			Name:    "ordinary prose is left alone",
+			SQL:     "-- Adds the column and explains why.\n\nSELECT 1;\n",
+			Flagged: []int{},
+		},
+		{
+			Name:    "a semicolon that ends a comment line is left alone",
+			SQL:     "-- Rollback: CREATE INDEX idx ON daily_logs(date);\n\nDROP INDEX idx;\n",
+			Flagged: []int{},
+		},
+		{
+			Name:    "a compound sentence in a trailing note is found",
+			SQL:     "SELECT 1; -- and a note; with more after it\n",
+			Flagged: []int{1},
+		},
+		{
+			Name:    "two dashes inside a string literal are not a comment",
+			SQL:     "UPDATE users SET email = '--a;b' WHERE id = 1;\n",
+			Flagged: []int{},
+		},
+	} {
+		got := commentSemicolonLines(fixture.SQL)
+		if len(got) == len(fixture.Flagged) && (len(got) == 0 || got[0] == fixture.Flagged[0]) {
+			continue
+		}
+		t.Fatalf("scanner anchor %q: commentSemicolonLines() = %v, want %v — the scanner no longer answers both ways, so the sweep below measures nothing", fixture.Name, got, fixture.Flagged)
+	}
+}
+
+// commentSemicolonLines returns the 1-based lines on which comment text carries
+// a `;` with more text after it on the same line — the form that turns the rest
+// of the sentence into the next chunk's opening SQL. A semicolon that ends the
+// line is not reported: it only closes the chunk early, and what closes is
+// comment-only.
+//
+// A `--` inside a single-quoted literal starts no comment, which is what keeps
+// a data-fixing migration from being reported for the contents of a string it
+// writes.
+func commentSemicolonLines(sqlText string) []int {
+	flagged := make([]int, 0)
+	for offset, line := range strings.Split(sqlText, "\n") {
+		inLiteral := false
+		for index := range len(line) {
+			if line[index] == '\'' {
+				inLiteral = !inLiteral
+				continue
+			}
+			if inLiteral || line[index] != '-' {
+				continue
+			}
+			if index+1 >= len(line) || line[index+1] != '-' {
+				continue
+			}
+			comment := line[index:]
+			if cut := strings.Index(comment, ";"); cut >= 0 && strings.TrimSpace(comment[cut+1:]) != "" {
+				flagged = append(flagged, offset+1)
+			}
+			break
+		}
+	}
+	return flagged
+}
+
 func countOIDCLogoutStatesWithNullUser(t *testing.T, database *gorm.DB) int64 {
 	t.Helper()
 

--- a/internal/db/migrations_symptom_name_uniqueness_test.go
+++ b/internal/db/migrations_symptom_name_uniqueness_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -56,6 +57,155 @@ func TestSymptomNameUniqueIndexIsCreatedAndCoversEveryRow(t *testing.T) {
 	}
 	if err := insert(owner, "joint stiffness"); err == nil {
 		t.Fatal("expected the index to refuse a case-only duplicate for one owner")
+	}
+}
+
+// TestParseCreateUniqueIndexStatementReadsOnlyWhatItCanDescribe covers the
+// decision that precedes the refusal: whether a statement is one whose coverage
+// the runner can state exactly.
+//
+// Every "not recognized" case here is a statement the engine still executes and
+// still refuses on a genuine conflict — only the diagnostic degrades. That is
+// the deliberate trade: a key list the runner half-understands would build a
+// duplicate query around a hole and could refuse a migration the engine would
+// have accepted, which is worse than a poor message.
+func TestParseCreateUniqueIndexStatementReadsOnlyWhatItCanDescribe(t *testing.T) {
+	for _, testCase := range []struct {
+		Name       string
+		Statement  string
+		Recognized bool
+		Table      string
+		KeyExprs   []string
+	}{
+		{
+			Name:       "the shipped statement, key expressions and all",
+			Statement:  "CREATE UNIQUE INDEX IF NOT EXISTS idx_symptom_types_user_name_unique\n    ON symptom_types (user_id, lower(name))",
+			Recognized: true,
+			Table:      "symptom_types",
+			KeyExprs:   []string{"user_id", "lower(name)"},
+		},
+		{
+			Name:       "a prose header does not hide the statement under it",
+			Statement:  "-- Per-owner uniqueness.\n--\n-- More prose.\nCREATE UNIQUE INDEX idx_x ON t (a, b)",
+			Recognized: true,
+			Table:      "t",
+			KeyExprs:   []string{"a", "b"},
+		},
+		{
+			Name:       "a comma inside a function call does not split the key list",
+			Statement:  "CREATE UNIQUE INDEX idx_x ON t (a, coalesce(b, c))",
+			Recognized: true,
+			Table:      "t",
+			KeyExprs:   []string{"a", "coalesce(b, c)"},
+		},
+		{
+			Name:       "a partial index is left to the engine",
+			Statement:  "CREATE UNIQUE INDEX IF NOT EXISTS idx_users_calendar_feed_selector\n    ON users (calendar_feed_selector)\n    WHERE calendar_feed_selector <> ''",
+			Recognized: false,
+		},
+		{
+			Name:       "an unclosed key list is left to the engine",
+			Statement:  "CREATE UNIQUE INDEX idx_x ON t (a, b",
+			Recognized: false,
+		},
+		{
+			Name:       "an empty entry in the middle of the key list is left to the engine",
+			Statement:  "CREATE UNIQUE INDEX idx_x ON t (a, , b)",
+			Recognized: false,
+		},
+		{
+			Name:       "an empty entry at the end of the key list is left to the engine",
+			Statement:  "CREATE UNIQUE INDEX idx_x ON t (a, b,)",
+			Recognized: false,
+		},
+		{
+			Name:       "a non-unique index is not this check's business",
+			Statement:  "CREATE INDEX idx_x ON t (a)",
+			Recognized: false,
+		},
+	} {
+		intent := parseCreateUniqueIndexStatement(testCase.Statement)
+		if intent.Recognized != testCase.Recognized {
+			t.Errorf("%s: Recognized = %t, want %t", testCase.Name, intent.Recognized, testCase.Recognized)
+			continue
+		}
+		if !testCase.Recognized {
+			continue
+		}
+		if intent.Table != testCase.Table {
+			t.Errorf("%s: Table = %q, want %q", testCase.Name, intent.Table, testCase.Table)
+		}
+		if strings.Join(intent.KeyExprs, "|") != strings.Join(testCase.KeyExprs, "|") {
+			t.Errorf("%s: KeyExprs = %v, want %v", testCase.Name, intent.KeyExprs, testCase.KeyExprs)
+		}
+	}
+}
+
+// probeMigration is a migration this test owns, used to drive the refusal
+// against statements the embedded set does not contain. Its version is far
+// above the tree's so it can never be confused with a real one.
+func probeMigration() embeddedMigration {
+	return embeddedMigration{Version: "900", Order: 900, Name: "900_probe.sql"}
+}
+
+// TestUniqueIndexRefusalOnStatementsTheEmbeddedSetDoesNotContain covers the
+// three answers the refusal gives besides "these rows conflict".
+func TestUniqueIndexRefusalOnStatementsTheEmbeddedSetDoesNotContain(t *testing.T) {
+	database := openSQLiteForMigrationBootstrapTest(t, filepath.Join(t.TempDir(), "symptom-name-probe.db"))
+
+	// A table this migration is about to create is not there when the check
+	// runs, and an index over no rows can conflict with nothing.
+	if err := refuseUniqueIndexOverExistingDuplicates(database, probeMigration(), "CREATE UNIQUE INDEX idx_probe ON not_a_table (a)"); err != nil {
+		t.Fatalf("a table that does not exist yet must not refuse the migration: %v", err)
+	}
+
+	// A key expression the engine rejects is a fault in the check, reported as
+	// one, rather than a verdict about the rows.
+	err := refuseUniqueIndexOverExistingDuplicates(database, probeMigration(), "CREATE UNIQUE INDEX idx_probe ON symptom_types (no_such_column)")
+	if err == nil {
+		t.Fatal("a duplicate query the engine cannot run must be reported, not passed over")
+	}
+	for _, fragment := range []string{"900_probe.sql", "symptom_types", "idx_probe"} {
+		if !strings.Contains(err.Error(), fragment) {
+			t.Fatalf("the inspection failure must name %q, got: %v", fragment, err)
+		}
+	}
+}
+
+// TestUniqueIndexRefusalNamesAtMostFiveGroupsAndSaysThereAreMore pins the
+// report's bound. An operator needs the shape of the problem, not a dump of the
+// table, and a truncated list that did not say it was truncated would read as a
+// complete one.
+func TestUniqueIndexRefusalNamesAtMostFiveGroupsAndSaysThereAreMore(t *testing.T) {
+	database := openSQLiteForMigrationBootstrapTest(t, filepath.Join(t.TempDir(), "symptom-name-groups.db"))
+	owner := createDailyLogTestUser(t, database, "symptom-groups-owner@example.com")
+
+	// Six icons, each on two rows: six groups under an index keyed on icon, one
+	// more than the report lists. The names stay distinct so the shipped index
+	// on (user_id, lower(name)) is untouched.
+	for group := range 6 {
+		for copyIndex := range 2 {
+			if err := database.Exec(
+				`INSERT INTO symptom_types (user_id, name, icon, color, is_builtin) VALUES (?, ?, ?, '#FF0000', 0)`,
+				owner,
+				fmt.Sprintf("Probe %d-%d", group, copyIndex),
+				fmt.Sprintf("i%d", group),
+			).Error; err != nil {
+				t.Fatalf("seed probe row %d-%d: %v", group, copyIndex, err)
+			}
+		}
+	}
+
+	err := refuseUniqueIndexOverExistingDuplicates(database, probeMigration(), "CREATE UNIQUE INDEX idx_probe ON symptom_types (icon)")
+	if err == nil {
+		t.Fatal("six conflicting groups must refuse the migration")
+	}
+	message := err.Error()
+	if groups := strings.Count(message, " -> "); groups != duplicateGroupReportLimit {
+		t.Fatalf("expected %d named groups, got %d in: %s", duplicateGroupReportLimit, groups, message)
+	}
+	if !strings.Contains(message, "and more") {
+		t.Fatalf("a truncated list must say it is truncated, got: %s", message)
 	}
 }
 

--- a/internal/db/migrations_symptom_name_uniqueness_test.go
+++ b/internal/db/migrations_symptom_name_uniqueness_test.go
@@ -1,0 +1,138 @@
+package db
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// symptomNameUniqueIndexName is migration 037's index. It is named here rather
+// than inlined so a rename shows up as one edit in this file and in the two
+// migration files, and never as a guard that quietly stopped looking.
+const symptomNameUniqueIndexName = "idx_symptom_types_user_name_unique"
+
+// TestSymptomNameUniqueIndexIsCreatedAndCoversEveryRow pins the shape of
+// migration 037's index on a clean bootstrap.
+//
+// UNIQUE and per owner is the point: two accounts on one instance each keep
+// their own "Cramps". Covering EVERY row rather than only the unarchived ones
+// is the deliberate half — ListByUser returns archived rows too, so the service
+// has always treated an archived name as taken, and a partial index would be
+// weaker than the rule it backs and would let an archive-then-recreate produce
+// a pair that can never be restored.
+func TestSymptomNameUniqueIndexIsCreatedAndCoversEveryRow(t *testing.T) {
+	database := openSQLiteForMigrationBootstrapTest(t, filepath.Join(t.TempDir(), "symptom-name-unique.db"))
+
+	indexSQL := loadSQLiteObjectSQL(t, database, "index", symptomNameUniqueIndexName)
+	definition := strings.ToLower(strings.Join(strings.Fields(indexSQL), ""))
+	if definition == "" {
+		t.Fatalf("expected index %s to exist after migration", symptomNameUniqueIndexName)
+	}
+	if !strings.Contains(definition, "uniqueindex") {
+		t.Fatalf("expected %s to be UNIQUE, got %q", symptomNameUniqueIndexName, indexSQL)
+	}
+	if !strings.Contains(definition, "(user_id,lower(name))") {
+		t.Fatalf("expected %s to key on (user_id, lower(name)), got %q", symptomNameUniqueIndexName, indexSQL)
+	}
+	if strings.Contains(definition, "where") {
+		t.Fatalf("expected %s to cover every row, including archived ones, got %q", symptomNameUniqueIndexName, indexSQL)
+	}
+
+	owner := createDailyLogTestUser(t, database, "symptom-index-owner@example.com")
+	other := createDailyLogTestUser(t, database, "symptom-index-other@example.com")
+
+	insert := func(userID uint, name string) error {
+		return database.Exec(
+			`INSERT INTO symptom_types (user_id, name, icon, color, is_builtin) VALUES (?, ?, 'x', '#FF0000', 0)`,
+			userID, name,
+		).Error
+	}
+
+	if err := insert(owner, "Joint stiffness"); err != nil {
+		t.Fatalf("insert first symptom: %v", err)
+	}
+	if err := insert(other, "Joint stiffness"); err != nil {
+		t.Fatalf("expected the index to be per owner, got %v", err)
+	}
+	if err := insert(owner, "joint stiffness"); err == nil {
+		t.Fatal("expected the index to refuse a case-only duplicate for one owner")
+	}
+}
+
+// TestMigrationRefusesToCreateTheSymptomNameIndexOverExistingDuplicates is the
+// migration's own refusal.
+//
+// A database that already holds duplicate names cannot take the index, and the
+// only ways to make room are deleting or merging somebody's symptom rows. This
+// is a health tracker: neither is acceptable without the owner, so the
+// migration stops, names every conflicting (user_id, lower(name)) group, and
+// leaves the database exactly as it found it.
+//
+// The setup replays the migration against a duplicate-carrying database the way
+// an upgrade would meet one: drop the index, forget the ledger row, seed the
+// pair the application never wrote, and boot again.
+func TestMigrationRefusesToCreateTheSymptomNameIndexOverExistingDuplicates(t *testing.T) {
+	databasePath := filepath.Join(t.TempDir(), "symptom-name-duplicates.db")
+
+	func() {
+		database := openSQLiteForMigrationBootstrapTest(t, databasePath)
+		owner := createDailyLogTestUser(t, database, "symptom-duplicate-owner@example.com")
+
+		if err := database.Exec(`DROP INDEX IF EXISTS ` + symptomNameUniqueIndexName).Error; err != nil {
+			t.Fatalf("drop index for replay: %v", err)
+		}
+		if err := database.Exec(`DELETE FROM schema_migrations WHERE version = '037'`).Error; err != nil {
+			t.Fatalf("forget migration 037: %v", err)
+		}
+		for _, name := range []string{"Cramps", "cramps"} {
+			if err := database.Exec(
+				`INSERT INTO symptom_types (user_id, name, icon, color, is_builtin) VALUES (?, ?, 'x', '#FF0000', 0)`,
+				owner, name,
+			).Error; err != nil {
+				t.Fatalf("seed duplicate %q: %v", name, err)
+			}
+		}
+		sqlDB, err := database.DB()
+		requireNoErr(t, err, "get sql db handle")
+		requireNoErr(t, sqlDB.Close(), "close sql db handle")
+	}()
+
+	database, err := OpenDatabase(Config{Driver: DriverSQLite, SQLitePath: databasePath})
+	if err == nil {
+		// Release the handle the successful open kept, so the failure below is
+		// the only thing this case reports on Windows.
+		if sqlDB, handleErr := database.DB(); handleErr == nil {
+			_ = sqlDB.Close()
+		}
+		t.Fatal("expected the migration to refuse a database that already holds duplicate symptom names")
+	}
+
+	message := err.Error()
+	for _, fragment := range []string{"037_symptom_name_uniqueness.sql", "symptom_types", "cramps", "2"} {
+		if !strings.Contains(strings.ToLower(message), strings.ToLower(fragment)) {
+			t.Fatalf("refusal must name the conflicting rows, %q is missing from: %s", fragment, message)
+		}
+	}
+
+	// Nothing was written: both rows are still there and the index is still absent.
+	reader := openSQLiteFileForReplayTest(t, databasePath)
+	defer closeReplayDatabase(t, reader)
+
+	var rows int64
+	if err := reader.Raw(`SELECT COUNT(*) FROM symptom_types WHERE lower(name) = 'cramps'`).Scan(&rows).Error; err != nil {
+		t.Fatalf("count duplicate rows after the refusal: %v", err)
+	}
+	if rows != 2 {
+		t.Fatalf("the refusal must leave every row untouched, found %d rows instead of 2", rows)
+	}
+
+	var indexSQL struct {
+		SQL string `gorm:"column:sql"`
+	}
+	if err := reader.Raw(`SELECT sql FROM sqlite_master WHERE type = 'index' AND name = ?`, symptomNameUniqueIndexName).Scan(&indexSQL).Error; err != nil {
+		t.Fatalf("read index after the refusal: %v", err)
+	}
+	if strings.TrimSpace(indexSQL.SQL) != "" {
+		t.Fatalf("expected no index after the refusal, got %q", indexSQL.SQL)
+	}
+}

--- a/internal/db/symptom_repository.go
+++ b/internal/db/symptom_repository.go
@@ -43,15 +43,25 @@ func (repo *SymptomRepository) ListByUser(ctx context.Context, userID uint) ([]m
 	return symptoms, nil
 }
 
+// classifySymptomWriteError names the one unique constraint symptom_types
+// carries besides its primary key: migration 037's per-owner index on
+// (user_id, lower(name)). Every symptom write goes through it, so the service
+// sees the database's refusal of a duplicate name as a unique-constraint error
+// it can map onto its own "name already exists", rather than as a driver
+// message it would report as an internal failure.
+func classifySymptomWriteError(err error) error {
+	return classifyUniqueConstraintError(err, "symptom_types.user_id_name")
+}
+
 func (repo *SymptomRepository) Create(ctx context.Context, symptom *models.SymptomType) error {
-	return repo.database.WithContext(ctx).Create(symptom).Error
+	return classifySymptomWriteError(repo.database.WithContext(ctx).Create(symptom).Error)
 }
 
 func (repo *SymptomRepository) CreateBatch(ctx context.Context, symptoms []models.SymptomType) error {
 	if len(symptoms) == 0 {
 		return nil
 	}
-	return repo.database.WithContext(ctx).Create(&symptoms).Error
+	return classifySymptomWriteError(repo.database.WithContext(ctx).Create(&symptoms).Error)
 }
 
 func (repo *SymptomRepository) FindByIDForUser(ctx context.Context, symptomID uint, userID uint) (models.SymptomType, error) {
@@ -71,9 +81,9 @@ func (repo *SymptomRepository) FindByIDForUser(ctx context.Context, symptomID ui
 // ArchivedAt=nil clears the column. Every caller sources symptom from
 // FindByIDForUser first, so a legitimate write always matches its row.
 func (repo *SymptomRepository) Update(ctx context.Context, symptom *models.SymptomType) error {
-	return repo.database.WithContext(ctx).
+	return classifySymptomWriteError(repo.database.WithContext(ctx).
 		Model(symptom).
 		Where("user_id = ?", symptom.UserID).
 		Select("*").
-		Updates(symptom).Error
+		Updates(symptom).Error)
 }

--- a/internal/services/symptom_entry_picker_hidden_set_test.go
+++ b/internal/services/symptom_entry_picker_hidden_set_test.go
@@ -1,0 +1,87 @@
+package services
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+)
+
+// Barrier for the entry-picker hide set.
+//
+// legacyEntryPickerHiddenSymptoms used to be keyed on a SPELLING of the builtin
+// name, looked up through normalizeSymptomNameKey, which lowercases and
+// collapses whitespace runs but never removes them. The entry "moodswings"
+// therefore matched no symptom the product can create: the builtin is named
+// "Mood swings" and normalizes to "mood swings", and a custom symptom never
+// reaches the lookup at all. The declared set said four symptoms are kept out
+// of the day-entry picker while three were, and nothing failed.
+//
+// The set is keyed on models.BuiltinSymptom.Key — the identity the catalogue
+// already carries — and the two cases below hold the map to it from both sides:
+// every key must name a real builtin, and every key must actually fire.
+
+func builtinSymptomKeysForTest() map[string]struct{} {
+	keys := make(map[string]struct{})
+	for _, symptom := range models.DefaultBuiltinSymptoms() {
+		keys[symptom.Key] = struct{}{}
+	}
+	return keys
+}
+
+// TestEveryEntryPickerHiddenKeyNamesABuiltinSymptom fails on a hide-set entry
+// that matches no builtin, so a stale spelling is refused at the point it is
+// written instead of quietly hiding nothing.
+func TestEveryEntryPickerHiddenKeyNamesABuiltinSymptom(t *testing.T) {
+	builtinKeys := builtinSymptomKeysForTest()
+
+	// Anti-vacuity anchors owned by this test rather than read off the set
+	// being judged: one spelling that must classify as a builtin key and one
+	// that must not. If the catalogue is ever read wrong, both fail here before
+	// the sweep below can report a clean verdict about nothing.
+	if _, ok := builtinKeys["mood_swings"]; !ok {
+		t.Fatal("anchor: expected mood_swings to be a builtin symptom key")
+	}
+	if _, ok := builtinKeys["moodswings"]; ok {
+		t.Fatal("anchor: expected moodswings NOT to be a builtin symptom key")
+	}
+
+	unknown := make([]string, 0)
+	for key := range legacyEntryPickerHiddenSymptoms {
+		if _, ok := builtinKeys[key]; !ok {
+			unknown = append(unknown, key)
+		}
+	}
+	if len(unknown) > 0 {
+		sort.Strings(unknown)
+		t.Fatalf("entry-picker hide set names %d key(s) that match no builtin symptom, so they hide nothing while the set claims they do: %s", len(unknown), strings.Join(unknown, ", "))
+	}
+}
+
+// TestEveryEntryPickerHiddenKeyActuallyHidesItsSymptom closes the other half:
+// a key can name a real builtin and still not fire if the lookup and the set
+// disagree about what a key is. It drives the shipped predicate with the
+// catalogue row each key names.
+func TestEveryEntryPickerHiddenKeyActuallyHidesItsSymptom(t *testing.T) {
+	byKey := make(map[string]models.BuiltinSymptom)
+	for _, symptom := range models.DefaultBuiltinSymptoms() {
+		byKey[symptom.Key] = symptom
+	}
+
+	// Anchor: a builtin that is not in the hide set must not be hidden, so a
+	// predicate that answered true for everything could not pass this case.
+	if shouldHideSymptomFromEntryPicker(models.SymptomType{Name: byKey["cramps"].Name, IsBuiltin: true}) {
+		t.Fatal("anchor: expected Cramps to stay in the entry picker")
+	}
+
+	for key := range legacyEntryPickerHiddenSymptoms {
+		builtin, ok := byKey[key]
+		if !ok {
+			continue // reported by the sweep above
+		}
+		if !shouldHideSymptomFromEntryPicker(models.SymptomType{Name: builtin.Name, IsBuiltin: true}) {
+			t.Fatalf("hide set lists %q but the entry picker still shows %q", key, builtin.Name)
+		}
+	}
+}

--- a/internal/services/symptom_entry_picker_hidden_set_test.go
+++ b/internal/services/symptom_entry_picker_hidden_set_test.go
@@ -85,3 +85,31 @@ func TestEveryEntryPickerHiddenKeyActuallyHidesItsSymptom(t *testing.T) {
 		}
 	}
 }
+
+// TestARowFlaggedBuiltinWithNoCatalogueEntryStaysInThePicker covers the state a
+// rename of the catalogue leaves behind.
+//
+// The lookup resolves a stored row to its catalogue entry by name, so a row
+// still marked builtin whose name no longer appears in the table — an account
+// migrated across a release that renamed a builtin, before any backfill — has
+// no key to test against. It stays visible rather than being hidden by a lookup
+// that found nothing: an unrecognized symptom is not evidence that the owner
+// asked for it to be hidden, and a person can always hide a symptom they can
+// see.
+//
+// The early return it covers is deliberately belt-and-braces: the zero-valued
+// catalogue entry a failed lookup returns carries an empty key, which the hide
+// set can never contain, so removing the branch would not change the answer and
+// this case cannot kill it. The branch stays because the rule should be legible
+// in the function rather than deduced from what the set happens not to hold,
+// and the case stays because the ANSWER is the invariant, whichever line gives
+// it.
+func TestARowFlaggedBuiltinWithNoCatalogueEntryStaysInThePicker(t *testing.T) {
+	orphan := models.SymptomType{Name: "Mood swings (retired spelling)", IsBuiltin: true}
+	if _, known := builtinSymptomByName(orphan.Name); known {
+		t.Fatalf("fixture is stale: %q is in the builtin catalogue and cannot stand for a row that is not", orphan.Name)
+	}
+	if shouldHideSymptomFromEntryPicker(orphan) {
+		t.Fatalf("expected a builtin row with no catalogue entry to stay in the picker, %q was hidden", orphan.Name)
+	}
+}

--- a/internal/services/symptom_name_uniqueness_barrier_test.go
+++ b/internal/services/symptom_name_uniqueness_barrier_test.go
@@ -1,0 +1,256 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/db"
+	"github.com/ovumcy/ovumcy-web/internal/models"
+	"gorm.io/gorm"
+)
+
+// Barrier for the per-owner symptom-name uniqueness class.
+//
+// The name rule used to live only in application code: the service listed the
+// owner's symptoms, compared normalized keys in memory and then issued an
+// unrelated INSERT, with no transaction, lock or constraint joining the two.
+// Two requests that pass the check before either writes both write, and the
+// owner ends up with two symptoms the picker, the frequency counts and the
+// export cannot tell apart. The builtin-seeding path had the same shape on a
+// READ path — two post-registration page loads each list, each compute the
+// missing builtins and each insert them — which is the more reachable half.
+//
+// What closes it is a UNIQUE index in the schema, so the second writer is
+// refused by the database rather than by a check it already passed. These cases
+// drive the real repository against a real SQLite file, because a fake
+// repository cannot refuse anything the service did not already refuse itself.
+//
+// What the index does NOT do is stated by
+// TestSymptomNameIndexDoesNotCollapseTheWhitespaceTheServiceCollapses below:
+// portable SQL can lower a name, it cannot collapse internal whitespace runs,
+// so the index is a backstop strictly weaker than the service rule and the
+// service check stays in front of it.
+
+// newSymptomListRendezvous returns a function that blocks until it has been
+// called by count goroutines, and lets every later call through.
+//
+// It is installed on the seam the class lives in — the return of ListByUser,
+// after the availability check has read the catalogue and before anything is
+// written — so both writers hold a decision made from the same snapshot. Simply
+// starting two goroutines together does not reproduce the defect reliably: one
+// usually finishes its INSERT before the other lists, and the guard then passes
+// on a tree that has no constraint at all.
+func newSymptomListRendezvous(count int) func() {
+	mutex := sync.Mutex{}
+	arrived := 0
+	gate := make(chan struct{})
+
+	return func() {
+		mutex.Lock()
+		if arrived < count {
+			arrived++
+			if arrived == count {
+				close(gate)
+			}
+		}
+		mutex.Unlock()
+		<-gate
+	}
+}
+
+// barrieredSymptomRepository is the real repository with a rendezvous on the
+// return of ListByUser. Everything else passes straight through, so the writes
+// under test are the shipped ones.
+type barrieredSymptomRepository struct {
+	SymptomRepository
+	afterList func()
+}
+
+func (repo barrieredSymptomRepository) ListByUser(ctx context.Context, userID uint) ([]models.SymptomType, error) {
+	symptoms, err := repo.SymptomRepository.ListByUser(ctx, userID)
+	repo.afterList()
+	return symptoms, err
+}
+
+// symptomUniquenessRace runs fn in parallel from n goroutines released
+// together, and returns each call's error in start order.
+func symptomUniquenessRace(count int, fn func(index int) error) []error {
+	release := make(chan struct{})
+	ready := sync.WaitGroup{}
+	done := sync.WaitGroup{}
+	results := make([]error, count)
+
+	for worker := range count {
+		ready.Add(1)
+		done.Add(1)
+		go func(index int) {
+			defer done.Done()
+			ready.Done()
+			<-release
+			results[index] = fn(index)
+		}(worker)
+	}
+
+	ready.Wait()
+	close(release)
+	done.Wait()
+	return results
+}
+
+func countSymptomRowsNamed(t *testing.T, database *gorm.DB, userID uint, name string) int64 {
+	t.Helper()
+
+	var rows int64
+	if err := database.Model(&models.SymptomType{}).
+		Where("user_id = ? AND name = ?", userID, name).
+		Count(&rows).Error; err != nil {
+		t.Fatalf("count symptom rows named %q: %v", name, err)
+	}
+	return rows
+}
+
+// TestConcurrentSymptomCreatesOfOneNameLeaveExactlyOneRow is the found red for
+// R2-0100: before the unique index existed both goroutines committed and the
+// owner held two rows called "Joint stiffness".
+func TestConcurrentSymptomCreatesOfOneNameLeaveExactlyOneRow(t *testing.T) {
+	_, database := newDayServiceIntegration(t)
+	user := createDayServiceTestUser(t, database, "symptom-name-race@example.com")
+
+	repositories := db.NewRepositories(database)
+	service := NewSymptomService(barrieredSymptomRepository{
+		SymptomRepository: repositories.Symptoms,
+		afterList:         newSymptomListRendezvous(2),
+	})
+
+	errs := symptomUniquenessRace(2, func(int) error {
+		_, err := service.CreateSymptomForUser(context.Background(), user.ID, "Joint stiffness", "🦴", "#334455")
+		return err
+	})
+
+	created := 0
+	for index, err := range errs {
+		switch {
+		case err == nil:
+			created++
+		case errors.Is(err, ErrSymptomNameAlreadyExists):
+		default:
+			t.Fatalf("concurrent create %d returned an unexpected error: %v", index, err)
+		}
+	}
+
+	if created != 1 {
+		t.Fatalf("expected exactly one concurrent create to succeed, got %d (errors: %v)", created, errs)
+	}
+	if rows := countSymptomRowsNamed(t, database, user.ID, "Joint stiffness"); rows != 1 {
+		t.Fatalf("expected exactly one stored row named %q, got %d", "Joint stiffness", rows)
+	}
+}
+
+// TestConcurrentBuiltinSeedingLeavesOneRowPerBuiltin covers the read-path half
+// of the same class. Two concurrent page loads both list, both compute the same
+// missing builtins and both insert them: the loser must not surface an error to
+// a page that only wanted to read, and must not double-seed the catalogue.
+func TestConcurrentBuiltinSeedingLeavesOneRowPerBuiltin(t *testing.T) {
+	_, database := newDayServiceIntegration(t)
+	user := createDayServiceTestUser(t, database, "symptom-seed-race@example.com")
+
+	repositories := db.NewRepositories(database)
+	service := NewSymptomService(barrieredSymptomRepository{
+		SymptomRepository: repositories.Symptoms,
+		afterList:         newSymptomListRendezvous(2),
+	})
+
+	errs := symptomUniquenessRace(2, func(int) error {
+		_, err := service.FetchSymptoms(context.Background(), user.ID)
+		return err
+	})
+	for index, err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent FetchSymptoms %d returned an error: %v", index, err)
+		}
+	}
+
+	var rows int64
+	if err := database.Model(&models.SymptomType{}).Where("user_id = ?", user.ID).Count(&rows).Error; err != nil {
+		t.Fatalf("count seeded symptoms: %v", err)
+	}
+	if expected := int64(len(models.DefaultBuiltinSymptoms())); rows != expected {
+		t.Fatalf("expected %d builtin rows after a concurrent seed, got %d", expected, rows)
+	}
+}
+
+// TestSymptomNameIndexDoesNotCollapseTheWhitespaceTheServiceCollapses pins the
+// residual the database backstop deliberately leaves.
+//
+// normalizeSymptomNameKey lowercases AND collapses internal whitespace runs to
+// a single space. Portable SQL can do the first and not the second, so the
+// index keys on lower(name) and "Joint  stiffness" and "Joint stiffness" are
+// two different keys to it while they are one name to the service. Both halves
+// are asserted here so a later reader cannot conclude from the index that the
+// database now enforces the application's rule: it enforces a weaker one, and
+// the service check in front of it is what covers the difference.
+func TestSymptomNameIndexDoesNotCollapseTheWhitespaceTheServiceCollapses(t *testing.T) {
+	_, database := newDayServiceIntegration(t)
+	user := createDayServiceTestUser(t, database, "symptom-name-residual@example.com")
+
+	repositories := db.NewRepositories(database)
+	service := NewSymptomService(repositories.Symptoms)
+
+	if _, err := service.CreateSymptomForUser(context.Background(), user.ID, "Joint stiffness", "🦴", "#334455"); err != nil {
+		t.Fatalf("create first symptom: %v", err)
+	}
+
+	// The service collapses the doubled space and refuses the name.
+	if _, err := service.CreateSymptomForUser(context.Background(), user.ID, "Joint  stiffness", "🦴", "#334455"); !errors.Is(err, ErrSymptomNameAlreadyExists) {
+		t.Fatalf("expected the service to refuse a whitespace-variant name, got %v", err)
+	}
+
+	// The index does not: a write that bypasses the service commits.
+	spaced := models.SymptomType{UserID: user.ID, Name: "Joint  stiffness", Icon: "🦴", Color: "#334455"}
+	if err := database.Create(&spaced).Error; err != nil {
+		t.Fatalf("expected the index to admit a whitespace-variant name it cannot normalize, got %v", err)
+	}
+
+	// A case-only variant IS covered, which is the half the index does carry.
+	cased := models.SymptomType{UserID: user.ID, Name: "joint stiffness", Icon: "🦴", Color: "#334455"}
+	if err := database.Create(&cased).Error; err == nil {
+		t.Fatal("expected the index to refuse a case-only variant of an existing name")
+	}
+}
+
+// TestSymptomNameUniquenessIsPerOwnerAndSurvivesArchival pins the two scopes the
+// index must NOT widen or narrow.
+//
+// Per owner: two accounts on one instance each hold their own "Joint stiffness".
+//
+// Across archival: ListByUser returns archived rows too, so the service already
+// treats an archived name as taken and RestoreSymptomForUser re-checks it. The
+// index therefore covers every row rather than only the unarchived ones — a
+// partial index would be weaker than the rule the service has always applied,
+// and would let an archive-then-recreate produce a pair that cannot be restored.
+func TestSymptomNameUniquenessIsPerOwnerAndSurvivesArchival(t *testing.T) {
+	_, database := newDayServiceIntegration(t)
+	first := createDayServiceTestUser(t, database, "symptom-name-owner-a@example.com")
+	second := createDayServiceTestUser(t, database, "symptom-name-owner-b@example.com")
+
+	repositories := db.NewRepositories(database)
+	service := NewSymptomService(repositories.Symptoms)
+
+	created, err := service.CreateSymptomForUser(context.Background(), first.ID, "Joint stiffness", "🦴", "#334455")
+	if err != nil {
+		t.Fatalf("create symptom for the first owner: %v", err)
+	}
+	if _, err := service.CreateSymptomForUser(context.Background(), second.ID, "Joint stiffness", "🦴", "#334455"); err != nil {
+		t.Fatalf("expected the second owner to hold the same name, got %v", err)
+	}
+
+	if err := service.ArchiveSymptomForUser(context.Background(), first.ID, created.ID, time.Now().UTC()); err != nil {
+		t.Fatalf("archive symptom: %v", err)
+	}
+	if _, err := service.CreateSymptomForUser(context.Background(), first.ID, "Joint stiffness", "🦴", "#334455"); !errors.Is(err, ErrSymptomNameAlreadyExists) {
+		t.Fatalf("expected an archived name to stay reserved for its owner, got %v", err)
+	}
+}

--- a/internal/services/symptom_name_uniqueness_barrier_test.go
+++ b/internal/services/symptom_name_uniqueness_barrier_test.go
@@ -254,3 +254,190 @@ func TestSymptomNameUniquenessIsPerOwnerAndSurvivesArchival(t *testing.T) {
 		t.Fatalf("expected an archived name to stay reserved for its owner, got %v", err)
 	}
 }
+
+// scriptedBuiltinSeedRepository answers ListByUser from a script and fails
+// CreateBatch with a fixed error, so the two readings of one refusal can be
+// driven apart.
+//
+// The embedded interface is nil on purpose: ensureBuiltinSymptomsListed touches
+// only these two methods, and a call to any other would panic loudly rather
+// than pass silently through a stub that answers everything with a zero value.
+type scriptedBuiltinSeedRepository struct {
+	SymptomRepository
+	lists     [][]models.SymptomType
+	listErrs  []error
+	listCalls int
+	batchErr  error
+}
+
+func (repo *scriptedBuiltinSeedRepository) ListByUser(context.Context, uint) ([]models.SymptomType, error) {
+	index := repo.listCalls
+	if index >= len(repo.lists) {
+		index = len(repo.lists) - 1
+	}
+	repo.listCalls++
+	if index < len(repo.listErrs) && repo.listErrs[index] != nil {
+		return nil, repo.listErrs[index]
+	}
+	result := make([]models.SymptomType, len(repo.lists[index]))
+	copy(result, repo.lists[index])
+	return result, nil
+}
+
+func (repo *scriptedBuiltinSeedRepository) CreateBatch(context.Context, []models.SymptomType) error {
+	return repo.batchErr
+}
+
+// builtinCatalogueRows renders the builtin catalogue as stored rows, optionally
+// leaving one out by key.
+func builtinCatalogueRows(userID uint, omitKey string) []models.SymptomType {
+	rows := make([]models.SymptomType, 0)
+	for index, builtin := range models.DefaultBuiltinSymptoms() {
+		if builtin.Key == omitKey {
+			continue
+		}
+		rows = append(rows, models.SymptomType{
+			ID:        uint(index + 1),
+			UserID:    userID,
+			Name:      builtin.Name,
+			Icon:      builtin.Icon,
+			Color:     builtin.Color,
+			IsBuiltin: true,
+		})
+	}
+	return rows
+}
+
+// TestBuiltinSeedingSwallowsARefusalTheRelistExplains is the benign half, and
+// the positive anchor for the case below: the insert was refused because a
+// concurrent load wrote the same builtins first, the re-list shows them, and a
+// page load that only wanted to read is answered with the catalogue.
+func TestBuiltinSeedingSwallowsARefusalTheRelistExplains(t *testing.T) {
+	repo := &scriptedBuiltinSeedRepository{
+		lists: [][]models.SymptomType{
+			builtinCatalogueRows(7, "insomnia"),
+			builtinCatalogueRows(7, ""),
+		},
+		batchErr: fakeUniqueConstraintError{},
+	}
+	service := NewSymptomService(repo)
+
+	symptoms, err := service.FetchSymptoms(context.Background(), 7)
+	if err != nil {
+		t.Fatalf("a refusal the re-list explains must not surface: %v", err)
+	}
+	if len(symptoms) != len(models.DefaultBuiltinSymptoms()) {
+		t.Fatalf("expected the full catalogue after the winning writer, got %d rows", len(symptoms))
+	}
+}
+
+// TestBuiltinSeedingReportsARefusalItCannotExplain is the half that made the
+// swallow unsafe.
+//
+// Discarding every unique-constraint refusal from the seeding insert assumes
+// the only way to hit one is a concurrent writer that wrote exactly this set.
+// Any other collision is permanent, and this is a READ path: it would repeat on
+// every page load, return a catalogue silently short a builtin, and report
+// nothing at all — where before the index existed the write error surfaced. The
+// refusal is swallowed only when the re-list shows the assumption held.
+func TestBuiltinSeedingReportsARefusalItCannotExplain(t *testing.T) {
+	repo := &scriptedBuiltinSeedRepository{
+		lists: [][]models.SymptomType{
+			builtinCatalogueRows(7, "insomnia"),
+			builtinCatalogueRows(7, "insomnia"),
+		},
+		batchErr: fakeUniqueConstraintError{},
+	}
+	service := NewSymptomService(repo)
+
+	symptoms, err := service.FetchSymptoms(context.Background(), 7)
+	if err == nil {
+		t.Fatalf("a refusal the re-list does NOT explain must surface, got a %d-row catalogue and no error", len(symptoms))
+	}
+	var uniqueErr interface{ UniqueConstraint() string }
+	if !errors.As(err, &uniqueErr) {
+		t.Fatalf("expected the constraint refusal itself, got %v", err)
+	}
+}
+
+// TestBuiltinSeedingReportsAFailedRelist covers the read the swallow now
+// depends on. The re-list is what decides whether a constraint refusal was the
+// benign race, so a re-list that fails leaves the question unanswered — and an
+// unanswered question is not permission to report success.
+func TestBuiltinSeedingReportsAFailedRelist(t *testing.T) {
+	relistFailed := errors.New("relist failed")
+	repo := &scriptedBuiltinSeedRepository{
+		lists:    [][]models.SymptomType{builtinCatalogueRows(7, "insomnia"), nil},
+		listErrs: []error{nil, relistFailed},
+		batchErr: fakeUniqueConstraintError{},
+	}
+
+	if _, err := NewSymptomService(repo).FetchSymptoms(context.Background(), 7); !errors.Is(err, relistFailed) {
+		t.Fatalf("expected the failed re-list to surface, got %v", err)
+	}
+}
+
+// TestConcurrentRenamesToOneNameLeaveExactlyOneWinner is the rename path's half
+// of the class, and the one a person actually meets: two tabs renaming two
+// different symptoms to the same new name. Neither list can see the other's new
+// name, because neither has been written yet, so both availability checks pass
+// and the index is the only thing left to refuse the second write.
+func TestConcurrentRenamesToOneNameLeaveExactlyOneWinner(t *testing.T) {
+	_, database := newDayServiceIntegration(t)
+	user := createDayServiceTestUser(t, database, "symptom-rename-race@example.com")
+	first := createSymptomServiceTestCustomSymptom(t, database, user.ID, "Alpha", "a", "#334455")
+	second := createSymptomServiceTestCustomSymptom(t, database, user.ID, "Beta", "b", "#334455")
+
+	repositories := db.NewRepositories(database)
+	service := NewSymptomService(barrieredSymptomRepository{
+		SymptomRepository: repositories.Symptoms,
+		afterList:         newSymptomListRendezvous(2),
+	})
+
+	targets := []uint{first.ID, second.ID}
+	errs := symptomUniquenessRace(2, func(index int) error {
+		_, err := service.UpdateSymptomForUser(context.Background(), user.ID, targets[index], "Gamma", "g", "#334455")
+		return err
+	})
+
+	renamed := 0
+	for index, err := range errs {
+		switch {
+		case err == nil:
+			renamed++
+		case errors.Is(err, ErrSymptomNameAlreadyExists):
+		default:
+			t.Fatalf("concurrent rename %d returned an unexpected error: %v", index, err)
+		}
+	}
+	if renamed != 1 {
+		t.Fatalf("expected exactly one concurrent rename to succeed, got %d (errors: %v)", renamed, errs)
+	}
+	if rows := countSymptomRowsNamed(t, database, user.ID, "Gamma"); rows != 1 {
+		t.Fatalf("expected exactly one stored row named %q, got %d", "Gamma", rows)
+	}
+}
+
+// TestRestoreMapsAConstraintRefusalOntoTheNameConflict pins the restore path's
+// mapping as POLICY, and says plainly that it is not a reachable state today.
+//
+// A restore can only collide with a row that already carries the name, and
+// ensureSymptomNameAvailable lists archived rows alongside active ones, so it
+// sees that row and refuses before the write. The mapping exists because the
+// index is the authority and the check is not: were the availability check ever
+// narrowed to active rows — the reading this schema change was very nearly
+// built on — the restore would start meeting the index, and a person renaming
+// in two tabs would get a 500 instead of the conflict every other path gives.
+// A stub supplies the refusal, since the schema will not.
+func TestRestoreMapsAConstraintRefusalOntoTheNameConflict(t *testing.T) {
+	archivedAt := time.Now().UTC()
+	repo := &stubSymptomRepo{
+		findResult: models.SymptomType{ID: 4, UserID: 7, Name: "Delta", ArchivedAt: &archivedAt},
+		updateErr:  fakeUniqueConstraintError{},
+	}
+	service := NewSymptomService(repo)
+
+	if err := service.RestoreSymptomForUser(context.Background(), 7, 4); !errors.Is(err, ErrSymptomNameAlreadyExists) {
+		t.Fatalf("expected a constraint refusal on restore to read as a name conflict, got %v", err)
+	}
+}

--- a/internal/services/symptom_service.go
+++ b/internal/services/symptom_service.go
@@ -246,6 +246,14 @@ func (service *SymptomService) CalculateFrequencies(ctx context.Context, userID 
 	return result, nil
 }
 
+// SeedBuiltinSymptoms has no caller in the application: registration seeds the
+// catalogue with the account row in one transaction, and every later path goes
+// through EnsureBuiltinSymptoms and ensureBuiltinSymptomsListed. It is left
+// exactly as it was rather than taught the per-owner name index's refusal
+// policy, because unreachable handling is handling nobody can hold to anything
+// — a caller wired in later has to adopt ensureBuiltinSymptomsListed's rule
+// (swallow a constraint refusal only once a re-read shows the work is done) as
+// part of wiring it.
 func (service *SymptomService) SeedBuiltinSymptoms(ctx context.Context, userID uint) error {
 	count, err := service.symptoms.CountBuiltinByUser(ctx, userID)
 	if err != nil {
@@ -254,17 +262,7 @@ func (service *SymptomService) SeedBuiltinSymptoms(ctx context.Context, userID u
 	if count > 0 {
 		return nil
 	}
-	if err := service.symptoms.CreateBatch(ctx, BuiltinSymptomRecordsForUser(userID)); err != nil {
-		if isSymptomNameConstraintViolation(err) {
-			// A concurrent seed of the same account got there first. The
-			// catalogue this call was asked to create is present either way,
-			// and the count above is a read the other writer can invalidate at
-			// any point before this insert.
-			return nil
-		}
-		return err
-	}
-	return nil
+	return service.symptoms.CreateBatch(ctx, BuiltinSymptomRecordsForUser(userID))
 }
 
 func (service *SymptomService) EnsureBuiltinSymptoms(ctx context.Context, userID uint) error {
@@ -280,32 +278,54 @@ func (service *SymptomService) ensureBuiltinSymptomsListed(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	existingByName := make(map[string]struct{}, len(existing))
-	for _, symptom := range existing {
-		key := normalizeSymptomNameKey(symptom.Name)
-		if key != "" {
-			existingByName[key] = struct{}{}
-		}
-	}
 
-	missing := MissingBuiltinSymptomsForUser(userID, existingByName)
+	missing := MissingBuiltinSymptomsForUser(userID, symptomNameKeySet(existing))
 	if len(missing) == 0 {
 		return existing, nil
 	}
-	if err := service.symptoms.CreateBatch(ctx, missing); err != nil {
-		// This is a READ path — a page load that happens to notice a builtin is
-		// absent — and it is the most reachable half of the duplicate-name
-		// class: two loads for one account both list, both compute the same
-		// missing set and both insert it. The loser is refused by the per-owner
-		// name index, and the right answer for it is the catalogue the winner
-		// wrote, not an error on a request that only wanted to read. Both
-		// callers derive the missing set from the same builtin table, so the
-		// winner's insert covers this one exactly.
-		if !isSymptomNameConstraintViolation(err) {
-			return nil, err
+	createErr := service.symptoms.CreateBatch(ctx, missing)
+	if createErr != nil && !isSymptomNameConstraintViolation(createErr) {
+		return nil, createErr
+	}
+
+	refreshed, err := service.symptoms.ListByUser(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	if createErr == nil {
+		return refreshed, nil
+	}
+
+	// This is a READ path — a page load that happens to notice a builtin is
+	// absent — and it is the most reachable half of the duplicate-name class:
+	// two loads for one account both list, both compute the same missing set
+	// and both insert it. The loser is refused by the per-owner name index, and
+	// the right answer for it is the catalogue the winner wrote, not an error
+	// on a request that only wanted to read.
+	//
+	// That is the ONLY refusal this path may swallow, and the re-list is what
+	// tells the two apart. A collision it cannot explain — a builtin whose name
+	// the schema will never accept for this account — is permanent, and
+	// discarding it here would repeat on every page load, return a catalogue
+	// silently short that builtin, and report nothing at all, where before the
+	// index existed the write error surfaced.
+	if len(MissingBuiltinSymptomsForUser(userID, symptomNameKeySet(refreshed))) > 0 {
+		return nil, createErr
+	}
+	return refreshed, nil
+}
+
+// symptomNameKeySet indexes a stored catalogue by the service's normalized name
+// key, which is what decides whether a builtin counts as already present.
+func symptomNameKeySet(symptoms []models.SymptomType) map[string]struct{} {
+	keys := make(map[string]struct{}, len(symptoms))
+	for _, symptom := range symptoms {
+		key := normalizeSymptomNameKey(symptom.Name)
+		if key != "" {
+			keys[key] = struct{}{}
 		}
 	}
-	return service.symptoms.ListByUser(ctx, userID)
+	return keys
 }
 
 func (service *SymptomService) FetchSymptoms(ctx context.Context, userID uint) ([]models.SymptomType, error) {

--- a/internal/services/symptom_service.go
+++ b/internal/services/symptom_service.go
@@ -43,8 +43,18 @@ type SymptomService struct {
 	reservedNameKeys map[string]struct{}
 }
 
+// legacyEntryPickerHiddenSymptoms names the builtins the day-entry picker keeps
+// out of the list unless the day already carries them.
+//
+// It is keyed on models.BuiltinSymptom.Key — the identity the catalogue itself
+// carries — rather than on a spelling of the display name. Keyed on a spelling
+// it was silently short: the entry "moodswings" was looked up through a
+// normalizer that lowercases and collapses whitespace runs but never removes
+// them, so it matched nothing at all, and the set declared four symptoms hidden
+// while three were. A key that names no builtin now fails
+// TestEveryEntryPickerHiddenKeyNamesABuiltinSymptom instead of hiding nothing.
 var legacyEntryPickerHiddenSymptoms = map[string]struct{}{
-	"moodswings":   {},
+	"mood_swings":  {},
 	"fatigue":      {},
 	"irritability": {},
 	"insomnia":     {},
@@ -74,9 +84,28 @@ func (service *SymptomService) CreateSymptomForUser(ctx context.Context, userID 
 	}
 
 	if err := service.symptoms.Create(ctx, &normalized); err != nil {
+		if isSymptomNameConstraintViolation(err) {
+			return models.SymptomType{}, ErrSymptomNameAlreadyExists
+		}
 		return models.SymptomType{}, fmt.Errorf("%w: %v", ErrCreateSymptomFailed, err)
 	}
 	return normalized, nil
+}
+
+// isSymptomNameConstraintViolation reports whether a symptom write was refused
+// by the database's own per-owner name index.
+//
+// ensureSymptomNameAvailable reads the catalogue and the write happens after
+// it, so between the two another request can claim the name — the loser then
+// arrives at storage with a decision that was true when it was made. The index
+// added in migration 037 is what refuses it, and symptom_types carries no other
+// unique constraint besides its primary key, whose values this layer never
+// supplies. The shape of the error is the persistence layer's, matched
+// structurally the way the registration path already matches it, so this
+// package keeps its distance from the driver.
+func isSymptomNameConstraintViolation(err error) bool {
+	var uniqueErr interface{ UniqueConstraint() string }
+	return errors.As(err, &uniqueErr)
 }
 
 func (service *SymptomService) UpdateSymptomForUser(ctx context.Context, userID uint, symptomID uint, name string, icon string, color string) (models.SymptomType, error) {
@@ -100,6 +129,9 @@ func (service *SymptomService) UpdateSymptomForUser(ctx context.Context, userID 
 	symptom.Icon = normalized.Icon
 	symptom.Color = normalized.Color
 	if err := service.symptoms.Update(ctx, &symptom); err != nil {
+		if isSymptomNameConstraintViolation(err) {
+			return models.SymptomType{}, ErrSymptomNameAlreadyExists
+		}
 		return models.SymptomType{}, fmt.Errorf("%w: %v", ErrUpdateSymptomFailed, err)
 	}
 	return symptom, nil
@@ -145,6 +177,9 @@ func (service *SymptomService) RestoreSymptomForUser(ctx context.Context, userID
 
 	symptom.ArchivedAt = nil
 	if err := service.symptoms.Update(ctx, &symptom); err != nil {
+		if isSymptomNameConstraintViolation(err) {
+			return ErrSymptomNameAlreadyExists
+		}
 		return fmt.Errorf("%w: %v", ErrRestoreSymptomFailed, err)
 	}
 	return nil
@@ -219,7 +254,17 @@ func (service *SymptomService) SeedBuiltinSymptoms(ctx context.Context, userID u
 	if count > 0 {
 		return nil
 	}
-	return service.symptoms.CreateBatch(ctx, BuiltinSymptomRecordsForUser(userID))
+	if err := service.symptoms.CreateBatch(ctx, BuiltinSymptomRecordsForUser(userID)); err != nil {
+		if isSymptomNameConstraintViolation(err) {
+			// A concurrent seed of the same account got there first. The
+			// catalogue this call was asked to create is present either way,
+			// and the count above is a read the other writer can invalidate at
+			// any point before this insert.
+			return nil
+		}
+		return err
+	}
+	return nil
 }
 
 func (service *SymptomService) EnsureBuiltinSymptoms(ctx context.Context, userID uint) error {
@@ -248,7 +293,17 @@ func (service *SymptomService) ensureBuiltinSymptomsListed(ctx context.Context, 
 		return existing, nil
 	}
 	if err := service.symptoms.CreateBatch(ctx, missing); err != nil {
-		return nil, err
+		// This is a READ path — a page load that happens to notice a builtin is
+		// absent — and it is the most reachable half of the duplicate-name
+		// class: two loads for one account both list, both compute the same
+		// missing set and both insert it. The loser is refused by the per-owner
+		// name index, and the right answer for it is the catalogue the winner
+		// wrote, not an error on a request that only wanted to read. Both
+		// callers derive the missing set from the same builtin table, so the
+		// winner's insert covers this one exactly.
+		if !isSymptomNameConstraintViolation(err) {
+			return nil, err
+		}
 	}
 	return service.symptoms.ListByUser(ctx, userID)
 }
@@ -384,7 +439,11 @@ func shouldHideSymptomFromEntryPicker(symptom models.SymptomType) bool {
 	if !symptom.IsBuiltin {
 		return false
 	}
-	_, hidden := legacyEntryPickerHiddenSymptoms[normalizeSymptomNameKey(symptom.Name)]
+	builtin, known := builtinSymptomByName(symptom.Name)
+	if !known {
+		return false
+	}
+	_, hidden := legacyEntryPickerHiddenSymptoms[builtin.Key]
 	return hidden
 }
 

--- a/migrations/037_symptom_name_uniqueness.sql
+++ b/migrations/037_symptom_name_uniqueness.sql
@@ -1,0 +1,48 @@
+-- Per-owner uniqueness for symptom names.
+--
+-- Until now the rule lived only in application code: the symptom service listed
+-- the owner's catalogue, compared normalized keys in memory and then issued an
+-- unrelated INSERT, with no transaction, lock or constraint joining the two. Two
+-- requests that both passed the check before either wrote both wrote, and the
+-- owner was left holding two symptoms the picker, the frequency counts and the
+-- export cannot tell apart. The builtin-seeding path had the same shape on a
+-- READ path -- two page loads each list the catalogue, each compute the same
+-- missing builtins and each insert them -- which is the more reachable half.
+--
+-- WHAT THIS INDEX GUARANTEES: for one user_id, at most one row per lower(name).
+-- It is keyed per owner, so two accounts on one instance keep their own
+-- "Cramps" independently.
+--
+-- WHAT IT DOES NOT: it is a backstop STRICTLY WEAKER than the application rule,
+-- and the service check stays in front of it. The service also collapses runs of
+-- internal whitespace to a single space and drops invalid UTF-8, and portable
+-- SQL can do neither, so "Mood  swings" and "Mood swings" are one name to the
+-- service and two keys here. The lower() half differs by engine as well: SQLite
+-- folds ASCII only, Postgres folds by locale, so a case-only variant of a
+-- non-ASCII name is covered on Postgres and not on SQLite. Read this index as
+-- "no owner ends up with two rows a normal request would have refused", never as
+-- "the database now enforces the name rule".
+--
+-- IT COVERS EVERY ROW, INCLUDING ARCHIVED ONES, on purpose. The service lists
+-- archived symptoms alongside active ones, so an archived name has always been
+-- taken for its owner, and restoring an archived symptom re-checks it. A partial
+-- index over the unarchived rows would be weaker still, and would admit a pair
+-- that can never be restored.
+--
+-- On a database that already holds duplicates the runner REFUSES this migration
+-- and names every conflicting (user_id, lower(name)) group instead of creating
+-- the index. It never deletes, merges or rewrites a row to make room: a person's
+-- symptom history is theirs, and a loud, diagnosable refusal is the only
+-- acceptable outcome here. Nothing is executed and the database is left exactly
+-- as it was.
+--
+-- Rollback: DROP INDEX idx_symptom_types_user_name_unique. This migration
+-- touches no data at all, so dropping the index restores the previous state
+-- exactly.
+--
+-- NOTE: keep prose in this file free of semicolons -- the migration runner
+-- splits statements on the semicolon character without stripping SQL comments,
+-- so a semicolon inside a comment is mis-parsed as a statement boundary.
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_symptom_types_user_name_unique
+    ON symptom_types (user_id, lower(name));

--- a/migrations/postgres/037_symptom_name_uniqueness.sql
+++ b/migrations/postgres/037_symptom_name_uniqueness.sql
@@ -1,0 +1,41 @@
+-- Postgres mirror of migrations/037_symptom_name_uniqueness.sql (per-owner
+-- uniqueness for symptom names). Same version number and basename so schema
+-- history stays aligned across engines.
+--
+-- WHAT THIS INDEX GUARANTEES: for one user_id, at most one row per lower(name).
+-- It is keyed per owner, so two accounts on one instance keep their own
+-- "Cramps" independently.
+--
+-- WHAT IT DOES NOT: it is a backstop STRICTLY WEAKER than the application rule,
+-- and the service check stays in front of it. The service also collapses runs of
+-- internal whitespace to a single space and drops invalid UTF-8, and portable
+-- SQL can do neither, so "Mood  swings" and "Mood swings" are one name to the
+-- service and two keys here. The lower() half is where the two engines part:
+-- Postgres folds by locale and covers a case-only variant of a non-ASCII name,
+-- SQLite folds ASCII only and does not. The SQL text is identical in both trees
+-- and the guarantee is not, which is why the application rule stays in front on
+-- both.
+--
+-- IT COVERS EVERY ROW, INCLUDING ARCHIVED ONES, on purpose. The service lists
+-- archived symptoms alongside active ones, so an archived name has always been
+-- taken for its owner, and restoring an archived symptom re-checks it. A partial
+-- index over the unarchived rows would be weaker still, and would admit a pair
+-- that can never be restored.
+--
+-- On a database that already holds duplicates the runner REFUSES this migration
+-- and names every conflicting (user_id, lower(name)) group instead of creating
+-- the index. It never deletes, merges or rewrites a row to make room: a person's
+-- symptom history is theirs, and a loud, diagnosable refusal is the only
+-- acceptable outcome here. Nothing is executed and the database is left exactly
+-- as it was.
+--
+-- Rollback: DROP INDEX idx_symptom_types_user_name_unique. This migration
+-- touches no data at all, so dropping the index restores the previous state
+-- exactly.
+--
+-- NOTE: keep prose in this file free of semicolons -- the migration runner
+-- splits statements on the semicolon character without stripping SQL comments,
+-- so a semicolon inside a comment is mis-parsed as a statement boundary.
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_symptom_types_user_name_unique
+    ON symptom_types (user_id, lower(name));


### PR DESCRIPTION
# Per-owner symptom name uniqueness, and an entry-picker hide set that hides what it declares

Two records, one subject: the symptom catalogue's name rule, which until now existed only as
application code and only as a spelling.

---

## R2-0100 — a duplicate name is refused by the schema, not by a check that already passed

### Re-derived against this tree

- `SymptomService.ensureSymptomNameAvailable` reads the owner's catalogue through `ListByUser`,
  compares normalized keys in memory and returns `nil`; the caller then issues an unrelated
  `Create`. No transaction, lock or `ON CONFLICT` joins the two.
- `models.SymptomType` declares its `Name` with a gorm not-null tag and nothing else. The schema
  carried only plain indexes — `idx_symptom_types_user_id` (`001_init.sql`) and
  `idx_symptom_types_user_archived_at` (`004_symptom_archival.sql`) — in both dialect trees.
- `ensureBuiltinSymptomsListed` repeats the shape on a **read** path: list, compute the missing
  builtins, `CreateBatch`. That is the more reachable half — it needs two overlapping page loads,
  not two overlapping form submissions. `SeedBuiltinSymptoms` has it too (`CountBuiltinByUser`,
  then `CreateBatch`).

All of it holds.

### Red → green (FOUND, not induced)

Both barrier cases rendezvous on the **return of `ListByUser`**, so both writers hold a decision
made from the same snapshot. Simply starting two goroutines together does not reproduce the
defect: one usually finishes its insert before the other lists, so a guard that only starts them
together goes green on a tree with no constraint at all.

Before the migration existed:

```
$ go test ./internal/services/ -run 'TestConcurrentSymptomCreatesOfOneNameLeaveExactlyOneRow|TestConcurrentBuiltinSeedingLeavesOneRowPerBuiltin|TestSymptomNameIndexDoesNotCollapseTheWhitespaceTheServiceCollapses' -count=1
--- FAIL: TestConcurrentSymptomCreatesOfOneNameLeaveExactlyOneRow (0.42s)
    symptom_name_uniqueness_barrier_test.go:145: expected exactly one concurrent create to succeed, got 2 (errors: [<nil> <nil>])
--- FAIL: TestConcurrentBuiltinSeedingLeavesOneRowPerBuiltin (0.45s)
    symptom_name_uniqueness_barrier_test.go:181: expected 16 builtin rows after a concurrent seed, got 32
--- FAIL: TestSymptomNameIndexDoesNotCollapseTheWhitespaceTheServiceCollapses (0.40s)
    symptom_name_uniqueness_barrier_test.go:220: expected the index to refuse a case-only variant of an existing name
FAIL	github.com/ovumcy/ovumcy-web/internal/services	6.957s
```

```
$ go test ./internal/db/ -run 'TestSymptomNameUniqueIndexIsCreatedAndCoversEveryRow|TestMigrationRefusesToCreateTheSymptomNameIndexOverExistingDuplicates' -count=1
--- FAIL: TestSymptomNameUniqueIndexIsCreatedAndCoversEveryRow (0.25s)
    migrations_symptom_name_uniqueness_test.go:29: expected index idx_symptom_types_user_name_unique to exist after migration
--- FAIL: TestMigrationRefusesToCreateTheSymptomNameIndexOverExistingDuplicates (2.18s)
    migrations_symptom_name_uniqueness_test.go:102: expected the migration to refuse a database that already holds duplicate symptom names
FAIL	github.com/ovumcy/ovumcy-web/internal/db	7.531s
```

After: both packages `ok`.

The refusal was checked a second way, against the tree the fix lives in. Gutting the body of
`refuseUniqueIndexOverExistingDuplicates` to `return nil` — leaving the migration and the call
site exactly as they ship — reddens the guard on the thing that is actually lost, the
diagnostic:

```
--- FAIL: TestMigrationRefusesToCreateTheSymptomNameIndexOverExistingDuplicates (0.53s)
    migrations_symptom_name_uniqueness_test.go:113: refusal must name the conflicting rows, "2" is
    missing from: apply embedded migrations: execute migration 037_symptom_name_uniqueness.sql
    statement "…": duplicated key not allowed
```

That is the whole value of the check in one line: the engine already refuses, it just cannot say
what it refused.

### The fix

- **Migration `037_symptom_name_uniqueness.sql`, in both trees**, identical SQL:
  `CREATE UNIQUE INDEX IF NOT EXISTS idx_symptom_types_user_name_unique ON symptom_types
  (user_id, lower(name))`.
- **`internal/db`** classifies the driver's duplicate-key refusal on `Create`, `CreateBatch` and
  `Update` as a unique-constraint error, through the existing `classifyUniqueConstraintError`.
  `symptom_types` carries no other unique constraint beside its primary key.
- **`internal/services`** maps that onto `ErrSymptomNameAlreadyExists` on **create**, **rename**
  and **restore** — all three already render 409 through `error_mapping_symptoms.go` — and, on
  the built-in seeding read path (`ensureBuiltinSymptomsListed`), onto the catalogue the winning
  writer produced, since a page load that only wanted to read has no business returning a
  conflict. Those are the **four** write paths the application reaches, and all four are covered.

  `SeedBuiltinSymptoms` is a fifth entry point with **no caller in the application** —
  registration seeds the catalogue with the account row in one transaction, and every later path
  goes through `EnsureBuiltinSymptoms`. It is left exactly as it was rather than taught the same
  refusal policy: unreachable handling is handling nobody can hold to anything, and an N-of-N+1
  divergence needs two paths that can both run. The method now carries a comment saying it has no
  caller and naming the rule a caller wired in later has to adopt. It belongs to the
  test-only-declaration campaign, not to this change.

### Exactly what the index guarantees, and what it does not

**Guarantees:** for one `user_id`, at most one row per `lower(name)`, over **every** row of the
table.

**Does not guarantee:** that the database enforces the application's name rule. It is a backstop
strictly weaker than it, and `ensureSymptomNameAvailable` stays in front:

- `normalizeSymptomNameKey` also collapses runs of internal whitespace to a single space and
  drops invalid UTF-8. Portable SQL can do neither, so `"Mood  swings"` and `"Mood swings"` are
  one name to the service and two keys to the index.
- `lower()` is not the same function on both engines: PostgreSQL folds by locale, SQLite folds
  ASCII only. A case-only variant of a **non-ASCII** name is covered on one and not on the other,
  from identical SQL text.

`TestSymptomNameIndexDoesNotCollapseTheWhitespaceTheServiceCollapses` pins both halves — the
service refuses the whitespace variant, a write that bypasses the service commits it, and a
case-only variant is refused by the index — so no later reader can conclude the stronger claim.
The whitespace residual is pinned because it holds on both engines and cannot change; the
ASCII-folding residual is stated in the migration and in this text but deliberately **not**
asserted, since a test that fails when a driver upgrade makes `lower()` stronger would be a test
that punishes an improvement.

### The migration's refusal, and its diagnostic

On a database that already holds conflicting rows the migration **stops**. It never deletes,
merges or rewrites a row: this instance stores one person's health history, and a schema change
is not consent to lose part of it. A loud, diagnosable refusal is the acceptable outcome; a
silent merge is not. The repository already prefers this shape —
`changelog.d/fix-refuse-destructive-migration-replay.md`,
`internal/db/migrations_destructive_replay_test.go` — and this check is written to match it: the
same "nothing was executed, the database is unchanged, here is what to restore" ending, in the
migration's own transaction, so a refusal rolls back every statement it ran.

**A Go-side check in the runner, not pure SQL** — deliberately. SQLite can only raise from a
trigger and PostgreSQL needs a `DO $$ … $$` block; neither is portable, and neither can render
"which rows" in a form an operator can act on. The check derives its query from the statement it
is about to run:

```
SELECT CAST(user_id AS TEXT) || ' | ' || CAST(lower(name) AS TEXT) AS conflict_key, COUNT(*) AS row_count
FROM symptom_types
WHERE (user_id) IS NOT NULL AND (lower(name)) IS NOT NULL
GROUP BY user_id, lower(name) HAVING COUNT(*) > 1 ORDER BY conflict_key LIMIT 6
```

so it covers the next unique index as well as this one, and the grouping and the index agree by
construction rather than by a hand-written mirror. `NULL` keys are excluded because both engines
treat those as distinct in a unique index — grouping them would refuse a migration the engine
would have accepted. A statement it cannot read — a partial index, anything trailing the key
list — is left to the engine, which still refuses a genuine conflict with its own message; only
the diagnostic degrades. The refusal names the migration, the table, the index, the key
expressions and up to five conflicting groups as `<key> -> <n> rows`.

Cost: one grouped scan per unique-index statement, at migration time only. It now also runs for
migration 002's `users` email index on a fresh bootstrap, over an empty table.

### Rollback

`DROP INDEX idx_symptom_types_user_name_unique` in both trees. The migration touches **no data
at all**, so dropping the index restores the previous state exactly. Re-run the dialect-parity
suite after any revert.

---

## R2-0095 — the entry-picker hide set

### Re-derived

`legacyEntryPickerHiddenSymptoms` held the key `"moodswings"`;
`shouldHideSymptomFromEntryPicker` looked it up through `normalizeSymptomNameKey`, which
lowercases and **collapses** whitespace but never removes it. The builtin is named
`"Mood swings"` and normalizes to `"mood swings"`, and a custom symptom returns early before the
lookup — so no reachable name could ever match. Fatigue, Irritability and Insomnia were kept out
of the picker; Mood swings was not, and was merely pushed into the overflow by an unrelated rule
in `symptom_picker_view.go` that keys on the translation key. Holds.

### Red (FOUND) → green

```
--- FAIL: TestEveryEntryPickerHiddenKeyNamesABuiltinSymptom (0.00s)
    symptom_entry_picker_hidden_set_test.go:58: entry-picker hide set names 1 key(s) that match no
    builtin symptom, so they hide nothing while the set claims they do: moodswings
```

The set is now keyed on `models.BuiltinSymptom.Key`, the identity the catalogue already carries,
and the lookup resolves the builtin by name first. Two cases hold it from both sides: every key
must name a real builtin, and every key must actually fire against that builtin's row. Both
carry anti-vacuity anchors the test owns rather than reads off the data it judges — one spelling
that must classify as a builtin key and one that must not, and one builtin that must stay
visible.

**This changes what a person sees:** Mood swings now leaves the day-entry picker's list unless
the day already carries it, which is what the set has claimed since it was written. The
changelog fragment says so.

---

## Blast radius

Two existing fixtures wrote states the index now refuses, and both were only constructible
because nothing stopped a duplicate name. Neither is a coverage loss:

- `TestSettingsSymptomsHTMXUpdateTooLongDoesNotEchoDraftName` created a custom symptom named
  after a built-in the account already carries. It only needs a custom symptom to `PATCH`, so it
  gets a name of its own.
- `TestRestoreSymptomRejectsDuplicateActiveName` seeded an active and an archived
  "Joint stiffness" for one owner — precisely the pair two concurrent creates used to be able to
  produce, which is why the state existed at all. The active row now differs by **one space**, so
  the collision stays constructible exactly where the backstop is weaker than the application
  rule, and the restore path still has to answer 409. The case now demonstrates the documented
  residual instead of depending on the defect.

Beyond the symptom paths, the duplicate pre-check newly runs for every `CREATE UNIQUE INDEX` the
runner executes — in practice migration 002's `users` email index on a fresh bootstrap, over an
empty table. Migration 029's index is partial and is left to the engine.

## Validation

```
go build ./...                                  OK
go vet ./...                                    OK
go test ./internal/db/...        -timeout 20m   ok  139.009s
go test ./internal/services/...  -timeout 20m   ok  152.794s
go test ./internal/api/...       -timeout 20m   ok  388.213s
golangci-lint run                               0 issues.
gofmt -l internal/db internal/services internal/models
    internal/services/day_service.go            (pre-existing)
    internal/services/settings_view_service.go  (pre-existing)
    internal/services/webhook_reminder.go       (pre-existing)
go run ./scripts/changelogd check               changelog fragment check OK.
```

The Postgres half of the dialect-parity suite skips without Docker on this host; the two 037
files carry identical SQL and the same version and basename, which is what
`TestEmbeddedMigrationSetsMatchAcrossDialects` compares.

## Review follow-up

### The swallow in `ensureBuiltinSymptomsListed` hid a permanent gap

Discarding **every** unique-constraint refusal from the seeding insert and re-listing is right
for the race it was written for and wrong for any other collision — and this is a read path, so
a permanent one repeats on every page load, returns a catalogue silently short a built-in, and
reports nothing, where before the index existed the write error surfaced.

Red, with a stub that refuses the insert and re-lists a catalogue still missing one built-in:

```
--- FAIL: TestBuiltinSeedingReportsARefusalItCannotExplain (0.00s)
    symptom_name_uniqueness_barrier_test.go:351: a refusal the re-list does NOT explain must
    surface, got a 15-row catalogue and no error
```

The refusal is now swallowed only when the re-list shows the missing built-ins present, which is
what tells "somebody else wrote it" apart from "this can never be written". A re-list that
**fails** is reported too: an unanswered question is not permission to report success. The benign
half is the positive anchor beside it (`TestBuiltinSeedingSwallowsARefusalTheRelistExplains`),
so the guard cannot pass by refusing everything.

### `SeedBuiltinSymptoms` is test-only, and is left alone

Confirmed: `grep -rn 'SeedBuiltinSymptoms(' --include=*.go` finds no caller outside tests and its
own declaration. Its handling is reverted to main's shape, its coverage question disappears with
it, and the write-path claim above is corrected. Deleting it — with its three test call sites,
two of them mutation kills — is the dead-declaration campaign's business, not this change's. The
method now says out loud that it has no caller and that a caller wired in later must adopt
`ensureBuiltinSymptomsListed`'s rule.

### The semicolon landmine is disarmed by a sweep

`TestNoEmbeddedMigrationCutsItsOwnProseInHalf` reads both dialect trees. The first, broad reading
— "no semicolon in comment text" — was **found red on the live tree**, which is what narrowed it:

```
    migration sqlite/025_drop_daily_logs_date_index.sql carries a semicolon inside comment text
    on line(s) [10]
    migration postgres/024_daily_logs_bbt_nullable.sql … on line(s) [10 11 12]
    migration postgres/025_drop_daily_logs_date_index.sql … on line(s) [8]
```

Those three are correct. A semicolon that **ends** a comment line only closes the chunk early,
and what closes is comment-only, which both engines accept; the three are `-- Rollback: …;`
lines. The defect is a semicolon with text **after** it on the same line: the `--` went with the
previous chunk, so the rest of the sentence opens the next one as bare SQL and the engine reports
a syntax error naming English. The sweep enforces exactly that, and it had to — applied
migrations are immutable, so a sweep condemning the three could never be made to pass.

The scanner is anchored on five fixtures the test owns (compound sentence in a header, ordinary
prose, a line-ending semicolon, a compound sentence in a trailing note, `--` inside a string
literal). Inducing the defect in a live file is **refused by design**: the `migration-immutability`
guard rejects the edit, which is the same rule that shaped the sweep.

The splitter itself is deliberately not changed: making it comment-aware alters how every
migration that has already run on every installation is parsed. The test comment says so, and
says the sweep is what to revisit if that ever happens.

### `patch-coverage`

Every line the gate named is now executed by a test; none is annotated away.

| gate's line | how |
| --- | --- |
| rename mapping | `TestConcurrentRenamesToOneNameLeaveExactlyOneWinner` — the same barrier the create path uses, two tabs renaming two symptoms to one new name. Neither list can see the other's new name, so both checks pass and the index refuses the second write. |
| restore mapping | `TestRestoreMapsAConstraintRefusalOntoTheNameConflict` — a stub supplies the refusal, because the schema will not: the availability check lists archived rows, so it always sees the row a restore would collide with. The mapping is policy, kept because the index is the authority and the check is not — narrow the check to active rows and the restore starts meeting the index. The test says this in full. |
| `SeedBuiltinSymptoms`' swallow | gone with the revert above. |
| hide-set `!known` branch | `TestARowFlaggedBuiltinWithNoCatalogueEntryStaysInThePicker` — a row still flagged built-in whose name a release renamed out of the catalogue stays visible. Stated in the test: the branch is belt-and-braces, since the zero-valued entry's empty key is not in the set either, so the case pins the **answer** and cannot kill the line. The branch stays because the rule should be legible in the function. |
| `migrations.go` parser helpers | `TestParseCreateUniqueIndexStatementReadsOnlyWhatItCanDescribe` — a table over the shapes it reads (the shipped statement, a prose header above it, a comma inside a function call) and the shapes it refuses (a partial index, an unclosed key list, an empty entry in the middle or at the end, a non-unique index). |
| refusal renderer | `TestUniqueIndexRefusalNamesAtMostFiveGroupsAndSaysThereAreMore` (six groups → five named plus "and more") and `TestUniqueIndexRefusalOnStatementsTheEmbeddedSetDoesNotContain` (a table that is not there yet, and a key expression the engine rejects, which is reported as a fault in the check rather than as a verdict about rows). |

Each new case was checked against a gutted subject rather than trusted:

```
--- FAIL: TestConcurrentRenamesToOneNameLeaveExactlyOneWinner
    concurrent rename 1 returned an unexpected error: update symptom failed: unique constraint
    violation: symptom_types.user_id_name
--- FAIL: TestRestoreMapsAConstraintRefusalOntoTheNameConflict
    expected a constraint refusal on restore to read as a name conflict, got restore symptom failed: …
--- FAIL: TestParseCreateUniqueIndexStatementReadsOnlyWhatItCanDescribe
    a partial index is left to the engine: Recognized = true, want false
--- FAIL: TestUniqueIndexRefusalNamesAtMostFiveGroupsAndSaysThereAreMore
    expected 5 named groups, got 6 in: …
```

Local `go test -coverprofile` now reports **no uncovered block** on any line this branch adds in
`internal/db/migrations.go`, `internal/db/symptom_repository.go` or
`internal/services/symptom_service.go`. The blocks still uncovered in those files predate the
branch.

## What was deliberately not done

- **No normalized-key column.** Persisting the service's own normalized key and indexing that
  would make the two rules identical, and it is more schema, a backfill, and a new invariant on
  every write path. The `lower(name)` backstop closes the realistic race — the same submitted
  string twice — and the residual is documented and pinned rather than hidden.
- **The index is not partial.** `ListByUser` returns archived rows, so the service has always
  treated an archived name as taken, and `RestoreSymptomForUser` re-checks it before clearing
  `archived_at`. A `WHERE archived_at IS NULL` index would be weaker than the rule it backs and
  would admit an archive-then-recreate pair that can never be restored.
  `TestSymptomNameUniquenessIsPerOwnerAndSurvivesArchival` pins both the per-owner scope and the
  archived one, and `TestSymptomNameUniqueIndexIsCreatedAndCoversEveryRow` pins the absence of a
  predicate in the shipped index.
- **`shouldDeferSymptomFromPrimaryPath` is left alone.** With Mood swings now hidden, the
  overflow rule that also singles it out can no longer fire for it. Removing it is a separate
  decision about the picker's layout, not part of this change.
- **No new dialect-parity mechanism.** `TestEmbeddedMigrationSetsMatchAcrossDialects` and
  `TestMigratedSchemasMatchAcrossDialects` compare versions, basenames, tables, columns and type
  families — not indexes, and not the strength of `lower()`. The two 037 files carry identical
  SQL, so the text cannot drift; what the parity suite cannot see is the engine-dependent folding
  described above, which is why it is written into both migration files.
