### PR TITLE
fix(templates,api): close the dashboard's estimate-qualifier gap and pin the template→consumer direction

### DIFF
--- a/changelog.d/fix-t0151-dashboard-dom-contract.md
+++ b/changelog.d/fix-t0151-dashboard-dom-contract.md
@@ -21,10 +21,14 @@ stylesheet. A hook nothing names is markup that reads like a contract and
 promises coverage that does not exist. The check counts both spellings a
 consumer can use, the literal attribute and the camel-cased `dataset` name, and
 tokenizes rather than substring-matches: three hooks looked consumed while the
-only names in the tree were their longer siblings. Thirty hooks render with no
+only names in the tree were their longer siblings, and a fourth — the cycle-stack
+period flag — looked consumed because its one-word `dataset` name is an ordinary
+English word some unrelated script happens to quote, which is why the bare-key
+spelling is accepted only where a hook's name actually looks like one.
+Thirty-one hooks render with no
 consumer today; each is recorded with the reason it is still there, and the list
 can only shrink — an entry whose hook has since gained a reader, or left the
-templates, fails as loudly as a new dead hook. Two of the thirty are not
+templates, fails as loudly as a new dead hook. Two of the thirty-one are not
 decoration and are named as such: the cycle-start confirm island renders an
 implantation flag no dialog reads while all its siblings are read, and the
 paused-estimate line carries a state key that is never asserted beside a hook

--- a/changelog.d/fix-t0151-dashboard-dom-contract.md
+++ b/changelog.d/fix-t0151-dashboard-dom-contract.md
@@ -1,0 +1,33 @@
+none
+
+Internal only: the DOM contract between the templates and the code that
+addresses them now runs both ways, and the dashboard's estimate qualifiers are
+pinned.
+
+The dashboard marks an ovulation estimate the luteal-phase clamp made inexact in
+three places — the status line's approximate marker, the cycle hero's estimate
+qualifier and the reminder banner's approximate marker — and nothing outside
+`internal/templates` named any of them: neither the two `data-*` hooks nor the
+i18n keys behind them appeared in a Go, TypeScript or CSS source, so a template
+edit could drop a medical-safety qualifier with every suite green. One
+regression now drives a fixture into that state and asserts the hooks per
+subtree; the status line's marker had no hook at all and gains one, attributes
+only, with copy and classes untouched.
+
+The wider class behind it has a barrier now: every `data-*` attribute rendered
+from `internal/templates` must be named at least once outside it — by a Go
+regression, a browser script, a Playwright spec or a component rule in the
+stylesheet. A hook nothing names is markup that reads like a contract and
+promises coverage that does not exist. The check counts both spellings a
+consumer can use, the literal attribute and the camel-cased `dataset` name, and
+tokenizes rather than substring-matches: three hooks looked consumed while the
+only names in the tree were their longer siblings. Thirty hooks render with no
+consumer today; each is recorded with the reason it is still there, and the list
+can only shrink — an entry whose hook has since gained a reader, or left the
+templates, fails as loudly as a new dead hook. Two of the thirty are not
+decoration and are named as such: the cycle-start confirm island renders an
+implantation flag no dialog reads while all its siblings are read, and the
+paused-estimate line carries a state key that is never asserted beside a hook
+that is.
+
+No rendered copy, status code, route or stored value changes.

--- a/internal/api/dashboard_prediction_disclaimer_test.go
+++ b/internal/api/dashboard_prediction_disclaimer_test.go
@@ -5,7 +5,10 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/ovumcy/ovumcy-web/internal/models"
+	"github.com/ovumcy/ovumcy-web/internal/services"
 	"golang.org/x/net/html"
 )
 
@@ -82,6 +85,100 @@ func TestSettingsEgressSurfacesRenderPredictionDisclaimer(t *testing.T) {
 					hook, index+1, len(elements), text)
 			}
 		}
