### PR TITLE
docs(self-hosted): require a stopped app for the volume archive, and point the restore checklist at the feed note

### DIFF
--- a/changelog.d/docs-t0808-restore-runbook-gaps.md
+++ b/changelog.d/docs-t0808-restore-runbook-gaps.md
@@ -1,0 +1,31 @@
+### Fixed
+
+- **The self-hosted backup runbook no longer calls a live whole-volume archive safe.** It stated
+  that the archive captures `ovumcy.db`, `ovumcy.db-wal` and `ovumcy.db-shm` together, and asked for
+  the app to be stopped only when an operator copies the files individually. Capturing all three is
+  necessary and, against a running instance, not sufficient: `tar` reads them one after another, and
+  a checkpoint landing between the read of the main database file and the read of the WAL writes the
+  WAL into the main file *after* that file was read, then empties the WAL *before* it is read. The
+  archive comes back carrying all three files and missing a commit that was in the database before
+  the backup began, with nothing about the run reporting a problem. The runbook now asks for the app
+  to be stopped before the data volume is archived — or for the archive to be taken from an atomic
+  snapshot of the volume — and says so where an operator meets the archive command as well as in the
+  backup contract.
+
+- **Post-Restore Verification now sends an operator back to the calendar feed.** A restore returns
+  the feed columns to their state at backup time, so a subscription an owner revoked or rotated
+  *after* that backup was taken is armed again at its old subscribe URL. This is a different trigger
+  from a `SECRET_KEY` rotation, which disarms feeds instead, and the runbook's rotation section
+  covers only that one. `docs/gdpr.md` had recorded the restore case — confirmed in a live restore
+  drill — and the file an operator actually follows through a restore never pointed at it. It is now
+  step 7 of the checklist.
+
+### Internal
+
+- Both corrections are held by a test rather than by the next reader. `internal/db` captures one
+  database twice, live with a checkpoint forced into the window between the main-file read and the
+  sidecar reads, and again with the connection closed: the live capture restores the day written
+  before the previous checkpoint and loses the one written after it, the stopped capture restores
+  every day, and stopping is the only difference between the two. `scripts/backuprestoredoc`, which
+  already executes the runbook's commands, now also holds both ends of the new cross-reference — the
+  link in the checklist and the heading it resolves to — so neither can go missing on its own.

