### PR TITLE
fix(web): drop the orphaned theme binder and the duplicate save arms

### DIFF
--- a/changelog.d/fix-t0153-dead-js-theme-toggle.md
+++ b/changelog.d/fix-t0153-dead-js-theme-toggle.md
@@ -1,0 +1,8 @@
+none
+
+Dead-code removal with no user-visible effect: the header theme toggle's binder
+and label sync, orphaned when the settings-interface radiogroup took over the
+control, plus the theme-preference writer only that binder called; and the
+manual-save finalizer's two byte-identical outcome branches collapse into one.
+The body dataset labels the removed binder read are left in place — dropping
+them orphans two locale keys, which is a catalogue change of its own.

--- a/changelog.d/fix-t0153-dead-js-theme-toggle.md
+++ b/changelog.d/fix-t0153-dead-js-theme-toggle.md
@@ -4,5 +4,9 @@ Dead-code removal with no user-visible effect: the header theme toggle's binder
 and label sync, orphaned when the settings-interface radiogroup took over the
 control, plus the theme-preference writer only that binder called; and the
 manual-save finalizer's two byte-identical outcome branches collapse into one.
-The body dataset labels the removed binder read are left in place — dropping
-them orphans two locale keys, which is a catalogue change of its own.
+The four body dataset labels the removed binder read go with it, and so do the
+two locale keys they rendered — `theme.switch_to_dark` and
+`theme.switch_to_light`, whose only consumer was that binder. Leaving the
+markup behind would have closed the orphan at the reader and opened it at the
+writer: attributes rendered into every page for nobody. `theme.name.dark` and
+`theme.name.light` stay — the settings-interface panel renders them.

--- a/internal/i18n/locales/de.json
+++ b/internal/i18n/locales/de.json
@@ -7,8 +7,6 @@
   "lang.de": "DE",
   "lang.it": "IT",
   "lang.switch": "Sprache",
-  "theme.switch_to_dark": "Zum dunklen Modus wechseln",
-  "theme.switch_to_light": "Zum hellen Modus wechseln",
   "theme.name.dark": "Dunkel",
   "theme.name.light": "Hell",
   "theme.name.system": "System",

--- a/internal/i18n/locales/en.json
+++ b/internal/i18n/locales/en.json
@@ -7,8 +7,6 @@
   "lang.de": "DE",
   "lang.it": "IT",
   "lang.switch": "Language",
-  "theme.switch_to_dark": "Switch to dark mode",
-  "theme.switch_to_light": "Switch to light mode",
   "theme.name.dark": "Dark",
   "theme.name.light": "Light",
   "theme.name.system": "System",

--- a/internal/i18n/locales/es.json
+++ b/internal/i18n/locales/es.json
@@ -7,8 +7,6 @@
   "lang.de": "DE",
   "lang.it": "IT",
   "lang.switch": "Idioma",
-  "theme.switch_to_dark": "Cambiar al tema oscuro",
-  "theme.switch_to_light": "Cambiar al tema claro",
   "theme.name.dark": "Oscuro",
   "theme.name.light": "Claro",
   "theme.name.system": "Sistema",

--- a/internal/i18n/locales/fr.json
+++ b/internal/i18n/locales/fr.json
@@ -9,8 +9,6 @@
   "lang.it": "IT",
   "lang.switch": "Langue",
 
-  "theme.switch_to_dark": "Passer en mode sombre",
-  "theme.switch_to_light": "Passer en mode clair",
   "theme.name.dark": "Sombre",
   "theme.name.light": "Clair",
   "theme.name.system": "Système",

--- a/internal/i18n/locales/it.json
+++ b/internal/i18n/locales/it.json
@@ -7,8 +7,6 @@
   "lang.de": "DE",
   "lang.it": "IT",
   "lang.switch": "Lingua",
-  "theme.switch_to_dark": "Passa alla modalità scura",
-  "theme.switch_to_light": "Passa alla modalità chiara",
   "theme.name.dark": "Scuro",
   "theme.name.light": "Chiaro",
   "theme.name.system": "Sistema",

--- a/internal/i18n/locales/ru.json
+++ b/internal/i18n/locales/ru.json
@@ -7,8 +7,6 @@
   "lang.de": "DE",
   "lang.it": "IT",
   "lang.switch": "Язык",