+	}
+}
+
+// TestDashboardMarksAnInexactOvulationEstimateWithAddressableQualifiers pins the
+// second half of the medical-safety labeling on the dashboard: beside the
+// persistent disclaimer above, the header marks the individual estimates that
+// are weaker than a plain date, and each such marker is addressable by a stable
+// data-* hook rather than by its copy.
+//
+// Both markers are rendered from the same signal — the luteal phase did not fit
+// the reference cycle length, so CalcOvulationDay clamped it and reported
+// OvulationExact=false — and until now nothing outside internal/templates named
+// either of them: neither the hooks nor the i18n keys behind them appeared in
+// any Go, TypeScript or CSS source, so the qualifiers could be dropped from the
+// header by a template edit with every suite still green.
+//
+// The fixture is deliberately narrow, since only a narrow band of inputs
+// produces an inexact estimate that the header still shows at all:
+//   - a 16-day reference cycle with the default 14-day luteal phase forces the
+//     clamp (CalcOvulationDay caps the luteal phase at cycleLength-5), which is
+//     what sets Approximate on both the cycle hero and the reminder banner;
+//   - a 3-day period keeps ovulation day 5 clear of periodLength+1, without
+//     which the cycle hero is not drawn and its qualifier never renders;
+//   - one previous cycle clears the first-cycle fertility floor
+//     (FertilityProjectionSuppressed), without which the ovulation slot and the
+//     ovulation reminder are withheld entirely;
+//   - cycle day 3 puts ovulation two days out, inside the default three-day
+//     reminder window, and the next period fourteen days out, outside it — so
+//     the banner summarizes ovulation rather than the period;
+//   - the trying-to-conceive goal is what puts the ovulation estimate in the
+//     status line at all (resolveDashboardTimingFrame).
+//
+// Anchors below assert the fixture actually reached that state before judging
+// the hooks, so a fixture that drifts out of the band fails loudly instead of
+// passing on an absent surface.
+func TestDashboardMarksAnInexactOvulationEstimateWithAddressableQualifiers(t *testing.T) {
+	app, database, _ := newOnboardingTestAppWithLocation(t, time.UTC)
+	user := createOnboardingTestUser(t, database, "dashboard-inexact-ovulation@example.com", "StrongPass1", true)
+
+	today := services.DateAtLocation(time.Now().UTC(), time.UTC)
+	const cycleLength = 16
+	const periodLength = 3
+	lastPeriodStart := today.AddDate(0, 0, -2)
+	if err := database.Model(&models.User{}).Where("id = ?", user.ID).Updates(map[string]any{
+		"cycle_length":      cycleLength,
+		"period_length":     periodLength,
+		"last_period_start": lastPeriodStart,
+		"usage_goal":        models.UsageGoalTrying,
+	}).Error; err != nil {
+		t.Fatalf("update inexact-ovulation cycle context: %v", err)
+	}
+	for _, cycleStart := range []time.Time{lastPeriodStart.AddDate(0, 0, -cycleLength), lastPeriodStart} {
+		for offset := range periodLength {
+			if err := database.Create(&models.DailyLog{
+				UserID:   user.ID,
+				Date:     cycleStart.AddDate(0, 0, offset),
+				IsPeriod: true,
+				Flow:     models.FlowMedium,
+			}).Error; err != nil {
+				t.Fatalf("create period log %s day %d: %v", cycleStart.Format("2006-01-02"), offset, err)
+			}
+		}
+	}
+
+	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
+	request := httptest.NewRequest(http.MethodGet, "/dashboard", nil)
+	request.Header.Set("Accept-Language", "en")
+	request.Header.Set("Cookie", authCookie)
+	response := mustAppResponse(t, app, request)
+	assertStatusCode(t, response, http.StatusOK)
+
+	document := mustParseHTMLDocument(t, mustReadBodyString(t, response.Body))
+	header := dashboardElementByDataAttr(document, "data-dashboard-status-header")
+	if header == nil {
+		t.Fatal("expected the dashboard status header")
+	}
+
+	ovulation := dashboardElementByDataAttr(header, "data-dashboard-ovulation")
+	if ovulation == nil {
+		t.Fatal("fixture anchor: expected the ovulation slot in the status line")
+	}
+	banner := dashboardElementByDataAttr(header, "data-dashboard-reminder-banner")
+	if banner == nil {
+		t.Fatal("fixture anchor: expected the ovulation reminder banner")
+	}
+
+	if dashboardElementByDataAttr(header, "data-dashboard-estimate-qualifier") == nil {
+		t.Fatal("expected the cycle-hero estimate qualifier to carry data-dashboard-estimate-qualifier")
+	}
+	if dashboardElementByDataAttr(ovulation, "data-dashboard-ovulation-approximate") == nil {
+		t.Fatal("expected the ovulation estimate's approximate marker to carry data-dashboard-ovulation-approximate")
+	}
+	if dashboardElementByDataAttr(banner, "data-dashboard-ovulation-approximate") == nil {
+		t.Fatal("expected the reminder banner's approximate marker to carry data-dashboard-ovulation-approximate")
 	}
 }
 

--- a/internal/templates/dashboard.html
+++ b/internal/templates/dashboard.html
@@ -87,7 +87,7 @@
                 {{else if .DisplayOvulationDate.IsZero}}
                   {{.NoDataLabel}}
                 {{else}}
-                  {{printf (t .Messages "dashboard.ovulation_estimate") (formatLocalizedDate .Lang .DisplayOvulationDate "display")}}{{if not .DisplayOvulationExact}} <span class="journal-muted">{{t .Messages "dashboard.ovulation_approximate"}}</span>{{end}}
+                  {{printf (t .Messages "dashboard.ovulation_estimate") (formatLocalizedDate .Lang .DisplayOvulationDate "display")}}{{if not .DisplayOvulationExact}} <span class="journal-muted" data-dashboard-ovulation-approximate>{{t .Messages "dashboard.ovulation_approximate"}}</span>{{end}}
                 {{end}}
               </span>
             </span>

--- a/internal/templates/dom_attribute_consumers_test.go
+++ b/internal/templates/dom_attribute_consumers_test.go
@@ -104,6 +104,7 @@ var domAttrConsumerResidual = map[string]string{
 	"data-cycle-start-implantation": "the only unread field of the cycle-start confirm island: its siblings (conflict-date, short-gap, replace-message) are all read, so the implantation warning the server computes reaches no dialog",
 	"data-next-period-paused-key":   "the state key beside data-dashboard-next-period-paused, which is asserted while its key is not",
 	"data-projected":                "the only ribbon-day flag with no reader; data-today, data-fertile and the rest are all addressed",
+	"data-period":                   "the cycle-stack day flag beside data-fertile, data-fertile-peak and data-logged, which are all addressed while it is not (stats.html:352)",
 }
 
 // domAttrConsumerSourceExtensions are the file kinds that can name a hook:
