### PR TITLE
test(e2e): arm the connection-drop allowance only where a drop is armed

### DIFF
--- a/changelog.d/fix-t0726-arm-drop-allowance-where-armed.md
+++ b/changelog.d/fix-t0726-arm-drop-allowance-where-armed.md
@@ -1,0 +1,12 @@
+none
+
+Test-only, and a narrowing of the browser-error fixture's per-test allowances rather than a change
+to it. The day-save resilience specs break a save on purpose, so htmx logging that failure is the
+behaviour under test and is tolerated. The refusal log names the URL and is scoped to the very path
+each interception routes; the connection-drop log carries no URL and cannot be scoped that way, so
+it is scoped by **arming** instead — raised the first time an interceptor is switched to
+`network-failure`, and never in a test that stays on the refusal outcome and drops nothing. Before
+this, the one spec that never aborts a request still tolerated a dropped connection from any
+endpoint, which would have let a real one pass unreported: these specs assert about the day form and
+nothing else. The refusal allowance stays unconditional on purpose, because an interceptor can
+refuse from its first request.

--- a/e2e/calendar-save-resilience.spec.ts
+++ b/e2e/calendar-save-resilience.spec.ts
@@ -78,10 +78,9 @@ async function interceptDayPUT(
   isoDate: string,
   browserErrors: BrowserErrorWatcher
 ): Promise<DayPUTInterceptor> {
-  browserErrors.allow(
-    HTMX_CONNECTION_DROP_LOG,
-    `this test aborts PUT /api/v1/days/${isoDate}, and htmx logging the dropped connection is the behaviour under test`
-  );
+  // Armed from construction, because `outcome` starts at `server-error`: this
+  // interceptor can refuse from its first request, so the refusal it will log is
+  // already the behaviour under test.
   browserErrors.allow(
     htmxRefusalLogFor(`/api/v1/days/${isoDate}`),
     `this test forces PUT /api/v1/days/${isoDate} to be refused, and htmx logging that refusal is the behaviour under test`
@@ -89,6 +88,7 @@ async function interceptDayPUT(
 
   let outcome: SaveOutcome = 'server-error';
   let attempts = 0;
+  let dropTolerated = false;
 
   await page.route(`**/api/v1/days/${isoDate}`, async (route) => {
     if (route.request().method() !== 'PUT') {
@@ -113,6 +113,19 @@ async function interceptDayPUT(
   return {
     attempts: () => attempts,
     set: (next: SaveOutcome) => {
+      // The connection-drop log carries no URL, so it cannot be scoped by path
+      // the way the refusal is. It is scoped by ARMING instead: a test that
+      // never switches this interceptor to `network-failure` never drops a
+      // connection, and must not tolerate one — a real drop elsewhere would
+      // otherwise pass unreported, since these tests assert about the day form
+      // and nothing else.
+      if (next === 'network-failure' && !dropTolerated) {
+        browserErrors.allow(
+          HTMX_CONNECTION_DROP_LOG,
+          `this test aborts PUT /api/v1/days/${isoDate}, and htmx logging the dropped connection is the behaviour under test`
+        );
+        dropTolerated = true;
+      }
       outcome = next;
     },
   };


### PR DESCRIPTION
Follow-up to #599, from the review of its own fix commit.

#599 pinned the htmx **refusal** allowance to the intercepted path and left the **connection-drop**
half unconditional. So `a rejected save keeps the typed entry and no save is announced` — the one
test that never calls `set("network-failure")` and never drops a connection — still tolerated
`htmx:sendError` and `htmx:afterRequest` from any endpoint. Same over-broad tolerance, in the half
that cannot be pinned by URL, because htmx's drop log carries none.

It is pinned by **arming** instead: the allowance is raised the first time the interceptor is
switched to `network-failure`. A test that never drops a connection never tolerates one. The
refusal allowance stays unconditional on purpose — `outcome` starts at `server-error`, so the
interceptor can refuse from its first request.

## Red → green

Induced, arming disabled:

```
x 2 ... a network failure is announced calmly and the retry resends the same entry
    - console.error: htmx:afterRequest, [object HTMLDivElement]
    - console.error: htmx:sendError, [object HTMLDivElement]
x 3 ... the failure notice is neutral, readable and localized, not a health alarm
ok 1 ... a rejected save keeps the typed entry and no save is announced
```

The rejected-save test passing there **is** the finding: it never needed the allowance it was
granted. Restored: `4 passed (33.0s)`, `npm run lint` (eslint + `tsc --noEmit`) clean.

No changelog fragment: #599's fragment already covers the fixture, and this narrows an allowance
inside it rather than changing anything an operator sees.

Single-commit revert; one spec file, no production code.
