### PR TITLE
test(apideps): bind every Dependencies field to its own requirement

### DIFF
--- a/changelog.d/test-t0690-apideps-requirements-completeness.md
+++ b/changelog.d/test-t0690-apideps-requirements-completeness.md
@@ -1,0 +1,25 @@
+none
+
+Test-only. A dependency of the HTTP layer is declared in three places — the
+`apideps.Dependencies` field, the `requirements()` row whose absence makes
+startup fail fast, and the bootstrap assignment that wires it — and only the
+middle one is a check. Nothing bound the three together: the existing test
+validates the zero value, and `Validate` reports the FIRST missing requirement
+and returns, so it stayed green no matter how many rows `requirements()` had
+dropped. A field added to the struct and forgotten in the inventory lost its
+fail-fast silently, turning a clear startup error into a nil dereference on the
+first request that reached the service.
+
+The new sweep binds rows to fields behaviourally, in both directions: every
+dependency field, nilled alone inside an otherwise fully wired `Dependencies`,
+must make `Validate` report an error, and the errors so produced are all
+distinct while `requirements()` lists exactly as many rows as there are
+dependency fields — so rows and fields are in bijection, and a stale or
+duplicated row is a count mismatch rather than dead weight. Exemptions are an
+explicit list carrying the reason each field cannot be a requirement
+(`AuditLogEnabled` is runtime config, where `false` is a legitimate value); a
+field the sweep cannot wire fails it instead of being skipped, and an exemption
+naming a field the struct no longer declares fails too. Production behaviour is
+unchanged — the 24 fields and the 24 rows already agreed, by hand, and no tag or
+naming convention had to be added to `requirements()` to make the binding
+checkable.