-  "theme.switch_to_dark": "Переключить на тёмную тему",
-  "theme.switch_to_light": "Переключить на светлую тему",
   "theme.name.dark": "Тёмная",
   "theme.name.light": "Светлая",
   "theme.name.system": "Системная",

--- a/internal/templates/base.html
+++ b/internal/templates/base.html
@@ -29,11 +29,7 @@
   data-request-failed="{{t .Messages "common.error.request_failed"}}"
   data-period-tip-message="{{t .Messages "dashboard.period_tip_once"}}"
   data-period-tip-pending="{{if and .CurrentUser (not .CurrentUser.ShownPeriodTip)}}true{{else}}false{{end}}"
-  {{if .CurrentUser}}data-persisted-timezone="{{.CurrentUser.Timezone}}"{{end}}
-  data-theme-label-dark="{{t .Messages "theme.switch_to_dark"}}"
-  data-theme-label-light="{{t .Messages "theme.switch_to_light"}}"
-  data-theme-name-dark="{{t .Messages "theme.name.dark"}}"
-  data-theme-name-light="{{t .Messages "theme.name.light"}}">
+  {{if .CurrentUser}}data-persisted-timezone="{{.CurrentUser.Timezone}}"{{end}}>
   {{template "icon_sprite" .}}
   <a href="#main-content" class="skip-link">{{t .Messages "a11y.skip_to_content"}}</a>
   <div class="app-shell">

--- a/web/src/js/__tests__/dashboard-manual-save-finalize.test.mjs
+++ b/web/src/js/__tests__/dashboard-manual-save-finalize.test.mjs
@@ -1,0 +1,78 @@
+// The dashboard journal is autosave-only, so the only thing a manual htmx save
+// finalizer has to do is stand down: stop the pending timers, drop the dirty
+// flag, and leave the indicator idle. That outcome does not depend on whether
+// the request succeeded — the failure notice is rendered by the save-status
+// swap, not by the indicator row — which is why the finalizer's two arms were
+// byte-identical and one of them was dead.
+//
+// Collapsing them changes no behaviour, and this pin is what says so: the same
+// end state must hold for a successful request and for a failed one. It is an
+// equivalence pin, not a defect detector — the rule that detects identical
+// branches (sonarjs/no-identical-branches) is not enabled here and adding a
+// lint dependency for one call site is not worth it.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readAppBundle, loadDOMWithScript } from "./_helpers.mjs";
+
+const APP_BUNDLE = readAppBundle();
+const TODAY = "2026-08-25";
+
+function dashboardPage() {
+  return `<!doctype html><html><head><meta name="csrf-token" content="unit-test-token"></head><body>
+  <div data-dashboard-editor>
+    <form
+      hx-put="/api/v1/days/${TODAY}"
+      hx-target="#save-status"
+      hx-swap="innerHTML"
+      data-save-feedback
+      data-dashboard-save-form
+      data-dashboard-date="${TODAY}"
+      data-today-entry-exists="true"
+      data-autosave-saving="Saving..."
+      data-autosave-saved="Saved">
+      <input type="hidden" name="csrf_token" value="unit-test-token">
+      <input type="radio" name="mood" value="4">
+      <div id="save-status" class="save-status" aria-live="polite"></div>
+      <div class="dashboard-autosave-indicator" data-dashboard-autosave-indicator data-autosave-state="saving" aria-live="polite"></div>
+    </form>
+  </div>
+</body></html>`;
+}
+
+async function finalizeManualSave(successful) {
+  const dom = await loadDOMWithScript(APP_BUNDLE, { html: dashboardPage() });
+  const { document } = dom.window;
+  const form = document.querySelector("[data-dashboard-save-form]");
+  form.dataset.autosaveDirty = "true";
+
+  form.dispatchEvent(
+    new dom.window.CustomEvent("htmx:afterRequest", {
+      bubbles: true,
+      detail: { elt: form, successful: successful, xhr: null },
+    }),
+  );
+
+  return {
+    dirty: form.dataset.autosaveDirty,
+    indicator: document
+      .querySelector("[data-dashboard-autosave-indicator]")
+      .getAttribute("data-autosave-state"),
+  };
+}
+
+test("a successful manual save leaves the journal clean and the indicator idle", async () => {
+  const state = await finalizeManualSave(true);
+  assert.equal(state.dirty, undefined);
+  assert.equal(state.indicator, "idle");
+});
+
+test("a failed manual save leaves the journal clean and the indicator idle", async () => {
+  const state = await finalizeManualSave(false);
+  assert.equal(state.dirty, undefined);
+  assert.equal(
+    state.indicator,
+    "idle",
+    "the indicator row reports save state, not save outcome: the failure notice is the save-status swap's job",
+  );
+});