--- a/docs/self-hosted.md
+++ b/docs/self-hosted.md
@@ -392,6 +392,10 @@ Stop the app first — `docker compose stop`, then `docker compose start` once t
 A portable manual backup flow is:
 
 ```bash
+# Stop the app first, or take the archive from an atomic snapshot of the volume:
+# archiving the live volume can drop a commit that was already in the database,
+# and the run reports nothing. The stop/start commands are in the paragraph
+# above this block, under "Docker Named Volume Backup".
 mkdir -p backups
 BACKUP_FILE="ovumcy-data-backup.tgz"
 
@@ -446,7 +450,7 @@ After restore:
 4. Sign in and confirm the records are there: open the calendar on a month you know had entries before the backup, or download `Settings → Export` and compare it against an export taken before the restore. Do this even when the app looks perfectly healthy — every signal above stays green on an empty database.
 5. Confirm the records are the ones **from the backup**, not the ones that were already in place. Before starting the restore, name a signal that is known to differ between the current database and the backup — the entry count for a month you edited since the dump was taken, a specific entry that exists in only one of the two — and check that signal afterwards. Phrase it so it can fail: "the calendar still shows entries" passes on a restore that did nothing, while "July shows 12 entries, not the 3 it showed an hour ago" does not. If you cannot name a differing signal, take a `Settings → Export` immediately before the restore and diff it against one taken after; an export that comes back unchanged after restoring a different generation of data is the failure, not a reassurance.
 6. If you restored with a different `SECRET_KEY`, expect existing auth sessions and sealed cookies to be invalid and require a fresh sign-in. Read that expectation carefully against step 4, because the two failures look similar for one screen and mean opposite things: with a changed key your **password still works** (password hashes do not depend on `SECRET_KEY`) and you are merely signed out — 2FA is the part that breaks, and the recovery path for it is in [Secret Handling and Rotation](#secret-handling-and-rotation). A sign-in that is rejected as *wrong credentials* is not a key symptom at all; it means the account is not in the restored database, which is step 4 failing.
-7. Re-check `Settings → Calendar feed` for every owner. A restore also returns the feed columns to their state at backup time, so a subscription an owner revoked or rotated *after* that backup was taken comes back live at its old subscribe URL — revoke or regenerate it again if it should no longer be armed. This is a different trigger from the `SECRET_KEY` rotation above, which disarms feeds instead: [docs/gdpr.md → Backup Restore and the Calendar Feed](gdpr.md#backup-restore-and-the-calendar-feed).
+7. Re-check your own `Settings → Calendar feed`, and tell every other owner on this instance to re-check theirs. A restore also returns the feed columns to their state at backup time, so a subscription an owner revoked or rotated *after* that backup was taken comes back live at its old subscribe URL — it has to be revoked or regenerated again if it should no longer be armed. Only the account itself can see or change that: every account is the sole owner of its own data, so there is no operator surface that shows another owner's feed, and an owner nobody tells keeps a live subscription they believe they revoked. This is a different trigger from the `SECRET_KEY` rotation above, which disarms feeds instead: [docs/gdpr.md → Backup Restore and the Calendar Feed](gdpr.md#backup-restore-and-the-calendar-feed).
 
 ## Safe Upgrade Procedure
 

--- a/docs/self-hosted.md
+++ b/docs/self-hosted.md
@@ -328,7 +328,7 @@ The supported self-hosted backup contract is intentionally narrow:
 - Treat every backup archive as sensitive health data.
 - Keep `.env` and the application secret backup (`SECRET_KEY` value or the file behind `SECRET_KEY_FILE`) separate from the SQLite data archive.
 - Expect existing auth-related cookies to become invalid if you restore data with a different application secret.
-- The SQLite database runs in WAL mode, so the data volume can also hold `ovumcy.db-wal` and `ovumcy.db-shm` next to `ovumcy.db`. The whole-volume archive flow below captures all three together. If you instead copy individual files, stop the app first so SQLite checkpoints the WAL into the main database file.
+- The SQLite database runs in WAL mode, so the data volume can also hold `ovumcy.db-wal` and `ovumcy.db-shm` next to `ovumcy.db`. The whole-volume archive flow below captures all three together — necessary, but on a running instance not sufficient. `tar` reads the three files one after another, and a checkpoint landing between the read of `ovumcy.db` and the read of `ovumcy.db-wal` writes the WAL into the main database file *after* that file was read, then empties the WAL *before* it is read: the archive carries all three files and is still missing a commit that was in the database before the backup began. Stop the app before you archive the data volume — or take the archive from an atomic snapshot of it rather than from the live volume. The same applies, for the same reason, if you copy individual files instead; stopping the app also checkpoints the WAL into the main database file.
 
 For the bundled local/private Postgres stack, use native PostgreSQL backup tooling instead of the SQLite archive workflow:
 
@@ -385,7 +385,11 @@ Bind mounts are still valid, but they are an advanced operator path. For bind mo
 
 ## Docker Named Volume Backup
 
-The default compose deployment uses the `ovumcy_data` named volume. A portable manual backup flow is:
+The default compose deployment uses the `ovumcy_data` named volume.
+
+Stop the app first — `docker compose stop`, then `docker compose start` once the archive is written — or take the archive from an atomic snapshot of the volume. Archiving the live volume runs the checkpoint race described in [Backup and Restore Contract](#backup-and-restore-contract): the archive comes back carrying all three WAL-set files and missing a commit that was already in the database when it started, and nothing about the run reports a problem.
+
+A portable manual backup flow is:
 
 ```bash
 mkdir -p backups
