### PR TITLE
test(services): close the T0492 coverage and vacuity gaps

### DIFF
--- a/changelog.d/test-t0492-services-coverage-gaps.md
+++ b/changelog.d/test-t0492-services-coverage-gaps.md
@@ -1,0 +1,17 @@
+none
+
+Test strengthening in `internal/services`, with no production behaviour change.
+Each guard was written against the mutant it exists to kill, the mutant applied
+to the production file and the red observed, then reverted: the three day-input
+sentinels no test produced (sex activity, BBT, cervical mucus), the mood upper
+bound and the exact notes cap, the untested `DayHasData` branches, the BBT lower
+bound, the equal-bounds and half-open export ranges, all seven dangerous CSV
+prefixes through the finished column, the login attempt counter's reset after a
+correct password, the recovery flow answering an unknown address exactly as a
+known one, the onboarding path policy under adversarial paths, every arm of the
+privacy breadcrumb label, and the pregnancy pause resolved under three log
+orders.
+
+The two day-log stubs now share one mirror of `models.DailyLog.BeforeSave` and
+canonicalize `Date` on write, and one workflow case drives a save and a read of
+the same day from a request zone east of UTC.

--- a/internal/api/onboarding_gate_path_normalization_test.go
+++ b/internal/api/onboarding_gate_path_normalization_test.go
@@ -1,0 +1,84 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/ovumcy/ovumcy-web/internal/services"
+)
+
+// The onboarding gate compares `c.Path()` against a literal prefix
+// (services.ShouldEnforceOnboardingAccess, called from AuthRequired), and
+// `/api/v1/onboarding/../days/2026-03-01` reads as an onboarding path to that
+// comparison, so the gate lets it through. That is safe today for one reason
+// and one only: the router matches the same unnormalized string, so the request
+// reaches no handler at all.
+//
+// internal/services pins the first half of that argument — the string function's
+// answer — and nothing pinned the second, which is the half that lives outside
+// this repository. A Fiber upgrade that routes on `URI().Path()` instead of
+// `URI().PathOriginal()`, or a config that enables UnescapePath, collapses the
+// traversal segment: the days route starts matching while the gate still reads
+// the raw string and waves the request past onboarding. The services test stays
+// green through all of it, because a pure string function cannot see a router.
+//
+// So this is the other half, asserted rather than assumed, and it fails in the
+// same release the assumption does.
+func TestRouterDoesNotNormalizeATraversalSegmentIntoAGatedRoute(t *testing.T) {
+	t.Parallel()
+
+	const traversal = "/api/v1/onboarding/../days/2026-03-01"
+
+	// The gate's own reading of the path, restated here so the two halves are
+	// visible together: it does NOT enforce onboarding on this path.
+	if services.ShouldEnforceOnboardingAccess(traversal) {
+		t.Fatal("fixture anchor: the gate is expected to read the traversal path as an onboarding path; " +
+			"if it no longer does, this guard's premise is gone and the services-side row is what changed")
+	}
+
+	app := fiber.New()
+	reached := ""
+	app.Get("/api/v1/days/:date", func(c fiber.Ctx) error {
+		reached = "days"
+		return c.SendStatus(fiber.StatusOK)
+	})
+	app.Get("/api/v1/onboarding/steps/:step", func(c fiber.Ctx) error {
+		reached = "onboarding"
+		return c.SendStatus(fiber.StatusOK)
+	})
+
+	response, err := app.Test(httptest.NewRequest(http.MethodGet, traversal, nil))
+	if err != nil {
+		t.Fatalf("app.Test(%q): %v", traversal, err)
+	}
+	defer func() {
+		_ = response.Body.Close()
+	}()
+
+	if reached != "" {
+		t.Fatalf("the router resolved %q to the %s handler; it now normalizes the traversal segment, "+
+			"so the onboarding gate — which still compares the raw path — passes a request that reaches a gated route. "+
+			"Clean the path in services.ShouldEnforceOnboardingAccess before this ships",
+			traversal, reached)
+	}
+	if response.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected %q to match no route (404), got %d", traversal, response.StatusCode)
+	}
+
+	// Positive control: the same router does resolve the plain path, so a
+	// 404 above is the traversal segment being taken literally and not a
+	// fixture that registered nothing.
+	plain := httptest.NewRequest(http.MethodGet, "/api/v1/days/2026-03-01", nil)
+	plainResponse, err := app.Test(plain)
+	if err != nil {
+		t.Fatalf("app.Test(plain days path): %v", err)
+	}
+	defer func() {
+		_ = plainResponse.Body.Close()
+	}()
+	if plainResponse.StatusCode != http.StatusOK || reached != "days" {
+		t.Fatalf("fixture anchor: the plain days path must reach its handler, got status %d and reached %q", plainResponse.StatusCode, reached)
+	}
+}

--- a/internal/services/day_input_mutation_test.go
+++ b/internal/services/day_input_mutation_test.go
@@ -54,6 +54,48 @@ func TestNormalizeDayEntryInputRejectsNegativeMood(t *testing.T) {
 	}
 }
 
+// TestNormalizeDayEntryInputRejectsMoodAboveMaximum is the upper-bound twin of
+// the negative-mood anchor. Every other mood case feeds MinDayMood, MaxDayMood
+// or a negative value, so deleting `value <= MaxDayMood` from IsValidDayMood
+// left the whole suite green: nothing ever submitted a mood one step above the
+// scale the mood control offers.
+func TestNormalizeDayEntryInputRejectsMoodAboveMaximum(t *testing.T) {
+	if _, err := NormalizeDayEntryInput(DayEntryInput{
+		Flow: models.FlowNone,
+		Mood: MaxDayMood + 1,
+	}); !errors.Is(err, ErrInvalidDayMood) {
+		t.Fatalf("expected ErrInvalidDayMood for mood %d, got %v", MaxDayMood+1, err)
+	}
+	// In-range maximum mood must still be accepted, so the guard is not merely
+	// rejecting everything at the top of the scale.
+	if _, err := NormalizeDayEntryInput(DayEntryInput{
+		Flow: models.FlowNone,
+		Mood: MaxDayMood,
+	}); err != nil {
+		t.Fatalf("NormalizeDayEntryInput() with maximum mood %d: unexpected error: %v", MaxDayMood, err)
+	}
+}
+
+// TestDayInputBoundsAreExactValues pins the notes cap and the mood scale to the
+// numbers themselves. Every other reference to them is symbolic — the input is
+// built from the constant and the expectation is read from the same constant —
+// so an ARITHMETIC mutant on a bound moves the fixture and the assertion
+// together and survives.
+//
+// The template cross-check in day_input_test.go catches a lone move of
+// MaxDayNotesLength, because the textareas still declare maxlength="2000". It
+// cannot catch the two sides moving TOGETHER: agreement is what it asserts, and a pair that agrees on
+// 500 satisfies it while silently cutting notes owners already typed. The mood
+// scale has no such second reader at all.
+func TestDayInputBoundsAreExactValues(t *testing.T) {
+	if MaxDayNotesLength != 2000 {
+		t.Fatalf("MaxDayNotesLength = %d, want 2000: the day-notes trim bound is the number the notes textareas declare as maxlength", MaxDayNotesLength)
+	}
+	if MinDayMood != 1 || MaxDayMood != 5 {
+		t.Fatalf("mood scale = [%d, %d], want [1, 5]: the mood control offers exactly five steps", MinDayMood, MaxDayMood)
+	}
+}
+
 // TestTrimDayNotesCapsCraftedInvalidUTF8 pins the character-counting loop in
 // TrimDayNotes (day_input.go) on crafted invalid input, which is reachable from
 // the untrusted day-notes field and which the valid-UTF-8 cases never produce.

