### PR TITLE
test(e2e): fail a spec on console errors and page errors

### DIFF
--- a/changelog.d/test-t0726-playwright-error-fixture.md
+++ b/changelog.d/test-t0726-playwright-error-fixture.md
@@ -1,0 +1,22 @@
+none
+
+Browser-suite strengthening, with no production behaviour change. The e2e suite
+had exactly one error handler — a `page.on('console')` collector inside a single
+register test — so a page could throw an uncaught exception, or log a console
+error, while every locator the spec asserted still resolved, and the run reported
+green. Every spec now imports `test` from `e2e/support/fixtures.ts`, which binds
+to the BrowserContext (so a page a spec opens itself is covered too) and fails
+the test on any console error or page error that no allowlist entry covers. Each
+allowlist entry carries its reason inline; the one entry there today is the
+non-2xx resource line every engine logs, which the suite provokes on purpose.
+
+The guard was observed failing before it was believed: a throwaway spec that logs
+a console error, and one that throws asynchronously in the page, both fail on the
+shared `test` and both pass on Playwright's stock `test` with every assertion
+green. An ESLint `no-restricted-imports` rule keeps a new spec from importing
+`@playwright/test` directly, so the converted set cannot grow a silent
+unconverted half; that rule was observed failing on a spec reverted to the stock
+import.
+
+`playwright.config.ts` gains a comment naming which of its three projects the
+gating pipeline actually installs and runs. The matrix itself is unchanged.

