### PR TITLE
docs: budget the documented test run and drop the drifting suite counts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,8 +14,11 @@ npm ci
 3. Run checks locally:
 
 ```bash
-# scoped past node_modules/, where a vendored JS dep ships a .go file
-go test ./cmd/... ./internal/... ./migrations/... ./scripts/... ./web/...
+# scoped past node_modules/, where a vendored JS dep ships a .go file;
+# -timeout 20m is the budget CI declares too — internal/api runs close enough to
+# Go's 10-minute PER PACKAGE default that the default aborts the run with
+# `panic: test timed out after 10m0s` (see TESTING.md)
+go test ./cmd/... ./internal/... ./migrations/... ./scripts/... ./web/... -timeout 20m
 go run ./scripts/archcheck
 npm run lint:js
 npm run build

--- a/README.md
+++ b/README.md
@@ -468,8 +468,10 @@ Notes:
 Common commands from the repository root:
 
 ```bash
-# scoped past node_modules/, where a vendored JS dep ships a .go file
-go test ./cmd/... ./internal/... ./migrations/... ./scripts/... ./web/...
+# scoped past node_modules/, where a vendored JS dep ships a .go file;
+# -timeout 20m raises Go's 10-minute PER PACKAGE default, which internal/api
+# outruns on a dev host (see TESTING.md)
+go test ./cmd/... ./internal/... ./migrations/... ./scripts/... ./web/... -timeout 20m
 npm run build
 go run ./cmd/ovumcy
 ```

--- a/TESTING.md
+++ b/TESTING.md
@@ -16,8 +16,19 @@ worth anything. Every claim here is backed by code in the repository and by CI.
 | **Fuzz** | Robustness of parsers/validators against arbitrary/invalid input | `internal/services/policy_fuzz_test.go` (native Go fuzzing) |
 | **Reference vectors** | Cycle predictions match the documented algorithm, number for number | `internal/services/cycles_reference_test.go` |
 
-Currently **2,300+ Go test functions** across `internal/` and **29 Playwright
-specs** (full suite on Chromium; cross-engine smoke on Firefox and WebKit).
+The Go suite runs to thousands of test functions across `internal/`, and the
+browser suite is every `e2e/*.spec.ts` file — `playwright.config.ts` declares
+only `testDir: 'e2e'`, with no `testMatch` or `testIgnore`, so the file listing
+*is* the suite (full suite on Chromium; cross-engine smoke on Firefox and
+WebKit). Exact figures are deliberately not written here: a number in prose
+goes stale on the next batch of tests and nothing re-derives it. Ask the tree
+instead:
+
+```bash
+grep -rE '^func Test[A-Z]' --include='*_test.go' internal | wc -l
+find e2e -name '*.spec.ts' | wc -l
+```
+
 Tests favor behavior and persisted state over markup or implementation details.
 
 ## We test our tests
@@ -30,7 +41,7 @@ fails ("kills" the mutant). Surviving mutants reveal weak assertions.
 - Run it locally: `scripts/mutation.sh baseline` (full) or `scripts/mutation.sh diff <ref>` (changed code only).
 - A weekly CI job tracks the trend; it is advisory and never blocks a merge.
 - Baseline scope now covers business-logic, security, and transport: `internal/services`, `internal/security`, and `internal/api`.
-- **Mutation efficacy** (gremlins, killed / (killed + survived); tracked weekly): `internal/services` **93.3%** (1529/1638), `internal/security` **97.8%** (134/137), and `internal/api` **97.3%** (649/667), measured on a clean-Linux CI run. Efficacy dipped from an earlier ~99% as v1.8.0 landed large new subsystems (webhooks, `.ics` feed, reminders) whose mutants were then triaged. An exhaustive per-mutant pass re-verified **every** survivor against a broad covering suite — the coverage-guided run over-reports survivors (Go leaves `const`/`case` lines uninstrumented, and its test selection can skip the killing test, so a mutant an existing test already kills can still show as survived) — closing the genuine gaps and documenting the residual as equivalents or coverage-attribution artifacts. `internal/api` is the slowest package to mutate — not the largest (`internal/services` is some 40% bigger in source lines) but the one whose tests are heavy DB integration — and it exceeds CI's 3h job timeout unsharded, so it runs as 5 file-subset shards (`internal_api_1`..`5`, a deterministic partition of the package's own files — see `scripts/mutation.sh`) merged into one `internal_api.json`. `internal/services` is sharded 5 ways on the same mechanism. Canonical efficacy comes only from the weekly clean-Linux job, never a local Windows run; per-package breakdowns live in [`.mutation/`](.mutation/).
+- **Mutation efficacy** (gremlins, killed / (killed + survived); tracked weekly): `internal/services` **93.3%** (1529/1638), `internal/security` **97.8%** (134/137), and `internal/api` **97.3%** (649/667), measured on a clean-Linux CI run. Efficacy dipped from an earlier ~99% as v1.8.0 landed large new subsystems (webhooks, `.ics` feed, reminders) whose mutants were then triaged. An exhaustive per-mutant pass re-verified **every** survivor against a broad covering suite — the coverage-guided run over-reports survivors (Go leaves `const`/`case` lines uninstrumented, and its test selection can skip the killing test, so a mutant an existing test already kills can still show as survived) — closing the genuine gaps and documenting the residual as equivalents or coverage-attribution artifacts. `internal/api` is the slowest package to mutate — not the largest (`internal/services` has more non-test source lines) but the one whose tests are heavy DB integration — and it exceeds CI's 3h job timeout unsharded, so it runs as 5 file-subset shards (`internal_api_1`..`5`, a deterministic partition of the package's own files — see `scripts/mutation.sh`) merged into one `internal_api.json`. `internal/services` is sharded 5 ways on the same mechanism. Canonical efficacy comes only from the weekly clean-Linux job, never a local Windows run; per-package breakdowns live in [`.mutation/`](.mutation/).
 - Statement coverage is lower than efficacy by design: mutation testing checks whether a test *fails when the code breaks*, not merely whether a line ran. The "not covered" mutants are dominated by package-level `const`/`var` declarations (which Go coverage never instruments) and the network-facing OIDC client (covered end-to-end).
 
 Surviving mutants are triaged honestly: a *real* gap gets a new behavior test; an
@@ -98,7 +109,11 @@ verify it against the numbers.
 # Go: unit + integration + property + fuzz seeds.
 # Scoped to the module's Go trees (not ./...) so a local node_modules/ — where a
 # vendored JS dependency ships a .go file — isn't swept into the wildcard.
-go test ./cmd/... ./internal/... ./migrations/... ./scripts/... ./web/...
+# -timeout 20m declares the same budget CI does: Go's default is 10 minutes PER
+# PACKAGE, and internal/api's DB-integration suite sits at that edge, so the
+# default run dies as `panic: test timed out after 10m0s` with a goroutine dump
+# that reads like a product bug. Read that panic as the budget, not as a defect.
+go test ./cmd/... ./internal/... ./migrations/... ./scripts/... ./web/... -timeout 20m
 
 # Active fuzzing of a single target
 go test ./internal/services/ -run '^$' -fuzz FuzzParseDayDate -fuzztime 30s
@@ -135,6 +150,7 @@ end to end. The two steps that matter are `go clean -testcache` and
 rm -f coverage.out
 go clean -testcache
 go test ./cmd/... ./internal/... ./migrations/... ./scripts/... ./web/... \
+  -timeout 20m \
   -coverprofile=coverage.out -covermode=atomic \
   -coverpkg=./cmd/...,./internal/...,./migrations/...,./scripts/...,./web/... \
   -count=1

--- a/changelog.d/docs-refresh-the-testing-guide-inventory.md
+++ b/changelog.d/docs-refresh-the-testing-guide-inventory.md
@@ -1,0 +1,18 @@
+### Internal
+
+- **The documented local Go command now declares the timeout budget CI declares.**
+  All four copies of `go test ./cmd/... ./internal/... ./migrations/... ./scripts/...
+  ./web/...` — `TESTING.md`'s run block and its patch-coverage recipe, `CONTRIBUTING.md`,
+  and `README.md` — pass `-timeout 20m`. Go's default is 10 minutes *per package* and
+  `internal/api`'s DB-integration suite runs at that edge, so the documented command
+  aborted with `panic: test timed out after 10m0s` and a goroutine dump that reads like
+  a product bug; the CI workflow has budgeted every one of its own `go test` calls since
+  the same measurement, and the docs handed contributors the unbudgeted spelling.
+- **`TESTING.md` no longer states test counts that go stale.** The header said "2,300+ Go
+  test functions across `internal/` and 29 Playwright specs"; the tree holds 2,720 and 33,
+  and the spec figure had already been corrected once. Both numbers are replaced by the
+  two commands that re-derive them, plus the fact that makes the spec listing authoritative
+  (`playwright.config.ts` sets only `testDir: 'e2e'`, with no `testMatch`/`testIgnore`).
+  The mutation section's "`internal/services` is some 40% bigger in source lines" —
+  measured at 18,245 non-test lines against `internal/api`'s 11,417, so nearer 60% — loses
+  the percentage for the ordering claim the sentence actually rests on.

--- a/changelog.d/docs-testing-counts.md
+++ b/changelog.d/docs-testing-counts.md
@@ -1,8 +1,8 @@
 ### Internal
 
-- **`TESTING.md`'s counts and package claims now match the suite that ships.** The sealed-cookie
-  section said eleven AEAD purposes and its table omitted `ovumcy_calendar_feed`, which the codec
-  security test has exercised since the `.ics` feed landed; the header figures said 27 Playwright
-  specs and 2,150+ Go test functions against 29 and 2,333; and the mutation section called
-  `internal/api` the largest package when `internal/services` is around 40% bigger and is sharded
-  the same 5 ways.
+- **`TESTING.md`'s sealed-cookie section now matches the codec that ships.** It said eleven AEAD
+  purposes and its table omitted `ovumcy_calendar_feed`, which the codec security test has
+  exercised since the `.ics` feed landed. The mutation section's claim that `internal/api` is the
+  largest package went with it: `internal/services` is bigger and is sharded the same 5 ways. The
+  header's test counts were corrected in the same pass; they are dropped entirely by the entry
+  below, which supersedes that half.


### PR DESCRIPTION
## What changed

Board group **T0813** — the testing guide's inventory. Documentation only; no Go, TypeScript or
CI file is touched.

1. **R2-0998 — the documented all-package Go run has no timeout budget.** All four copies of
   `go test ./cmd/... ./internal/... ./migrations/... ./scripts/... ./web/...` now pass
   `-timeout 20m`: `TESTING.md:116` (run block), `TESTING.md:152` (patch-coverage recipe),
   `CONTRIBUTING.md:21`, `README.md:474`. Go's default is 10 minutes **per package** and
   `internal/api`'s DB-integration suite runs at that edge, so the documented command aborts
   with `panic: test timed out after 10m0s` plus a goroutine dump that reads like a product
   defect. Each site carries a one-clause reason; `TESTING.md` carries the long form.
2. **R2-0813 — the header counts drift.** "2,300+ Go test functions across `internal/` and 29
   Playwright specs" is replaced by the two commands that re-derive both numbers, plus the fact
   that makes the spec listing authoritative (`playwright.config.ts` sets only `testDir: 'e2e'`
   — no `testMatch`, no `testIgnore`).
3. **R2-0814 — "`internal/services` is some 40% bigger in source lines"** becomes
   "`internal/services` has more non-test source lines". The measured gap is ~60%, not 40%, and
   the ordering is the only thing the surrounding sentence rests on.

## Red — the measurements that contradicted the committed text

Every figure below was taken on this worktree at `c0bbb235`, before the edit.

Playwright specs — `TESTING.md:19` said **29**:

```
$ find e2e -name '*.spec.ts' | wc -l
33
```

Go test functions — `TESTING.md:19` said **2,300+ across `internal/`** (true as a floor, stale
as a statement; the same sentence was already corrected once, see the still-unreleased
`changelog.d/docs-testing-counts.md`):

```
$ grep -rE '^func Test[A-Z]' --include=*_test.go internal | wc -l
2720
$ grep -rE '^func Test[A-Z]' --include=*_test.go internal cmd migrations scripts web | wc -l
2947
```

Package size — `TESTING.md:33` said **some 40% bigger**:

```
$ find internal/services -name '*.go' ! -name '*_test.go' -print0 | xargs -0 cat | wc -l
18245
$ find internal/api -name '*.go' ! -name '*_test.go' -print0 | xargs -0 cat | wc -l
11417
```

18245 / 11417 = 1.598 → `internal/services` is ~**60%** bigger by non-test source lines, not 40%.

The missing timeout budget — the class, found by grepping for the command shape across tracked
files rather than by trusting the record's file list:

```
$ git grep -n 'go test \./cmd/\.\.\.'
CONTRIBUTING.md:18:go test ./cmd/... ./internal/... ./migrations/... ./scripts/... ./web/...
README.md:472:go test ./cmd/... ./internal/... ./migrations/... ./scripts/... ./web/...
TESTING.md:101:go test ./cmd/... ./internal/... ./migrations/... ./scripts/... ./web/...
TESTING.md:137:go test ./cmd/... ./internal/... ./migrations/... ./scripts/... ./web/... \
```

Four copies, none budgeted — against `.github/workflows/ci.yml`, where **every** `go test` that
runs a suite declares `-timeout 20m` (lines 137, 233, 723, 761, 772; the two bare calls at 134
and 720 are `go test -list`, which runs nothing). The measurement behind CI's budget is recorded
in that workflow's own comment at `.github/workflows/ci.yml:199-207`: `internal/api` at 603 s
alone, 610 s inside the wildcard run, against a 600 s default, with coverage instrumentation
slower still. The suite was deliberately **not** re-run here to reproduce the panic: a ten-minute
run that ends in a timeout is precisely the cost this PR documents away, and the repository has
the measurement four times over.

## Green — after the edit

```
$ git grep -n 'go test \./cmd/\.\.\.'
CONTRIBUTING.md:21:go test ./cmd/... ./internal/... ./migrations/... ./scripts/... ./web/... -timeout 20m
README.md:474:go test ./cmd/... ./internal/... ./migrations/... ./scripts/... ./web/... -timeout 20m
TESTING.md:116:go test ./cmd/... ./internal/... ./migrations/... ./scripts/... ./web/... -timeout 20m
TESTING.md:152:go test ./cmd/... ./internal/... ./migrations/... ./scripts/... ./web/... \
```

`TESTING.md:152` takes `-timeout 20m` on its own continuation line inside the coverage recipe.
Flag-after-package ordering was checked against the real toolchain rather than assumed:

```
$ go test ./scripts/readmeversion/... -timeout 20m
ok  github.com/ovumcy/ovumcy-web/scripts/readmeversion 1.037s
```

(That package is also the one guard that reads `README.md`, so it doubles as proof the README
edit did not disturb the release-tag drift check.)

The two commands the guide now hands the reader run as written:

```
$ grep -rE '^func Test[A-Z]' --include='*_test.go' internal | wc -l
2720
$ find e2e -name '*.spec.ts' | wc -l
33
```

## Which fix shape, and why

R2-0813 offered two: a `scripts/readmeversion`-style CI checker that re-derives both counts, or
dropping the numbers for language that cannot go stale. **Chosen: drop the numbers.** A checker
would have to encode a tolerance ("no more than N below the measured value"), and a tolerance is
a second number that drifts silently in the other direction — it stays green precisely while the
document is getting more wrong, which is the failure mode already observed twice here. The
guide's numbers are decorative: nothing in the repository consumes them, and no reader's decision
turns on 2,720 versus 2,300. So the document now says how to ask the tree and leaves the answer
to the tree. `README.md`'s release tag is different in kind — several files must agree on one
value, which is why `scripts/readmeversion` earns its keep and this would not.

R2-0814's guard is **`none-practical`**, in the record's own words: "a rough prose approximation
— not worth automating; lowest-priority of the count-drift items." Stated plainly rather than
papered over with a check. The fix removes the drifting quantity instead of refreshing it, for
the same reason as above — "some 60%" would be a fresh instance of the defect being repaired,
two paragraphs from where it was repaired.

R2-0998 has no guard in this PR either. Its record proposes "run the exact documented command in
a clean CI job on every change to `TESTING.md`" — a 20-minute lane whose only subject is a code
block, on a workflow that already runs that package set on every PR. The asymmetry it needs to
detect is static and is now closed at all four sites.

## Deferred — owner decision

The group nominally also carried two `LICENSE` records. Both are **already resolved on `main`**,
so there is no wording to defer: commit `6ad13ff5` ("docs: carry the full AGPL-3.0 text in
LICENSE") landed before this branch, and `changelog.d/docs-license-full-agpl-text.md` records it.
Verified on this tree, not assumed:

- **R2-0816** — "LICENSE contains only a short AGPLv3 notice, not the full canonical text"
  (confidence 0.35, guard `none-practical`). `LICENSE` is now **661 lines**: the canonical
  AGPL-3.0 text, sections 0–17 included. The copyright line moved to `README.md:514`.
  **No proposal; nothing to decide.**
- **R2-0815** — "LICENSE labels the AGPLv3 §13 network-copyleft restatement an 'ADDITIONAL TERM
  under Section 7'" (confidence 0.40, guard `none-practical`). That paragraph is gone; the only
  occurrences of "additional terms" left in the file are section 7's own canonical body
  (`LICENSE:331`ff). The plain-English restatement now sits in `README.md:518-519`, where it is
  editorial commentary and not a licence term. **No proposal; nothing to decide.**

Both records were audited against a snapshot predating `6ad13ff5`; they should be closed as
already-fixed rather than actioned. `LICENSE` is untouched by this branch.

## Checks

Docs-only diff, so the final pass is the docs-only pass:

- `go build ./...` — clean.
- `golangci-lint run` — `0 issues.`
- `go run ./scripts/changelogd check` — `changelog fragment check OK.`
- `go test ./scripts/readmeversion/... -timeout 20m` — ok (the one guard that reads `README.md`).

No Go suite was run: no Go file is in the diff.

## Noticed, not fixed

`.github/workflows/ci.yml:1148` names an agent-only path in a comment, which tracked sources are
not supposed to do. Out of scope for this PR; reported rather than fixed.