@@ -140,7 +141,15 @@ var domAttrConsumerSkipDirectories = map[string]bool{
 var (
 	domAttrConsumerAttrPattern    = regexp.MustCompile(`\bdata-[a-z0-9-]*[a-z0-9]`)
 	domAttrConsumerCommentPattern = regexp.MustCompile(`(?s)\{\{/\*.*?\*/\}\}|<!--.*?-->`)
-	domAttrConsumerDatasetPattern = regexp.MustCompile(`dataset\.([A-Za-z0-9_$]+)|["']([A-Za-z][A-Za-z0-9]*)["']`)
+	// The second alternative is the bare-key spelling: a script that passes a
+	// dataset name as a string rather than reading it through `dataset.`. It
+	// requires a lower-case first letter followed by an upper-case one, which
+	// is what a multi-segment hook's dataset name looks like and what an
+	// ordinary English word does not. Accepting any quoted word instead made a
+	// hook whose name IS an ordinary word live on a coincidence:
+	// `data-period` (stats.html) has no consumer at all, and `case "period":`
+	// in the autosave script classified it as read.
+	domAttrConsumerDatasetPattern = regexp.MustCompile(`dataset\.([A-Za-z0-9_$]+)|["']([a-z][a-z0-9]*[A-Z][A-Za-z0-9]*)["']`)
 )
 
 // TestEveryTemplateDataHookIsNamedOutsideTheTemplates is the DOM contract's
@@ -234,6 +243,21 @@ func TestDomAttrConsumerScanClassifiesItsOwnFixtures(t *testing.T) {
 	domAttrConsumerIndexSource(`page.locator('[data-fixture-live-hook="on"]')`, ".ts", literals, datasets)
 	if !domAttrConsumerNamed("data-fixture-live-hook", literals, datasets) {
 		t.Fatal("a hook named by a spec selector must classify as named")
+	}
+
+	// The bare-key spelling, both halves. Without the second assertion the
+	// alternative could be widened back to any quoted word and stay green,
+	// which is how data-period — a hook with no consumer at all — classified
+	// as read on the strength of `case "period":` in an unrelated script.
+	bareLiterals := map[string]bool{}
+	bareDatasets := map[string]bool{}
+	domAttrConsumerIndexSource(`notify(form, "fixtureBareKey");`, ".js", bareLiterals, bareDatasets)
+	domAttrConsumerIndexSource(`switch (kind) { case "fixture": break; }`, ".js", bareLiterals, bareDatasets)
+	if !domAttrConsumerNamed("data-fixture-bare-key", bareLiterals, bareDatasets) {
+		t.Fatal("a hook whose dataset name is passed as a bare quoted key must classify as named")
+	}
+	if domAttrConsumerNamed("data-fixture", bareLiterals, bareDatasets) {
+		t.Fatal("a quoted ordinary word must not classify a single-segment hook of the same name as named")
 	}
 
 	if got := domAttrConsumerDatasetName("data-fixture-dataset-hook"); got != "fixtureDatasetHook" {

--- a/internal/templates/dom_attribute_consumers_test.go
+++ b/internal/templates/dom_attribute_consumers_test.go
@@ -1,0 +1,393 @@
+package templates
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// The DOM contract runs one way only, and nothing checked the other end of it.
+// A template declares a `data-*` hook so that something outside the template —
+// a Go regression, a Playwright spec, a browser script, a component rule in the
+// stylesheet — can address that element. A hook no such consumer names is not a
+// contract: it is markup that reads like one, survives every refactor because
+// it looks load-bearing, and quietly promises coverage that does not exist.
+//
+// This file is that missing direction: every `data-*` attribute rendered from
+// internal/templates must be named at least once outside internal/templates.
+// It deliberately does NOT walk the opposite direction — a selector in a script
+// or a spec pointing at markup that no longer renders — which is its own check.
+//
+// Reading the guard's own blind spots as defects is the failure mode here, so
+// the consumer side is deliberately generous and each gate below exists because
+// a narrower reading reported a live hook as dead:
+//
+//  1. Literal attribute names, tokenized rather than substring-matched. A Go
+//     assertion writes `htmlHasAttr(node, "data-foo")`, a spec writes
+//     `[data-foo="bar"]`, a stylesheet writes `[data-foo]` — all three yield the
+//     token `data-foo`. Substring matching instead reports `data-foo` as live
+//     the moment anything anywhere mentions `data-foo-bar`, which is how three
+//     hooks here (`data-auto-period-fill`, `data-onboarding-usage-goal`,
+//     `data-pwa-install-title`) looked consumed while the only names in the
+//     tree were their longer siblings.
+//  2. The camel-cased dataset form, for scripts that never spell the attribute:
+//     `data-theme-label-dark` is only ever read as `dataset.themeLabelDark`, and
+//     the recovery panel passes its message keys as bare `"copySuccessMessage"`
+//     strings. Both spellings count.
+//  3. Stylesheets count as consumers, sources and built bundles alike: a hook
+//     whose only reader is a component rule is live.
+//  4. The built JS bundle under web/static counts alongside its sources, so a
+//     hook read only by generated code is not reported.
+//  5. Template comments are stripped before hooks are collected, so a hook named
+//     only in prose is not counted as rendered.
+//  6. Hidden directories and dependency/report trees are skipped, so a stray
+//     checkout under one of them cannot supply a phantom consumer.
+//
+// What it still cannot see: a selector assembled at runtime
+// (`"[data-" + name + "]"`). That is the one shape a residual entry below may
+// legitimately carry as its reason.
+//
+// The residual map is the ratchet. It is not an allowlist that may sit still:
+// every entry is re-checked, and an entry whose hook has since gained a consumer
+// — or disappeared from the templates — fails just as loudly as a new dead hook,
+// so the list can only shrink.
+
+// domAttrConsumerResidual holds the `data-*` hooks that render today with no
+// consumer outside internal/templates, each with the reason it is still here.
+// Closing one is a per-hook judgement — delete the markup, add the assertion, or
+// wire the reader that was supposed to exist — not a sweep, so they are recorded
+// rather than removed wholesale.
+var domAttrConsumerResidual = map[string]string{
+	// State mirrored into an attribute that nothing reads back. The value is
+	// already visible in the markup beside it, so the mirror is either an
+	// assertion someone meant to write or markup to delete.
+	"data-auto-period-fill":   "onboarding mirrors the auto-fill toggle; the spec drives the checkbox itself",
+	"data-calendar-has-sex":   "day-cell flag with no grid assertion and no component rule",
+	"data-cycle-factor-count": "the count is rendered as chip text beside it; no reader",
+	"data-symptom-active":     "picker state mirrored from the same field the option already renders",
+	"data-symptom-label":      "preview-only mirror behind IncludePreviewHooks; no preview reader exists",
+	"data-temperature-unit":   "the unit is rendered in the field label; no reader",
+
+	// Container and landmark hooks: addressable by design, addressed by nobody.
+	"data-cycle-stack-rows":             "stats cycle-stack list container",
+	"data-dashboard-cycle-start-form":   "manual cycle-start form container",
+	"data-dashboard-quick-actions":      "quick-action row container; the buttons carry their own data-quick-action",
+	"data-dashboard-shell":              "dashboard page shell",
+	"data-export-presets":               "export preset row container",
+	"data-onboarding-usage-goal":        "usage-goal step container; the spec addresses the choices",
+	"data-settings-reminders-form":      "reminder settings form container",
+	"data-stats-factor-patterns":        "stats factor-pattern grid container",
+	"data-usage-goal-quick-switch-form": "quick-switch form container; the spec addresses data-usage-goal-choice",
+
+	// Control hooks nothing drives.
+	"data-day-editor-cancel":           "calendar day-editor cancel button",
+	"data-dashboard-more-toggle":       "journal More disclosure summary; the details element carries data-dashboard-more",
+	"data-saving-label":                "the in-flight button caption, declared at nine sites and read at none",
+	"data-settings-cycle-submit":       "cycle settings submit button",
+	"data-settings-reminder-lead-days": "reminder lead-days field",
+	"data-settings-reminders-save":     "reminder settings save button",
+
+	// Copy surfaces carrying a hook with no spec behind it.
+	"data-calendar-feed-hint":       "calendar-feed URL hint",
+	"data-calendar-month-label":     "calendar month label",
+	"data-import-status":            "import status container; the id is what the request targets",
+	"data-pwa-install-title":        "superseded by the data-pwa-install-title-key sibling the spec asserts",
+	"data-stats-perimenopause-hint": "perimenopause hint card",
+	"data-symptom-card-title":       "custom-symptom card title",
+
+	// These two are not decoration, and closing them is a change of its own.
+	"data-cycle-start-implantation": "the only unread field of the cycle-start confirm island: its siblings (conflict-date, short-gap, replace-message) are all read, so the implantation warning the server computes reaches no dialog",
+	"data-next-period-paused-key":   "the state key beside data-dashboard-next-period-paused, which is asserted while its key is not",
+	"data-projected":                "the only ribbon-day flag with no reader; data-today, data-fertile and the rest are all addressed",
+}
+
+// domAttrConsumerSourceExtensions are the file kinds that can name a hook:
+// Go (backend regressions), the browser sources and their built bundle,
+// TypeScript (Playwright specs and helpers) and CSS (component rules).
+var domAttrConsumerSourceExtensions = map[string]bool{
+	".go":  true,
+	".js":  true,
+	".mjs": true,
+	".ts":  true,
+	".tsx": true,
+	".css": true,
+}
+
+// domAttrConsumerScriptExtensions are the subset whose camel-cased dataset
+// spelling of a hook counts as naming it.
+var domAttrConsumerScriptExtensions = map[string]bool{
+	".js":  true,
+	".mjs": true,
+	".ts":  true,
+	".tsx": true,
+}
+
+// domAttrConsumerSkipDirectories are the trees that hold no source of this
+// repository: dependency installs and generated report output. Hidden
+// directories are skipped separately, by name prefix.
+var domAttrConsumerSkipDirectories = map[string]bool{
+	"node_modules":      true,
+	"coverage":          true,
+	"test-results":      true,
+	"playwright-report": true,
+}
+
+var (
+	domAttrConsumerAttrPattern    = regexp.MustCompile(`\bdata-[a-z0-9-]*[a-z0-9]`)
+	domAttrConsumerCommentPattern = regexp.MustCompile(`(?s)\{\{/\*.*?\*/\}\}|<!--.*?-->`)
+	domAttrConsumerDatasetPattern = regexp.MustCompile(`dataset\.([A-Za-z0-9_$]+)|["']([A-Za-z][A-Za-z0-9]*)["']`)
+)
+
+// TestEveryTemplateDataHookIsNamedOutsideTheTemplates is the DOM contract's
+// missing half: a rendered `data-*` hook that no Go regression, browser script,
+// Playwright spec or stylesheet names addresses nothing.
+func TestEveryTemplateDataHookIsNamedOutsideTheTemplates(t *testing.T) {
+	root := domAttrConsumerRepoRoot(t)
+	hooks := domAttrConsumerTemplateHooks(t, filepath.Join(root, "internal", "templates"), root)
+	literals, datasets, files := domAttrConsumerConsumerIndex(t, root)
+
+	// Corpus anchors: a mis-resolved root would otherwise report an empty tree
+	// as a clean one. The bounds are floors, not counts, so ordinary churn does
+	// not touch them.
+	if len(hooks) < 100 {
+		t.Fatalf("expected the templates to declare at least 100 distinct data-* hooks, found %d — the template scan resolved nothing", len(hooks))
+	}
+	if files < 100 {
+		t.Fatalf("expected at least 100 consumer sources outside internal/templates, found %d — the consumer scan resolved nothing", files)
+	}
+
+	var unreported []string
+	for hook, sites := range hooks {
+		if domAttrConsumerNamed(hook, literals, datasets) {
+			continue
+		}
+		if _, recorded := domAttrConsumerResidual[hook]; recorded {
+			continue
+		}
+		unreported = append(unreported, hook+" — rendered at "+strings.Join(sites, ", "))
+	}
+	if len(unreported) > 0 {
+		sort.Strings(unreported)
+		t.Fatalf("%d data-* hook(s) render with no consumer outside internal/templates.\n"+
+			"Give each one a reader (Go regression, browser script, Playwright spec or component rule) or delete the markup:\n\t%s",
+			len(unreported), strings.Join(unreported, "\n\t"))
+	}
+
+	var stale []string
+	for hook, reason := range domAttrConsumerResidual {
+		sites, rendered := hooks[hook]
+		switch {
+		case !rendered:
+			stale = append(stale, hook+" is no longer rendered by any template — drop the residual entry ("+reason+")")
+		case domAttrConsumerNamed(hook, literals, datasets):
+			stale = append(stale, hook+" (rendered at "+strings.Join(sites, ", ")+") now has a consumer — drop the residual entry ("+reason+")")
+		}
+	}
+	if len(stale) > 0 {
+		sort.Strings(stale)
+		t.Fatalf("%d residual entr(ies) are stale; the list may only shrink:\n\t%s", len(stale), strings.Join(stale, "\n\t"))
+	}
+}
+
+// TestDomAttrConsumerScanClassifiesItsOwnFixtures anchors the guard above on
+// inputs this file owns: one hook that must classify as named and one that must
+// classify as unnamed, plus the two spellings and the comment strip that the
+// gates depend on. Anchoring on the live tree instead would leave the guard
+// reporting success the day its scan silently stopped resolving anything.
+func TestDomAttrConsumerScanClassifiesItsOwnFixtures(t *testing.T) {
+	template := `<div data-fixture-live-hook data-fixture-dataset-hook="x">
+  {{/* data-fixture-commented-hook is named only in prose */}}
+  <span data-fixture-dead-hook></span>
+</div>`
+	hooks := domAttrConsumerHooksInTemplate(template, "fixture.html")
+	for _, expected := range []string{"data-fixture-live-hook", "data-fixture-dataset-hook", "data-fixture-dead-hook"} {
+		if _, found := hooks[expected]; !found {
+			t.Fatalf("fixture template must yield the hook %q, got %v", expected, hooks)
+		}
+	}
+	if _, found := hooks["data-fixture-commented-hook"]; found {
+		t.Fatal("a hook named only inside a template comment must not count as rendered")
+	}
+	if got := hooks["data-fixture-live-hook"]; len(got) != 1 || got[0] != "fixture.html:1" {
+		t.Fatalf("expected the hook site to carry file and line, got %v", got)
+	}
+
+	literals := map[string]bool{}
+	datasets := map[string]bool{}
+	domAttrConsumerIndexSource(`htmlHasAttr(node, "data-fixture-live-hook-suffix")`, ".go", literals, datasets)
+	domAttrConsumerIndexSource(`const label = root.dataset.fixtureDatasetHook;`, ".js", literals, datasets)
+
+	if !domAttrConsumerNamed("data-fixture-dataset-hook", literals, datasets) {
+		t.Fatal("a hook read through its camel-cased dataset name must classify as named")
+	}
+	if domAttrConsumerNamed("data-fixture-live-hook", literals, datasets) {
+		t.Fatal("a longer attribute that merely starts with the hook must not classify it as named")
+	}
+	if domAttrConsumerNamed("data-fixture-dead-hook", literals, datasets) {
+		t.Fatal("a hook no source names must classify as unnamed")
+	}
+	domAttrConsumerIndexSource(`page.locator('[data-fixture-live-hook="on"]')`, ".ts", literals, datasets)
+	if !domAttrConsumerNamed("data-fixture-live-hook", literals, datasets) {
+		t.Fatal("a hook named by a spec selector must classify as named")
+	}
+
+	if got := domAttrConsumerDatasetName("data-fixture-dataset-hook"); got != "fixtureDatasetHook" {
+		t.Fatalf("dataset spelling of data-fixture-dataset-hook must be fixtureDatasetHook, got %q", got)
+	}
+}
+
+// domAttrConsumerNamed reports whether either spelling of the hook appears in
+// the consumer index.
+func domAttrConsumerNamed(hook string, literals, datasets map[string]bool) bool {
+	return literals[hook] || datasets[domAttrConsumerDatasetName(hook)]
+}
+
+// domAttrConsumerDatasetName converts data-theme-label-dark to themeLabelDark,
+// the name a script reads it under.
+func domAttrConsumerDatasetName(hook string) string {
+	segments := strings.Split(strings.TrimPrefix(hook, "data-"), "-")
+	name := segments[0]
+	for _, segment := range segments[1:] {
+		if segment == "" {
+			continue
+		}
+		name += strings.ToUpper(segment[:1]) + segment[1:]
+	}
+	return name
+}
+
+// domAttrConsumerRepoRoot resolves the repository root from this file's own
+// location, so the scan does not depend on the working directory.
+func domAttrConsumerRepoRoot(t *testing.T) string {
+	t.Helper()
+
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot resolve this test file's path")
+	}
+	root := filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+	if _, err := os.Stat(filepath.Join(root, "go.mod")); err != nil {
+		t.Fatalf("resolved repository root %s carries no go.mod: %v", root, err)
+	}
+	return root
+}
+
+// domAttrConsumerTemplateHooks collects every data-* hook rendered under the
+// templates directory, mapped to the file:line sites that render it.
+func domAttrConsumerTemplateHooks(t *testing.T, templateDir, root string) map[string][]string {
+	t.Helper()
+
+	hooks := map[string][]string{}
+	walkErr := filepath.WalkDir(templateDir, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() || filepath.Ext(path) != ".html" {
+			return nil
+		}
+		content, readErr := os.ReadFile(path) //nolint:gosec // walked path under the repository's own template tree
+		if readErr != nil {
+			return readErr
+		}
+		relative, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return relErr
+		}
+		for hook, sites := range domAttrConsumerHooksInTemplate(string(content), filepath.ToSlash(relative)) {
+			hooks[hook] = append(hooks[hook], sites...)
+		}
+		return nil
+	})
+	if walkErr != nil {
+		t.Fatalf("walk %s: %v", templateDir, walkErr)
+	}
+	for hook := range hooks {
+		sort.Strings(hooks[hook])
+	}
+	return hooks
+}
+
+// domAttrConsumerHooksInTemplate is the pure half: hooks and their file:line
+// sites in one template, with template and HTML comments stripped first.
+func domAttrConsumerHooksInTemplate(content, name string) map[string][]string {
+	stripped := domAttrConsumerCommentPattern.ReplaceAllStringFunc(content, func(comment string) string {
+		return strings.Repeat("\n", strings.Count(comment, "\n"))
+	})
+	hooks := map[string][]string{}
+	for index, line := range strings.Split(stripped, "\n") {
+		for _, hook := range domAttrConsumerAttrPattern.FindAllString(line, -1) {
+			site := name + ":" + strconv.Itoa(index+1)
+			if sites := hooks[hook]; len(sites) > 0 && sites[len(sites)-1] == site {
+				continue
+			}
+			hooks[hook] = append(hooks[hook], site)
+		}
+	}
+	return hooks
+}
+
+// domAttrConsumerConsumerIndex indexes every attribute token and dataset name
+// that any source outside the templates tree spells out, and returns how many
+// files it read.
+func domAttrConsumerConsumerIndex(t *testing.T, root string) (map[string]bool, map[string]bool, int) {
+	t.Helper()
+
+	literals := map[string]bool{}
+	datasets := map[string]bool{}
+	templateDir := filepath.Join(root, "internal", "templates")
+	files := 0
+
+	walkErr := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			name := entry.Name()
+			if path != root && (strings.HasPrefix(name, ".") || domAttrConsumerSkipDirectories[name]) {
+				return filepath.SkipDir
+			}
+			if path == templateDir {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		extension := filepath.Ext(path)
+		if !domAttrConsumerSourceExtensions[extension] {
+			return nil
+		}
+		content, readErr := os.ReadFile(path) //nolint:gosec // walked path under the repository root
+		if readErr != nil {
+			return readErr
+		}
+		files++
+		domAttrConsumerIndexSource(string(content), extension, literals, datasets)
+		return nil
+	})
+	if walkErr != nil {
+		t.Fatalf("walk %s: %v", root, walkErr)
+	}
+	return literals, datasets, files
+}
+
+// domAttrConsumerIndexSource records the attribute tokens one source spells out,
+// plus — for a browser or spec source — the dataset names it reads.
+func domAttrConsumerIndexSource(content, extension string, literals, datasets map[string]bool) {
+	for _, token := range domAttrConsumerAttrPattern.FindAllString(content, -1) {
+		literals[token] = true
+	}
+	if !domAttrConsumerScriptExtensions[extension] {
+		return
+	}
+	for _, match := range domAttrConsumerDatasetPattern.FindAllStringSubmatch(content, -1) {
+		if match[1] != "" {
+			datasets[match[1]] = true
+			continue
+		}
+		datasets[match[2]] = true
+	}
+}