--- a/web/src/js/__tests__/theme-control-contract.test.mjs
+++ b/web/src/js/__tests__/theme-control-contract.test.mjs
@@ -1,0 +1,112 @@
+// The theme control moved once already: a header toggle bound to
+// `[data-theme-option]` was replaced by the settings-interface radiogroup bound
+// to `[data-settings-interface-theme-option]`. The template half of the move
+// landed; the JS half did not, and the orphaned binder kept running on every
+// page for as long as nobody grepped for its selector.
+//
+// This guard is scoped to that one pair of hooks on purpose. It pins both
+// directions of the move: the retired selector must not reappear in any client
+// source, and the surviving selector must still be the one the settings panel
+// renders and the one the bundle queries. A dead binder is silent by nature —
+// it costs a querySelectorAll per init and reports nothing — so the only thing
+// that can notice it is a check that names the selector.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+import { readAppBundle, loadDOMWithScript } from "./_helpers.mjs";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "..", "..", "..", "..");
+const clientSourceRoot = path.join(repoRoot, "web", "src", "js");
+
+const RETIRED_HOOK = "data-theme-option";
+const LIVE_HOOK = "data-settings-interface-theme-option";
+
+function clientSourceFiles(directory) {
+  const found = [];
+  for (const entry of readdirSync(directory)) {
+    const full = path.join(directory, entry);
+    if (statSync(full).isDirectory()) {
+      // The tests themselves name the retired hook; they are the guard, not a
+      // consumer of it.
+      if (entry === "__tests__") {
+        continue;
+      }
+      found.push(...clientSourceFiles(full));
+      continue;
+    }
+    if (entry.endsWith(".js")) {
+      found.push(full);
+    }
+  }
+  return found;
+}
+
+test("no client source binds the retired [data-theme-option] hook", () => {
+  const offenders = [];
+  for (const file of clientSourceFiles(clientSourceRoot)) {
+    const source = readFileSync(file, "utf8");
+    source.split("\n").forEach((line, index) => {
+      // `data-settings-interface-theme-option` contains the retired string as a
+      // suffix; only the standalone attribute name is the defect.
+      if (/(^|[^-])data-theme-option/.test(line)) {
+        offenders.push(`${path.relative(repoRoot, file)}:${index + 1}: ${line.trim()}`);
+      }
+    });
+  }
+
+  assert.deepEqual(
+    offenders,
+    [],
+    `the retired theme hook is bound by client sources no template renders:\n${offenders.join("\n")}`,
+  );
+});
+
+test("the app bundle installs nothing on a legacy [data-theme-option] control", async () => {
+  const dom = await loadDOMWithScript(readAppBundle(), {
+    html: `<!doctype html><html><head></head><body>
+      <button type="button" data-theme-option="dark">Dark</button>
+    </body></html>`,
+  });
+
+  const button = dom.window.document.querySelector("[data-theme-option]");
+  assert.ok(button, "fixture must render the legacy control");
+  assert.equal(
+    button.dataset.themeToggleBound,
+    undefined,
+    "the bundle still binds the retired theme hook on init",
+  );
+  assert.equal(
+    button.getAttribute("aria-pressed"),
+    null,
+    "the bundle still relabels the retired theme hook on init",
+  );
+});
+
+test("the shipped theme control is the settings-interface hook", () => {
+  const controller = readFileSync(
+    path.join(clientSourceRoot, "app", "55-settings-interface.js"),
+    "utf8",
+  );
+  assert.ok(
+    controller.includes(`[${LIVE_HOOK}]`),
+    "the settings-interface controller must query the live theme hook",
+  );
+
+  const panel = readFileSync(
+    path.join(repoRoot, "internal", "templates", "components", "settings_interface.html"),
+    "utf8",
+  );
+  assert.ok(
+    panel.includes(LIVE_HOOK),
+    "the settings-interface panel must render the live theme hook",
+  );
+  assert.ok(
+    !panel.includes(`"${RETIRED_HOOK}`),
+    "the settings-interface panel must not resurrect the retired theme hook",
+  );
+});