@@ -442,6 +446,7 @@ After restore:
 4. Sign in and confirm the records are there: open the calendar on a month you know had entries before the backup, or download `Settings → Export` and compare it against an export taken before the restore. Do this even when the app looks perfectly healthy — every signal above stays green on an empty database.
 5. Confirm the records are the ones **from the backup**, not the ones that were already in place. Before starting the restore, name a signal that is known to differ between the current database and the backup — the entry count for a month you edited since the dump was taken, a specific entry that exists in only one of the two — and check that signal afterwards. Phrase it so it can fail: "the calendar still shows entries" passes on a restore that did nothing, while "July shows 12 entries, not the 3 it showed an hour ago" does not. If you cannot name a differing signal, take a `Settings → Export` immediately before the restore and diff it against one taken after; an export that comes back unchanged after restoring a different generation of data is the failure, not a reassurance.
 6. If you restored with a different `SECRET_KEY`, expect existing auth sessions and sealed cookies to be invalid and require a fresh sign-in. Read that expectation carefully against step 4, because the two failures look similar for one screen and mean opposite things: with a changed key your **password still works** (password hashes do not depend on `SECRET_KEY`) and you are merely signed out — 2FA is the part that breaks, and the recovery path for it is in [Secret Handling and Rotation](#secret-handling-and-rotation). A sign-in that is rejected as *wrong credentials* is not a key symptom at all; it means the account is not in the restored database, which is step 4 failing.
+7. Re-check `Settings → Calendar feed` for every owner. A restore also returns the feed columns to their state at backup time, so a subscription an owner revoked or rotated *after* that backup was taken comes back live at its old subscribe URL — revoke or regenerate it again if it should no longer be armed. This is a different trigger from the `SECRET_KEY` rotation above, which disarms feeds instead: [docs/gdpr.md → Backup Restore and the Calendar Feed](gdpr.md#backup-restore-and-the-calendar-feed).
 
 ## Safe Upgrade Procedure
 

--- a/internal/db/sqlite_backup_restore_test.go
+++ b/internal/db/sqlite_backup_restore_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"github.com/ovumcy/ovumcy-web/internal/models"
+	"gorm.io/gorm"
 )
 
 // TestSQLiteBackupRestorePreservesHealthData proves that the standard self-host
@@ -187,5 +189,195 @@ func copyFileForBackupTest(t *testing.T, src, dst string) {
 	}
 	if err := out.Close(); err != nil {
 		t.Fatalf("close backup file: %v", err)
+	}
+}
+
+// sqliteVolumeDatabaseFile is the database file inside the data volume, the one
+// docs/self-hosted.md names beside its two WAL sidecars.
+const sqliteVolumeDatabaseFile = "ovumcy.db"
+
+// TestLiveWholeVolumeCaptureLosesACommitToACheckpointMidCapture takes the
+// documented whole-volume archive apart at the one seam a sequential archiver
+// has. `tar czf` reads `ovumcy.db`, then `ovumcy.db-shm`, then `ovumcy.db-wal`,
+// one after another, and nothing holds the three still between those reads. A
+// checkpoint landing in that window folds the WAL into the main database file
+// AFTER the main file was read, and empties the WAL BEFORE the WAL is read — so
+// the archive carries all three files, which is the property the runbook states,
+// and still misses a commit that was in the database before the backup began.
+//
+// The test captures one database twice, and the only difference between the two
+// captures is whether the app was stopped first:
+//
+//   - live, with a checkpoint in the window: the WAL-resident day is gone from
+//     the restore, while the day written before the previous checkpoint is still
+//     there — a partial archive, not an empty one;
+//   - stopped, the way the runbook now tells an operator to take it: every day
+//     reads back.
+//
+// The first half characterizes filesystem and WAL semantics, not a defect this
+// repository can fix. If it ever goes green, a whole-volume archive no longer
+// needs the stop step and docs/self-hosted.md should be relaxed back.
+func TestLiveWholeVolumeCaptureLosesACommitToACheckpointMidCapture(t *testing.T) {
+	sourceDir := t.TempDir()
+	livePath := filepath.Join(sourceDir, sqliteVolumeDatabaseFile)
+
+	liveDB, err := OpenDatabase(Config{Driver: DriverSQLite, SQLitePath: livePath})
+	if err != nil {
+		t.Fatalf("open live database: %v", err)
+	}
+	repos := NewRepositories(liveDB)
+	user := createBackupRaceOwner(t, repos)
+
+	createBackupRaceDay(t, repos, user.ID, "2026-03-01")
+	checkpointWALTruncate(t, liveDB)
+
+	// The commit the operator already has when the backup starts: written after
+	// the previous checkpoint, so it lives in `ovumcy.db-wal` and nowhere else.
+	createBackupRaceDay(t, repos, user.ID, "2026-03-02")
+	assertWALCarriesBytes(t, livePath)
+
+	liveCapture := filepath.Join(t.TempDir(), "live")
+	captureWALSet(t, sourceDir, liveCapture, func() { checkpointWALTruncate(t, liveDB) })
+
+	liveDays := restoredDayList(t, filepath.Join(liveCapture, sqliteVolumeDatabaseFile), user.ID)
+	if !slices.Contains(liveDays, "2026-03-01") {
+		t.Fatalf("the live capture restored %v — an archive that lost everything says nothing about the checkpoint window this test is about", liveDays)
+	}
+	if slices.Contains(liveDays, "2026-03-02") {
+		t.Fatalf("the live capture restored %v, the WAL-resident commit included: a checkpoint between the main-file read and the sidecar reads no longer loses it here, so the whole-volume archive in docs/self-hosted.md can drop its stop step again", liveDays)
+	}
+
+	// The same database, in the same WAL-resident shape, captured after the app
+	// was stopped — which is what the runbook requires.
+	createBackupRaceDay(t, repos, user.ID, "2026-03-03")
+	closeBackupTestDatabase(t, liveDB)
+
+	stoppedCapture := filepath.Join(t.TempDir(), "stopped")
+	captureWALSet(t, sourceDir, stoppedCapture, nil)
+
+	stoppedDays := restoredDayList(t, filepath.Join(stoppedCapture, sqliteVolumeDatabaseFile), user.ID)
+	for _, day := range []string{"2026-03-01", "2026-03-02", "2026-03-03"} {
+		if !slices.Contains(stoppedDays, day) {
+			t.Fatalf("the capture taken with the app stopped restored %v, missing %s: stopping first is the requirement docs/self-hosted.md states, so it has to be sufficient", stoppedDays, day)
+		}
+	}
+}
+
+// captureWALSet copies the WAL set the way a sequential archiver reads it: the
+// main database file first, then the sidecars, with the database live and free
+// to move in between. betweenReads, when set, runs in exactly that window.
+func captureWALSet(t *testing.T, sourceDir, targetDir string, betweenReads func()) {
+	t.Helper()
+
+	if err := os.MkdirAll(targetDir, 0o750); err != nil {
+		t.Fatalf("create the capture directory: %v", err)
+	}
+	copyFileForBackupTest(t,
+		filepath.Join(sourceDir, sqliteVolumeDatabaseFile),
+		filepath.Join(targetDir, sqliteVolumeDatabaseFile))
+
+	if betweenReads != nil {
+		betweenReads()
+	}
+
+	for _, sidecar := range []string{sqliteVolumeDatabaseFile + "-shm", sqliteVolumeDatabaseFile + "-wal"} {
+		source := filepath.Join(sourceDir, sidecar)
+		if _, err := os.Stat(source); errors.Is(err, os.ErrNotExist) {
+			continue // an archiver carries a sidecar only when it is there
+		}
+		copyFileForBackupTest(t, source, filepath.Join(targetDir, sidecar))
+	}
+}
+
+// checkpointWALTruncate folds the WAL into the main database file and truncates
+// it — the checkpoint SQLite runs on its own once the WAL passes its threshold,
+// and on the last connection closing.
+func checkpointWALTruncate(t *testing.T, database *gorm.DB) {
+	t.Helper()
+
+	var busy, walPages, checkpointed int
+	if err := database.Raw("PRAGMA wal_checkpoint(TRUNCATE)").Row().Scan(&busy, &walPages, &checkpointed); err != nil {
+		t.Fatalf("checkpoint the WAL: %v", err)
+	}
+	if busy != 0 {
+		t.Fatalf("the checkpoint was blocked (busy=%d), so the window this test needs never opened", busy)
+	}
+}
+
+// assertWALCarriesBytes proves the commit under test really is WAL-resident when
+// the capture starts; without it the whole test could pass on a database that
+// had already checkpointed itself.
+func assertWALCarriesBytes(t *testing.T, databasePath string) {
+	t.Helper()
+
+	info, err := os.Stat(databasePath + "-wal")
+	if err != nil {
+		t.Fatalf("stat the write-ahead log: %v", err)
+	}
+	if info.Size() == 0 {
+		t.Fatal("the write-ahead log is empty, so the commit this test is about already sits in the main database file")
+	}
+}
+
+// restoredDayList opens a captured database and returns the days it holds for
+// one owner, sorted.
+func restoredDayList(t *testing.T, databasePath string, userID uint) []string {
+	t.Helper()
+
+	restored, err := OpenDatabase(Config{Driver: DriverSQLite, SQLitePath: databasePath})
+	if err != nil {
+		t.Fatalf("open the restored database: %v", err)
+	}
+	defer closeBackupTestDatabase(t, restored)
+
+	logs, err := NewRepositories(restored).DailyLogs.ListByUser(context.Background(), userID)
+	if err != nil {
+		t.Fatalf("list restored logs: %v", err)
+	}
+
+	days := make([]string, 0, len(logs))
+	for _, entry := range logs {
+		days = append(days, entry.Date.Format("2006-01-02"))
+	}
+	slices.Sort(days)
+	return days
+}
+
+func createBackupRaceOwner(t *testing.T, repos *Repositories) *models.User {
+	t.Helper()
+
+	user := &models.User{
+		Email:            "race-owner@example.com",
+		PasswordHash:     "hash",
+		RecoveryCodeHash: "recovery",
+		Role:             models.RoleOwner,
+		CycleLength:      models.DefaultCycleLength,
+		PeriodLength:     models.DefaultPeriodLength,
+		CreatedAt:        time.Now().UTC(),
+	}
+	if err := repos.Users.Create(context.Background(), user); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	return user
+}
+
+func createBackupRaceDay(t *testing.T, repos *Repositories, userID uint, day string) {
+	t.Helper()
+
+	entry := &models.DailyLog{UserID: userID, Date: backupRestoreDay(t, day), IsPeriod: true, Flow: "medium"}
+	if err := repos.DailyLogs.Create(context.Background(), entry); err != nil {
+		t.Fatalf("create day log %s: %v", day, err)
+	}
+}
+
+func closeBackupTestDatabase(t *testing.T, database *gorm.DB) {
+	t.Helper()
+
+	sqlDB, err := database.DB()
+	if err != nil {
+		t.Fatalf("reach the sql.DB handle: %v", err)
+	}
+	if err := sqlDB.Close(); err != nil {
+		t.Fatalf("close database: %v", err)
 	}
 }