### PR DESCRIPTION

Board group **T0151** — records R2-0151 (P2, test-coverage-gap) and R2-0154 (P3, dom-contract).

Both records are about the same missing direction: a template declares a `data-*` hook so that
something outside it can address that element, and nothing checked that the other end exists. The
opposite direction — a selector pointing at markup that no longer renders — is deliberately out of
scope here.

---

## R2-0151 — the dashboard's inexact-estimate qualifiers

The header marks an ovulation estimate the luteal-phase clamp made inexact in three places:

- `internal/templates/dashboard.html:90` — the status line's approximate marker, which had **no
  hook at all**;
- `internal/templates/dashboard.html:106` — `data-dashboard-estimate-qualifier`, on the cycle
  hero's estimate qualifier;
- `internal/templates/dashboard.html:177` — `data-dashboard-ovulation-approximate`, on the reminder
  banner's approximate marker.

Re-checked on this tree: neither hook, nor any of the i18n keys behind them
(`dashboard.ovulation_estimate`, `dashboard.ovulation_approximate`,
`dashboard.cycle_hero_estimated`), appears in a single Go, TypeScript, JS or CSS source. A template
edit could drop a medical-safety qualifier from a predictive surface with every suite green.

`internal/api/dashboard_prediction_disclaimer_test.go` gains
`TestDashboardMarksAnInexactOvulationEstimateWithAddressableQualifiers`. Only a narrow band of
inputs produces an inexact estimate the header still shows, so the fixture is explicit about every
constraint and each is documented at the test: a 16-day reference cycle against the default 14-day
luteal phase forces `CalcOvulationDay` to clamp (`OvulationExact=false`); a 3-day period keeps
ovulation day 5 clear of `periodLength+1`, without which the cycle hero is not drawn; one previous
cycle clears `FertilityProjectionSuppressed`; cycle day 3 puts ovulation inside the default
three-day reminder window and the next period outside it; the trying-to-conceive goal is what puts
the ovulation estimate in the status line at all. Two anchors assert the fixture reached that state
(`data-dashboard-ovulation`, `data-dashboard-reminder-banner`) before the hooks are judged, so a
fixture that drifts out of the band fails loudly instead of passing on an absent surface.