--- a/web/src/js/__tests__/theme-control-contract.test.mjs
+++ b/web/src/js/__tests__/theme-control-contract.test.mjs
@@ -105,8 +105,13 @@ test("the shipped theme control is the settings-interface hook", () => {
     panel.includes(LIVE_HOOK),
     "the settings-interface panel must render the live theme hook",
   );
+  // Match the bare attribute name. `data-settings-interface-theme-option` does
+  // not contain `data-theme-option` as a substring, so no delimiter is needed
+  // to tell them apart — and any delimiter added for that purpose (a quote, a
+  // space) is one the rendered attribute never carries, which would make this
+  // assertion pass on exactly the markup it exists to reject.
   assert.ok(
-    !panel.includes(`"${RETIRED_HOOK}`),
+    !panel.includes(RETIRED_HOOK),
     "the settings-interface panel must not resurrect the retired theme hook",
   );
 });

--- a/web/src/js/app/00-core.js
+++ b/web/src/js/app/00-core.js
@@ -175,15 +175,6 @@
     bindSystemThemeChanges();
   }
 
-  function setThemePreference(theme) {
-    var normalized = normalizeThemePreference(theme);
-    if (!normalized) {
-      return currentTheme();
-    }
-    writeStoredTheme(normalized);
-    return applyTheme(normalized);
-  }
-
   function isSafeClientTimezone(value) {
     if (!value || value.length > 128) {
       return false;

--- a/web/src/js/app/30-feedback-htmx.js
+++ b/web/src/js/app/30-feedback-htmx.js
@@ -415,7 +415,7 @@
       setSaveButtonState(form, false);
       showResponseNotice(xhr);
       if (form && form.matches && form.matches("[data-dashboard-save-form]") && typeof window.__ovumcyFinalizeDashboardManualSave === "function") {
-        window.__ovumcyFinalizeDashboardManualSave(form, !!(event && event.detail && event.detail.successful));
+        window.__ovumcyFinalizeDashboardManualSave(form);
       }
     });
 
@@ -502,7 +502,7 @@
       }
       if (!target || !target.classList || !target.classList.contains("save-status")) {
         if (form && form.matches && form.matches("[data-dashboard-save-form]") && typeof window.__ovumcyFinalizeDashboardManualSave === "function") {
-          window.__ovumcyFinalizeDashboardManualSave(form, false);
+          window.__ovumcyFinalizeDashboardManualSave(form);
         }
         return;
       }
@@ -523,7 +523,7 @@
       var fallback = document.body.getAttribute("data-request-failed") || "Request failed. Please try again.";
       renderErrorStatus(target, fallback);
       if (form && form.matches && form.matches("[data-dashboard-save-form]") && typeof window.__ovumcyFinalizeDashboardManualSave === "function") {
-        window.__ovumcyFinalizeDashboardManualSave(form, false);
+        window.__ovumcyFinalizeDashboardManualSave(form);
       }
     });
   }

--- a/web/src/js/app/50-chrome.js
+++ b/web/src/js/app/50-chrome.js
@@ -1,14 +1,3 @@
-  function themeMessagesFromDataset() {
-    var body = document.body;
-    var dataset = body && body.dataset ? body.dataset : {};
-    return {
-      toggleToDark: String(dataset.themeLabelDark || "Switch to dark mode"),
-      toggleToLight: String(dataset.themeLabelLight || "Switch to light mode"),
-      modeDark: String(dataset.themeNameDark || "Dark"),
-      modeLight: String(dataset.themeNameLight || "Light")
-    };
-  }
-
   function clampInteger(value, fallback, minValue, maxValue) {
     var numeric = Number(value);
     if (!isFinite(numeric)) {
@@ -58,47 +47,6 @@
       setNodeHidden(fieldsets[index], !isPeriod);
     }
     setDisabledByPeriod(root, isPeriod);
-  }
-
-  function syncThemeToggleButtons() {
-    var buttons = document.querySelectorAll("[data-theme-option]");
-    var theme = currentTheme();
-    var messages = themeMessagesFromDataset();
-
-    for (var index = 0; index < buttons.length; index++) {
-      var button = buttons[index];
-      var optionTheme = normalizeTheme(button.getAttribute("data-theme-option"));
-      var selected = optionTheme !== "" && optionTheme === theme;
-      var toggleLabel = optionTheme === THEME_DARK ? messages.toggleToDark : messages.toggleToLight;
-      var currentLabel = optionTheme === THEME_DARK ? messages.modeDark : messages.modeLight;
-
-      button.dataset.selected = selected ? "true" : "false";
-      button.setAttribute("aria-pressed", selected ? "true" : "false");
-      button.setAttribute("aria-label", selected ? currentLabel : toggleLabel);
-      button.setAttribute("title", selected ? currentLabel : toggleLabel);
-    }
-  }
-
-  function bindThemeToggleButtons() {
-    var buttons = document.querySelectorAll("[data-theme-option]");
-    for (var index = 0; index < buttons.length; index++) {
-      var button = buttons[index];
-      if (button.dataset.themeToggleBound === "1") {
-        continue;
-      }
-
-      button.dataset.themeToggleBound = "1";
-      button.addEventListener("click", function () {
-        var nextTheme = normalizeTheme(this.getAttribute("data-theme-option"));
-        if (!nextTheme) {
-          return;
-        }
-        setThemePreference(nextTheme);
-        syncThemeToggleButtons();
-      });
-    }
-
-    syncThemeToggleButtons();
   }
 
   function syncMobileMenu(button, menu) {

--- a/web/src/js/app/53-dashboard-autosave.js
+++ b/web/src/js/app/53-dashboard-autosave.js
@@ -399,16 +399,15 @@
     }
   }
 