--- a/scripts/backuprestoredoc/main_test.go
+++ b/scripts/backuprestoredoc/main_test.go
@@ -51,6 +51,9 @@
 // this package never starts the application, it writes the volume and reads it
 // back itself — and the operator-side checklist in Post-Restore Verification,
 // which is performed against a running instance and cannot be seen from here.
+// Its ONE property that can be seen from here is checked:
+// TestPostRestoreVerificationPointsAtTheCalendarFeedNote holds the checklist to
+// the cross-reference an operator needs and nothing else enforces.
 package backuprestoredoc
 
 import (
@@ -70,6 +73,16 @@ const (
 	// the page.
 	runbookPath     = "docs/self-hosted.md"
 	postgresSection = "## Backup and Restore Contract"
+
+	// postRestoreSection is the checklist an operator works through after a
+	// restore, and the two constants under it are the ends of the one
+	// cross-reference it has to carry. The link itself is DERIVED from the
+	// heading rather than written out a second time, so a heading that is
+	// reworded takes the expected anchor with it instead of leaving a link that
+	// still matches a section that no longer exists.
+	postRestoreSection      = "## Post-Restore Verification"
+	calendarFeedNoteDoc     = "docs/gdpr.md"
+	calendarFeedNoteHeading = "## Backup Restore and the Calendar Feed"
 
 	// composeExecPrefix is how the runbook reaches the database: the bundled
 	// compose stack's postgres service, without a TTY. It is the ONE part of a
@@ -298,6 +311,35 @@ func TestChangeDetectionRunsTheGoLanesForARunbookOnlyDiff(t *testing.T) {
 		if !strings.Contains(string(workflow), required.fragment) {
 			t.Errorf(".github/workflows/ci.yml no longer carries %q: %s, and this guard would not run on a change to %s", required.fragment, required.why, runbookPath)
 		}
+	}
+}
+
+// TestPostRestoreVerificationPointsAtTheCalendarFeedNote holds the restore
+// checklist to the one consequence of a restore that is invisible from inside
+// it: the calendar-feed columns come back with everything else, so a
+// subscription an owner revoked or rotated AFTER the backup was taken is armed
+// again at its old subscribe URL. docs/gdpr.md records that — confirmed in a
+// live restore drill — and an operator who follows this runbook alone never
+// opens that page, which is why the checklist has to carry the pointer itself.
+//
+// Both ends of the link are checked, because either one rotting leaves the same
+// operator uninformed: the pointer has to be in the section being read, and the
+// section it points at has to still exist under the anchor it resolves to.
+func TestPostRestoreVerificationPointsAtTheCalendarFeedNote(t *testing.T) {
+	anchor := strings.ToLower(strings.ReplaceAll(strings.TrimPrefix(calendarFeedNoteHeading, "## "), " ", "-"))
+	link := strings.TrimPrefix(calendarFeedNoteDoc, "docs/") + "#" + anchor
+
+	checklist := runbookSectionText(t, postRestoreSection)
+	if !strings.Contains(checklist, link) {
+		t.Errorf("%s: section %q does not link %q — an operator following only the runbook is never told that a revoked or rotated calendar feed comes back with the restored data", runbookPath, postRestoreSection, link)
+	}
+
+	content, err := os.ReadFile(filepath.Join(repoRoot(t), filepath.FromSlash(calendarFeedNoteDoc)))
+	if err != nil {
+		t.Fatalf("read %s: %v", calendarFeedNoteDoc, err)
+	}
+	if !strings.Contains(strings.ReplaceAll(string(content), "\r\n", "\n"), "\n"+calendarFeedNoteHeading+"\n") {
+		t.Errorf("%s: heading %q is gone, so the runbook's cross-reference resolves to nothing", calendarFeedNoteDoc, calendarFeedNoteHeading)
 	}
 }
 

--- a/scripts/backuprestoredoc/volume_test.go
+++ b/scripts/backuprestoredoc/volume_test.go
@@ -55,10 +55,29 @@ const (
 	composeDownCommand = "docker compose down"
 	composeUpCommand   = "docker compose up -d"
 
+	// composeStopCommand stops the app before the volume is archived. The
+	// section's prose has to spell it out; the block beside it may NOT, because
+	// runScript refuses to execute any script containing `docker compose` and
+	// that refusal is what keeps a developer's `go test ./...` away from a real
+	// deployment. So the block carries stopBeforeArchiveMarker instead, and the
+	// two halves are checked together by
+	// TestVolumeBackupBlockCarriesTheStopRequirement.
+	composeStopCommand = "docker compose stop"
+
+	// stopBeforeArchiveMarker is how the requirement travels with the block
+	// itself: a comment, which every shell ignores and every operator who
+	// copies the block still reads.
+	stopBeforeArchiveMarker = "Stop the app first"
+
 	// sqliteDatabaseFile is the database inside the data volume. The two
-	// sidecars beside it are what `docs/self-hosted.md` promises the
-	// whole-volume archive captures together with it — the claim
-	// assertArchiveCarriesTheWholeWALSet checks.
+	// sidecars beside it are the NECESSARY half of what `docs/self-hosted.md`
+	// asks of an archive — the claim assertArchiveCarriesTheWholeWALSet checks,
+	// and all this package can check, since it never runs the application. The
+	// sufficiency half is not here and is not implied: capturing all three from
+	// a LIVE volume still loses a commit to a checkpoint landing mid-capture,
+	// which is why the runbook requires a stopped app or an atomic snapshot.
+	// internal/db's TestLiveWholeVolumeCaptureLosesACommitToACheckpointMidCapture
+	// is where that half is proven.
 	sqliteDatabaseFile = "ovumcy.db"
 
 	dockerCommandTimeout = 3 * time.Minute
@@ -68,6 +87,8 @@ const (
 // written live in the `-wal` file until a checkpoint, which is exactly why an
 // archive that carries only `ovumcy.db` restores an instance that boots clean
 // and empty — the failure the runbook's Post-Restore Verification describes.
+// Carrying all three is where that failure stops, not where the contract ends:
+// see sqliteDatabaseFile above for the half proven elsewhere.
 var walSetFiles = []string{sqliteDatabaseFile, sqliteDatabaseFile + "-wal", sqliteDatabaseFile + "-shm"}
 
 var (
@@ -184,6 +205,45 @@ func agreedValue(t *testing.T, name string, pattern *regexp.Regexp, blocks ...st
 		}
 	}
 	return agreed
+}
+
+// TestVolumeBackupBlockCarriesTheStopRequirement keeps the one requirement that
+// decides whether the archive is complete inside the artefact an operator
+// actually takes away. A fenced block in a runbook is copied — into a cron job,
+// into a wiki, into a shell — and the prose around it is not; an operator who
+// copies this block and never re-reads the section archives a live volume, and
+// a checkpoint landing between tar's read of `ovumcy.db` and its read of
+// `ovumcy.db-wal` drops a commit that was already in the database, with nothing
+// in the run reporting a problem.
+//
+// The requirement stays a COMMENT, and one that does not name the compose
+// command: this package executes the block verbatim, and runScript refuses any
+// script containing `docker compose` — the refusal that keeps a developer's
+// `go test ./...` from addressing a real deployment. Weakening it to let a
+// comment through would trade a live-deployment guard for a doc convenience.
+// So the block carries the marker and the section's prose carries the command,
+// and both ends are checked here: a block whose comment was dropped stops
+// travelling with the requirement, and prose that lost the command leaves the
+// comment pointing at nothing.
+func TestVolumeBackupBlockCarriesTheStopRequirement(t *testing.T) {
+	block := singleShellBlock(t, volumeBackupSection)
+
+	marked := false
+	for _, line := range strings.Split(block, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "#") && strings.Contains(trimmed, stopBeforeArchiveMarker) {
+			marked = true
+			break
+		}
+	}
+	if !marked {
+		t.Errorf("%s: the %s block carries no comment saying %q, so an operator who copies the block without the prose around it archives a live volume and can lose a commit that was already in the database:\n%s",
+			runbookPath, volumeBackupSection, stopBeforeArchiveMarker, block)
+	}
+
+	if section := runbookSectionText(t, volumeBackupSection); !strings.Contains(section, composeStopCommand) {
+		t.Errorf("%s: section %q no longer names %q, so the block's comment sends the operator to a paragraph that no longer tells them how to stop the app", runbookPath, volumeBackupSection, composeStopCommand)
+	}
 }
 
 // singleShellBlock returns the one fenced shell block of a runbook section.


### PR DESCRIPTION
## T0808 — two gaps in the same restore runbook

Board group T0808, records **R2-0850** and **R2-0808**, both anchored on `docs/self-hosted.md`.

### R2-0850 — the live whole-volume tar was documented as safe, and is not

**Claim.** `docs/self-hosted.md` called the whole-volume `tar` archive safe because it captures
`ovumcy.db`, `ovumcy.db-wal` and `ovumcy.db-shm` together, and scoped the stop requirement to
per-file copies. A checkpoint landing between the archiver's read of the main file and its read of
the WAL yields an archive that carries all three files and misses a commit that was in the database
before the backup began. The record states the lane's race probe was **not** reproduced — the loss
mechanism was inference from the doc text plus WAL semantics.

**Outcome: the race reproduces on this tree.** `internal/db` now captures one database twice, and
the only difference between the two captures is whether the app was stopped first
(`internal/db/sqlite_backup_restore_test.go`,
`TestLiveWholeVolumeCaptureLosesACommitToACheckpointMidCapture`): a day is written, the WAL is
checkpointed, a second day is written (WAL-resident, asserted non-empty on disk), then the main file
is copied, `PRAGMA wal_checkpoint(TRUNCATE)` is forced into the window, then the sidecars are
copied. The restored copy holds `2026-03-01` and **not** `2026-03-02` — the commit that existed
before the capture started. Captured after the connection is closed, the same database restores
every day.

Red → green, per assertion. The guard as committed is green; each of its two assertions was
reddened on its own, by feeding it the exact input it names:

1. *The loss is caused by the checkpoint in the window.* Induced: the mid-capture checkpoint hook
   removed (`captureWALSet(..., nil)`).

   ```
   --- FAIL: TestLiveWholeVolumeCaptureLosesACommitToACheckpointMidCapture (2.54s)
       sqlite_backup_restore_test.go:247: the live capture restored [2026-03-01 2026-03-02], the
       WAL-resident commit included: a checkpoint between the main-file read and the sidecar reads
       no longer loses it here, so the whole-volume archive in docs/self-hosted.md can drop its stop
       step again
   ```

2. *Stopping the app is what makes the capture complete.* Induced: the second capture taken before
   `closeBackupTestDatabase`, with the same checkpoint in the window.

   ```
   --- FAIL: TestLiveWholeVolumeCaptureLosesACommitToACheckpointMidCapture (0.82s)
       sqlite_backup_restore_test.go:261: the capture taken with the app stopped restored
       [2026-03-01 2026-03-02], missing 2026-03-03: stopping first is the requirement
       docs/self-hosted.md states, so it has to be sufficient
   ```

   Restored to the committed form:
   `--- PASS: TestLiveWholeVolumeCaptureLosesACommitToACheckpointMidCapture (0.51s)`.

The first half is a characterization of filesystem and WAL semantics, not of a defect this
repository can fix; the test says so, and says that if it ever goes green the runbook should be
relaxed back.

**Doc change, held to what the test proves.** The WAL bullet of *Backup and Restore Contract* now
says the three-file capture is necessary and, on a running instance, not sufficient, and names the
window; the requirement is *stop the app before archiving the data volume, or take the archive from
an atomic snapshot of it*, with the same sentence beside the archive command in *Docker Named Volume
Backup*. Both remedies are stated because an unconditional "always stop" would charge every operator
downtime a snapshot avoids. The old per-file guidance is kept.

### R2-0808 — the runbook never mentioned that a revoked calendar feed comes back

**Claim.** `docs/gdpr.md` records — confirmed in a live restore drill — that a restore returns
`calendar_feed_selector` and the verifier columns to their state at backup time, so a subscription
an owner revoked or rotated after the backup was taken is armed again at its old subscribe URL.
`docs/self-hosted.md` did not mention or link it anywhere; its *Secret Handling and Rotation*
section covers only the key-epoch disarm, which is the opposite trigger.

**Fix.** *Post-Restore Verification* gains step 7: re-check `Settings → Calendar feed` for every
owner, with the pointer to the gdpr.md section. The record offered a doc-lint check as the other
half of the guard, and the repository already has the harness for it — `scripts/backuprestoredoc`
reads the runbook by section — so the assertion lives there
(`TestPostRestoreVerificationPointsAtTheCalendarFeedNote`). It holds **both** ends of the link, and
derives the expected anchor from the heading constant rather than restating it.

Red → green: both assertions induced separately, each fed the string it names.

1. *The pointer is in the section an operator reads.* Induced: the link in step 7 shortened to
   `[docs/gdpr.md](gdpr.md)`.

   ```
   --- FAIL: TestPostRestoreVerificationPointsAtTheCalendarFeedNote (0.00s)
       main_test.go:334: docs/self-hosted.md: section "## Post-Restore Verification" does not link
       "gdpr.md#backup-restore-and-the-calendar-feed" — an operator following only the runbook is
       never told that a revoked or rotated calendar feed comes back with the restored data
   ```

2. *The section it points at still exists.* Induced: the gdpr.md heading reworded to
   `## Backup Restore and Calendar Feeds`.

   ```
   --- FAIL: TestPostRestoreVerificationPointsAtTheCalendarFeedNote (0.00s)
       main_test.go:342: docs/gdpr.md: heading "## Backup Restore and the Calendar Feed" is gone, so
       the runbook's cross-reference resolves to nothing
   ```

   Both inductions reverted; `docs/gdpr.md` is unchanged by this PR.

### Deliberately not fixed

- The `docker compose stop` / `start` pair is **prose beside** the fenced backup block, not inside
  it. `scripts/backuprestoredoc` executes every command of that block verbatim against a throwaway
  volume and never starts the application; a compose lifecycle line inside the block would be run
  with no stack to run it against. The restore block's existing `down` / `up -d` bracket is asserted
  and skipped by the same harness, and is untouched.
- *Post-Restore Verification* still calls a per-file copy of `ovumcy.db` "the usual way" to end up
  with an archive that missed the database. That remains true, and rewriting the paragraph to rank
  the two causes is outside this change.
- No restore semantics changed: the restore procedure, the volume lifecycle and the Postgres half
  are as they were.
- `internal/api` was not run. Nothing in it reads the sections this PR edits — the only Go readers of
  `docs/self-hosted.md` are `scripts/backuprestoredoc` (run in full, green, docker included) and two
  comments; `scripts/readmeversion` reads `README.md` and `SECURITY.md`, neither of which is touched.

### Validation

`go build ./...`; `go test ./internal/db/` (369.5 s, ok); `go test ./scripts/backuprestoredoc/
-timeout 20m` (126.5 s, ok — the docker-backed Postgres and named-volume halves included);
`go test ./internal/i18n/...` (ok); `golangci-lint run` (0 issues); `go run ./scripts/changelogd
check` (OK).

### Rollback

Single-commit revert. Docs, one test file, one guard file and a changelog fragment; no persisted
data, no schema, no public contract.

## Review round (second commit)

Three findings, all acted on.

**The requirement was in the prose, not in the block an operator copies.** A fenced block in a
runbook is the artefact that travels — into a cron job, into a wiki — and `scripts/backuprestoredoc`
extracts and executes exactly that block. An operator who copied it and never re-read the section
still archived a live volume and still ran the race this PR documents. The block now opens with a
comment naming the requirement and pointing at the paragraph that spells out the commands.

The comment deliberately does **not** name `docker compose stop`. `runScript` refuses to execute any
script containing `docker compose`, and that refusal is what keeps a developer's `go test ./...`
from addressing a real deployment — trading it for a doc convenience would be the wrong way round.
So the block carries the marker and the prose carries the command, and
`TestVolumeBackupBlockCarriesTheStopRequirement` holds both ends. Two induced reds, one per end:

```
volume_test.go:240: docs/self-hosted.md: the ## Docker Named Volume Backup block carries no comment saying "Stop the app first", so an operator who copies the block without the prose around it archives a live volume and can lose a commit that was already in the database
volume_test.go:245: docs/self-hosted.md: section "## Docker Named Volume Backup" no longer names "docker compose stop", so the block's comment sends the operator to a paragraph that no longer tells them how to stop the app
```

Both edits reverted; the guard is green on the shipped tree.

**Post-Restore step 7 asked for something the product forbids.** It told the operator to re-check
`Settings → Calendar feed` "for every owner". Every account is the sole owner of its own data, so no
operator surface shows another owner's feed — the step was unperformable as written on an instance
hosting more than one owner, and the owner nobody told kept a live subscription they believed they
had revoked. It now says to re-check your own and to tell every other owner to re-check theirs, and
says why there is no other way to do it.

**The named-volume harness described the necessary half as the whole contract.** Its comments called
carrying the three WAL-set files the runbook's promise, and an archive holding only `ovumcy.db` the
failure mode. That is the half this package can see — it never starts the application. The
sufficiency half is proven two directories away by
`TestLiveWholeVolumeCaptureLosesACommitToACheckpointMidCapture`, and the comments now say so, so an
auditor reading the guard cannot conclude the live flow is proven safe.

Re-run after the fixes: `go build ./...` OK · `go test ./scripts/backuprestoredoc/ -timeout 20m
-count=1` ok (27.9 s, docker up) · `golangci-lint run` 0 issues · `BASE_REF=origin/main go run
./scripts/changelogd check` OK. `internal/db` was not re-run: the review fixes touch only
`docs/self-hosted.md` and `scripts/backuprestoredoc`, and no test in `internal/db` reads either.