### Red → green

**Natural red — `dashboard.html:90`.** The status line's marker genuinely had no hook, so the guard
failed on the unfixed tree with no induction:

```
--- FAIL: TestDashboardMarksAnInexactOvulationEstimateWithAddressableQualifiers (1.13s)
    dashboard_prediction_disclaimer_test.go:178: expected the ovulation estimate's approximate marker to carry data-dashboard-ovulation-approximate
```

Fix: the span at `dashboard.html:90` gains `data-dashboard-ovulation-approximate`, the same hook its
reminder-banner counterpart already carries. Attributes only — markup, classes and copy untouched.
Green after.

**INDUCED red — `dashboard.html:106`.** This half is latent (the hook exists; nothing named it), so
the red was induced by **gutting the production markup**: the whole
`{{if .CycleHero.Approximate}}` block was replaced with `{{if false}}{{end}}`, which is the failure
mode the guard exists to catch.

```
--- FAIL: TestDashboardMarksAnInexactOvulationEstimateWithAddressableQualifiers (1.33s)
    dashboard_prediction_disclaimer_test.go:175: expected the cycle-hero estimate qualifier to carry data-dashboard-estimate-qualifier
```

The induction was then **reverted**; the block is byte-identical to `main`.

**INDUCED red — `dashboard.html:177`.** Same shape: the `{{if .ReminderBannerApproximate}}` span was
replaced with `{{if false}}{{end}}`.