--- a/internal/services/day_input_test.go
+++ b/internal/services/day_input_test.go
@@ -23,6 +23,69 @@ func TestNormalizeDayEntryInputRejectsInvalidFlow(t *testing.T) {
 	}
 }
 
+// TestNormalizeDayEntryInputRejectsEachFieldWithItsOwnSentinel pins the whole
+// rejection mapping of NormalizeDayEntryInput, not one arm of it: every tracked
+// field has its own sentinel, and an invalid value must surface THAT sentinel.
+// The guards run in a fixed order, so a field whose check is deleted does not
+// stop rejecting — the value falls through to the next check and is reported
+// under a neighbour's error, which the API's error mapping then renders as the
+// wrong field. Three of these sentinels (sex activity, BBT, cervical mucus)
+// were produced by no test in this package at all.
+func TestNormalizeDayEntryInputRejectsEachFieldWithItsOwnSentinel(t *testing.T) {
+	outOfRangeBBT := 50.0
+
+	tests := []struct {
+		name  string
+		input DayEntryInput
+		want  error
+	}{
+		{
+			name:  "flow",
+			input: DayEntryInput{IsPeriod: true, Flow: "bad-flow"},
+			want:  ErrInvalidDayFlow,
+		},
+		{
+			name:  "mood",
+			input: DayEntryInput{Flow: models.FlowNone, Mood: MaxDayMood + 1},
+			want:  ErrInvalidDayMood,
+		},
+		{
+			name:  "sex activity",
+			input: DayEntryInput{Flow: models.FlowNone, SexActivity: "bad-activity"},
+			want:  ErrInvalidDaySexActivity,
+		},
+		{
+			name:  "bbt",
+			input: DayEntryInput{Flow: models.FlowNone, BBT: &outOfRangeBBT},
+			want:  ErrInvalidDayBBT,
+		},
+		{
+			name:  "cervical mucus",
+			input: DayEntryInput{Flow: models.FlowNone, CervicalMucus: "bad-mucus"},
+			want:  ErrInvalidDayCervicalMucus,
+		},
+		{
+			name:  "pregnancy test",
+			input: DayEntryInput{Flow: models.FlowNone, PregnancyTest: "bad-test"},
+			want:  ErrInvalidDayPregnancyTest,
+		},
+		{
+			name:  "cycle factors",
+			input: DayEntryInput{Flow: models.FlowNone, CycleFactorKeys: []string{"unknown"}},
+			want:  ErrInvalidDayCycleFactors,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NormalizeDayEntryInput(tt.input)
+			if !errors.Is(err, tt.want) {
+				t.Fatalf("NormalizeDayEntryInput() = %v, want %v", err, tt.want)
+			}
+		})
+	}
+}
+
 func TestNormalizeDayEntryInputNormalizesNonPeriodDay(t *testing.T) {
 	normalized, err := NormalizeDayEntryInput(DayEntryInput{
 		IsPeriod:   false,

--- a/internal/services/day_service_integration_test.go
+++ b/internal/services/day_service_integration_test.go
@@ -125,13 +125,27 @@ func TestDayServiceFetchLogByDateNilsOutOfRangeStoredBBT(t *testing.T) {
 	}
 }
 
+// TestMergePreservedDayEntryInputDropsOutOfRangeExistingBBT covers both ends of
+// the stored range. Only the above-maximum value was checked, here and on the
+// read path, so the lower bound could be dropped from IsValidDayBBT and a
+// stored value no thermometer produced — a Fahrenheit reading saved on a
+// Celsius form, say — would be carried forward into the next save untouched.
 func TestMergePreservedDayEntryInputDropsOutOfRangeExistingBBT(t *testing.T) {
-	outOfRange := 200.0
-	existing := models.DailyLog{BBT: &outOfRange}
+	for _, outOfRange := range []float64{200.0, 20.0} {
+		existing := models.DailyLog{BBT: &outOfRange}
 
-	merged := mergePreservedDayEntryInput(existing, DayEntryInput{PreserveBBT: true})
-	if merged.BBT != nil {
-		t.Fatalf("expected preserved out-of-range bbt to be dropped to nil, got %v", *merged.BBT)
+		merged := mergePreservedDayEntryInput(existing, DayEntryInput{PreserveBBT: true})
+		if merged.BBT != nil {
+			t.Fatalf("expected preserved out-of-range bbt %.2f to be dropped to nil, got %v", outOfRange, *merged.BBT)
+		}
+	}
+
+	// Positive control: a real reading must still be preserved, so the guard is
+	// not simply dropping every stored temperature.
+	inRange := 36.6
+	merged := mergePreservedDayEntryInput(models.DailyLog{BBT: &inRange}, DayEntryInput{PreserveBBT: true})
+	if merged.BBT == nil || *merged.BBT != inRange {
+		t.Fatalf("expected an in-range stored bbt to be preserved, got %v", merged.BBT)
 	}
 }
 

--- a/internal/services/day_service_mutation_round3_test.go
+++ b/internal/services/day_service_mutation_round3_test.go
@@ -16,9 +16,9 @@ import (
 // tests full control over write capture and error injection.
 //
 // Entries are keyed by the canonical UTC-midnight calendar date of the stored
-// Date value. Writes emulate models.DailyLog.BeforeSave (re-anchor the value's
-// own y/m/d to UTC-midnight), which is the on-disk convention DayRange queries
-// against. This keeps the stub coherent under non-UTC request locations.
+// Date value, and writes canonicalize it through canonicalStoredDayDate
+// (day_service_workflow_test.go), the package's single mirror of
+// models.DailyLog.BeforeSave.
 type mr3dayLogStub struct {
 	entries map[string]models.DailyLog
 	nextID  uint
@@ -39,18 +39,8 @@ func newMr3dayLogStub() *mr3dayLogStub {
 	}
 }
 
-// mr3canonicalDate mirrors models.DailyLog.BeforeSave: take the calendar
-// components of value in its own location and re-anchor them to UTC-midnight.
-func mr3canonicalDate(value time.Time) time.Time {
-	if value.IsZero() {
-		return value
-	}
-	y, m, d := value.Date()
-	return time.Date(y, m, d, 0, 0, 0, 0, time.UTC)
-}
-
 func mr3dayKey(value time.Time) string {
-	return mr3canonicalDate(value).Format("2006-01-02")
+	return canonicalStoredDayDate(value).Format("2006-01-02")
 }
 
 func (s *mr3dayLogStub) ListByUser(ctx context.Context, userID uint) ([]models.DailyLog, error) {
@@ -114,7 +104,7 @@ func (s *mr3dayLogStub) Create(ctx context.Context, entry *models.DailyLog) erro
 		entry.ID = s.nextID
 		s.nextID++
 	}
-	entry.Date = mr3canonicalDate(entry.Date)
+	entry.Date = canonicalStoredDayDate(entry.Date)
 	s.entries[mr3dayKey(entry.Date)] = *entry
 	return nil
 }
@@ -132,7 +122,7 @@ func (s *mr3dayLogStub) Save(ctx context.Context, entry *models.DailyLog) error 
 	if s.failSaveWhenCycleStart != nil && entry.CycleStart {
 		return s.failSaveWhenCycleStart
 	}
-	entry.Date = mr3canonicalDate(entry.Date)
+	entry.Date = canonicalStoredDayDate(entry.Date)
 	key := mr3dayKey(entry.Date)
 	prev, existed := s.entries[key]
 	if existed && prev.IsPeriod && !entry.IsPeriod {

--- a/internal/services/day_service_workflow_test.go
+++ b/internal/services/day_service_workflow_test.go
@@ -42,8 +42,25 @@ func newDayLogRepositoryStub() *dayLogRepositoryStub {
 	}
 }
 
+// canonicalStoredDayDate mirrors models.DailyLog.BeforeSave: take the calendar
+// components of a value in its own location and re-anchor them to UTC-midnight.
+// That is the only shape a daily_logs row ever has on disk (migration 019 +
+// BeforeSave), and it is the shape DayRange queries against, so every day-log
+// stub in this package canonicalizes on write. A stub that stores the caller's
+// zone instead is coherent only while the request location happens to be UTC:
+// under any offset zone its rows sit hours away from the bounds the service
+// asks for, and the tests written against it agree with a database that cannot
+// exist.
+func canonicalStoredDayDate(value time.Time) time.Time {
+	if value.IsZero() {
+		return value
+	}
+	year, month, day := value.Date()
+	return time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+}
+
 func (stub *dayLogRepositoryStub) dayKey(value time.Time) string {
-	return value.Format("2006-01-02")
+	return canonicalStoredDayDate(value).Format("2006-01-02")
 }
 
 func (stub *dayLogRepositoryStub) ListByUser(ctx context.Context, userID uint) ([]models.DailyLog, error) {
@@ -131,6 +148,7 @@ func (stub *dayLogRepositoryStub) Create(ctx context.Context, entry *models.Dail
 		entry.ID = stub.nextID
 		stub.nextID++
 	}
+	entry.Date = canonicalStoredDayDate(entry.Date)
 	stub.entries[key] = *entry
 	return nil
 }
@@ -152,6 +170,7 @@ func (stub *dayLogRepositoryStub) Save(ctx context.Context, entry *models.DailyL
 			return err
 		}
 	}
+	entry.Date = canonicalStoredDayDate(entry.Date)
 	stub.entries[key] = *entry
 	return nil
 }
@@ -226,6 +245,40 @@ func (stub *dayUserRepositoryStub) UpdateByID(ctx context.Context, userID uint, 
 		}
 	}
 	return nil
