### PR TITLE
refactor(templates): render the cycle-start confirm island from one component

### DIFF
--- a/changelog.d/refactor-t0157-cycle-start-form-component.md
+++ b/changelog.d/refactor-t0157-cycle-start-form-component.md
@@ -1,0 +1,18 @@
+### Internal
+
+- **The manual cycle-start control and its confirmation policy are one
+  component.** The form and the hidden `[data-cycle-start-policy]` node beside it
+  were copied four times — three branches of the calendar day panel and the
+  dashboard journal — and the eleven attributes on that node are the whole
+  contract with the browser script that stands between a mis-tap and replacing a
+  recorded cycle start. All four copies were complete, so nothing rendered wrong;
+  what the duplication cost was that adding a twelfth attribute, renaming one or
+  changing a message key meant four edits, and no reader could tell a deliberate
+  branch difference from an omission. The four call sites now go through one
+  `cycle_start_form` define, with the three differences that track the branch
+  each serves — the htmx target, the wrapper class and whether the button paints
+  as the primary action — passed as parameters. A new barrier derives the
+  expected attribute set from the confirm script itself and fails on any policy
+  node that renders without all of it, so a partial copy can no longer look like
+  a deliberate one. The rendered markup is unchanged apart from indentation and,
+  on the dashboard, the order in which the form's own attributes appear.

--- a/internal/templates/components/cycle_start_form.html
+++ b/internal/templates/components/cycle_start_form.html
@@ -1,0 +1,57 @@
+{{/* cycle_start_form renders the manual cycle-start control together with the
+     hidden policy node the confirm script reads. The two are one unit on
+     purpose: the script resolves the node through the form's parent element, so
+     a surface that renders the form without its policy sibling — or with a copy
+     of it missing an attribute — submits straight past the confirmation that
+     stands between a mis-tap and replacing a recorded cycle start.
+
+     Parameters (dict):
+       Messages, Lang, CSRFToken — page context.
+       Surface     — "dashboard" or "calendar"; picks the form/button hooks the
+                     browser scripts and the browser specs address.
+       Endpoint    — the cycle-start URL, source query included.
+       Target      — hx-target of this surface's status or panel container.
+       FormClass   — optional class on the form; omitted when empty.
+       DateParam   — the ISO day the surface acts on, mirrored into its hook.
+       TargetDate  — the same day as a date value, for the localized dialog copy.
+       Active      — whether the control paints as the primary action; the
+                     empty-day branch passes false rather than the day's flag.
+       Conflict, ConflictDate, ShortGap, PreviousDate, Implantation — the
+                     manual cycle-start policy this day was evaluated under. */}}
+{{define "cycle_start_form"}}
+<form
+  hx-post="{{.Endpoint}}"
+  hx-target="{{.Target}}"
+  hx-swap="innerHTML"
+{{- if .FormClass}}
+  class="{{.FormClass}}"
+{{- end}}
+  data-cycle-start-confirm-form
+{{- if eq .Surface "dashboard"}}
+  data-dashboard-cycle-start-form
+  data-dashboard-date="{{.DateParam}}"
+{{- else}}
+  data-day-cycle-start-form
+  data-day-cycle-start-date="{{.DateParam}}"
+{{- end}}>
+
+  <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
+  <input type="hidden" name="ack_period_tip" value="false" data-period-tip-ack>
+  <input type="hidden" name="replace_existing" value="false" data-cycle-start-replace-input>
+  <input type="hidden" name="mark_uncertain" value="false" data-cycle-start-uncertain-input>
+  <button type="submit" class="{{if .Active}}btn-primary{{else}}btn-secondary{{end}}" {{if eq .Surface "dashboard"}}data-dashboard-cycle-start-button{{else}}data-day-cycle-start-button{{end}}>{{t .Messages "dashboard.manual_cycle_start"}}</button>
+</form>
+<div
+  hidden
+  data-cycle-start-policy
+  data-cycle-start-conflict="{{if .Conflict}}true{{else}}false{{end}}"
+  data-cycle-start-conflict-date="{{if .Conflict}}{{formatLocalizedDate .Lang .ConflictDate "display"}}{{end}}"
+  data-cycle-start-target-date="{{formatLocalizedDate .Lang .TargetDate "display"}}"
+  data-cycle-start-short-gap="{{.ShortGap}}"
+  data-cycle-start-previous-date="{{if gt .ShortGap 0}}{{formatLocalizedDate .Lang .PreviousDate "display"}}{{end}}"
+  data-cycle-start-implantation="{{if .Implantation}}true{{else}}false{{end}}"
+  data-cycle-start-replace-message="{{t .Messages "dashboard.cycle_start_replace_message"}}"
+  data-cycle-start-replace-accept="{{t .Messages "dashboard.cycle_start_replace_accept"}}"
+  data-cycle-start-short-gap-message="{{t .Messages "dashboard.cycle_start_short_gap_message"}}"
+  data-cycle-start-short-gap-accept="{{t .Messages "dashboard.cycle_start_short_gap_accept"}}"></div>
+{{end}}