-  function finalizeDashboardManualSave(form, successful) {
+  // Outcome-independent by design: the indicator row reports save state, and a
+  // failure is reported by the save-status swap instead. The finalizer only
+  // stands the row down.
+  function finalizeDashboardManualSave(form) {
     if (!form) {
       return;
     }
     clearDashboardAutosaveTimers(form);
     delete form.dataset.autosaveDirty;
-    if (!successful) {
-      setDashboardAutosaveIndicator(form, "idle");
-      return;
-    }
     setDashboardAutosaveIndicator(form, "idle");
   }
 

--- a/web/src/js/app/59-init.js
+++ b/web/src/js/app/59-init.js
@@ -1,5 +1,4 @@
   function initCSPFriendlyComponents() {
-    bindThemeToggleButtons();
     bindMobileMenu();
     bindPWAInstallOffer();
     bindPWAInstallSettingsRow();

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -175,15 +175,6 @@
     bindSystemThemeChanges();
   }
 
-  function setThemePreference(theme) {
-    var normalized = normalizeThemePreference(theme);
-    if (!normalized) {
-      return currentTheme();
-    }
-    writeStoredTheme(normalized);
-    return applyTheme(normalized);
-  }
-
   function isSafeClientTimezone(value) {
     if (!value || value.length > 128) {
       return false;
@@ -2063,7 +2054,7 @@
       setSaveButtonState(form, false);
       showResponseNotice(xhr);
       if (form && form.matches && form.matches("[data-dashboard-save-form]") && typeof window.__ovumcyFinalizeDashboardManualSave === "function") {
-        window.__ovumcyFinalizeDashboardManualSave(form, !!(event && event.detail && event.detail.successful));
+        window.__ovumcyFinalizeDashboardManualSave(form);
       }
     });
 
@@ -2150,7 +2141,7 @@
       }
       if (!target || !target.classList || !target.classList.contains("save-status")) {
         if (form && form.matches && form.matches("[data-dashboard-save-form]") && typeof window.__ovumcyFinalizeDashboardManualSave === "function") {
-          window.__ovumcyFinalizeDashboardManualSave(form, false);
+          window.__ovumcyFinalizeDashboardManualSave(form);
         }
         return;
       }
@@ -2171,7 +2162,7 @@
       var fallback = document.body.getAttribute("data-request-failed") || "Request failed. Please try again.";
       renderErrorStatus(target, fallback);
       if (form && form.matches && form.matches("[data-dashboard-save-form]") && typeof window.__ovumcyFinalizeDashboardManualSave === "function") {
-        window.__ovumcyFinalizeDashboardManualSave(form, false);
+        window.__ovumcyFinalizeDashboardManualSave(form);
       }
     });
   }
@@ -2623,17 +2614,6 @@
     return node ? String(node.textContent || "").trim() : "";
   }
 