+}
+
+// TestUpsertDayEntryWithAutoFillReReadsItsOwnWriteFromAnOffsetZone drives one
+// save and one read of the same calendar day under a request zone east of UTC.
+// It is the case the shared stub was silently unable to represent: it stored
+// the caller's local midnight, which is the previous day in UTC, while the
+// service asks for the [UTC-midnight, +24h) bounds a real row occupies — so the
+// day the owner had just saved read back as empty. Every other workflow test
+// passes time.UTC, where the two shapes coincide and the difference is
+// invisible.
+func TestUpsertDayEntryWithAutoFillReReadsItsOwnWriteFromAnOffsetZone(t *testing.T) {
+	logs := newDayLogRepositoryStub()
+	service := NewDayService(logs, &dayUserRepositoryStub{})
+
+	// East of UTC, so local midnight lands on the previous UTC day.
+	zone := time.FixedZone("test+03", 3*60*60)
+	day := time.Date(2026, time.March, 10, 9, 30, 0, 0, zone)
+
+	saved, err := service.UpsertDayEntryWithAutoFill(context.Background(), 10, day,
+		DayEntryInput{Flow: models.FlowNone, Notes: "saved from +03"}, zone)
+	if err != nil {
+		t.Fatalf("UpsertDayEntryWithAutoFill() unexpected error: %v", err)
+	}
+	if want := time.Date(2026, time.March, 10, 0, 0, 0, 0, time.UTC); !saved.Date.Equal(want) {
+		t.Fatalf("expected the stored day to be anchored at %s, got %s", want, saved.Date)
+	}
+
+	entry, err := service.FetchLogByDate(context.Background(), 10, day, zone)
+	if err != nil {
+		t.Fatalf("FetchLogByDate() unexpected error: %v", err)
+	}
+	if entry.Notes != "saved from +03" {
+		t.Fatalf("expected the day just saved to read back, got notes %q", entry.Notes)
+	}
 }
 
 func TestUpsertDayEntryWithAutoFillNormalizesNonPeriodInput(t *testing.T) {

--- a/internal/services/day_tracking_mutation_test.go
+++ b/internal/services/day_tracking_mutation_test.go
@@ -20,6 +20,22 @@ func TestIsValidDayBBTAcceptsUpperBoundCelsius(t *testing.T) {
 	}
 }
 