--- a/e2e/a11y-wcag-audit.spec.ts
+++ b/e2e/a11y-wcag-audit.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from '@playwright/test';
+import { expect, test, type Page } from './support/fixtures';
 import {
   completeOnboardingIfPresent,
   continueFromRecoveryCode,

--- a/e2e/auth-2fa.spec.ts
+++ b/e2e/auth-2fa.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test, type Page } from './support/fixtures';
 import { generateSync } from 'otplib';
 import {
   completeOnboardingIfPresent,
@@ -19,7 +19,7 @@ const DISABLE_2FA_SUBMIT =
 
 // Reads the raw TOTP secret from the visible manual-entry element on the
 // enrollment page (the same string the user copies into their authenticator).
-async function readTOTPSecret(page: import('@playwright/test').Page): Promise<string> {
+async function readTOTPSecret(page: Page): Promise<string> {
   const el = page.locator('[data-totp-manual-secret]');
   await expect(el).toBeVisible();
   const secret = (await el.textContent())?.trim() ?? '';

--- a/e2e/auth-login-register.spec.ts
+++ b/e2e/auth-login-register.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './support/fixtures';
 import {
   apiOriginHeader,
   completeOnboardingIfPresent,
@@ -239,13 +239,10 @@ test.describe('Auth: register, login, logout', () => {
   });
 
   test('register form rejects emoji email via client validation', async ({ page }) => {
-    const consoleErrors: string[] = [];
-    page.on('console', (message) => {
-      if (message.type() === 'error') {
-        consoleErrors.push(message.text());
-      }
-    });
-
+    // The `page.on('console')` collector that used to live here — the suite's
+    // only error handler — is now the shared fixture's job, and it is
+    // stricter: it fails this test on ANY unallowlisted console error, not
+    // just on the invalid-pattern one below. One mechanism, every spec.
     await page.goto('/register');
     await expect(page).toHaveURL(/\/register(?:\?.*)?$/);
 
@@ -274,9 +271,9 @@ test.describe('Auth: register, login, logout', () => {
     await expect(page.locator('#register-client-status .status-error')).toContainText(
       declaredEmailMessage
     );
-    expect(
-      consoleErrors.some((text) => /Pattern attribute value .* is not a valid regular expression/i.test(text))
-    ).toBe(false);
+    // The "Pattern attribute value ... is not a valid regular expression"
+    // console error this test used to look for is covered by the fixture,
+    // which is why the local collector is gone.
   });
 
   test('register empty submit validates in top-down order and places the error next to the active field', async ({

--- a/e2e/auth-oidc.spec.ts
+++ b/e2e/auth-oidc.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from '@playwright/test';
+import { expect, test, type Page } from './support/fixtures';
 import {
   DEFAULT_STRONG_PASSWORD,
   completeOnboardingIfPresent,

--- a/e2e/auth-recovery.spec.ts
+++ b/e2e/auth-recovery.spec.ts
@@ -1,5 +1,5 @@
 import fs from 'node:fs/promises';
-import { expect, test } from '@playwright/test';
+import { expect, test } from './support/fixtures';
 import {
   completeOnboardingIfPresent,
   continueFromRecoveryCode,

--- a/e2e/auth-session-rotation.spec.ts
+++ b/e2e/auth-session-rotation.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Locator, type Page } from '@playwright/test';
+import { expect, test, type Locator, type Page } from './support/fixtures';
 import {
   completeOnboardingIfPresent,
   confirmRecoveryCode,
@@ -39,6 +39,7 @@ async function registerOwnerAndOpenSettings(page: Page, prefix: string) {
 test.describe('Auth session rotation', () => {
   test('regenerating recovery code revokes other active sessions but keeps the originating one', async ({
     browser,
+    browserErrors,
     page,
   }) => {
     const state = await registerOwnerAndOpenSettings(page, 'session-rotation');
@@ -46,6 +47,10 @@ test.describe('Auth session rotation', () => {
     // Open a second, isolated browser context and sign in with the same
     // credentials. Two contexts means two separate cookie jars / "devices".
     const otherContext = await browser.newContext();
+    // The fixture watches the built-in context; a context the spec makes
+    // itself has to be handed over, or the second "device" is the one place
+    // in the suite where a crash goes unreported.
+    browserErrors.watch(otherContext);
     const otherPage = await otherContext.newPage();
     try {
       await loginViaUI(otherPage, { email: state.email, password: state.password });

--- a/e2e/bugs.spec.ts
+++ b/e2e/bugs.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from '@playwright/test';
+import { expect, test, type Page } from './support/fixtures';
 import { fillDateField, formatDisplayDate } from './support/date-field-helpers';
 import { selectOnboardingStartDate } from './support/onboarding-helpers';
 import { openCalendarDayEditor } from './support/stats-helpers';

--- a/e2e/calendar-autofill-clear.spec.ts
+++ b/e2e/calendar-autofill-clear.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from '@playwright/test';
+import { expect, test, type Page } from './support/fixtures';
 import {
   completeOnboardingIfPresent,
   continueFromRecoveryCode,

--- a/e2e/calendar-save-resilience.spec.ts
+++ b/e2e/calendar-save-resilience.spec.ts
@@ -1,4 +1,10 @@
-import { expect, test, type Locator, type Page } from '@playwright/test';
+import {
+  expect,
+  test,
+  type BrowserErrorWatcher,
+  type Locator,
+  type Page,
+} from './support/fixtures';
 import {
   completeOnboardingIfPresent,
   continueFromRecoveryCode,
@@ -42,11 +48,31 @@ interface DayPUTInterceptor {
 }
 
 /**
+ * htmx logs its own request-failure events on the console: `htmx:sendError`
+ * and `htmx:afterRequest` when the connection drops, and
+ * `Response Status Error Code NNN from …` when the server refuses. Every save
+ * this file breaks produces them by construction, so they are tolerated where
+ * the breakage is armed rather than suppressed suite-wide — a save failing
+ * anywhere else still fails its test.
+ */
+const HTMX_REQUEST_FAILURE_LOG =
+  /^console\.error: (?:htmx:(?:sendError|afterRequest)|Response Status Error Code )/;
+
+/**
  * Routes the day-entry PUT for one date. The outcome is switchable so a single
  * test can fail a save, fail its retry, and then let the retry through — the
  * three phases of the flow under test — without re-registering the route.
  */
-async function interceptDayPUT(page: Page, isoDate: string): Promise<DayPUTInterceptor> {
+async function interceptDayPUT(
+  page: Page,
+  isoDate: string,
+  browserErrors: BrowserErrorWatcher
+): Promise<DayPUTInterceptor> {
+  browserErrors.allow(
+    HTMX_REQUEST_FAILURE_LOG,
+    `this test forces PUT /api/v1/days/${isoDate} to fail, and htmx logging the failure is the behaviour under test`
+  );
+
   let outcome: SaveOutcome = 'server-error';
   let attempts = 0;
 
@@ -115,12 +141,12 @@ async function expectDayEntryStillTyped(form: Locator, note: string): Promise<vo
 }
 
 test.describe('day-entry save resilience', () => {
-  test('a rejected save keeps the typed entry and no save is announced', async ({ page }) => {
+  test('a rejected save keeps the typed entry and no save is announced', async ({ browserErrors, page }) => {
     const todayISO = await registerOwnerOnCalendar(page, 'day-save-rejected');
     const targetISO = shiftISODate(todayISO, -20);
     const note = 'slept badly, headache since morning';
 
-    const interceptor = await interceptDayPUT(page, targetISO);
+    const interceptor = await interceptDayPUT(page, targetISO, browserErrors);
     const form = await openCalendarDayEditor(page, targetISO);
     await fillDayEntry(form, note);
 
@@ -156,13 +182,14 @@ test.describe('day-entry save resilience', () => {
   });
 
   test('a network failure is announced calmly and the retry resends the same entry', async ({
+    browserErrors,
     page,
   }) => {
     const todayISO = await registerOwnerOnCalendar(page, 'day-save-offline');
     const targetISO = shiftISODate(todayISO, -22);
     const note = 'cramps in the evening';
 
-    const interceptor = await interceptDayPUT(page, targetISO);
+    const interceptor = await interceptDayPUT(page, targetISO, browserErrors);
     interceptor.set('network-failure');
     const form = await openCalendarDayEditor(page, targetISO);
     await fillDayEntry(form, note);
@@ -215,12 +242,13 @@ test.describe('day-entry save resilience', () => {
   });
 
   test('the failure notice is neutral, readable and localized, not a health alarm', async ({
+    browserErrors,
     page,
   }) => {
     const todayISO = await registerOwnerOnCalendar(page, 'day-save-notice');
     const targetISO = shiftISODate(todayISO, -24);
 
-    const interceptor = await interceptDayPUT(page, targetISO);
+    const interceptor = await interceptDayPUT(page, targetISO, browserErrors);
     interceptor.set('network-failure');
     const form = await openCalendarDayEditor(page, targetISO);
     await fillDayEntry(form, 'quiet day');
@@ -251,7 +279,7 @@ test.describe('day-entry save resilience', () => {
     await saveSettingsLanguage(page, 'ru');
 
     const localizedISO = shiftISODate(todayISO, -26);
-    const localizedInterceptor = await interceptDayPUT(page, localizedISO);
+    const localizedInterceptor = await interceptDayPUT(page, localizedISO, browserErrors);
     localizedInterceptor.set('network-failure');
     const localizedForm = await openCalendarDayEditor(page, localizedISO);
     await fillDayEntry(localizedForm, 'тихий день');
@@ -289,12 +317,13 @@ async function registerOwnerOnDashboard(page: Page, prefix: string): Promise<str
 
 test.describe('dashboard autosave resilience', () => {
   test('an autosave that never lands keeps the entry and offers the same retry', async ({
+    browserErrors,
     page,
   }) => {
     const todayISO = await registerOwnerOnDashboard(page, 'dashboard-autosave-offline');
     const note = 'walked in the evening';
 
-    const interceptor = await interceptDayPUT(page, todayISO);
+    const interceptor = await interceptDayPUT(page, todayISO, browserErrors);
     interceptor.set('network-failure');
 
     const notes = await ensureNotesFieldVisible(page, '#today-notes');

--- a/e2e/calendar-save-resilience.spec.ts
+++ b/e2e/calendar-save-resilience.spec.ts
@@ -54,9 +54,19 @@ interface DayPUTInterceptor {
  * this file breaks produces them by construction, so they are tolerated where
  * the breakage is armed rather than suppressed suite-wide — a save failing
  * anywhere else still fails its test.
+ *
+ * The refusal log names the URL, so the allowance is scoped to the very path
+ * the interception is breaking. Left as a bare `Response Status Error Code `
+ * prefix it would also swallow an htmx-reported failure from an unrelated
+ * endpoint during the same test — a real 500 elsewhere would merge green here,
+ * because these tests assert about the day form and nothing else. The
+ * connection-drop logs carry no URL and stay as they are; `route.abort` is the
+ * only thing in these tests that drops a connection.
  */
-const HTMX_REQUEST_FAILURE_LOG =
-  /^console\.error: (?:htmx:(?:sendError|afterRequest)|Response Status Error Code )/;
+const HTMX_CONNECTION_DROP_LOG = /^console\.error: htmx:(?:sendError|afterRequest)/;
+
+const htmxRefusalLogFor = (path: string): RegExp =>
+  new RegExp(`^console\\.error: Response Status Error Code \\d+ from ${path.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`);
 
 /**
  * Routes the day-entry PUT for one date. The outcome is switchable so a single
@@ -69,8 +79,12 @@ async function interceptDayPUT(
   browserErrors: BrowserErrorWatcher
 ): Promise<DayPUTInterceptor> {
   browserErrors.allow(
-    HTMX_REQUEST_FAILURE_LOG,
-    `this test forces PUT /api/v1/days/${isoDate} to fail, and htmx logging the failure is the behaviour under test`
+    HTMX_CONNECTION_DROP_LOG,
+    `this test aborts PUT /api/v1/days/${isoDate}, and htmx logging the dropped connection is the behaviour under test`
+  );
+  browserErrors.allow(
+    htmxRefusalLogFor(`/api/v1/days/${isoDate}`),
+    `this test forces PUT /api/v1/days/${isoDate} to be refused, and htmx logging that refusal is the behaviour under test`
   );
 
   let outcome: SaveOutcome = 'server-error';

--- a/e2e/calendar.spec.ts
+++ b/e2e/calendar.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Locator, type Page } from '@playwright/test';
+import { expect, test, type Locator, type Page } from './support/fixtures';
 import {
   completeOnboardingIfPresent,
   continueFromRecoveryCode,

--- a/e2e/cross-browser-smoke.spec.ts
+++ b/e2e/cross-browser-smoke.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from '@playwright/test';
+import { expect, test, type Page } from './support/fixtures';
 import {
   completeOnboardingIfPresent,
   continueFromRecoveryCode,

--- a/e2e/dashboard-cycle-start-suggestion.spec.ts
+++ b/e2e/dashboard-cycle-start-suggestion.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, type Page } from './support/fixtures';
 import { apiOriginHeader } from './support/auth-helpers';
 import { cancelConfirmDialog, mutatingRequestsDuring } from './support/confirm-dialog-helpers';
 import { localeText } from './support/locale-helpers';

--- a/e2e/dashboard-fertility.spec.ts
+++ b/e2e/dashboard-fertility.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, type Page } from './support/fixtures';
 import {
   completeOnboardingIfPresent,
   continueFromRecoveryCode,

--- a/e2e/dashboard-late-cycle-notice.spec.ts
+++ b/e2e/dashboard-late-cycle-notice.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from '@playwright/test';
+import { expect, test, type Page } from './support/fixtures';
 import { saveSettingsLanguage } from './support/language-helpers';
 import { localeText, localeTextByLocale, type Locale } from './support/locale-helpers';
 import {

--- a/e2e/dashboard-prediction-range.spec.ts
+++ b/e2e/dashboard-prediction-range.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './support/fixtures';
 import { displayDatesIn } from './support/date-field-helpers';
 import { dashboardNextPeriodText } from './support/dashboard-helpers';
 import { localeText } from './support/locale-helpers';

--- a/e2e/dashboard-pregnancy-pause.spec.ts
+++ b/e2e/dashboard-pregnancy-pause.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, type Page } from './support/fixtures';
 import {
   completeOnboardingIfPresent,
   continueFromRecoveryCode,

--- a/e2e/dashboard-reminder-banner.spec.ts
+++ b/e2e/dashboard-reminder-banner.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './support/fixtures';
 import { registerAndOnboardWithStartDaysAgo } from './support/stats-helpers';
 
 // Onboarding seeds a single cycle (last_period_start + the default 28-day

--- a/e2e/dashboard-warnings.spec.ts
+++ b/e2e/dashboard-warnings.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, type Page } from './support/fixtures';
 import {
   completeOnboardingIfPresent,
   continueFromRecoveryCode,

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Locator, type Page } from '@playwright/test';
+import { expect, test, type Locator, type Page } from './support/fixtures';
 import {
   completeOnboardingIfPresent,
   continueFromRecoveryCode,

--- a/e2e/navigation-language.spec.ts
+++ b/e2e/navigation-language.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from '@playwright/test';
+import { expect, test, type Page } from './support/fixtures';
 import {
   completeOnboardingIfPresent,
   continueFromRecoveryCode,

--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Locator, type Page } from '@playwright/test';
+import { expect, test, type Locator, type Page } from './support/fixtures';
 import { dashboardNextPeriodText } from './support/dashboard-helpers';
 import {
   apiOriginHeader,
@@ -116,7 +116,18 @@ test.describe('Onboarding flow', () => {
     await expect(page).toHaveURL(/\/dashboard$/);
   });
 
-  test('step 1 blocks an empty submit and the today shortcut fills the date', async ({ page }) => {
+  test('step 1 blocks an empty submit and the today shortcut fills the date', async ({
+    browserErrors,
+    page,
+  }) => {
+    // The empty submit below is meant to reach the server and be refused, so
+    // htmx logs the 400 on the console. That log is the subject here, not a
+    // fault: the assertion two lines down is that the refusal rendered.
+    browserErrors.allow(
+      /^console\.error: Response Status Error Code 400 from \/api\/v1\/onboarding\/steps\/1/,
+      'this test submits step 1 empty on purpose and asserts the rejection is rendered'
+    );
+
     await registerAndOpenOnboarding(page, 'onboarding-step1-quickpick');
 
     const transport = page.locator('#last-period-start');

--- a/e2e/privacy.spec.ts
+++ b/e2e/privacy.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './support/fixtures';
 import { localeText } from './support/locale-helpers';
 import {
   completeOnboardingIfPresent,

--- a/e2e/pwa-install.spec.ts
+++ b/e2e/pwa-install.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from '@playwright/test';
+import { expect, test, type Page } from './support/fixtures';
 import {
   completeOnboardingIfPresent,
   continueFromRecoveryCode,

--- a/e2e/security-role.spec.ts
+++ b/e2e/security-role.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from '@playwright/test';
+import { expect, test, type Page } from './support/fixtures';
 import {
   completeOnboardingIfPresent,
   continueFromRecoveryCode,

--- a/e2e/settings-calendar-feed.spec.ts
+++ b/e2e/settings-calendar-feed.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Locator, type Page } from '@playwright/test';
+import { expect, test, type Locator, type Page } from './support/fixtures';
 import {
   apiOriginHeader,
   completeOnboardingIfPresent,

--- a/e2e/settings-import.spec.ts
+++ b/e2e/settings-import.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from '@playwright/test';
+import { expect, test, type Page } from './support/fixtures';
 import {
   apiOriginHeader,
   completeOnboardingIfPresent,

--- a/e2e/settings-password-export-danger.spec.ts
+++ b/e2e/settings-password-export-danger.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Locator, type Page } from '@playwright/test';
+import { expect, test, type Locator, type Page } from './support/fixtures';
 import { saveDashboardEntry } from './support/dashboard-helpers';
 import { clearDateField, fillDateField } from './support/date-field-helpers';
 import { ensureNotesFieldVisible } from './support/note-helpers';

--- a/e2e/settings-profile-cycle.spec.ts
+++ b/e2e/settings-profile-cycle.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Locator, type Page } from '@playwright/test';
+import { expect, test, type Locator, type Page } from './support/fixtures';
 import { fillDateField } from './support/date-field-helpers';
 import {
   dashboardNextPeriodText,

--- a/e2e/settings-webhook.spec.ts
+++ b/e2e/settings-webhook.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Locator, type Page } from '@playwright/test';
+import { expect, test, type Locator, type Page } from './support/fixtures';
 import {
   completeOnboardingIfPresent,
   continueFromRecoveryCode,

--- a/e2e/stats-factor-context.spec.ts
+++ b/e2e/stats-factor-context.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './support/fixtures';
 import { logoutViaAPI } from './support/auth-helpers';
 import { dashboardNextPeriodText } from './support/dashboard-helpers';
 import { displayDatesIn, fillDateField } from './support/date-field-helpers';

--- a/e2e/stats-insights.spec.ts
+++ b/e2e/stats-insights.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, type Page } from './support/fixtures';
 import { apiOriginHeader } from './support/auth-helpers';
 import {
   isoToday,

--- a/e2e/support/fixtures.ts
+++ b/e2e/support/fixtures.ts
@@ -1,0 +1,121 @@
+import { test as base, expect } from '@playwright/test';
+import type { BrowserContext } from '@playwright/test';
+
+/**
+ * The suite's own `test`, and the only one specs may import.
+ *
+ * Playwright's stock `test` reports a page that threw an uncaught exception as
+ * a pass, as long as the locators the spec happened to assert still resolved:
+ * a user-visible JavaScript crash coexists with green assertions and merges
+ * unnoticed. Before this fixture existed the suite had exactly one error
+ * handler — a `page.on('console')` inside a single register test — so every
+ * new spec had to remember its own error plumbing and none of them did.
+ *
+ * The listeners bind to the **BrowserContext**, not to a page, so a page the
+ * spec opens itself (`context.newPage()`) is covered without doing anything.
+ * A spec that builds its own context (`browser.newContext()`) takes the
+ * `browserErrors` fixture and calls `watch` on it — see
+ * `auth-session-rotation.spec.ts`.
+ *
+ * Rendered-copy assertions still come from `locale-helpers.ts`; this file only
+ * judges what the browser itself reports.
+ */
+
+/** A browser error that is expected, with the reason it is not a defect. */
+interface AllowedBrowserError {
+  readonly pattern: RegExp;
+  /** Why this class of message is noise rather than a product fault. */
+  readonly reason: string;
+}
+
+/**
+ * Errors every test tolerates. Each entry carries its reason inline on
+ * purpose: a bare regex list rots into a mute button the moment nobody
+ * remembers what a pattern was covering. Anything not matched here fails the
+ * test that produced it.
+ */
+const ALLOWED_EVERYWHERE: readonly AllowedBrowserError[] = [
+  {
+    pattern: /^console\.error: Failed to load resource: /,
+    reason:
+      'The engine logs every non-2xx or aborted response on the console, and this suite drives ' +
+      'rejections through the UI constantly — a sweep of the whole suite recorded 363 of these ' +
+      'for 403 alone, plus 400/401/500 and net::ERR_FAILED, all from tests whose subject IS the ' +
+      'refusal. The status is asserted where it matters, so the line carries no information ' +
+      'this suite does not already have; a script that then breaks on the response still ' +
+      'reports its own uncaught error, which this fixture does not tolerate.',
+  },
+];
+
+/** Collects what the browser reported, and judges it at the end of the test. */
+export class BrowserErrorWatcher {
+  private readonly observed: string[] = [];
+  private readonly allowed: AllowedBrowserError[] = [...ALLOWED_EVERYWHERE];
+
+  /**
+   * Binds to a context the spec created itself. The fixture already watches
+   * the built-in `context`, so this is only for `browser.newContext()`.
+   */
+  watch(context: BrowserContext): void {
+    context.on('console', (message) => {
+      if (message.type() === 'error') {
+        this.observed.push(`console.error: ${message.text()}`);
+      }
+    });
+    context.on('weberror', (webError) => {
+      this.observed.push(`pageerror: ${webError.error().message || String(webError.error())}`);
+    });
+  }
+
+  /**
+   * Tolerates one class of error in this test only, for a stated reason. Use
+   * it when the test's own subject is a page provoked into erroring; a
+   * blanket suppression belongs in `ALLOWED_EVERYWHERE` with its reason, not
+   * here.
+   */
+  allow(pattern: RegExp, reason: string): void {
+    this.allowed.push({ pattern, reason });
+  }
+
+  /** Everything recorded that no allowlist entry covers. */
+  unexpected(): string[] {
+    return this.observed.filter((text) => !this.allowed.some(({ pattern }) => pattern.test(text)));
+  }
+}
+
+export const test = base.extend<{ browserErrors: BrowserErrorWatcher }>({
+  // `auto` so a spec inherits the guard without naming it: a fixture that has
+  // to be opted into is the per-spec plumbing this replaces.
+  browserErrors: [
+    async ({ context }, use, testInfo) => {
+      const watcher = new BrowserErrorWatcher();
+      watcher.watch(context);
+
+      await use(watcher);
+
+      const unexpected = watcher.unexpected();
+      if (unexpected.length === 0) {
+        return;
+      }
+
+      const report = unexpected.map((text) => `  - ${text}`).join('\n');
+      if (testInfo.status !== testInfo.expectedStatus) {
+        // The test is already red for its own reason. Reporting these as the
+        // failure would bury it, since a broken page tends to produce both.
+        await testInfo.attach('browser-errors', { body: report, contentType: 'text/plain' });
+        return;
+      }
+
+      throw new Error(
+        `The browser reported ${unexpected.length} unexpected error(s) during this test; ` +
+          'every assertion passed anyway, which is the false green this guard exists for. ' +
+          'Fix the page, or allowlist the class with its reason in e2e/support/fixtures.ts.\n' +
+          report
+      );
+    },
+    { auto: true },
+  ],
+});
+
+export { expect };
+export type { BrowserContext, Frame, Locator, Page, Request } from '@playwright/test';

--- a/e2e/theme-dark-mode.spec.ts
+++ b/e2e/theme-dark-mode.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Frame, type Page } from '@playwright/test';
+import { expect, test, type Frame, type Page } from './support/fixtures';
 import { expectDashboardStatusHeader } from './support/dashboard-helpers';
 import { cancelConfirmDialog } from './support/confirm-dialog-helpers';
 import { saveInterfaceSettingsForm } from './support/settings-interface-helpers';

--- a/e2e/visual-a11y.spec.ts
+++ b/e2e/visual-a11y.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from '@playwright/test';
+import { expect, test, type Page } from './support/fixtures';
 import { mutatingRequestsDuring } from './support/confirm-dialog-helpers';
 import { fillDateField } from './support/date-field-helpers';
 import {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -86,5 +86,29 @@ export default [
       // what makes the failure legible.
       "@typescript-eslint/no-non-null-assertion": "off"
     }
+  },
+  {
+    // Every spec runs on the suite's own `test`, which fails a test on an
+    // unallowlisted console error or an uncaught page exception. A spec that
+    // imports Playwright's stock `test` instead opts out of that guard
+    // silently, and a half-converted suite is worse than an unconverted one:
+    // the two halves diverge and nobody can tell which spec is watched. The
+    // fixture module re-exports `expect` and the types the specs use, so the
+    // conversion is a one-line import swap.
+    files: ["e2e/**/*.spec.ts"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "@playwright/test",
+              message:
+                "Import { expect, test } from './support/fixtures' instead — it fails a test on console errors and page errors."
+            }
+          ]
+        }
+      ]
+    }
   }
 ];

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -27,6 +27,13 @@ export default defineConfig({
     trace: 'retain-on-failure',
     video: 'retain-on-failure',
   },
+  // Three projects are DEFINED here; the gating pipeline does not run three.
+  // Every `e2e*` script pins `--project=chromium`, and the sharded CI job
+  // installs chromium alone, so the full suite is a chromium result. Firefox
+  // and WebKit are exercised by `npm run e2e:cross-browser`, which is scoped
+  // to `e2e/cross-browser-smoke.spec.ts`. Running all specs on all three would
+  // roughly triple e2e wall-clock, so the narrow lane is the accepted trade —
+  // stated here because this list on its own reads like coverage that exists.
   projects: [
     {
       name: 'chromium',


### PR DESCRIPTION
## What this closes

Board group T0726, `test-coverage-gap / playwright.config.ts`. Two records, both
anchored on `playwright.config.ts`, both confirmed. They are not the same defect
and only one of them is closable.

### R2-0980 — closed here

Claim: the browser suite has no shared error plumbing. A whole-scope static scan
counted 45 files importing `@playwright/test` directly and exactly **one** error
handler among them — a `page.on('console')` collector inside a single register
test in `auth-login-register.spec.ts`, recording console errors for that one
test. No `pageerror` handler and no shared fixture existed. The consequence: a
user-visible JavaScript crash coexists with passing assertions and merges
unnoticed, and every new spec has to remember its own error plumbing, so new
client exceptions do not affect test results.

### R2-0726 — reported, not closed

Claim: `playwright.config.ts` defines chromium/firefox/webkit, but the gating
pipeline runs one browser over the suite. Its stated minimal guard is
**`none-practical`**. See "Left unfixed" below.

## The fix (R2-0980)

`e2e/support/fixtures.ts` extends Playwright's `test` with an `auto` fixture that
fails a test on any console error and any uncaught page exception the allowlist
does not cover.

- It binds to the **BrowserContext**, not to a page, so a page a spec opens
  itself (`context.newPage()`, five sites) is watched without any spec change.
  The one spec that builds its own context (`auth-session-rotation.spec.ts`, the
  second "device") takes the `browserErrors` fixture and hands the context over
  explicitly.
- The allowlist is a list of `{ pattern, reason }`, each reason inline. A bare
  regex list rots into a mute button. It has exactly one suite-wide entry: the
  `Failed to load resource: …` line the engine logs for a non-2xx or aborted
  response. That entry is not a guess — the discovery sweep below recorded 363
  of them for 403 alone, plus 400/401/500 and `net::ERR_FAILED`, every one from
  a test whose subject IS the refusal.
- `browserErrors.allow(pattern, reason)` tolerates a class in **one test**, and
  is used where a spec deliberately breaks a save and htmx logs the failure it
  was asked to produce: `interceptDayPUT` in `calendar-save-resilience.spec.ts`
  arms it at the moment it arms the breakage (five call sites, one place), and
  the empty step-1 submit in `onboarding.spec.ts` allows exactly
  `Response Status Error Code 400 from /api/v1/onboarding/steps/1`. Scoping
  those per test rather than suite-wide is deliberate: an htmx request failure
  anywhere else still fails its test.
- When the test is already failing for its own reason, the collected errors are
  attached to the report rather than thrown, so the primary failure stays
  legible.

**All 33 specs converted**, none left behind. The remainder cannot grow: an
ESLint `no-restricted-imports` rule on `e2e/**/*.spec.ts` refuses
`@playwright/test`, naming the fixture in its message. Support helpers under
`e2e/support/` still import `@playwright/test` for `expect` and types — they
never receive a `test`, so they cannot create an unwatched page; the fixture
module re-exports `expect` and the four types the specs use, so each conversion
is a one-line import swap.

The one-test `page.on('console')` collector in `auth-login-register.spec.ts` is
gone, folded into the fixture: the fixture is strictly stricter (any console
error, not only the invalid-`pattern` one) and there is now one mechanism, not
two.

## Red → green, induced

The red was **induced**, not natural — nothing in the suite is currently
crashing. A throwaway `e2e/zz-induced-red.spec.ts` was added with two tests whose
every assertion passes and which each emit one browser error, then deleted.

Against the shared `test` (this branch), `npm run e2e -- e2e/zz-induced-red.spec.ts`:

```
  2 failed
    [chromium] › e2e\zz-induced-red.spec.ts:4:7 › … › console error with every assertion passing
    [chromium] › e2e\zz-induced-red.spec.ts:13:7 › … › uncaught page exception with every assertion passing
[e2e] failed: Playwright failed with exit code 1
```

with the failures naming the exact probe fed to each:

```
    Error: The browser reported 1 unexpected error(s) during this test; every assertion
    passed anyway, which is the false green this guard exists for. …
      - console.error: induced console error: ovumcy-e2e-fixture-probe

    Error: The browser reported 1 unexpected error(s) during this test; every assertion
    passed anyway, which is the false green this guard exists for. …
      - pageerror: induced page error: ovumcy-e2e-fixture-probe
```

Two probes, two inductions: the console-error assertion and the page-error
assertion each got the exact input it names.

The same spec on the unfixed tree — one character changed, the import pointed
back at `@playwright/test` — passes:

```
Running 2 tests using 1 worker

  ok 1 [chromium] › e2e\zz-induced-red.spec.ts:4:7 › … › console error with every assertion passing (768ms)
  ok 2 [chromium] › e2e\zz-induced-red.spec.ts:13:7 › … › uncaught page exception with every assertion passing (811ms)

  2 passed (2.9s)
[e2e] completed successfully
```

That green is the defect, stated as a run.

The ESLint guard is a separate assertion and got its own induction: reverting
`e2e/privacy.spec.ts:1` to `from '@playwright/test'` produces

```
e2e\privacy.spec.ts
  1:1  error  '@playwright/test' import is restricted from being used. Import { expect, test }
              from './support/fixtures' instead — it fails a test on console errors and page
              errors  no-restricted-imports
```

and restoring the line returns exit 0.

## How the allowlist was derived, and what was run

The allowlist was not guessed. A discovery pass ran the whole suite once with
the fixture temporarily reporting instead of throwing, printing every console
error and page error it saw. `npm run e2e` — 195 passed, 5 skipped, 23.9m, one
failure — inventoried nothing but transport-failure logging:

```
    363 console.error: Failed to load resource: the server responded with a status of 403 (Forbidden)
      4 console.error: Failed to load resource: net::ERR_FAILED
      3 console.error: htmx:sendError, [object HTMLDivElement]
      3 console.error: htmx:afterRequest, [object HTMLDivElement]
      2 console.error: Response Status Error Code 500 from /api/v1/days/2026-08-05, …
      2 console.error: Failed to load resource: the server responded with a status of 500 …
      2 console.error: Failed to load resource: the server responded with a status of 400 …
      1 console.error: Response Status Error Code 400 from /api/v1/onboarding/steps/1, …
      1 console.error: Failed to load resource: the server responded with a status of 401 …
```

No page error anywhere: the suite is not currently hiding a crash, which is why
the red had to be induced. The `Failed to load resource` half became the one
suite-wide entry; the htmx half is confined to the five tests that provoke it.

The single failure in that sweep was `visual-a11y.spec.ts › mobile tabbar paints
opaquely …`, and it is a machine flake, not this change: it failed inside
`registerOwnerViaUI` with `toHaveURL` reading `""` and a context teardown
overrunning the 30s test timeout, with no browser error recorded. Re-run alone
it passes (`1 passed (9.2s)`).

With the fixture switched back to throwing, the specs that needed a per-test
allowance were re-run and are green:
`calendar-save-resilience.spec.ts`, `onboarding.spec.ts`,
`settings-import.spec.ts` — `22 passed (2.1m)`; and
`auth-session-rotation.spec.ts`, the one hand-wired second context —
`1 passed (11.5s)`.

The rest of the suite is green by construction rather than by a second 24-minute
run: `unexpected()` is `observed` minus the allowlist, the sweep enumerated
everything observed, and every observed line is now covered.

Also run: `npm run lint` (eslint + `tsc --noEmit`), `go build ./...`,
`golangci-lint run` (`0 issues.`), `go test ./internal/i18n/...`,
`go run ./scripts/changelogd check` (OK). No Go package is touched by this
change.

## Left unfixed — R2-0726, `none-practical`

`playwright.config.ts` declares three projects, but the pipeline that gates
merges is a chromium result: `e2e`, `e2e:ci`, `e2e:fast`, `e2e:postgres`,
`e2e:ci:postgres` and `e2e:fast:postgres` all pin `--project=chromium`, the
sharded `e2e-shard` job installs chromium alone, and the only three-browser lane,
`npm run e2e:cross-browser`, is hard-scoped to `e2e/cross-browser-smoke.spec.ts`.
A Firefox- or WebKit-only regression in any of the other 32 specs ships to
self-hosted operators with CI never having exercised it.

The record's own minimal guard is **`none-practical` to fully close without
materially increasing CI cost**: a full 33-spec × 3-browser run would roughly
triple e2e wall-clock, and its counter-evidence notes that no document in the
repository — `TESTING.md` included — claims full cross-browser coverage exists,
so this reads as an accepted scope-vs-cost trade rather than an oversight.
Nothing here expands the CI matrix, rewrites
`cross-browser-smoke.spec.ts`, or touches the `--project=chromium` pins.

The one thing that was in scope is the misreading the config invites, and it is
addressed with a comment above `projects:` naming which of the three the gating
pipeline installs and runs, and why. The matrix itself is unchanged.

One incidental note: this PR's fixture is what makes the narrow cross-browser
lane worth more than it was — `cross-browser-smoke.spec.ts` now fails on a
Firefox- or WebKit-only JavaScript crash in the flow it does cover, which it
previously would not have. That narrows R2-0726 slightly; it does not close it.

## Rollback

Single-commit revert. Every item in this change is a test, guard, doc or local
lint-config change; none alters persisted data or a public contract.

## Review round (second commit)

**One finding, fixed: this file armed the broadest allowance in the suite.**
`HTMX_REQUEST_FAILURE_LOG` tolerated `Response Status Error Code ` with no status and no URL, so
once `interceptDayPUT` armed it, an htmx-reported failure from *any* endpoint during that test was
dropped. These tests assert about the day form and nothing else, so a real 500 elsewhere would have
merged green — in the file that suppresses the most. The sibling allowance in `onboarding.spec.ts`
already pinned both the status and the exact path.

The refusal log names the URL, so the allowance now names it too, built from the very date the
interception routes. The connection-drop logs (`htmx:sendError` / `htmx:afterRequest`) carry no URL
and stay as they were; `route.abort` is the only thing in these tests that drops a connection.

Induced red — the allowance armed for a date the test does not touch:

```
The browser reported 2 unexpected error(s) during this test; every assertion passed anyway ...
  - console.error: Response Status Error Code 500 from /api/v1/days/2026-08-05, [object HTMLDivElement]
```

That is both the proof that the pin matches the real message and the proof that a different-path
allowance does not cover it. Reverted; `calendar-save-resilience` + `onboarding` → `18 passed (1.3m)`,
`npm run lint` (eslint + `tsc --noEmit`) clean.

**Checked and NOT changed: the `Failed to load resource` entry in `ALLOWED_EVERYWHERE`.** It reads
broadly enough to hide a 404 on the app's own bundle, which would be the exact false green this
fixture exists to prevent — so it was measured rather than argued. A probe that 404s
`/static/js/app.js` and asserts only a trivially-true condition **fails**, because the missing bundle
produces a downstream CSP `console.error` that no allowlist entry covers; the same spec without the
interception passes clean. The claimed false green does not reproduce on this tree, so the entry
stays as the sweep justified it. The residual is worth stating rather than fixing blind: the catch is
a *downstream symptom*, not the 404 itself, so a future asset failure that produces no secondary
console error would pass. Narrowing the entry needs the same kind of full-suite measurement that
produced it, not a guess — a wrong narrowing reddens legitimately provoked 400/401/403/500 responses
and costs a 24-minute run to discover.