--- a/internal/apideps/dependencies_completeness_test.go
+++ b/internal/apideps/dependencies_completeness_test.go
@@ -2,6 +2,7 @@ package apideps
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -26,6 +27,14 @@ import (
 //     so rows and fields are in bijection. A row answering for two fields shows
 //     up as a repeated message, a duplicated or otherwise stale row as a count
 //     mismatch, and an empty sweep as a count mismatch too.
+//
+// Residual, stated rather than asserted: this proves one row per field, not
+// that a row carries its own field's name. Two rows whose messages are mutually
+// swapped stay distinct and keep the count, so they pass — the startup error
+// would then name the wrong service. Pinning message to field would need a
+// per-row override table (three rows do not name their field verbatim), and the
+// drift that actually happens — a message copy-pasted onto a second row — is a
+// repeat, which is caught.
 
 // exemptDependencyFields names the Dependencies fields Validate deliberately
 // does not check, each with the reason it cannot be a requirement. A field that
@@ -61,20 +70,34 @@ func interfacePortStubs() map[reflect.Type]reflect.Value {
 }
 
 // dependencyFiller returns a non-nil stand-in for a dependency field of the
-// given type, or the reason it cannot build one. Pointer fields are allocated
-// outright, so a new *services.X dependency needs no entry anywhere. Refusing
-// is a failure of the sweep, never a skip — a field the sweep cannot wire is
-// exactly the field whose validation nobody would notice missing.
+// given type, or the reason it cannot build one. Pointer, map and slice fields
+// are allocated outright, so a new *services.X dependency needs no entry
+// anywhere. Refusing is a failure of the sweep, never a skip — a field the
+// sweep cannot wire is exactly the field whose validation nobody would notice
+// missing.
+//
+// The kinds handled here are the ones missing() nil-checks, and the two
+// refusals say which side the maintainer has to act on. A kind missing() DOES
+// nil-check is a requirement whatever the sweep can build, so its refusal asks
+// for a stand-in and never for an exemption: exempting such a field would drop
+// a validated dependency out of the sweep, which is the failure this guard
+// exists to prevent.
 func dependencyFiller(fieldType reflect.Type) (reflect.Value, string) {
 	switch fieldType.Kind() {
 	case reflect.Pointer:
 		return reflect.New(fieldType.Elem()), ""
+	case reflect.Map:
+		return reflect.MakeMap(fieldType), ""
+	case reflect.Slice:
+		return reflect.MakeSlice(fieldType, 0, 0), ""
 	case reflect.Interface:
 		stub, known := interfacePortStubs()[fieldType]
 		if !known {
 			return reflect.Value{}, "it is an interface port with no stand-in; add one to interfacePortStubs so the field stays swept"
 		}
 		return stub, ""
+	case reflect.Chan, reflect.Func:
+		return reflect.Value{}, "Validate DOES nil-check this kind, so the field is a requirement and must not be exempted; teach dependencyFiller to build a non-nil stand-in for it instead"
 	default:
 		return reflect.Value{}, "Validate detects a missing dependency by its nil, and a value of this kind is never nil; validate it another way or record it in exemptDependencyFields with the reason"
 	}
@@ -145,7 +168,7 @@ func TestEveryDependencyFieldHasItsOwnRequirement(t *testing.T) {
 // that silently exempts nothing, and the next field to take that name would
 // inherit the exemption without anyone deciding it should.
 func TestDependencyExemptionsNameLiveFields(t *testing.T) {
-	dependencyType := reflect.TypeOf(Dependencies{})
+	dependencyType := reflect.TypeFor[Dependencies]()
 	for name, reason := range exemptDependencyFields {
 		if _, live := dependencyType.FieldByName(name); !live {
 			t.Errorf("exemptDependencyFields names %q, which Dependencies no longer declares; drop the entry rather than leaving it to exempt a future field of that name", name)
@@ -157,11 +180,17 @@ func TestDependencyExemptionsNameLiveFields(t *testing.T) {
 }
 
 // TestDependencyFillerRefusesAFieldItCannotWire anchors the sweep on fixtures
-// it owns, in both directions: the two shapes a dependency can take must be
-// wired to a non-nil value, and the two shapes the guard cannot honestly wire
-// must be refused rather than passed over. Without this, a filler that returned
-// "no problem" for everything would leave the sweep nilling fields that were
-// never wired in the first place.
+// it owns, in both directions: the shapes a dependency can take must be wired
+// to a non-nil value, and the shapes the guard cannot honestly wire must be
+// refused rather than passed over. Without this, a filler that returned "no
+// problem" for everything would leave the sweep nilling fields that were never
+// wired in the first place.
+//
+// Each case also carries a check derived from missing() itself rather than from
+// the table, so the filler cannot drift away from what Validate actually does:
+// a kind whose zero value missing() reports as absent IS a requirement, so
+// refusing it may only ask for a stand-in — pointing such a field at
+// exemptDependencyFields would drop a validated dependency out of the sweep.
 func TestDependencyFillerRefusesAFieldItCannotWire(t *testing.T) {
 	cases := []struct {
 		name        string
@@ -170,20 +199,32 @@ func TestDependencyFillerRefusesAFieldItCannotWire(t *testing.T) {
 	}{
 		{"service pointer", reflect.TypeFor[*Dependencies](), false},
 		{"known interface port", reflect.TypeFor[RegisterPickupTokenStore](), false},
+		{"slice field", reflect.TypeFor[[]string](), false},
+		{"map field", reflect.TypeFor[map[string]string](), false},
 		{"unknown interface port", reflect.TypeFor[interface{ Unwired() }](), true},
+		{"channel field", reflect.TypeFor[chan struct{}](), true},
+		{"func field", reflect.TypeFor[func()](), true},
 		{"non-nilable field", reflect.TypeFor[string](), true},
 	}
 	for _, testCase := range cases {
 		t.Run(testCase.name, func(t *testing.T) {
+			zeroIsMissing := (dependencyRequirement{value: reflect.Zero(testCase.fieldType).Interface()}).missing()
+
 			filler, refusal := dependencyFiller(testCase.fieldType)
 			if testCase.wantRefusal {
 				if refusal == "" {
 					t.Fatalf("dependencyFiller(%s) wired the field instead of refusing it", testCase.fieldType)
 				}
+				if zeroIsMissing && strings.Contains(refusal, "exemptDependencyFields") {
+					t.Fatalf("dependencyFiller(%s) refuses a kind Validate DOES nil-check by offering an exemption: %s — exempting it would drop a validated dependency out of the sweep; the refusal has to ask for a stand-in", testCase.fieldType, refusal)
+				}
 				return
 			}
 			if refusal != "" {
 				t.Fatalf("dependencyFiller(%s) refused a field it can wire: %s", testCase.fieldType, refusal)
+			}
+			if !zeroIsMissing {
+				t.Fatalf("dependencyFiller(%s) wired a kind whose zero value Validate already accepts; nilling such a field proves nothing, so it must be refused instead", testCase.fieldType)
 			}
 			if (dependencyRequirement{value: filler.Interface()}).missing() {
 				t.Fatalf("dependencyFiller(%s) returned a value Validate still reads as missing", testCase.fieldType)

--- a/internal/apideps/dependencies_completeness_test.go
+++ b/internal/apideps/dependencies_completeness_test.go
@@ -1,0 +1,193 @@
+package apideps
+
+import (
+	"reflect"
+	"testing"
+)
+
+// A dependency lives in three places — the Dependencies field, the
+// requirements() row that makes its absence fail fast, and the bootstrap
+// assignment that wires it — and only the middle one is a check. Nothing bound
+// the three together: TestDependenciesValidateReportsMissing passes on the zero
+// value even if requirements() returned a single row, because Validate reports
+// the FIRST missing requirement and then returns. A field added to the struct
+// and forgotten in requirements() therefore loses its fail-fast silently; if it
+// is later also dropped from the wiring, the binary boots green and nil-panics
+// on the first request that reaches that service.
+//
+// The sweep below binds rows to fields behaviourally, in both directions, so
+// requirements() needs no tags or naming convention to be checkable:
+//
+//   - field -> row: every dependency field, nilled alone inside an otherwise
+//     fully wired Dependencies, must make Validate report an error. Only a row
+//     that reads THAT field can produce one.
+//   - row -> field: the errors those fields produce are all distinct, and
+//     requirements() lists exactly as many rows as there are dependency fields,
+//     so rows and fields are in bijection. A row answering for two fields shows
+//     up as a repeated message, a duplicated or otherwise stale row as a count
+//     mismatch, and an empty sweep as a count mismatch too.
+
+// exemptDependencyFields names the Dependencies fields Validate deliberately
+// does not check, each with the reason it cannot be a requirement. A field that
+// is not named here has to be validated: the sweep fails on an unknown field
+// rather than skipping it, which makes this list a decision record rather than
+// a way to silence the guard.
+var exemptDependencyFields = map[string]string{
+	"AuditLogEnabled": "runtime config (AUDIT_LOG_ENABLED), not a service: false is the default and a legitimate value, so no state of it means missing",
+}
+
+// The interface-typed ports cannot be allocated by reflection the way a
+// *services.X field can, so the sweep needs one concrete stand-in each. A
+// struct embedding the port satisfies it without restating its methods; the
+// sweep only ever needs the field to be non-nil and never calls into it.
+type stubRegistrationWorkflowService struct{ RegistrationWorkflowService }
+
+type stubLoginWorkflowService struct{ LoginWorkflowService }
+
+type stubOIDCWorkflowService struct{ OIDCWorkflowService }
+
+type stubRegisterPickupTokenStore struct{ RegisterPickupTokenStore }
+
+// interfacePortStubs maps each interface-typed dependency to its stand-in. It
+// is a lookup, not an escape hatch: a port added without an entry fails the
+// sweep instead of dropping out of it.
+func interfacePortStubs() map[reflect.Type]reflect.Value {
+	return map[reflect.Type]reflect.Value{
+		reflect.TypeFor[RegistrationWorkflowService](): reflect.ValueOf(stubRegistrationWorkflowService{}),
+		reflect.TypeFor[LoginWorkflowService]():        reflect.ValueOf(stubLoginWorkflowService{}),
+		reflect.TypeFor[OIDCWorkflowService]():         reflect.ValueOf(stubOIDCWorkflowService{}),
+		reflect.TypeFor[RegisterPickupTokenStore]():    reflect.ValueOf(stubRegisterPickupTokenStore{}),
+	}
+}
+
+// dependencyFiller returns a non-nil stand-in for a dependency field of the
+// given type, or the reason it cannot build one. Pointer fields are allocated
+// outright, so a new *services.X dependency needs no entry anywhere. Refusing
+// is a failure of the sweep, never a skip — a field the sweep cannot wire is
+// exactly the field whose validation nobody would notice missing.
+func dependencyFiller(fieldType reflect.Type) (reflect.Value, string) {
+	switch fieldType.Kind() {
+	case reflect.Pointer:
+		return reflect.New(fieldType.Elem()), ""
+	case reflect.Interface:
+		stub, known := interfacePortStubs()[fieldType]
+		if !known {
+			return reflect.Value{}, "it is an interface port with no stand-in; add one to interfacePortStubs so the field stays swept"
+		}
+		return stub, ""
+	default:
+		return reflect.Value{}, "Validate detects a missing dependency by its nil, and a value of this kind is never nil; validate it another way or record it in exemptDependencyFields with the reason"
+	}
+}
+
+// fullyWiredDependencies builds a Dependencies with every non-exempt field set
+// to a non-nil stand-in — the state a correct bootstrap hands the handler.
+func fullyWiredDependencies(t *testing.T) Dependencies {
+	t.Helper()
+
+	dependencies := Dependencies{}
+	value := reflect.ValueOf(&dependencies).Elem()
+	for index := range value.NumField() {
+		field := value.Type().Field(index)
+		if _, exempt := exemptDependencyFields[field.Name]; exempt {
+			continue
+		}
+		filler, refusal := dependencyFiller(field.Type)
+		if refusal != "" {
+			t.Fatalf("Dependencies.%s (%s) cannot be wired by this guard: %s", field.Name, field.Type, refusal)
+		}
+		value.Field(index).Set(filler)
+	}
+	return dependencies
+}
+
+// TestEveryDependencyFieldHasItsOwnRequirement is the completeness guard: one
+// requirements() row per dependency field, each reading its own field and
+// reporting its own message.
+func TestEveryDependencyFieldHasItsOwnRequirement(t *testing.T) {
+	wired := fullyWiredDependencies(t)
+	if err := wired.Validate(); err != nil {
+		t.Fatalf("a fully wired Dependencies must validate, got %v; every case below reads the error left after nilling one field, so it means nothing unless the wired baseline is clean", err)
+	}
+
+	value := reflect.ValueOf(&wired).Elem()
+	reporter := map[string]string{}
+	dependencyFields := 0
+	for index := range value.NumField() {
+		field := value.Type().Field(index)
+		if _, exempt := exemptDependencyFields[field.Name]; exempt {
+			continue
+		}
+		dependencyFields++
+
+		probe := wired
+		reflect.ValueOf(&probe).Elem().Field(index).Set(reflect.Zero(field.Type))
+
+		err := probe.Validate()
+		if err == nil {
+			t.Errorf("Dependencies.%s is nil and Validate accepted it: requirements() has no row reading that field, so a build that forgets to wire it starts anyway and nil-panics on the first request reaching it", field.Name)
+			continue
+		}
+		if owner, repeated := reporter[err.Error()]; repeated {
+			t.Errorf("Dependencies.%s and Dependencies.%s both report %q: one requirements() row is answering for two fields, so the startup error cannot name the culprit", field.Name, owner, err.Error())
+			continue
+		}
+		reporter[err.Error()] = field.Name
+	}
+
+	if rows := len(wired.requirements()); rows != dependencyFields {
+		t.Errorf("requirements() lists %d row(s) against %d dependency field(s): with every field proven to have a row of its own, a surplus row is a stale or duplicated one and a shortfall means the sweep saw no fields at all", rows, dependencyFields)
+	}
+}
+
+// TestDependencyExemptionsNameLiveFields keeps the exemption list from
+// outliving what it exempts: a renamed or removed field would leave an entry
+// that silently exempts nothing, and the next field to take that name would
+// inherit the exemption without anyone deciding it should.
+func TestDependencyExemptionsNameLiveFields(t *testing.T) {
+	dependencyType := reflect.TypeOf(Dependencies{})
+	for name, reason := range exemptDependencyFields {
+		if _, live := dependencyType.FieldByName(name); !live {
+			t.Errorf("exemptDependencyFields names %q, which Dependencies no longer declares; drop the entry rather than leaving it to exempt a future field of that name", name)
+		}
+		if reason == "" {
+			t.Errorf("exemptDependencyFields exempts %q with no reason", name)
+		}
+	}
+}
+
+// TestDependencyFillerRefusesAFieldItCannotWire anchors the sweep on fixtures
+// it owns, in both directions: the two shapes a dependency can take must be
+// wired to a non-nil value, and the two shapes the guard cannot honestly wire
+// must be refused rather than passed over. Without this, a filler that returned
+// "no problem" for everything would leave the sweep nilling fields that were
+// never wired in the first place.
+func TestDependencyFillerRefusesAFieldItCannotWire(t *testing.T) {
+	cases := []struct {
+		name        string
+		fieldType   reflect.Type
+		wantRefusal bool
+	}{
+		{"service pointer", reflect.TypeFor[*Dependencies](), false},
+		{"known interface port", reflect.TypeFor[RegisterPickupTokenStore](), false},
+		{"unknown interface port", reflect.TypeFor[interface{ Unwired() }](), true},
+		{"non-nilable field", reflect.TypeFor[string](), true},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			filler, refusal := dependencyFiller(testCase.fieldType)
+			if testCase.wantRefusal {
+				if refusal == "" {
+					t.Fatalf("dependencyFiller(%s) wired the field instead of refusing it", testCase.fieldType)
+				}
+				return
+			}
+			if refusal != "" {
+				t.Fatalf("dependencyFiller(%s) refused a field it can wire: %s", testCase.fieldType, refusal)
+			}
+			if (dependencyRequirement{value: filler.Interface()}).missing() {
+				t.Fatalf("dependencyFiller(%s) returned a value Validate still reads as missing", testCase.fieldType)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What this closes

Two records, one defect seen from two sides; one guard closes both.

**R2-0690** — `test-coverage-gap / internal/apideps/dependencies_test.go`. The direct test is
`if err := (Dependencies{}).Validate(); err == nil { t.Fatal(...) }`. `Validate` returns on the
FIRST missing requirement, so that test passes even if `requirements()` returned a single row.
24 service-typed fields on `Dependencies`, 24 rows in `requirements()` — they agree today by hand,
not by a guard. A service field added to the struct and forgotten in `requirements()` loses its
fail-fast; if it is later also dropped from `BuildDependencies`, the binary boots green and
nil-panics on the first request reaching that service.

**R2-0824** — `test-coverage-gap / internal/apideps/dependencies.go`. Same inventory repeated three
times (struct field, validation row, bootstrap assignment) with only the middle one enforced;
the only direct test proves the all-zero value reports *some* first error. A missing dependency can
survive startup and become a nil dereference or a 500 on the first affected request.

## The guard

`internal/apideps/dependencies_completeness_test.go` binds rows to fields **behaviourally**, per
field, in both directions, and needs no production change to do it:

- **field → row:** each dependency field, nilled *alone* inside an otherwise fully wired
  `Dependencies`, must make `Validate` report an error. Only a row that reads that field can
  produce one, so this is per-field by construction rather than by name matching.
- **row → field:** the errors those 24 fields produce are all distinct, and `requirements()` lists
  exactly as many rows as there are dependency fields. With every field proven to own a row, that
  makes rows and fields a bijection: a row answering for two fields shows up as a repeated message,
  a duplicated or otherwise stale row as a count mismatch, and an empty sweep as a count mismatch
  too. A count-only test would have gone green on a field added *and* a stale row left behind; this
  one cannot.
- **anti-vacuity anchors the test owns:** the fully wired baseline must validate cleanly before any
  case reads a nilled field's error, and `TestDependencyFillerRefusesAFieldItCannotWire` pins the
  filler on four fixtures — a service pointer and a known interface port must be wired to a value
  `missing()` reads as present, an unknown interface port and a non-nilable field must be refused.
- **exemptions are a documented allowlist, not a skip list:** `exemptDependencyFields` carries the
  reason each field cannot be a requirement (`AuditLogEnabled` is runtime config — `false` is the
  default and a legitimate value, so no state of it means missing). A field the sweep cannot
  honestly wire *fails* it and asks for a decision; an exemption naming a field the struct no longer
  declares fails too, so the list cannot outlive what it exempts.

**Does `dependencies.go` need a change so the reflection can bind entries to fields?** No — and
that was checked rather than assumed. Because the binding is behavioural (nil one field, read the
error), a row needs no tag, no field name and no naming convention to be attributable; the rows'
distinct messages plus the row count supply the reverse direction. `requirements()`, `Validate`,
`missing()` and `internal/bootstrap` are byte-identical to `main`.

## Red → green

The 24 rows and 24 fields agree today, so the guard is GREEN as written against the unfixed tree.
Every red below was **induced**: the edit was made, the failure captured, then reverted. Every
mutant was re-run against the FINAL guard rather than an earlier draft of it, so each transcript is
the tree this PR ships. None of the induced edits ships — `git diff main -- internal/apideps/dependencies.go` is empty.

**R2-0690 — a row dropped from `requirements()`** (deleted the `ViewerService` row):

```
--- FAIL: TestEveryDependencyFieldHasItsOwnRequirement (0.00s)
    dependencies_completeness_test.go:128: Dependencies.ViewerService is nil and Validate accepted it: requirements() has no row reading that field, so a build that forgets to wire it starts anyway and nil-panics on the first request reaching it
    dependencies_completeness_test.go:139: requirements() lists 23 row(s) against 24 dependency field(s): ...
```

`TestDependenciesValidateReportsMissing` — the pre-existing test both records name — stayed GREEN
through that same edit, which is the gap itself, observed.

**R2-0824 — a dependency field added to the struct with no row** (`InducedRedService
*services.StatsService`), the exact three-places-one-check scenario:

```
--- FAIL: TestEveryDependencyFieldHasItsOwnRequirement (0.00s)
    dependencies_completeness_test.go:128: Dependencies.InducedRedService is nil and Validate accepted it: requirements() has no row reading that field, ...
    dependencies_completeness_test.go:139: requirements() lists 24 row(s) against 25 dependency field(s): ...
```

One induced red per remaining assertion, each fed the input it names:

| assertion | induced edit | observed red |
| --- | --- | --- |
| a field the sweep cannot wire fails it | same probe field retyped `string` | `Dependencies.InducedRedService (string) cannot be wired by this guard: Validate detects a missing dependency by its nil, and a value of this kind is never nil; ...` |
| one row may not answer for two fields | `ViewerService`'s row given the `stats service is required` message | `Dependencies.StatsService and Dependencies.ViewerService both report "stats service is required": one requirements() row is answering for two fields, ...` |
| rows and fields are in bijection | a second, stale `ViewerService` row appended | `requirements() lists 25 row(s) against 24 dependency field(s): ...` |
| the wired baseline anchors the sweep | `missing()` body gutted to `return true` | `a fully wired Dependencies must validate, got auth service is required; every case below reads the error left after nilling one field, so it means nothing unless the wired baseline is clean` |
| an exemption must name a live field | `RenamedAwayService` added to the allowlist | `exemptDependencyFields names "RenamedAwayService", which Dependencies no longer declares; ...` |
| an exemption must carry its reason | `AuditLogEnabled`'s reason emptied | `exemptDependencyFields exempts "AuditLogEnabled" with no reason` |
| the filler refuses what it cannot wire | `dependencyFiller` gutted to `return reflect.New(fieldType).Elem(), ""` | all four fixtures red: two `... wired the field instead of refusing it`, two `... returned a value Validate still reads as missing` |

Green after every revert: `go test ./internal/apideps/... -count=1` → `ok`, all five tests passing.

## Deliberately not fixed

- **The three-place repetition itself.** `Dependencies`, `requirements()` and the bootstrap wiring
  still list the same inventory by hand. Collapsing them into one generated source is a
  restructuring of the composition layer, well past what a coverage-gap guard should carry; the
  guard makes the divergence fail loudly instead, which is what the records asked for.
- **`internal/bootstrap`.** R2-0824 names `bootstrap.go:146-172` as part of the repetition, but the
  sweep needs nothing from it, so it is untouched. A field wired nowhere is now caught at startup by
  the requirement the guard forces to exist.
- **Message wording, and the residual that follows from it.** Three rows do not name their field
  verbatim (`OIDCLogoutStateSvc` → "oidc logout state service", `CalendarFeedSettings` → "…
  settings service", `RegisterPickupTokens` → "register pickup token store"), so asserting a
  field-name-to-message convention would need a per-row override table that rots. What the guard
  proves is therefore **one row per field, not that a row carries its own field's name**: two rows
  whose messages are mutually swapped stay distinct and keep the count, so they pass, and a startup
  failure would then name the wrong service. The drift that actually happens — a message
  copy-pasted onto a second row — leaves a repeat, which *is* caught. The residual is stated in the
  test's own header comment rather than left to be rediscovered.
- **A field-count floor.** A constant such as `wantDependencyFields = 24` would need editing on
  every legitimate addition. The row-count-against-field-count comparison already fails on an empty
  sweep, so the floor would buy nothing it does not already have.

## Review round (second commit)

Review found the filler contradicting the production predicate it exists to serve.
`dependencyFiller` refused every non-pointer, non-interface kind with the reason that such a value
"is never nil", and pointed the maintainer at `exemptDependencyFields`. But `missing()` nil-checks
**Chan, Func, Map, Pointer, Slice and Interface** — so a dependency added as a slice or a map was
refused by the sweep with a false explanation, and following that explanation would have exempted a
field `Validate` does check. That is precisely the silent loss of coverage this guard exists to
prevent, arriving through the guard's own error message.

Red, induced: a `InducedSliceHooks []string` field with a correct `requirements()` row.

```
--- FAIL: TestEveryDependencyFieldHasItsOwnRequirement (0.00s)
    dependencies_completeness_test.go:108: Dependencies.InducedSliceHooks ([]string) cannot be wired by this guard: Validate detects a missing dependency by its nil, and a value of this kind is never nil; validate it another way or record it in exemptDependencyFields with the reason
```

Fixed: maps and slices are allocated like pointers, so such a field is swept the moment it appears.
Channels and funcs keep a refusal — a stand-in for them is speculative machinery today — but the
refusal now says what it means: the field IS a requirement, teach the filler to build one rather
than exempt it. The induced field was reverted; `git diff main -- internal/apideps/dependencies.go
internal/bootstrap` is still empty.

Two fixtures now derive from `missing()` itself rather than from the case table, so the filler
cannot drift away from production again: no refusal for a nil-checked kind may mention
`exemptDependencyFields`, and no kind whose zero value `Validate` already accepts may be wired.
Red, induced, by restoring the old wording on the chan/func branch:

```
--- FAIL: TestDependencyFillerRefusesAFieldItCannotWire/channel_field
    dependencies_completeness_test.go:211: dependencyFiller(chan struct {}) refuses a kind Validate DOES nil-check by offering an exemption: ... — exempting it would drop a validated dependency out of the sweep; the refusal has to ask for a stand-in
--- FAIL: TestDependencyFillerRefusesAFieldItCannotWire/func_field
```

Also from the review: `reflect.TypeOf(Dependencies{})` became `reflect.TypeFor[Dependencies]()`, the
form the rest of the file uses; and the row→field residual above is now recorded in the test header.

## Rollback

Two-commit revert (or a single revert of the branch merge). Two new test commits and one changelog
fragment; no production code, no persisted data, no public contract.

## Verification run

First commit:

- `go build ./...` — OK
- `go vet ./internal/apideps/...` — OK
- `go test ./internal/apideps/... -count=1` — ok (5 tests)
- `go test ./internal/i18n/... -count=1` — ok
- `golangci-lint run` — 0 issues (whole tree)
- `BASE_REF=origin/main go run ./scripts/changelogd check` — OK

Review commit, re-run in full:

- `gofmt -l internal/apideps/` — clean
- `go build ./...` — OK
- `go vet ./internal/apideps/...` — OK
- `go test ./internal/apideps/... -count=1` — ok
- `golangci-lint run` — 0 issues
- `BASE_REF=origin/main go run ./scripts/changelogd check` — OK