+// TestIsValidDayBBTRejectsOutsideThePhysiologicalRange is the rejecting half of
+// the range check. Both endpoints were accepted by their own anchors and the
+// only refusal anywhere was an above-maximum stored value, so removing
+// `*value >= MinDayBBTCelsius` left every BBT test green: nothing submitted a
+// reading below the range, which is what a Fahrenheit value entered on a
+// Celsius form looks like.
+func TestIsValidDayBBTRejectsOutsideThePhysiologicalRange(t *testing.T) {
+	t.Parallel()
+
+	for _, value := range []float64{MinDayBBTCelsius - 0.1, 20.0, MaxDayBBTCelsius + 0.1, 200.0} {
+		if IsValidDayBBT(bbtPtr(value)) {
+			t.Fatalf("expected IsValidDayBBT(%.2f) = false outside [%.2f, %.2f], got true", value, MinDayBBTCelsius, MaxDayBBTCelsius)
+		}
+	}
+}
+
 func TestIsValidDayBBTNilIsUnmeasured(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/day_utils_test.go
+++ b/internal/services/day_utils_test.go
@@ -7,6 +7,10 @@ import (
 	"github.com/ovumcy/ovumcy-web/internal/models"
 )
 
+func dayHasDataBBT(value float64) *float64 {
+	return &value
+}
+
 func TestDayHasData(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -42,6 +46,35 @@ func TestDayHasData(t *testing.T) {
 			name:  "pregnancy test present",
 			entry: models.DailyLog{PregnancyTest: models.PregnancyTestPositive},
 			want:  true,
+		},
+		// One row per tracked field, each carrying nothing else: a day whose
+		// only content is intimacy, a temperature or a mucus observation is a
+		// day with data. Without these three the corresponding branches could
+		// all be deleted at once and the table stayed green, which meant an
+		// empty-looking day could be cleared out from under a value the owner
+		// had entered.
+		{
+			name:  "sex activity present",
+			entry: models.DailyLog{SexActivity: models.SexActivityProtected},
+			want:  true,
+		},
+		{
+			name:  "bbt present",
+			entry: models.DailyLog{BBT: dayHasDataBBT(36.6)},
+			want:  true,
+		},
+		{
+			name:  "cervical mucus present",
+			entry: models.DailyLog{CervicalMucus: models.CervicalMucusCreamy},
+			want:  true,
+		},
+		// An out-of-range stored temperature is not a reading: DayHasData asks
+		// IsValidDayBBT, so this row keeps the branch from degrading into a
+		// bare nil check.
+		{
+			name:  "out of range bbt is not data",
+			entry: models.DailyLog{Flow: models.FlowNone, BBT: dayHasDataBBT(200)},
+			want:  false,
 		},
 		{
 			name:  "empty entry",

--- a/internal/services/export_range_policy_test.go
+++ b/internal/services/export_range_policy_test.go
@@ -32,6 +32,53 @@ func TestParseExportRange(t *testing.T) {
 		}
 	})
 
+	// A single-day export has from == to. The order guard rejects only a `to`
+	// strictly BEFORE `from`, and nothing exercised the equal case, so the
+	// boundary mutant `to.Before(*from)` -> `!to.After(*from)` refused a
+	// one-day range with no test noticing.
+	t.Run("single day range", func(t *testing.T) {
+		from, to, err := ParseExportRange("2026-02-10", "2026-02-10", location)
+		if err != nil {
+			t.Fatalf("expected a single-day range to be accepted, got %v", err)
+		}
+		if from == nil || to == nil {
+			t.Fatalf("expected non-nil range bounds")
+		}
+		if !from.Equal(*to) {
+			t.Fatalf("expected identical bounds, got from=%s to=%s", from, to)
+		}
+	})
+
+	// The export form submits either half on its own, and the export service's
+	// own tests drive those half-open ranges — but nothing reached the policy
+	// with one bound set and the other empty, where the order guard's nil
+	// operands decide whether it runs at all.
+	t.Run("open ended from", func(t *testing.T) {
+		from, to, err := ParseExportRange("2026-02-10", "", location)
+		if err != nil {
+			t.Fatalf("expected an open-ended range to be accepted, got %v", err)
+		}
+		if from == nil || from.Format("2006-01-02") != "2026-02-10" {
+			t.Fatalf("expected from=2026-02-10, got %v", from)
+		}
+		if to != nil {
+			t.Fatalf("expected nil to, got %v", to)
+		}
+	})
+
+	t.Run("open ended to", func(t *testing.T) {
+		from, to, err := ParseExportRange("", "2026-02-20", location)
+		if err != nil {
+			t.Fatalf("expected an open-ended range to be accepted, got %v", err)
+		}
+		if from != nil {
+			t.Fatalf("expected nil from, got %v", from)
+		}
+		if to == nil || to.Format("2006-01-02") != "2026-02-20" {
+			t.Fatalf("expected to=2026-02-20, got %v", to)
+		}
+	})
+
 	t.Run("invalid from", func(t *testing.T) {
 		_, _, err := ParseExportRange("not-a-date", "2026-02-20", location)
 		if !errors.Is(err, ErrExportFromDateInvalid) {

--- a/internal/services/export_service_test.go
+++ b/internal/services/export_service_test.go
@@ -382,6 +382,107 @@ func TestExportBuildCSVRowsNeutralizesFormulaLikeCells(t *testing.T) {
 	}
 }
 
+// TestExportBuildCSVRowsNeutralizesEveryDangerousPrefix drives every prefix the
+// policy treats as dangerous through the finished CSV column, not through the
+// helper. Only '=' and '@' were ever exercised, so the other five switch cases
+// could be deleted together and the export still looked neutralized: a note
+// opening with '+', '-', a tab or a bare CR/LF went into the file as a live
+// formula for whatever spreadsheet the owner opens their own health export in.
+//
+// The leading-space variants matter separately — the check trims spaces before
+// reading the first byte, which is exactly the disguise a hostile value uses.
+func TestExportBuildCSVRowsNeutralizesEveryDangerousPrefix(t *testing.T) {
+	dangerous := []struct {
+		name   string
+		prefix string
+		// printable marks the prefixes a symptom NAME can still carry: names
+		// reach the cell through TrimSpace (export_service.go), which strips a
+		// tab or a bare CR/LF along with the padding. Notes are stored verbatim
+		// and carry all seven.
+		printable bool
+	}{
+		{name: "equals", prefix: "=", printable: true},
+		{name: "plus", prefix: "+", printable: true},
+		{name: "minus", prefix: "-", printable: true},
+		{name: "at", prefix: "@", printable: true},
+		{name: "tab", prefix: "\t"},
+		{name: "carriage return", prefix: "\r"},
+		{name: "line feed", prefix: "\n"},
+	}
+
+	for _, entry := range dangerous {
+		for _, lead := range []struct {
+			name  string
+			value string
+		}{
+			{name: "bare", value: ""},
+			{name: "space padded", value: "  "},
+		} {
+			t.Run(entry.name+" "+lead.name, func(t *testing.T) {
+				note := lead.value + entry.prefix + `cmd|' /C calc'!A0`
+				symptom := entry.prefix + "Doctor export"
+
+				columns, indexByHeader := exportCSVColumnsForCell(t, note, symptom)
+
+				if got := columns[indexByHeader["Notes"]]; got != "'"+note {
+					t.Fatalf("expected the notes cell to be neutralized, got %q", got)
+				}
+				if !entry.printable {
+					return
+				}
+				if got := columns[indexByHeader["Other"]]; got != "'"+symptom {
+					t.Fatalf("expected the other-symptom cell to be neutralized, got %q", got)
+				}
+			})
+		}
+	}
+
+	// Positive control: an ordinary note must reach the file unchanged, so the
+	// guard is not simply quoting every cell.
+	t.Run("ordinary text is untouched", func(t *testing.T) {
+		columns, indexByHeader := exportCSVColumnsForCell(t, "cramps in the evening", "Doctor export")
+
+		if got := columns[indexByHeader["Notes"]]; got != "cramps in the evening" {
+			t.Fatalf("expected an ordinary note to survive unquoted, got %q", got)
+		}
+		if got := columns[indexByHeader["Other"]]; got != "Doctor export" {
+			t.Fatalf("expected an ordinary symptom name to survive unquoted, got %q", got)
+		}
+	})
+}
+
+// exportCSVColumnsForCell builds the single CSV row of a day carrying `note`
+// and one custom symptom named `symptom`.
+func exportCSVColumnsForCell(t *testing.T, note string, symptom string) ([]string, map[string]int) {
+	t.Helper()
+
+	service := NewExportService(
+		&stubExportDayReader{
+			logs: []models.DailyLog{
+				{
+					Date:       mustParseExportDay(t, "2026-02-18"),
+					SymptomIDs: []uint{1},
+					Notes:      note,
+				},
+			},
+		},
+		&stubExportSymptomReader{
+			symptoms: []models.SymptomType{
+				{ID: 1, Name: symptom},
+			},
+		},
+	)
+
+	rows, err := service.BuildCSVRows(context.Background(), 42, nil, nil, time.UTC)
+	if err != nil {
+		t.Fatalf("BuildCSVRows() unexpected error: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected one row, got %d", len(rows))
+	}
+	return rows[0].Columns(), exportCSVIndexByHeader()
+}
+
 func TestExportServicePropagatesDependencyErrors(t *testing.T) {
 	dayErrService := NewExportService(
 		&stubExportDayReader{err: errors.New("load failed")},

--- a/internal/services/login_service_test.go
+++ b/internal/services/login_service_test.go
@@ -170,6 +170,47 @@ func TestLoginServiceAuthenticateRateLimitsByIdentityAcrossIPs(t *testing.T) {
 	}
 }
 
+// TestLoginServiceAuthenticateClearsTheIdentityCounterOnASuccessfulSignIn pins
+// the counter reset that follows a correct password. Every rate-limit test
+// drives failures only and asserts the lock, so deleting the Reset call left
+// them all green — and an owner who mistypes on Monday, signs in, and mistypes
+// again on Tuesday would be locked out of their own instance by attempts that
+// were already answered correctly.
+func TestLoginServiceAuthenticateClearsTheIdentityCounterOnASuccessfulSignIn(t *testing.T) {
+	auth := &stubLoginAuthService{user: models.User{ID: 31}, err: ErrAuthInvalidCreds}
+	service := NewLoginService(auth, &stubLoginResetTokenIssuer{}, NewAttemptLimiter())
+	service.ConfigureAttemptLimits(2, time.Hour)
+
+	secret := []byte("secret")
+	const clientKey = "10.0.0.1"
+	const email = "owner@example.com"
+
+	if _, err := service.Authenticate(context.Background(), secret, clientKey, email, "wrong", loginServiceTestTTL, loginServiceTestNow); !errors.Is(err, ErrAuthInvalidCreds) {
+		t.Fatalf("expected invalid credentials on the first attempt, got %v", err)
+	}
+
+	auth.err = nil
+	if _, err := service.Authenticate(context.Background(), secret, clientKey, email, "StrongPass1", loginServiceTestTTL, loginServiceTestNow.Add(time.Minute)); err != nil {
+		t.Fatalf("Authenticate() with the correct password: unexpected error: %v", err)
+	}
+
+	// One more failure. With the counter cleared this is the FIRST recent
+	// failure and the next attempt still reaches the credential check; without
+	// the reset it is the second and the identity is locked.
+	auth.err = ErrAuthInvalidCreds
+	if _, err := service.Authenticate(context.Background(), secret, clientKey, email, "wrong", loginServiceTestTTL, loginServiceTestNow.Add(2*time.Minute)); !errors.Is(err, ErrAuthInvalidCreds) {
+		t.Fatalf("expected invalid credentials after the successful sign-in, got %v", err)
+	}
+
+	callsBefore := auth.calls
+	if _, err := service.Authenticate(context.Background(), secret, clientKey, email, "wrong", loginServiceTestTTL, loginServiceTestNow.Add(3*time.Minute)); !errors.Is(err, ErrAuthInvalidCreds) {
+		t.Fatalf("expected the successful sign-in to have cleared the earlier failure, got %v", err)
+	}
+	if auth.calls != callsBefore+1 {
+		t.Fatalf("expected the credential check to run again after the reset, got %d calls", auth.calls-callsBefore)
+	}
+}
+
 func TestLoginServiceAuthenticateMapsResetTokenIssueError(t *testing.T) {
 	auth := &stubLoginAuthService{user: models.User{ID: 12, MustChangePassword: true}}
 	reset := &stubLoginResetTokenIssuer{err: errors.New("sign failed")}

--- a/internal/services/onboarding_access_policy_test.go
+++ b/internal/services/onboarding_access_policy_test.go
@@ -26,6 +26,15 @@ func TestIsOnboardingPath(t *testing.T) {
 		//     unnormalized value and no other route matches it, but it is the
 		//     one row here that fails OPEN. If path cleaning is ever introduced
 		//     upstream, this row is the decision to revisit.
+		//
+		// That last row is half an argument: it pins what this string function
+		// answers, and the safety rests on what the ROUTER does with the same
+		// string — which lives outside this repository and cannot be seen from
+		// here. The other half is
+		// TestRouterDoesNotNormalizeATraversalSegmentIntoAGatedRoute
+		// (internal/api), which fails the release the assumption stops holding.
+		// Change either row without the other and the pair stops meaning
+		// anything.
 		{name: "bare collection path", path: "/api/v1/onboarding", want: false},
 		{name: "upper cased prefix", path: "/API/v1/onboarding/steps/1", want: false},
 		{name: "traversal segment under the prefix", path: "/api/v1/onboarding/../days/2026-03-01", want: true},

--- a/internal/services/onboarding_access_policy_test.go
+++ b/internal/services/onboarding_access_policy_test.go
@@ -15,6 +15,20 @@ func TestIsOnboardingPath(t *testing.T) {
 		{name: "trimmed onboarding path", path: " /api/v1/onboarding/steps/2 ", want: true},
 		{name: "non onboarding path", path: "/dashboard", want: false},
 		{name: "similar prefix only", path: "/onboardingx", want: false},
+		// Adversarial rows. The prefix is matched on the exact string the
+		// router matches, so each of these decides an access gate:
+		//   - the bare collection path has no trailing slash and is not the
+		//     page path, so it is NOT an onboarding path and stays gated;
+		//   - the match is case-sensitive, so an upper-cased variant stays
+		//     gated too — the fail-closed direction in both cases;
+		//   - a traversal segment still reads as the onboarding prefix. It is
+		//     not an access bypass, because Fiber routes on this same
+		//     unnormalized value and no other route matches it, but it is the
+		//     one row here that fails OPEN. If path cleaning is ever introduced
+		//     upstream, this row is the decision to revisit.
+		{name: "bare collection path", path: "/api/v1/onboarding", want: false},
+		{name: "upper cased prefix", path: "/API/v1/onboarding/steps/1", want: false},
+		{name: "traversal segment under the prefix", path: "/api/v1/onboarding/../days/2026-03-01", want: true},
 	}
 
 	for _, testCase := range tests {
@@ -42,6 +56,12 @@ func TestShouldEnforceOnboardingAccess(t *testing.T) {
 		{name: "onboarding page bypasses onboarding gate", path: "/onboarding", want: false},
 		{name: "onboarding step bypasses onboarding gate", path: "/api/v1/onboarding/steps/1", want: false},
 		{name: "logout api bypasses onboarding gate", path: "/api/v1/sessions/current", want: false},
+		// The same adversarial set, read as the gate decision it drives: the
+		// two fail-closed rows must still be gated, and the traversal row is
+		// the one that is not.
+		{name: "bare collection path requires onboarding gate", path: "/api/v1/onboarding", want: true},
+		{name: "upper cased prefix requires onboarding gate", path: "/API/v1/onboarding/steps/1", want: true},
+		{name: "traversal segment bypasses onboarding gate", path: "/api/v1/onboarding/../days/2026-03-01", want: false},
 	}
 
 	for _, testCase := range tests {

--- a/internal/services/password_reset_service_test.go
+++ b/internal/services/password_reset_service_test.go
@@ -111,6 +111,75 @@ func TestPasswordResetServiceStartRecoveryWrongPasswordAddsFailure(t *testing.T)
 	}
 }
 
+// TestPasswordResetServiceStartRecoveryAnswersAnUnknownAddressLikeAKnownOne
+// pins the enumeration-safe collapse on the branch a MALFORMED code never
+// reaches. Both negative cases in this file submit "invalid", which
+// ValidateRecoveryCodeFormat refuses before the lookup runs, so the not-found
+// mapping and the attempt it books were exercised by nothing: an unknown
+// address could start answering differently — or for free, outside the attempt
+// budget — and this file stayed green. The two calls below differ only in
+// whether the account exists, and everything observable about them must match.
+func TestPasswordResetServiceStartRecoveryAnswersAnUnknownAddressLikeAKnownOne(t *testing.T) {
+	recoveryCode, recoveryHash, err := GenerateRecoveryCodeHash()
+	if err != nil {
+		t.Fatalf("GenerateRecoveryCodeHash() unexpected error: %v", err)
+	}
+	passwordHash, err := bcrypt.GenerateFromPassword([]byte("StrongPass1"), bcrypt.DefaultCost)
+	if err != nil {
+		t.Fatalf("hash password: %v", err)
+	}
+
+	newService := func() *PasswordResetService {
+		repo := &stubAuthUserRepo{
+			findByEmailOptionalEmail: "owner@example.com",
+			findByEmailOptionalFound: true,
+			findByEmailOptionalUser: models.User{
+				ID:               77,
+				Email:            "owner@example.com",
+				PasswordHash:     string(passwordHash),
+				RecoveryCodeHash: recoveryHash,
+				LocalAuthEnabled: true,
+				Role:             models.RoleOwner,
+			},
+		}
+		service := NewPasswordResetService(NewAuthService(repo), NewAttemptLimiter())
+		service.ConfigureRecoveryAttemptLimits(1, DefaultRecoveryAttemptsWindow)
+		return service
+	}
+
+	secretKey := []byte("test-secret")
+	now := time.Date(2026, time.March, 1, 10, 0, 0, 0, time.UTC)
+	key := "127.0.0.1"
+
+	// A well-formed code the format check accepts, so both calls reach the
+	// lookup. The known address gets the wrong code; the unknown address gets
+	// the right one and does not exist.
+	unknownService := newService()
+	_, unknownErr := unknownService.StartRecovery(context.Background(), secretKey, key, "stranger@example.com", recoveryCode, "StrongPass1", now, 30*time.Minute)
+
+	knownService := newService()
+	_, knownErr := knownService.StartRecovery(context.Background(), secretKey, key, "owner@example.com", "OVUM-ABCD-2345-EFGH", "StrongPass1", now, 30*time.Minute)
+
+	if !errors.Is(unknownErr, ErrPasswordRecoveryCodeInvalid) {
+		t.Fatalf("an unknown address must answer with ErrPasswordRecoveryCodeInvalid, got %v", unknownErr)
+	}
+	if !errors.Is(knownErr, ErrPasswordRecoveryCodeInvalid) {
+		t.Fatalf("a known address with a wrong code must answer with ErrPasswordRecoveryCodeInvalid, got %v", knownErr)
+	}
+	if unknownErr != knownErr {
+		t.Fatalf("the two answers must be the same value, got %v and %v", unknownErr, knownErr)
+	}
+
+	// Both must also cost an attempt: an unmetered miss on a non-existent
+	// address is a free oracle even when the error text matches.
+	if !unknownService.recoveryPolicy.TooManyRecent(secretKey, key, "stranger@example.com", now) {
+		t.Fatal("expected the unknown-address attempt to be booked against the limiter")
+	}
+	if !knownService.recoveryPolicy.TooManyRecent(secretKey, key, "owner@example.com", now) {
+		t.Fatal("expected the wrong-code attempt to be booked against the limiter")
+	}
+}
+
 func TestPasswordResetServiceStartRecoveryRateLimitsByIdentityAcrossIPs(t *testing.T) {
 	repo := &stubAuthUserRepo{}
 	authService := NewAuthService(repo)

--- a/internal/services/pregnancy_pause_test.go
+++ b/internal/services/pregnancy_pause_test.go
@@ -81,6 +81,84 @@ func TestResolvePregnancyPauseUsesLatestPositive(t *testing.T) {
 	}
 }
 
+// TestResolvePregnancyPauseIsIndependentOfLogOrder pins that the two scans pick
+// the LATEST matching day rather than the last entry they happen to see. Every
+// other fixture in this file places the decisive event last, so replacing both
+// date comparisons with plain last-entry-wins assignments changed nothing —
+// while a repository that returns rows in a different order (or a caller that
+// appends a backdated entry) would silently unpause a pregnancy, or pause on a
+// stale positive test that a later cycle start has already lifted.
+func TestResolvePregnancyPauseIsIndependentOfLogOrder(t *testing.T) {
+	tests := []struct {
+		name      string
+		logs      []models.DailyLog
+		wantPause bool
+		wantDate  time.Time
+	}{
+		{
+			name: "latest positive with no cycle start after it",
+			logs: []models.DailyLog{
+				{Date: ppDay(2026, time.March, 1), IsPeriod: true, CycleStart: true},
+				{Date: ppDay(2026, time.March, 5), PregnancyTest: models.PregnancyTestPositive},
+				{Date: ppDay(2026, time.March, 20), PregnancyTest: models.PregnancyTestPositive},
+			},
+			wantPause: true,
+			wantDate:  ppDay(2026, time.March, 20),
+		},
+		{
+			name: "a later cycle start lifts the pause",
+			logs: []models.DailyLog{
+				// One cycle start on each side of the positive test, so an
+				// order-dependent scan can pick the earlier one and conclude
+				// the pause is still on.
+				{Date: ppDay(2026, time.March, 5), IsPeriod: true, CycleStart: true},
+				{Date: ppDay(2026, time.March, 10), PregnancyTest: models.PregnancyTestPositive},
+				{Date: ppDay(2026, time.April, 5), IsPeriod: true, CycleStart: true},
+			},
+			wantPause: false,
+		},
+	}
+
+	orders := []struct {
+		name    string
+		reorder func([]models.DailyLog) []models.DailyLog
+	}{
+		{name: "ascending", reorder: func(logs []models.DailyLog) []models.DailyLog { return logs }},
+		{name: "descending", reorder: reversedDailyLogs},
+		// A fixed rotation stands in for "shuffled": it is deterministic, so a
+		// failure here is reproducible, and it puts a middle entry last, which
+		// is what a last-entry-wins scan reads as the decision.
+		{name: "rotated", reorder: func(logs []models.DailyLog) []models.DailyLog {
+			return append(append([]models.DailyLog{}, logs[len(logs)-1]), logs[:len(logs)-1]...)
+		}},
+	}
+
+	for _, testCase := range tests {
+		for _, order := range orders {
+			t.Run(testCase.name+" "+order.name, func(t *testing.T) {
+				date, paused := ResolvePregnancyPause(order.reorder(append([]models.DailyLog{}, testCase.logs...)))
+				if paused != testCase.wantPause {
+					t.Fatalf("ResolvePregnancyPause() paused = %v, want %v", paused, testCase.wantPause)
+				}
+				if !testCase.wantPause {
+					return
+				}
+				if !date.Equal(testCase.wantDate) {
+					t.Fatalf("ResolvePregnancyPause() date = %s, want %s", date, testCase.wantDate)
+				}
+			})
+		}
+	}
+}
+
+func reversedDailyLogs(logs []models.DailyLog) []models.DailyLog {
+	reversed := make([]models.DailyLog, 0, len(logs))
+	for index := len(logs) - 1; index >= 0; index-- {
+		reversed = append(reversed, logs[index])
+	}
+	return reversed
+}
+
 func TestResolvePregnancyPauseIgnoresCycleStartWithoutPeriod(t *testing.T) {
 	positive := ppDay(2026, time.March, 10)
 	logs := []models.DailyLog{

--- a/internal/services/privacy_page_policy_test.go
+++ b/internal/services/privacy_page_policy_test.go
@@ -49,6 +49,50 @@ func TestBuildPrivacyBackNavigationUsesCalendarBackLabelWhenRequested(t *testing
 	}
 }
 
+// TestBuildPrivacyBackNavigationLabelsEveryBackDestination table-drives the
+// breadcrumb label over all six arms of the mapping. Three of them — insights,
+// settings, and the generic "/" arm that splits on the session — were reached
+// by no test, so they could be deleted or reordered and the page would send an
+// owner back to their insights under a "Home" breadcrumb. The generic arm is
+// driven from both sides of isAuthenticated, since that is the only thing that
+// distinguishes its two answers.
+func TestBuildPrivacyBackNavigationLabelsEveryBackDestination(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		back            string
+		isAuthenticated bool
+		wantPath        string
+		wantLabelKey    string
+	}{
+		{name: "calendar", back: "/calendar", isAuthenticated: true, wantPath: "/calendar", wantLabelKey: "nav.calendar"},
+		{name: "stats", back: "/stats", isAuthenticated: true, wantPath: "/stats", wantLabelKey: "nav.insights"},
+		{name: "settings", back: "/settings", isAuthenticated: true, wantPath: "/settings", wantLabelKey: "nav.settings"},
+		{name: "dashboard", back: "/dashboard", isAuthenticated: true, wantPath: "/dashboard", wantLabelKey: "nav.dashboard"},
+		{name: "login", back: "/login", isAuthenticated: false, wantPath: "/login", wantLabelKey: "common.home"},
+		{name: "register", back: "/register", isAuthenticated: false, wantPath: "/register", wantLabelKey: "common.home"},
+		// Any other local path falls to the generic arm, which answers by
+		// session state rather than by destination.
+		{name: "other local path signed in", back: "/help", isAuthenticated: true, wantPath: "/help", wantLabelKey: "nav.dashboard"},
+		{name: "other local path signed out", back: "/help", isAuthenticated: false, wantPath: "/help", wantLabelKey: "common.home"},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			navigation := BuildPrivacyBackNavigation(testCase.back, testCase.isAuthenticated)
+			if navigation.BackPath != testCase.wantPath {
+				t.Fatalf("BuildPrivacyBackNavigation(%q, %v).BackPath = %q, want %q", testCase.back, testCase.isAuthenticated, navigation.BackPath, testCase.wantPath)
+			}
+			if navigation.BreadcrumbBackLabelKey != testCase.wantLabelKey {
+				t.Fatalf("BuildPrivacyBackNavigation(%q, %v).BreadcrumbBackLabelKey = %q, want %q", testCase.back, testCase.isAuthenticated, navigation.BreadcrumbBackLabelKey, testCase.wantLabelKey)
+			}
+		})
+	}
+}
+
 // TestBuildPrivacyBackNavigationFiltersTheQueryOfTheBackPath pins the second
 // surface that echoes a caller-supplied query into the markup: the privacy
 // page's own back link. SanitizeRedirectPath accepts any local path, so without


### PR DESCRIPTION

Board group **T0492**, 14 records, all inside `internal/services`. Tests only — no
production file is changed by this branch.

Every guard was written first and then proven to bite: the mutant each record names
was applied to the production file, the **red was INDUCED and observed**, the mutant
was reverted, and the guard is green again on the unmutated tree. Each mutant gutted
the body of the check it targets — never the call site — so a guard that recomputes
its expectation from the code under test could not pass by accident.

Validation: `go build ./...`, `go test ./internal/services/` (120 s, ok),
`go test ./internal/i18n/...`, `golangci-lint run` (0 issues),
`go run ./scripts/changelogd check` (OK). `./internal/api/...` was not run: this
branch edits `_test.go` files in one package and changes no production code, so no
API behaviour is reachable from it. The Postgres-backed cases in
`day_service_integration_test.go` skip here (no Docker); the case added there is a
pure unit test that ran.

## Per record

**R2-0492 — day-input sentinels.** Added a table feeding one invalid value per
tracked field and asserting `errors.Is` on that field's own sentinel
(`day_input_test.go`). INDUCED red 1: `IsValidDaySexActivity` gutted to `return
true` → `…/sex_activity: NormalizeDayEntryInput() = <nil>, want invalid day sex
activity`. INDUCED red 2: `IsValidDayBBT`'s range comparison and
`IsValidDayCervicalMucus`'s switch gutted → the `bbt` and `cervical_mucus` rows fail
with their own sentinels. Mutants reverted; green.

**R2-0493 — day-log stub canonicalization.** Both stubs now share one package-level
mirror of `models.DailyLog.BeforeSave` (`canonicalStoredDayDate`,
`day_service_workflow_test.go:45`); `mr3canonicalDate` is gone and the round-3 stub
calls the shared helper. Added the workflow case that saves and re-reads one day
from a zone east of UTC. **The fidelity change itself has no inducible red**, and it
is reported that way: gutting `canonicalStoredDayDate` to return its argument leaves
the new test green, because `UpsertDayEntryWithAutoFillAt` writes `DayRange(day,
location)` — already UTC-midnight — so the stub never receives a value it could
store differently. The new test is a guard on the production anchoring instead:
INDUCED red with `DayRange` no longer re-anchoring to UTC-midnight →
`expected the stored day to be anchored at 2026-03-10 00:00:00 +0000 UTC, got
2026-03-09 00:00:00 +0000 UTC`. Mutant reverted; green.

**R2-0497 — notes truncation vacuity: ALREADY FIXED, no change.** The record's
subject (a byte-measured rewind with `end--`) no longer exists: `TrimDayNotes` counts
characters and its table asserts an exact rune count plus `strings.HasPrefix`.
Verified rather than assumed — the equivalent mutant (cut at `value[:0]`) reddens
three tests: `TestTrimDayNotes` (all three over-limit rows),
`TestNormalizeDayEntryInputTrimsNotes`, `TestTrimDayNotesCapsCraftedInvalidUTF8`.

**R2-0498 — `MaxDayNotesLength` exact value.** Added
`TestMaxDayNotesLengthIsAnExactValue`. INDUCED red: `const MaxDayNotesLength = 2000 /
2` → `MaxDayNotesLength = 1000, want 2000`. Reverted; green. Reported honestly:
that lone mutant is *also* caught today by the template cross-check
(`maxlength=2000` vs the constant), which landed after the audit snapshot. What the
new pin adds is the case that check cannot see — both sides moving together, since
agreement is all it asserts.

**R2-0509 — `DayHasData` branches.** Added the three missing `want=true` rows (sex
activity, BBT, cervical mucus) plus an out-of-range-BBT `want=false` row. INDUCED red
1: the three branches deleted together → all three rows fail. INDUCED red 2: `entry.BBT
!= nil && IsValidDayBBT(entry.BBT)` reduced to `entry.BBT != nil` →
`out_of_range_bbt_is_not_data: DayHasData() = true, want false`. Reverted; green.

**R2-0515 — export range.** Added the equal-bounds case and both half-open pointer
cases. INDUCED red 1: `to.Before(*from)` → `!to.After(*from)` →
`single_day_range: expected a single-day range to be accepted, got export invalid
range`. INDUCED red 2: the `from != nil` operand dropped from the guard →
`open_ended_to` panics on the nil dereference, which is the "a missing operand
disables the check" shape. Reverted; green.

**R2-0517 — login attempt reset.** Added a test that fails, signs in successfully,
fails again, and requires the next attempt to still reach the credential check.
INDUCED red: `service.attemptPolicy.Reset(...)` (login_service.go:69) deleted →
`expected the successful sign-in to have cleared the earlier failure, got auth login
rate limited`. Reverted; green.

**R2-0527 — recovery enumeration answer: PARTLY ALREADY CLOSED.** The record says no
test reaches the not-found mapping; on this tree
`TestPasswordResetServiceStartRecoveryWrongPasswordAddsFailure` does (it submits a
well-formed code), so gutting the mapping reddens it. What nothing asserted is the
*equality* of the two answers, which is the enumeration invariant. Added a test
driving an unknown address and a known one with well-formed codes, asserting the same
error value and that both cost an attempt. INDUCED red: the unknown-account arm of
`FindUserByEmailRecoveryCodeAndPassword` returning its own error instead of
`ErrRecoveryCodeNotFound` → `an unknown address must answer with
ErrPasswordRecoveryCodeInvalid, got recovery: no account for that address`.
Reverted; green.

**R2-0533 — onboarding path policy.** Added the bare collection path, an upper-cased
prefix and a traversal segment to both tables. INDUCED red: the prefix match widened
to `strings.HasPrefix(strings.ToLower(cleanPath), "/api/v1/onboarding")` → four
rows fail across both tables. Reverted; green. **Noted in the test, not silently
pinned:** the traversal row is the one that fails *open* —
`/api/v1/onboarding/../days/2026-03-01` reads as an onboarding path and skips the
gate. It is not a bypass today, because Fiber routes on the same unnormalized string
and no other route matches it, but the row records the decision to revisit if path
cleaning is ever introduced upstream.

**R2-0534 — privacy back label.** Table-drove all six arms. INDUCED red 1: the
`nav.insights` and `nav.settings` arms deleted → both rows report `nav.dashboard`.
INDUCED red 2: the generic `/` arm collapsed to `common.home` →
`other_local_path_signed_in` fails. Reverted; green.

**R2-0935 — mood upper bound.** Added the `MaxDayMood+1` rejection beside the
existing anchors. INDUCED red: `value <= MaxDayMood` removed from `IsValidDayMood` →
`expected ErrInvalidDayMood for mood 6, got <nil>`. Reverted; green.

**R2-0936 — BBT lower bound.** Added a below-minimum rejection set and a
below-minimum *stored* value to the preserved-BBT merge case, with an in-range
positive control. INDUCED red: `*value >= MinDayBBTCelsius` removed → both
`TestIsValidDayBBTRejectsOutsideThePhysiologicalRange` and
`TestMergePreservedDayEntryInputDropsOutOfRangeExistingBBT` fail. Reverted; green.
The raw-SQL read-path twin (`TestDayServiceFetchLogByDateNilsOutOfRangeStoredBBT`)
was left alone: it needs Postgres, which is not started here, so a second value there
would have been unverifiable.

**R2-0943 — CSV formula prefixes.** Table-drove all seven dangerous prefixes, bare
and space-padded, through the finished Notes column, plus the four printable ones
through the Other-symptoms column, with an ordinary note as the positive control.
INDUCED red 1: the switch reduced to `case '=', '@'` → ten subtests fail naming
`'+'`, `'-'`, tab, CR and LF. INDUCED red 2: `strings.TrimLeft(value, " ")` given an
empty cutset → every space-padded row fails. Reverted; green. One measured limit is
written into the test: a symptom *name* passes through `TrimSpace`
(`export_service.go:408`), so it can only ever carry a printable prefix — asserting
the control characters on that column would have asserted the trim, not the policy.

**R2-0950 — pregnancy pause order independence.** Added one paused and one lifted
fixture, each resolved ascending, descending and rotated, with a cycle start on both
sides of the positive test. INDUCED red: both latest-date comparisons replaced by
last-entry-wins assignments → four subtests fail (wrong pause date in one fixture,
`paused = true, want false` in the other). Reverted; green. `stats_service.go` and
`day_feedback_policy.go` are pure consumers of `ResolvePregnancyPause`, so the guard
sits at the single source.

## Not done

- No production file is modified, and no strengthened test revealed a production
  defect. The one behaviour worth a second opinion is the traversal row in R2-0533,
  described above.
- R2-0493's stub-fidelity half ships without a red of its own (`none-practical` at
  this scope) for the reason given above.
- `gofmt -l internal/services/` reports `day_service.go`, `settings_view_service.go`
  and `webhook_reminder.go` — pre-existing on `main`, untouched here.