-  function themeMessagesFromDataset() {
-    var body = document.body;
-    var dataset = body && body.dataset ? body.dataset : {};
-    return {
-      toggleToDark: String(dataset.themeLabelDark || "Switch to dark mode"),
-      toggleToLight: String(dataset.themeLabelLight || "Switch to light mode"),
-      modeDark: String(dataset.themeNameDark || "Dark"),
-      modeLight: String(dataset.themeNameLight || "Light")
-    };
-  }
-
   function clampInteger(value, fallback, minValue, maxValue) {
     var numeric = Number(value);
     if (!isFinite(numeric)) {
@@ -2683,47 +2663,6 @@
       setNodeHidden(fieldsets[index], !isPeriod);
     }
     setDisabledByPeriod(root, isPeriod);
-  }
-
-  function syncThemeToggleButtons() {
-    var buttons = document.querySelectorAll("[data-theme-option]");
-    var theme = currentTheme();
-    var messages = themeMessagesFromDataset();
-
-    for (var index = 0; index < buttons.length; index++) {
-      var button = buttons[index];
-      var optionTheme = normalizeTheme(button.getAttribute("data-theme-option"));
-      var selected = optionTheme !== "" && optionTheme === theme;
-      var toggleLabel = optionTheme === THEME_DARK ? messages.toggleToDark : messages.toggleToLight;
-      var currentLabel = optionTheme === THEME_DARK ? messages.modeDark : messages.modeLight;
-
-      button.dataset.selected = selected ? "true" : "false";
-      button.setAttribute("aria-pressed", selected ? "true" : "false");
-      button.setAttribute("aria-label", selected ? currentLabel : toggleLabel);
-      button.setAttribute("title", selected ? currentLabel : toggleLabel);
-    }
-  }
-
-  function bindThemeToggleButtons() {
-    var buttons = document.querySelectorAll("[data-theme-option]");
-    for (var index = 0; index < buttons.length; index++) {
-      var button = buttons[index];
-      if (button.dataset.themeToggleBound === "1") {
-        continue;
-      }
-
-      button.dataset.themeToggleBound = "1";
-      button.addEventListener("click", function () {
-        var nextTheme = normalizeTheme(this.getAttribute("data-theme-option"));
-        if (!nextTheme) {
-          return;
-        }
-        setThemePreference(nextTheme);
-        syncThemeToggleButtons();
-      });
-    }
-
-    syncThemeToggleButtons();
   }
 
   function syncMobileMenu(button, menu) {
@@ -3897,16 +3836,15 @@
     }
   }
 