```
--- FAIL: TestDashboardMarksAnInexactOvulationEstimateWithAddressableQualifiers (1.04s)
    dashboard_prediction_disclaimer_test.go:181: expected the reminder banner's approximate marker to carry data-dashboard-ovulation-approximate
```

Reverted; byte-identical to `main`.

### Skipped from this record

`dashboard.html:201` / `data-dashboard-prediction-past` is **already covered on this tree** —
`internal/api/dashboard_regressions_test.go:838` asserts the hook. The audit snapshot predates it.
No work manufactured for that row.

---

## R2-0154 — the template→consumer direction

New file `internal/templates/dom_attribute_consumers_test.go` (package `templates`, every helper
prefixed `domAttrConsumer` so it cannot collide with a sibling PR's new file in the same package).
`TestEveryTemplateDataHookIsNamedOutsideTheTemplates` requires every `data-*` attribute rendered
from `internal/templates` to be named at least once outside it.

**CSS counts as a consumer**, as do Go, the browser sources, the built bundle under `web/static`,
and the Playwright specs. The gates, each of which exists because a narrower reading reported a live
hook as dead:

1. Literal attribute names, **tokenized rather than substring-matched**. `htmlHasAttr(node,
   "data-foo")`, `[data-foo="bar"]` and a stylesheet's `[data-foo]` all yield the token `data-foo`;
   substring matching instead calls `data-foo` live the moment anything mentions `data-foo-bar`.
   Three hooks here (`data-auto-period-fill`, `data-onboarding-usage-goal`,
   `data-pwa-install-title`) looked consumed for exactly that reason — the only names in the tree
   were their longer siblings (`data-onboarding-auto-period-fill`, `data-onboarding-usage-goal-skip`,
   `data-pwa-install-title-key`).
2. The camel-cased `dataset` spelling: `data-theme-label-dark` is only ever read as
   `dataset.themeLabelDark`, and the recovery panel passes its keys as bare `"copySuccessMessage"`
   strings. Ten hooks are live only through this gate.
3. Template and HTML comments are stripped before hooks are collected, so a hook named only in prose
   does not count as rendered.
4. Hidden directories and dependency/report trees are skipped, so a stray checkout cannot supply a
   phantom consumer.
5. Corpus floors (≥100 template hooks, ≥100 consumer sources) fail a scan that resolved nothing
   instead of reporting a clean tree.

Known blind spot, stated in the file: a selector assembled at runtime (`"[data-" + name + "]"`).
That is the one shape a residual entry may legitimately carry as its reason.

### The number I actually found

**30**, not the audit's 32 — re-derived on this tree, not taken from the snapshot. The delta is
accounted for: `data-dashboard-estimate-qualifier` and `data-dashboard-ovulation-approximate` become
live in this same PR via R2-0151's test, and the tokenized/dataset gates move several hooks in both
directions relative to the audit's plain `grep -F`. `data-projected` (`dashboard.html:159`) is in the
dead set and stays there: the camel token `projected` appears in two e2e files only as the English
word inside a comment, which a looser gate reads as a consumer.

### Red → green

**Natural red.** The guard was written and run with an **empty** residual map, against the tree as
it is. It reproduced the record's finding directly:

```
--- FAIL: TestEveryTemplateDataHookIsNamedOutsideTheTemplates (0.75s)
    dom_attribute_consumers_test.go:134: 30 data-* hook(s) render with no consumer outside internal/templates.
        Give each one a reader (Go regression, browser script, Playwright spec or component rule) or delete the markup:
        	data-auto-period-fill — rendered at internal/templates/onboarding.html:11
        	data-calendar-feed-hint — rendered at internal/templates/components/settings_calendar_feed.html:16
        	data-calendar-has-sex — rendered at internal/templates/calendar.html:68
        	data-calendar-month-label — rendered at internal/templates/calendar.html:6
        	data-cycle-factor-count — rendered at internal/templates/stats.html:192, internal/templates/stats.html:206
        	... (30 total)
        	data-usage-goal-quick-switch-form — rendered at internal/templates/dashboard.html:128
```

Green once the thirty are recorded with a per-hook reason.

**Mutants, re-run after the fix** (a guard is written against the tree it will live in):

| mutant | result |
| --- | --- |
| dataset gate gutted (`domAttrConsumerNamed` drops the `datasets` lookup) | **red** — 10 live hooks reported as dead, *and* the owned-fixture anchor test reds: `a hook read through its camel-cased dataset name must classify as named` |
| classifier gutted to `return true` | **red** — `30 residual entr(ies) are stale; the list may only shrink` |
| a new dead hook added to a template (`data-dashboard-mutant-hook` on `dashboard.html:4`) | **red** — `1 data-* hook(s) render with no consumer outside internal/templates` |

All three inductions reverted; `git diff` against the committed tree is empty.

### Why the thirty are recorded rather than swept

Deleting 30 attributes across ten template files is not this record's minimal patch, and it would be
wrong for several of them: a `*-key` attribute is *required* beside its state hook, and two entries
are pointers at other defects rather than decoration. Each is recorded with the reason it is still
there. The map is a ratchet, not a resting allowlist — an entry whose hook has since gained a
consumer, or left the templates, fails as loudly as a new dead hook, so it can only shrink. The
anti-vacuity anchors are fixtures the file owns (one input that must classify named, one that must
classify unnamed), never the live exemption list.

Two entries are called out in the file as not-decoration:

- **`data-cycle-start-implantation`** (`dashboard.html:459`, `day_editor_partial.html:151,210,253`) —
  the only unread field of the cycle-start confirm island. Its siblings (`-conflict-date`,
  `-short-gap`, `-replace-message`, `-target-date`) are all read, so the implantation warning the
  server computes reaches no dialog. Closing it means writing browser code, which belongs to the
  JS-direction PR in this wave, not here.
- **`data-next-period-paused-key`** (`dashboard.html:47`) — the state key beside
  `data-dashboard-next-period-paused`, which *is* asserted while its key is not. The frontend rule
  requires the `*-key` attribute when the chosen state is the subject, so the fix is an assertion,
  not a deletion.

### Known residual in a sibling's file

`data-saving-label` renders at nine sites, one of which is
`internal/templates/components/settings_tracking.html:153` — owned by a sibling agent this wave. The
file is untouched here; the hook is recorded in the residual map, which covers all nine sites at
once.

### Not built

No `scripts/domgraph*` and no JS→template selector scanner: that direction belongs to a sibling PR
in this wave. This PR owns the template→consumer direction only.

---

## Validation

`go build ./...`; `go test ./internal/api/... -timeout 20m`; `go test ./internal/templates/...`;
`go test ./internal/i18n/...`; `golangci-lint run ./internal/templates/... ./internal/api/...` —
0 issues; `go run ./scripts/changelogd check` — OK.

Changelog fragment: `changelog.d/fix-t0151-dashboard-dom-contract.md` (`none` — no user-visible
change; the only markup edit is one added attribute).

Rollback: single-commit revert per commit. Nothing here alters persisted data or a public contract.