--- a/internal/templates/cycle_start_policy_contract_test.go
+++ b/internal/templates/cycle_start_policy_contract_test.go
@@ -45,9 +45,16 @@ const cycleStartPolicyScriptPath = "web/src/js/app/23-cycle-start-confirm.js"
 
 var (
 	// The two shapes in which the script names an attribute of the policy node:
-	// the selector that resolves the node, and every read off it.
-	cycleStartPolicySelectorPattern = regexp.MustCompile(`querySelector\(\s*"\[(data-cycle-start-[a-z0-9-]*[a-z0-9])]"`)
-	cycleStartPolicyGetAttrPattern  = regexp.MustCompile(`getAttribute\(\s*"(data-cycle-start-[a-z0-9-]*[a-z0-9])"`)
+	// the selector that resolves the node, and every read off it. Both are bound
+	// to the receiver, because "an attribute of the policy node" is what this
+	// guard means and a bare `getAttribute(` or `querySelector(` is not that: the
+	// script also addresses form-level hooks by name, and those entering the
+	// expected set would report every correct node as incomplete while naming a
+	// remedy — put the form's hook on the policy div — that is wrong. If the
+	// receiver is ever renamed the derivation empties, which the floor below
+	// turns into a loud failure naming this file.
+	cycleStartPolicySelectorPattern = regexp.MustCompile(`parentElement\.querySelector\(\s*"\[(data-cycle-start-[a-z0-9-]*[a-z0-9])]"`)
+	cycleStartPolicyGetAttrPattern  = regexp.MustCompile(`policyNode\.getAttribute\(\s*"(data-cycle-start-[a-z0-9-]*[a-z0-9])"`)
 
 	// Template actions and comments are removed before the markup is scanned:
 	// an action carries quotes of its own (`{{t .Messages "key"}}`) that would
@@ -117,6 +124,8 @@ func TestCycleStartPolicyScanClassifiesItsOwnFixtures(t *testing.T) {
 	  hasConflict: policyNode.getAttribute("data-cycle-start-conflict") === "true",
 	  replaceMessage: String(policyNode.getAttribute("data-cycle-start-replace-message") || ""),
 	  setCycleStartHiddenValue(form, "[data-cycle-start-replace-input]", false);
+	  form.querySelector("[data-cycle-start-uncertain-input]");
+	  form.getAttribute("data-cycle-start-confirm-form");
 	  if (!form.matches("form[data-cycle-start-confirm-form]")) { return; }
 	`
 	expected := cycleStartPolicyAttributesFromScript(script)
@@ -154,6 +163,142 @@ func TestCycleStartPolicyScanClassifiesItsOwnFixtures(t *testing.T) {
 	if strings.Join(missing, " ") != "data-cycle-start-replace-message" {
 		t.Fatalf("the partial fixture node must be reported as missing data-cycle-start-replace-message, got %v", missing)
 	}
+}
+
+// cycleStartFormComponentPath is the one definition of the confirm island, and
+// cycleStartFormTemplateName the name every surface renders it by.
+const (
+	cycleStartFormComponentPath = "internal/templates/components/cycle_start_form.html"
+	cycleStartFormTemplateName  = "cycle_start_form"
+)
+
+var (
+	// The component's parameters, derived from the component: every `.Field` its
+	// body reads, after its own comments are stripped. Written by hand this list
+	// would agree with the component by construction and stop agreeing the day it
+	// gains a parameter — which is the day a call site can silently omit one.
+	cycleStartFormParamPattern = regexp.MustCompile(`\.([A-Z][A-Za-z0-9]*)`)
+	cycleStartFormCommentOnly  = regexp.MustCompile(`(?s)\{\{/\*.*?\*/\}\}`)
+
+	// One invocation, from `{{template "cycle_start_form"` to the `}}` that
+	// closes it. The dict spans lines and carries parenthesised sub-expressions,
+	// but no nested action, so the first `}}` is the right end.
+	cycleStartFormCallPattern = regexp.MustCompile(`(?s)\{\{template "` + cycleStartFormTemplateName + `"(.*?)\}\}`)
+)
+
+// TestEveryCycleStartFormCallSitePassesTheWholeParameterSet is the other half of
+// the contract, and after the extraction it is the half that can still fail.
+// Rendering the island from one component means no surface can lose an attribute
+// any more — but `dict` builds a plain map with no arity or key checking, and Go
+// templates read a missing map key as the zero value rather than as an error. So
+// a call site that drops `"Conflict"` from its fifteen key/value lines renders
+// `data-cycle-start-conflict="false"`, the confirm script reads false, the
+// replace dialog never opens, and a mis-tap replaces a cycle start the owner
+// already recorded. The completeness guard above stays green throughout: the one
+// policy node, in the component, still declares every attribute.
+//
+// `Implantation` and `Active` fail the same silent way. `ShortGap` happens to
+// error instead — `{{gt .ShortGap 0}}` refuses nil — which is luck, not a
+// property to rely on.
+func TestEveryCycleStartFormCallSitePassesTheWholeParameterSet(t *testing.T) {
+	root := domAttrConsumerRepoRoot(t)
+
+	component, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(cycleStartFormComponentPath)))
+	if err != nil {
+		t.Fatalf("read the component that defines the parameter set (%s): %v", cycleStartFormComponentPath, err)
+	}
+	parameters := cycleStartFormParameters(string(component))
+	if len(parameters) < 10 {
+		t.Fatalf("expected %s to read at least 10 parameters, derived %d: %v — a derivation that resolved almost nothing would pass every call site",
+			cycleStartFormComponentPath, len(parameters), parameters)
+	}
+
+	sites := cycleStartFormCallSites(t, filepath.Join(root, "internal", "templates"), root)
+	if len(sites) == 0 {
+		t.Fatalf("found no {{template %q}} call site — the scan resolved nothing", cycleStartFormTemplateName)
+	}
+
+	var incomplete []string
+	for _, site := range sites {
+		var missing []string
+		for _, parameter := range parameters {
+			if !strings.Contains(site.Action, `"`+parameter+`"`) {
+				missing = append(missing, parameter)
+			}
+		}
+		if len(missing) > 0 {
+			incomplete = append(incomplete, site.Site+" omits "+strings.Join(missing, ", "))
+		}
+	}
+	if len(incomplete) > 0 {
+		sort.Strings(incomplete)
+		t.Fatalf("%d of %d %q call site(s) omit a parameter the component reads.\n"+
+			"An omitted key is not an error — the component reads it as the zero value, so a dropped policy flag renders as \"false\" and skips the confirmation:\n\t%s",
+			len(incomplete), len(sites), cycleStartFormTemplateName, strings.Join(incomplete, "\n\t"))
+	}
+}
+
+// cycleStartFormParameters derives the component's parameter names from its own
+// body, with its documentation comment stripped first so the parameter list in
+// the prose cannot stand in for a parameter the markup actually reads.
+func cycleStartFormParameters(component string) []string {
+	found := map[string]bool{}
+	for _, match := range cycleStartFormParamPattern.FindAllStringSubmatch(cycleStartFormCommentOnly.ReplaceAllString(component, ""), -1) {
+		found[match[1]] = true
+	}
+	names := make([]string, 0, len(found))
+	for name := range found {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// cycleStartFormCallSite is one invocation: where it is, and the action text
+// whose quoted keys are the parameters it passes.
+type cycleStartFormCallSite struct {
+	Site   string
+	Action string
+}
+
+// cycleStartFormCallSites collects every invocation under the templates
+// directory, skipping the component's own definition.
+func cycleStartFormCallSites(t *testing.T, templateDir, root string) []cycleStartFormCallSite {
+	t.Helper()
+
+	var sites []cycleStartFormCallSite
+	walkErr := filepath.WalkDir(templateDir, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() || filepath.Ext(path) != ".html" {
+			return nil
+		}
+		content, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		relative, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return relErr
+		}
+		name := filepath.ToSlash(relative)
+		if name == cycleStartFormComponentPath {
+			return nil
+		}
+		for _, match := range cycleStartFormCallPattern.FindAllStringSubmatchIndex(string(content), -1) {
+			line := strconv.Itoa(strings.Count(string(content)[:match[0]], "\n") + 1)
+			sites = append(sites, cycleStartFormCallSite{
+				Site:   name + ":" + line,
+				Action: string(content)[match[0]:match[1]],
+			})
+		}
+		return nil
+	})
+	if walkErr != nil {
+		t.Fatalf("walk %s: %v", templateDir, walkErr)
+	}
+	return sites
 }
 
 // cycleStartPolicyAttributesFromScript derives the expected attribute set from

--- a/internal/templates/cycle_start_policy_contract_test.go
+++ b/internal/templates/cycle_start_policy_contract_test.go
@@ -1,0 +1,268 @@
+package templates
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// The manual cycle-start confirmation is the only thing standing between a
+// mis-tap and replacing a cycle start the owner already recorded. It is driven
+// entirely from markup: the browser script finds the hidden
+// `[data-cycle-start-policy]` node beside the submitting form and reads the
+// conflict flags, the dates and the dialog copy off it as attributes. A copy of
+// that node missing one attribute does not fail — it silently degrades. A lost
+// `data-cycle-start-conflict` skips the replace dialog altogether; a lost
+// `data-cycle-start-replace-message` opens it with an empty question.
+//
+// This guard is the completeness half of that contract: every policy node the
+// template tree renders must carry every attribute the confirm script reads off
+// one. The expected set is derived from the script itself, never re-listed here
+// — a list written by hand agrees with the reader by construction and stops
+// agreeing the day the script gains a twelfth name or renames one.
+//
+// The derivation is deliberately narrow: only names the script reads *through
+// the policy node* count — `getAttribute("…")` on the node it resolved, plus the
+// selector that resolves it. The form-level hooks the same script names
+// (`data-cycle-start-confirm-form`, and the hidden inputs it addresses as
+// `[data-cycle-start-replace-input]` / `[data-cycle-start-uncertain-input]`)
+// belong to the form, not to the policy node, and requiring them here would
+// report every correct node as incomplete.
+//
+// What it does not check: that the attribute *values* are the right ones, and
+// that a form carrying `data-cycle-start-confirm-form` has a policy node beside
+// it at all. Both are their own contract; this file is only about a node that
+// renders with a hole in it.
+
+// cycleStartPolicyScriptPath is the browser source that defines the contract:
+// the reader whose string literals are the expected attribute set. If it moves,
+// this guard fails rather than quietly deriving an empty set.
+const cycleStartPolicyScriptPath = "web/src/js/app/23-cycle-start-confirm.js"
+
+var (
+	// The two shapes in which the script names an attribute of the policy node:
+	// the selector that resolves the node, and every read off it.
+	cycleStartPolicySelectorPattern = regexp.MustCompile(`querySelector\(\s*"\[(data-cycle-start-[a-z0-9-]*[a-z0-9])]"`)
+	cycleStartPolicyGetAttrPattern  = regexp.MustCompile(`getAttribute\(\s*"(data-cycle-start-[a-z0-9-]*[a-z0-9])"`)
+
+	// Template actions and comments are removed before the markup is scanned:
+	// an action carries quotes of its own (`{{t .Messages "key"}}`) that would
+	// desynchronize the attribute-value scan, and a hook named only in prose is
+	// not rendered.
+	cycleStartPolicyActionPattern   = regexp.MustCompile(`(?s)\{\{/\*.*?\*/\}\}|<!--.*?-->|\{\{[^{}]*\}\}`)
+	cycleStartPolicyAttrNamePattern = regexp.MustCompile(`\bdata-cycle-start-[a-z0-9-]*[a-z0-9]`)
+)
+
+// cycleStartPolicyNode is one rendered `[data-cycle-start-policy]` element: the
+// file:line that renders it and the attribute names it carries.
+type cycleStartPolicyNode struct {
+	Site       string
+	Attributes map[string]bool
+}
+
+// TestEveryCycleStartPolicyNodeCarriesTheAttributesTheConfirmScriptReads is the
+// completeness guard: a partial copy of the confirm island is a skipped
+// confirmation, not a rendering bug, so every node must carry the full set.
+func TestEveryCycleStartPolicyNodeCarriesTheAttributesTheConfirmScriptReads(t *testing.T) {
+	root := domAttrConsumerRepoRoot(t)
+
+	source, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(cycleStartPolicyScriptPath)))
+	if err != nil {
+		t.Fatalf("read the confirm script that defines the contract (%s): %v", cycleStartPolicyScriptPath, err)
+	}
+	expected := cycleStartPolicyAttributesFromScript(string(source))
+
+	// Anchors against a silent no-op: a derivation that resolved nothing, or a
+	// scan that found no node, would otherwise report a clean tree. Both are
+	// floors, not counts — the contract may grow a name and the island may be
+	// rendered from one place or from several.
+	if len(expected) < 8 {
+		t.Fatalf("expected %s to name at least 8 attributes of the policy node, derived %d: %v",
+			cycleStartPolicyScriptPath, len(expected), expected)
+	}
+	nodes := cycleStartPolicyNodes(t, filepath.Join(root, "internal", "templates"), root)
+	if len(nodes) == 0 {
+		t.Fatal("found no [data-cycle-start-policy] node in the template tree — the markup scan resolved nothing")
+	}
+
+	var incomplete []string
+	for _, node := range nodes {
+		missing := cycleStartPolicyMissing(node.Attributes, expected)
+		if len(missing) == 0 {
+			continue
+		}
+		incomplete = append(incomplete, node.Site+" is missing "+strings.Join(missing, ", "))
+	}
+	if len(incomplete) > 0 {
+		sort.Strings(incomplete)
+		t.Fatalf("%d of %d [data-cycle-start-policy] node(s) render without every attribute %s reads.\n"+
+			"A node with a hole in it skips the confirmation instead of failing:\n\t%s",
+			len(incomplete), len(nodes), cycleStartPolicyScriptPath, strings.Join(incomplete, "\n\t"))
+	}
+}
+
+// TestCycleStartPolicyScanClassifiesItsOwnFixtures anchors the guard above on
+// inputs this file owns — one node that must classify as complete and one that
+// must classify as incomplete, plus the two derivation shapes and the form-level
+// hooks that must stay out of the expected set. Anchoring on the live tree
+// instead would leave the guard green the day its scan stopped resolving
+// anything.
+func TestCycleStartPolicyScanClassifiesItsOwnFixtures(t *testing.T) {
+	script := `
+	  return form.parentElement.querySelector("[data-cycle-start-policy]");
+	  hasConflict: policyNode.getAttribute("data-cycle-start-conflict") === "true",
+	  replaceMessage: String(policyNode.getAttribute("data-cycle-start-replace-message") || ""),
+	  setCycleStartHiddenValue(form, "[data-cycle-start-replace-input]", false);
+	  if (!form.matches("form[data-cycle-start-confirm-form]")) { return; }
+	`
+	expected := cycleStartPolicyAttributesFromScript(script)
+	want := []string{
+		"data-cycle-start-conflict",
+		"data-cycle-start-policy",
+		"data-cycle-start-replace-message",
+	}
+	if strings.Join(expected, " ") != strings.Join(want, " ") {
+		t.Fatalf("expected the fixture script to yield exactly %v, derived %v", want, expected)
+	}
+
+	template := `<div
+  hidden
+  data-cycle-start-policy
+  data-cycle-start-conflict="{{if .ManualCycleStartConflict}}true{{else}}false{{end}}"
+  data-cycle-start-replace-message="{{t .Messages "dashboard.cycle_start_replace_message"}}"></div>
+{{/* data-cycle-start-policy named in prose is not a rendered node */}}
+<form data-cycle-start-confirm-form>
+  <input type="hidden" data-cycle-start-replace-input>
+</form>
+<div hidden data-cycle-start-policy data-cycle-start-conflict="false"></div>`
+
+	nodes := cycleStartPolicyNodesInTemplate(template, "fixture.html")
+	if len(nodes) != 2 {
+		t.Fatalf("expected the fixture markup to yield exactly two policy nodes, got %d: %v", len(nodes), nodes)
+	}
+	if nodes[0].Site != "fixture.html:1" {
+		t.Fatalf("expected the node site to carry file and line, got %q", nodes[0].Site)
+	}
+	if missing := cycleStartPolicyMissing(nodes[0].Attributes, expected); len(missing) != 0 {
+		t.Fatalf("the complete fixture node must classify as complete, reported missing %v", missing)
+	}
+	missing := cycleStartPolicyMissing(nodes[1].Attributes, expected)
+	if strings.Join(missing, " ") != "data-cycle-start-replace-message" {
+		t.Fatalf("the partial fixture node must be reported as missing data-cycle-start-replace-message, got %v", missing)
+	}
+}
+
+// cycleStartPolicyAttributesFromScript derives the expected attribute set from
+// the confirm script: the selector that resolves the policy node plus every
+// attribute read off it, sorted and deduplicated.
+func cycleStartPolicyAttributesFromScript(source string) []string {
+	found := map[string]bool{}
+	for _, pattern := range []*regexp.Regexp{cycleStartPolicySelectorPattern, cycleStartPolicyGetAttrPattern} {
+		for _, match := range pattern.FindAllStringSubmatch(source, -1) {
+			found[match[1]] = true
+		}
+	}
+	names := make([]string, 0, len(found))
+	for name := range found {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// cycleStartPolicyMissing reports which of the expected attribute names the node
+// does not carry.
+func cycleStartPolicyMissing(attributes map[string]bool, expected []string) []string {
+	var missing []string
+	for _, name := range expected {
+		if !attributes[name] {
+			missing = append(missing, name)
+		}
+	}
+	return missing
+}
+
+// cycleStartPolicyNodes collects every policy node rendered under the templates
+// directory, with sites relative to the repository root.
+func cycleStartPolicyNodes(t *testing.T, templateDir, root string) []cycleStartPolicyNode {
+	t.Helper()
+
+	var nodes []cycleStartPolicyNode
+	walkErr := filepath.WalkDir(templateDir, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() || filepath.Ext(path) != ".html" {
+			return nil
+		}
+		content, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		relative, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return relErr
+		}
+		nodes = append(nodes, cycleStartPolicyNodesInTemplate(string(content), filepath.ToSlash(relative))...)
+		return nil
+	})
+	if walkErr != nil {
+		t.Fatalf("walk %s: %v", templateDir, walkErr)
+	}
+	return nodes
+}
+
+// cycleStartPolicyNodesInTemplate is the pure half: the policy nodes one
+// template renders, with template actions and comments removed first.
+func cycleStartPolicyNodesInTemplate(content, name string) []cycleStartPolicyNode {
+	stripped := cycleStartPolicyActionPattern.ReplaceAllStringFunc(content, func(action string) string {
+		return strings.Repeat("\n", strings.Count(action, "\n"))
+	})
+
+	var nodes []cycleStartPolicyNode
+	cursor := 0
+	for {
+		relative := strings.IndexByte(stripped[cursor:], '<')
+		if relative < 0 {
+			return nodes
+		}
+		open := cursor + relative
+		end := cycleStartPolicyTagEnd(stripped, open)
+		if end < 0 {
+			return nodes
+		}
+		attributes := map[string]bool{}
+		for _, attribute := range cycleStartPolicyAttrNamePattern.FindAllString(stripped[open:end], -1) {
+			attributes[attribute] = true
+		}
+		if attributes["data-cycle-start-policy"] {
+			line := strconv.Itoa(strings.Count(stripped[:open], "\n") + 1)
+			nodes = append(nodes, cycleStartPolicyNode{Site: name + ":" + line, Attributes: attributes})
+		}
+		cursor = end + 1
+	}
+}
+
+// cycleStartPolicyTagEnd returns the index of the `>` that closes the tag
+// opening at start, ignoring one inside a quoted attribute value.
+func cycleStartPolicyTagEnd(content string, start int) int {
+	var quote byte
+	for index := start + 1; index < len(content); index++ {
+		character := content[index]
+		switch {
+		case quote != 0:
+			if character == quote {
+				quote = 0
+			}
+		case character == '"' || character == '\'':
+			quote = character
+		case character == '>':
+			return index
+		}
+	}
+	return -1
+}

--- a/internal/templates/dashboard.html
+++ b/internal/templates/dashboard.html
@@ -434,33 +434,22 @@
 
       {{if .AllowManualCycleStart}}
       <div id="dashboard-cycle-start" class="dashboard-secondary-actions">
-        <form
-          class="dashboard-secondary-form"
-          hx-post="/api/v1/days/{{.Today}}/cycle-start?source=dashboard"
-          hx-target="#save-status"
-          hx-swap="innerHTML"
-          data-dashboard-cycle-start-form
-          data-cycle-start-confirm-form
-          data-dashboard-date="{{.Today}}">
-          <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
-          <input type="hidden" name="ack_period_tip" value="false" data-period-tip-ack>
-          <input type="hidden" name="replace_existing" value="false" data-cycle-start-replace-input>
-          <input type="hidden" name="mark_uncertain" value="false" data-cycle-start-uncertain-input>
-          <button type="submit" class="{{if .TodayEntry.CycleStart}}btn-primary{{else}}btn-secondary{{end}}" data-dashboard-cycle-start-button>{{t .Messages "dashboard.manual_cycle_start"}}</button>
-        </form>
-        <div
-          hidden
-          data-cycle-start-policy
-          data-cycle-start-conflict="{{if .ManualCycleStartConflict}}true{{else}}false{{end}}"
-          data-cycle-start-conflict-date="{{if .ManualCycleStartConflict}}{{formatLocalizedDate .Lang .ManualCycleStartConflictDate "display"}}{{end}}"
-          data-cycle-start-target-date="{{formatLocalizedDate .Lang .TodayDateRaw "display"}}"
-          data-cycle-start-short-gap="{{.ManualCycleStartShortGap}}"
-          data-cycle-start-previous-date="{{if gt .ManualCycleStartShortGap 0}}{{formatLocalizedDate .Lang .ManualCycleStartPreviousDate "display"}}{{end}}"
-          data-cycle-start-implantation="{{if .ManualCycleStartPotentialImplantation}}true{{else}}false{{end}}"
-          data-cycle-start-replace-message="{{t .Messages "dashboard.cycle_start_replace_message"}}"
-          data-cycle-start-replace-accept="{{t .Messages "dashboard.cycle_start_replace_accept"}}"
-          data-cycle-start-short-gap-message="{{t .Messages "dashboard.cycle_start_short_gap_message"}}"
-          data-cycle-start-short-gap-accept="{{t .Messages "dashboard.cycle_start_short_gap_accept"}}"></div>
+        {{template "cycle_start_form" (dict
+          "Messages" .Messages
+          "Lang" .Lang
+          "CSRFToken" .CSRFToken
+          "Surface" "dashboard"
+          "Endpoint" (printf "/api/v1/days/%s/cycle-start?source=dashboard" .Today)
+          "Target" "#save-status"
+          "FormClass" "dashboard-secondary-form"
+          "DateParam" .Today
+          "TargetDate" .TodayDateRaw
+          "Active" .TodayEntry.CycleStart
+          "Conflict" .ManualCycleStartConflict
+          "ConflictDate" .ManualCycleStartConflictDate
+          "ShortGap" .ManualCycleStartShortGap
+          "PreviousDate" .ManualCycleStartPreviousDate
+          "Implantation" .ManualCycleStartPotentialImplantation)}}
         {{/* The question beside the period toggle already asks this. */}}
         {{if and .ShowCycleStartSuggestion (not .ShowCycleStartQuestion)}}
         <p class="journal-muted text-sm" data-cycle-start-suggestion data-notice-key="dashboard.cycle_start_suggestion">{{t .Messages "dashboard.cycle_start_suggestion"}}</p>

--- a/internal/templates/day_editor_partial.html
+++ b/internal/templates/day_editor_partial.html
@@ -126,33 +126,22 @@
   </form>
 
   {{if .AllowManualCycleStart}}
-  <form
-    hx-post="/api/v1/days/{{.DateString}}/cycle-start?source=calendar"
-    hx-target="#calendar-save-status"
-    hx-swap="innerHTML"
-    class="pt-3"
-    data-cycle-start-confirm-form
-    data-day-cycle-start-form
-    data-day-cycle-start-date="{{.DateString}}">
-    <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
-    <input type="hidden" name="ack_period_tip" value="false" data-period-tip-ack>
-    <input type="hidden" name="replace_existing" value="false" data-cycle-start-replace-input>
-    <input type="hidden" name="mark_uncertain" value="false" data-cycle-start-uncertain-input>
-    <button type="submit" class="{{if .Log.CycleStart}}btn-primary{{else}}btn-secondary{{end}}" data-day-cycle-start-button>{{t .Messages "dashboard.manual_cycle_start"}}</button>
-  </form>
-  <div
-    hidden
-    data-cycle-start-policy
-    data-cycle-start-conflict="{{if .ManualCycleStartConflict}}true{{else}}false{{end}}"
-    data-cycle-start-conflict-date="{{if .ManualCycleStartConflict}}{{formatLocalizedDate .Lang .ManualCycleStartConflictDate "display"}}{{end}}"
-    data-cycle-start-target-date="{{formatLocalizedDate .Lang .Date "display"}}"
-    data-cycle-start-short-gap="{{.ManualCycleStartShortGap}}"
-    data-cycle-start-previous-date="{{if gt .ManualCycleStartShortGap 0}}{{formatLocalizedDate .Lang .ManualCycleStartPreviousDate "display"}}{{end}}"
-    data-cycle-start-implantation="{{if .ManualCycleStartPotentialImplantation}}true{{else}}false{{end}}"
-    data-cycle-start-replace-message="{{t .Messages "dashboard.cycle_start_replace_message"}}"
-    data-cycle-start-replace-accept="{{t .Messages "dashboard.cycle_start_replace_accept"}}"
-    data-cycle-start-short-gap-message="{{t .Messages "dashboard.cycle_start_short_gap_message"}}"
-    data-cycle-start-short-gap-accept="{{t .Messages "dashboard.cycle_start_short_gap_accept"}}"></div>
+  {{template "cycle_start_form" (dict
+    "Messages" .Messages
+    "Lang" .Lang
+    "CSRFToken" .CSRFToken
+    "Surface" "calendar"
+    "Endpoint" (printf "/api/v1/days/%s/cycle-start?source=calendar" .DateString)
+    "Target" "#calendar-save-status"
+    "FormClass" "pt-3"
+    "DateParam" .DateString
+    "TargetDate" .Date
+    "Active" .Log.CycleStart
+    "Conflict" .ManualCycleStartConflict
+    "ConflictDate" .ManualCycleStartConflictDate
+    "ShortGap" .ManualCycleStartShortGap
+    "PreviousDate" .ManualCycleStartPreviousDate
+    "Implantation" .ManualCycleStartPotentialImplantation)}}
   {{if .ShowFutureCycleStartNotice}}
   <p class="journal-muted text-sm" data-future-cycle-start-notice data-notice-key="warning.future_cycle_start">{{t .Messages "warning.future_cycle_start"}}</p>
   {{end}}
@@ -186,32 +175,22 @@
     <div class="flex flex-wrap items-center gap-3">
       <button type="button" class="btn-primary" hx-get="/calendar/day/{{.DateString}}?mode=edit" hx-target="#day-editor" hx-swap="innerHTML" data-day-editor-open="{{.DateString}}" data-action-weight="primary">{{t .Messages "calendar.edit_entry"}}</button>
       {{if .AllowManualCycleStart}}
-      <form
-        hx-post="/api/v1/days/{{.DateString}}/cycle-start?source=calendar"
-        hx-target="#day-editor"
-        hx-swap="innerHTML"
-        data-cycle-start-confirm-form
-        data-day-cycle-start-form
-        data-day-cycle-start-date="{{.DateString}}">
-        <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
-        <input type="hidden" name="ack_period_tip" value="false" data-period-tip-ack>
-        <input type="hidden" name="replace_existing" value="false" data-cycle-start-replace-input>
-        <input type="hidden" name="mark_uncertain" value="false" data-cycle-start-uncertain-input>
-        <button type="submit" class="{{if .Log.CycleStart}}btn-primary{{else}}btn-secondary{{end}}" data-day-cycle-start-button>{{t .Messages "dashboard.manual_cycle_start"}}</button>
-      </form>
-      <div
-        hidden
-        data-cycle-start-policy
-        data-cycle-start-conflict="{{if .ManualCycleStartConflict}}true{{else}}false{{end}}"
-        data-cycle-start-conflict-date="{{if .ManualCycleStartConflict}}{{formatLocalizedDate .Lang .ManualCycleStartConflictDate "display"}}{{end}}"
-        data-cycle-start-target-date="{{formatLocalizedDate .Lang .Date "display"}}"
-        data-cycle-start-short-gap="{{.ManualCycleStartShortGap}}"
-        data-cycle-start-previous-date="{{if gt .ManualCycleStartShortGap 0}}{{formatLocalizedDate .Lang .ManualCycleStartPreviousDate "display"}}{{end}}"
-        data-cycle-start-implantation="{{if .ManualCycleStartPotentialImplantation}}true{{else}}false{{end}}"
-        data-cycle-start-replace-message="{{t .Messages "dashboard.cycle_start_replace_message"}}"
-        data-cycle-start-replace-accept="{{t .Messages "dashboard.cycle_start_replace_accept"}}"
-        data-cycle-start-short-gap-message="{{t .Messages "dashboard.cycle_start_short_gap_message"}}"
-        data-cycle-start-short-gap-accept="{{t .Messages "dashboard.cycle_start_short_gap_accept"}}"></div>
+      {{template "cycle_start_form" (dict
+        "Messages" .Messages
+        "Lang" .Lang
+        "CSRFToken" .CSRFToken
+        "Surface" "calendar"
+        "Endpoint" (printf "/api/v1/days/%s/cycle-start?source=calendar" .DateString)
+        "Target" "#day-editor"
+        "FormClass" ""
+        "DateParam" .DateString
+        "TargetDate" .Date
+        "Active" .Log.CycleStart
+        "Conflict" .ManualCycleStartConflict
+        "ConflictDate" .ManualCycleStartConflictDate
+        "ShortGap" .ManualCycleStartShortGap
+        "PreviousDate" .ManualCycleStartPreviousDate
+        "Implantation" .ManualCycleStartPotentialImplantation)}}
       {{end}}
     </div>
     {{if .ShowFutureCycleStartNotice}}
@@ -229,32 +208,24 @@
       <div class="flex flex-wrap items-center gap-3">
         <button type="button" class="btn-primary" hx-get="/calendar/day/{{.DateString}}?mode=edit" hx-target="#day-editor" hx-swap="innerHTML" data-day-editor-open="{{.DateString}}" data-action-weight="primary">{{t .Messages "calendar.add_entry"}}</button>
         {{if .AllowManualCycleStart}}
-        <form
-          hx-post="/api/v1/days/{{.DateString}}/cycle-start?source=calendar"
-          hx-target="#day-editor"
-          hx-swap="innerHTML"
-          data-cycle-start-confirm-form
-          data-day-cycle-start-form
-          data-day-cycle-start-date="{{.DateString}}">
-          <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
-          <input type="hidden" name="ack_period_tip" value="false" data-period-tip-ack>
-          <input type="hidden" name="replace_existing" value="false" data-cycle-start-replace-input>
-          <input type="hidden" name="mark_uncertain" value="false" data-cycle-start-uncertain-input>
-          <button type="submit" class="btn-secondary" data-day-cycle-start-button>{{t .Messages "dashboard.manual_cycle_start"}}</button>
-        </form>
-        <div
-          hidden
-          data-cycle-start-policy
-          data-cycle-start-conflict="{{if .ManualCycleStartConflict}}true{{else}}false{{end}}"
-          data-cycle-start-conflict-date="{{if .ManualCycleStartConflict}}{{formatLocalizedDate .Lang .ManualCycleStartConflictDate "display"}}{{end}}"
-          data-cycle-start-target-date="{{formatLocalizedDate .Lang .Date "display"}}"
-          data-cycle-start-short-gap="{{.ManualCycleStartShortGap}}"
-          data-cycle-start-previous-date="{{if gt .ManualCycleStartShortGap 0}}{{formatLocalizedDate .Lang .ManualCycleStartPreviousDate "display"}}{{end}}"
-          data-cycle-start-implantation="{{if .ManualCycleStartPotentialImplantation}}true{{else}}false{{end}}"
-          data-cycle-start-replace-message="{{t .Messages "dashboard.cycle_start_replace_message"}}"
-          data-cycle-start-replace-accept="{{t .Messages "dashboard.cycle_start_replace_accept"}}"
-          data-cycle-start-short-gap-message="{{t .Messages "dashboard.cycle_start_short_gap_message"}}"
-          data-cycle-start-short-gap-accept="{{t .Messages "dashboard.cycle_start_short_gap_accept"}}"></div>
+        {{/* No entry exists on this day yet, so the control stays secondary
+             whatever the day's own flag says. */}}
+        {{template "cycle_start_form" (dict
+          "Messages" .Messages
+          "Lang" .Lang
+          "CSRFToken" .CSRFToken
+          "Surface" "calendar"
+          "Endpoint" (printf "/api/v1/days/%s/cycle-start?source=calendar" .DateString)
+          "Target" "#day-editor"
+          "FormClass" ""
+          "DateParam" .DateString
+          "TargetDate" .Date
+          "Active" false
+          "Conflict" .ManualCycleStartConflict
+          "ConflictDate" .ManualCycleStartConflictDate
+          "ShortGap" .ManualCycleStartShortGap
+          "PreviousDate" .ManualCycleStartPreviousDate
+          "Implantation" .ManualCycleStartPotentialImplantation)}}
         {{end}}
       </div>
       {{if .ShowFutureCycleStartNotice}}


### PR DESCRIPTION
## R2-0157 — duplication / `internal/templates/day_editor_partial.html`

**The record's claim (P2, confidence 0.90, effort M, disposition partially-confirmed):** four copies
of the manual cycle-start form and its `[data-cycle-start-policy]` sibling — three branches of the
calendar day panel and one on the dashboard journal. The attribute names on that node are the whole
contract with `web/src/js/app/23-cycle-start-confirm.js`, which reads them as string literals after
resolving the node through `form.parentElement.querySelector("[data-cycle-start-policy]")`. The
counter-evidence held: all four copies carry every attribute today, and the three differences
between them (htmx target, wrapper class, button class) each track the branch the copy serves. What
duplication costs here is future edits — a twelfth attribute, a rename, a changed message key — and
the fact that nothing could tell a deliberate branch difference from an omission. A copy that lost
`data-cycle-start-conflict` or `data-cycle-start-replace-message` would silently skip the
confirmation that stands between a mis-tap and replacing a recorded cycle start.

## Guard first, then the extraction

`internal/templates/cycle_start_policy_contract_test.go` derives the expected attribute set from the
confirm script itself — the selector that resolves the policy node plus every `getAttribute("…")`
read off it — and fails on any `[data-cycle-start-policy]` node in the template tree that renders
without all of it. Nothing is re-listed by hand: a list written here would agree with the reader by
construction and stop agreeing the day the script gains a name or renames one.

The derivation is deliberately narrow. Only names read *through the policy node* count; the
form-level hooks the same script names (`data-cycle-start-confirm-form`, and the hidden inputs it
addresses as `[data-cycle-start-replace-input]` / `[data-cycle-start-uncertain-input]`) belong to the
form, and requiring them on the policy node would report every correct node as incomplete. That is
also why the guard covers **ten** names, not the record's eleven: the eleventh attribute the markup
carries, `data-cycle-start-implantation`, is read by nothing — it is already recorded as such in
`internal/templates/dom_attribute_consumers_test.go:104`, and asserting it here would mean inventing
a name the contract's reader does not have.

The extraction that follows is `internal/templates/components/cycle_start_form.html`: one define
holding the form and its policy sibling, called from all four sites with `dict`, the same convention
`components/date_field.html` and the password-toggle component use. Endpoint, htmx target, wrapper
class, date, surface and the policy values are parameters; the three per-branch differences the
record found stay per call site — the empty-day branch passes `"Active" false` rather than the day's
own flag, exactly as its hard-coded `btn-secondary` did.

## Red → green

**The first red was induced, and the record predicted it would have to be.** All four copies are
complete today, so the guard was green the moment it was written. Deleting
`data-cycle-start-replace-message` from the second copy in `day_editor_partial.html` and running
`go test ./internal/templates/ -run CycleStart`:

```
--- FAIL: TestEveryCycleStartPolicyNodeCarriesTheAttributesTheConfirmScriptReads (0.03s)
    cycle_start_policy_contract_test.go:102: 1 of 4 [data-cycle-start-policy] node(s) render without every attribute web/src/js/app/23-cycle-start-confirm.js reads.
        A node with a hole in it skips the confirmation instead of failing:
        	internal/templates/day_editor_partial.html:202 is missing data-cycle-start-replace-message
```

The deletion was reverted; the induced defect is not in this branch. Note the count in that message:
the guard saw all four copies before the extraction, and sees the one define after it.

The guard's own moving parts were reddened one at a time, each by gutting the function under it
rather than by unwiring its call site:

- derivation returning nothing → `expected web/src/js/app/23-cycle-start-confirm.js to name at least
  8 attributes of the policy node, derived 0: []` (the live-tree floor) and `expected the fixture
  script to yield exactly [data-cycle-start-conflict data-cycle-start-policy
  data-cycle-start-replace-message], derived []` (the fixture);
- markup scan returning no node → `found no [data-cycle-start-policy] node in the template tree — the
  markup scan resolved nothing` and `expected the fixture markup to yield exactly two policy nodes,
  got 0: []`;
- the completeness comparison neutered → `the partial fixture node must be reported as missing
  data-cycle-start-replace-message, got []`.

Green after the extraction: `go build ./...`, `go test ./internal/templates/... ./internal/i18n/...`,
`go test ./internal/api/... -timeout 20m` (1042 s), `golangci-lint run` (0 issues),
`go run ./scripts/changelogd check`.

## Rendered markup

Every call site was rendered before and after against the same values, twice — once with a conflict,
a short gap and an implantation flag set, once with all of them clear:

- the three calendar copies are identical apart from indentation, which a component necessarily
  re-indents (`components/date_field.html` renders at its own indentation the same way);
- the dashboard copy renders the same set of lines with the same values, and differs in the **order
  of three attributes on the `<form>` element**: `class` now follows `hx-swap` instead of leading,
  and `data-cycle-start-confirm-form` precedes `data-dashboard-cycle-start-form`. Attribute order
  carries no meaning in HTML, and nothing addresses these by order: the browser specs use attribute
  selectors (`e2e/calendar.spec.ts:389`, `e2e/support/stats-helpers.ts:115`), the backend
  regressions use single-attribute substring assertions. No locale key changes — the four
  `dashboard.cycle_start_*` keys and `dashboard.manual_cycle_start` are rendered by the same `t`
  calls, moved verbatim. No JS selector changes: every hook the confirm script, the autosave script
  and the specs name is still rendered, with the same values.
- `web/static/css/tailwind.css` rebuilds byte-identical, with `.pt-3` and `.dashboard-secondary-form`
  still generated — both class names still appear as literals in the scanned template tree, now as
  `FormClass` arguments.

## Deliberately not fixed

- **`data-cycle-start-implantation` is still read by nobody.** It is the server's implantation
  warning, computed and never reaching a dialog. It is an open residual entry with its reason
  written out, and closing it is a change of its own — wire the reader or delete the markup — not a
  side effect of moving markup into a component.
- **Nothing asserts that a form carrying `data-cycle-start-confirm-form` has a policy node beside
  it.** That is the other direction of the same contract and its own guard; this one is about a node
  that renders with a hole in it.
- **The suggestion and implantation paragraphs that also repeat across the three day-panel branches
  are left alone.** They are `<p>` elements with no cross-file contract behind them, and the record
  names the form and its policy node.

## Rollback

Single-commit revert. The change is templates and one test file: no persisted data, no public
contract, no migration.

## Review round (second commit)

**The barrier was tracking the failure mode this PR removed.** Rendering the island from one
component means no surface can lose an attribute any more. What a surface can lose is a **dict key**
— and `dict` builds a plain map with no arity or key checking, while Go templates read a missing map
key as the zero value rather than as an error. A call site that drops `"Conflict"` from its fifteen
key/value lines renders `data-cycle-start-conflict="false"`; the confirm script reads false, the
replace dialog never opens, and a mis-tap replaces a cycle start the owner already recorded. That is
the outcome R2-0157 names, reached by a different route. `Implantation` and `Active` fail the same
silent way; `ShortGap` happens to error instead, because `{{gt .ShortGap 0}}` refuses nil — luck, not
a property to rely on.

`TestEveryCycleStartFormCallSitePassesTheWholeParameterSet` derives the parameter set from the
component's own body (its documentation comment stripped first, so the prose list cannot stand in for
what the markup reads) and requires every call site to pass all of it. Induced red — `"Conflict"`
dropped from the dashboard call:

```
--- FAIL: TestEveryCycleStartFormCallSitePassesTheWholeParameterSet
    cycle_start_policy_contract_test.go:235: 1 of 4 "cycle_start_form" call site(s) omit a parameter the component reads.
        	internal/templates/dashboard.html:437 omits Conflict
```

The completeness guard stayed **green** through that same edit, which is the finding observed rather
than argued. Edit reverted; `git diff -- internal/templates/dashboard.html` is empty.

**The script derivation now binds to its receiver.** `getAttribute(` and `querySelector(` matched
anywhere in the file, so inlining the selector at `23-cycle-start-confirm.js:49` — an ordinary
simplification — would have pulled a form-level hook into the expected set and reported all four
nodes incomplete, naming a remedy (put the hidden input's hook on the policy div) that is wrong. The
file's header comment already promised the derivation was narrow; the patterns now enforce what it
promised. The fixture script covers both shapes, and the existing `len(expected) < 8` floor turns a
receiver rename into a loud failure naming this file rather than an empty set.

Re-run after the fixes: `gofmt -l internal/templates/` clean · `go build ./...` OK ·
`go test ./internal/templates/... ./internal/i18n/... -count=1` ok · `golangci-lint run` 0 issues ·
`BASE_REF=origin/main go run ./scripts/changelogd check` OK. `./internal/api/...` was not re-run: the
review fixes touch one test file, and every rendered template is byte-identical to the commit the
1042 s api run already covered.