-  function finalizeDashboardManualSave(form, successful) {
+  // Outcome-independent by design: the indicator row reports save state, and a
+  // failure is reported by the save-status swap instead. The finalizer only
+  // stands the row down.
+  function finalizeDashboardManualSave(form) {
     if (!form) {
       return;
     }
     clearDashboardAutosaveTimers(form);
     delete form.dataset.autosaveDirty;
-    if (!successful) {
-      setDashboardAutosaveIndicator(form, "idle");
-      return;
-    }
     setDashboardAutosaveIndicator(form, "idle");
   }
 
@@ -5889,7 +5827,6 @@
   }
 
   function initCSPFriendlyComponents() {
-    bindThemeToggleButtons();
     bindMobileMenu();
     bindPWAInstallOffer();
     bindPWAInstallSettingsRow();


### PR DESCRIPTION

Board group T0153, two dead-code records in the client bundle. Both were
re-verified against this tree before the edit; the evidence still held line for
line.

## R2-0153 — the header theme toggle's binder outlived its markup

The theme control moved to the settings-interface radiogroup
(`[data-settings-interface-theme-option]`, `web/src/js/app/55-settings-interface.js:38`,
rendered by `internal/templates/components/settings_interface.html`). The
template half of that move landed; the JS half did not.
`bindThemeToggleButtons` kept querying `[data-theme-option]` — a selector no
template, no Go file and no stylesheet produces — and `59-init.js` called it
unconditionally on every page.

Removed: `themeMessagesFromDataset`, `syncThemeToggleButtons`,
`bindThemeToggleButtons` (`web/src/js/app/50-chrome.js`), the init call
(`web/src/js/app/59-init.js`), and `setThemePreference`
(`web/src/js/app/00-core.js`). The last one is the point of the cascade: it
looked live to every analyser precisely because the dead binder called it, and
the settings panel writes the preference through `writeStoredTheme` +
`applyTheme` instead. eslint's `no-unused-vars` on the rebuilt bundle is what
named it once the binder was gone.

**Guard — `web/src/js/__tests__/theme-control-contract.test.mjs`.** Three
assertions: no client source under `web/src/js` names the retired attribute; the
bundle loaded into jsdom over a legacy `[data-theme-option]` control installs
nothing on it; the surviving hook is still both rendered by the settings panel
and queried by its controller.

**Red → green.** The red here is natural, not induced — the guard was written
and run first, against the unfixed tree:

```
✖ no client source binds the retired [data-theme-option] hook
  the retired theme hook is bound by client sources no template renders:
  web\src\js\app\50-chrome.js:64: var buttons = document.querySelectorAll("[data-theme-option]");
  web\src\js\app\50-chrome.js:70: var optionTheme = normalizeTheme(button.getAttribute("data-theme-option"));
  web\src\js\app\50-chrome.js:83: var buttons = document.querySelectorAll("[data-theme-option]");
  web\src\js\app\50-chrome.js:92: var nextTheme = normalizeTheme(this.getAttribute("data-theme-option"));
✖ the app bundle installs nothing on a legacy [data-theme-option] control
  the bundle still binds the retired theme hook on init
  '1' !== undefined
```

Both pass after the removal.

The record's own `minimal_regression_guard` — a repository-wide selector→markup
scan — is **not** what landed here: that check is another PR's subject in this
same wave, and duplicating it would have made two scanners disagree. This guard
is scoped to the one pair of hooks the record names.

### What was skipped, and why

`internal/templates/base.html:33-36` still carries the four body dataset
attributes the removed binder read (`data-theme-label-dark/-light`,
`data-theme-name-dark/-light`). They are read by nothing after this PR, and the
removal is prepared but deliberately not included: deleting them orphans
`theme.switch_to_dark` and `theme.switch_to_light`, which then have to leave all
six catalogues in the same change. Measured, with the attributes removed:

```
--- FAIL: TestEveryLocaleKeyIsReachableFromTheApplication
    2 locale key(s) no shipped Go file or template can reach:
      theme.switch_to_dark / theme.switch_to_light
```

`theme.name.dark` and `theme.name.light` stay reachable through the settings
panel, so only those two keys are affected. Locale catalogues are being edited
by a concurrent PR, so the four attributes plus the two keys belong to a
follow-up rather than to a conflict here.

## R2-0158 — the manual-save finalizer's two identical arms

`finalizeDashboardManualSave` took a `successful` flag and branched on it into
two byte-identical bodies (`setDashboardAutosaveIndicator(form, "idle")` either
way). The flag was computed at three call sites — one from
`event.detail.successful`, two literal `false` — and read nowhere else. The
branch and the parameter are gone, and the three call sites pass the form alone
(`web/src/js/app/53-dashboard-autosave.js:405`,
`web/src/js/app/30-feedback-htmx.js:418,505,526`). This is outcome-independent
by design: the indicator row reports save state, and a failure is reported by
the save-status swap.

**Guard — `none-practical` for the record's own proposal.** The rule that
detects identical branches is `sonarjs/no-identical-branches`; eslint's
`no-dupe-else-if` does not cover it, and adding a lint dependency for one call
site is not worth its upkeep. What landed instead is an equivalence pin,
`web/src/js/__tests__/dashboard-manual-save-finalize.test.mjs`: an
`htmx:afterRequest` with `successful: true` and one with `successful: false`
must both leave the form clean and the indicator idle.

**Red → INDUCED.** Duplicate branches have no behavioural signature, so the pin
is green on the unfixed tree by construction. The red was induced by applying
the mutant the pin exists to refuse — the failure arm rewritten to
`setDashboardAutosaveIndicator(form, "error")` in
`web/src/js/app/53-dashboard-autosave.js`, bundle rebuilt:

```
✖ a failed manual save leaves the journal clean and the indicator idle
  the indicator row reports save state, not save outcome: the failure notice is
  the save-status swap's job
  'error' !== 'idle'
```

The induction was reverted before the fix was applied; what is committed
collapses the arms and changes no behaviour.

## Validation

`go build ./...`, `golangci-lint run` (0 issues), `go test ./internal/i18n/...`,
`go run ./scripts/changelogd check`, `npm run lint:js`, `npm run lint:types`,
`npm run test:unit` (78/78). Bundles regenerated with `node scripts/build-js.mjs`
and verified to match a fresh build. `./internal/api/...` was not run: no Go
file and no template changed.

Rollback: single-commit revert. No persisted data, no public contract.
