### PR TITLE
fix(reminders): retry a failed notify pass instead of closing the day

### DIFF
--- a/changelog.d/reminders-retry-a-failed-notify-pass.md
+++ b/changelog.d/reminders-retry-a-failed-notify-pass.md
@@ -1,0 +1,16 @@
+### Fixed
+
+- **A reminder pass that failed outright no longer costs the whole day's reminders.** The built-in
+  scheduler keeps a once-per-local-day marker so a restart cannot re-fire the day's pass, and it used
+  to advance that marker even when the pass had returned an error. The only error a pass raises at
+  that level is "the list of owners could not be read" — raised before a single owner is processed —
+  so a moment of database trouble at the scheduled hour recorded a day on which nothing was sent as a
+  day already done, and a restart later the same day saw the marker, skipped the run, and sent
+  nothing either. Marking it was deliberate: it stopped a broken database from making the scheduler
+  spin. The pass is now retried instead — a few minutes apart, up to three attempts in the same slot
+  — and the day is marked only once one succeeds or the attempts are spent, so the anti-spin property
+  is kept while a transient failure costs minutes rather than every owner's reminders. A process
+  stopped between two attempts leaves the day unmarked, so the next start catches it up, and the
+  per-reminder watermark still guarantees a retry cannot re-send what an earlier attempt delivered.
+  A pass that panics is unchanged: it is still contained, still leaves the day unmarked, and is still
+  retried by the next scheduled fire rather than immediately.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -210,6 +210,12 @@ Notes:
 - If the process was down when the scheduled hour passed, it catches up with
   **at most one pass for the current day** on the next start — it never
   backfills multiple missed days.
+- If a pass fails before it can send anything (the database was unreachable, so
+  the list of owners could not be read), the day is **not** counted as done: the
+  pass is retried a few minutes later, up to three attempts, and only then does
+  the scheduler give up until the next day's hour. A restart in between still
+  catches the day up, and the idempotency watermark below means a retry never
+  re-sends a reminder an earlier attempt already delivered.
 - On graceful shutdown (`SIGINT`/`SIGTERM`), the server waits briefly for an
   in-flight pass to finish before closing the database.
 - It reuses the exact same delivery path, idempotency watermark, and security

--- a/internal/reminders/scheduler.go
+++ b/internal/reminders/scheduler.go
@@ -226,25 +226,36 @@ func (s *Scheduler) runCatchUp(ctx context.Context) {
 // not spend the error budget — an attempt is only worth repeating immediately
 // when the failure is the transient shape a returned error describes.
 //
-// now is resolved once per attempt so each attempt's pass clock and the date it
-// would mark agree.
+// Each attempt resolves its own clock, so a pass always computes due reminders
+// against the moment it actually runs. The MARKED day is not that clock: it is
+// the slot's own day, resolved once below. The two differ whenever a slot's
+// backoff crosses local midnight — reachable because runCatchUp fires at any
+// hour, so a late-evening start can spend its whole budget past midnight — and
+// marking the last attempt's day would then close TOMORROW, a day whose pass has
+// not run and whose scheduled hour has not arrived. A restart on that day reads
+// marker == today and skips its catch-up, losing exactly the day this retry
+// exists to save. Guard: TestSpentBudgetMarksTheSlotsOwnDayNotTheDayItsRetriesRanInto.
 func (s *Scheduler) runScheduledPass(ctx context.Context) {
+	slotNow := s.now()
 	for attempt := 1; ; attempt++ {
-		now := s.now()
+		now := slotNow
+		if attempt > 1 {
+			now = s.now()
+		}
 		completed, err := s.runPassRecovered(ctx, now)
 		if !completed {
 			// Panicked: leave the marker untouched so the next fire retries.
 			return
 		}
 		if err == nil {
-			s.markRan(ctx, now)
+			s.markRan(ctx, slotNow)
 			return
 		}
 		// The error itself is logged by reason only; RunOnce already logged the
 		// per-owner detail and never surfaces reminder contents.
 		if attempt >= maxPassAttempts {
 			log.Printf("reminder scheduler: notify pass failed %d times (see prior notify logs), marking today and giving up until the next scheduled run", attempt)
-			s.markRan(ctx, now)
+			s.markRan(ctx, slotNow)
 			return
 		}
 		log.Printf("reminder scheduler: notify pass returned an error (see prior notify logs), attempt %d of %d, retrying in %s", attempt, maxPassAttempts, passRetryDelay)

--- a/internal/reminders/scheduler.go
+++ b/internal/reminders/scheduler.go
@@ -4,8 +4,10 @@
 // due reminders, delivering, and writing each per-reminder watermark — is
 // unchanged and remains the authoritative idempotency guard. This package adds
 // ONLY the trigger: when to call the pass, a once-per-local-day "ran today"
-// marker for restart safety and current-day catch-up, panic isolation so a bad
-// pass cannot crash the web process, and a bounded drain on shutdown.
+// marker for restart safety and current-day catch-up, a bounded retry when a
+// pass fails outright (so a transient failure costs minutes, not the whole
+// day), panic isolation so a bad pass cannot crash the web process, and a
+// bounded drain on shutdown.
 //
 // Why here and not in cmd/ovumcy: keeping the schedule math (nextRun),
 // catch-up, marker handling, and drain in an internal package makes them fully
@@ -38,6 +40,21 @@ import (
 // dates (not instants) is what makes "already ran today" independent of the
 // wall-clock time within the day.
 const dateLayout = "2006-01-02"
+
+// maxPassAttempts bounds how many times ONE scheduled slot may attempt the
+// notify pass before it gives up for the day. A pass-level error aborts the pass
+// before any owner is processed (the owner listing is what fails), so the whole
+// day's reminders are still unsent and only another attempt can save them. The
+// budget is what preserves the anti-busy-loop property the day marker used to
+// provide on its own: a permanently broken database costs a bounded number of
+// attempts per slot, never an unbounded spin.
+const maxPassAttempts = 3
+
+// passRetryDelay is the wait between two attempts inside one slot. Long enough
+// that a transient outage (a database restart, a lock storm) has plausibly
+// passed by the next attempt, short enough that the whole budget is spent well
+// inside the local day the slot belongs to.
+const passRetryDelay = 5 * time.Minute
 
 // PassRunner is the single behavior the scheduler needs from the notify service:
 // run one pass. It is satisfied by *services.WebhookNotifyService.RunOnce, kept
@@ -129,7 +146,8 @@ func New(runner PassRunner, marker MarkerStore, config Config) *Scheduler {
 //     (covers "the process was down when the scheduled hour passed"). A marker
 //     equal to today means a same-day restart — skip, do not re-fire.
 //  2. Loop: arm a timer to the next instant whose local hour == Hour, wait for
-//     it (or ctx), run one pass, mark today, and recompute the next instant.
+//     it (or ctx), run one pass (with the bounded in-slot retry runScheduledPass
+//     describes), mark today, and recompute the next instant.
 //     Recomputing each cycle (rather than a fixed 24h ticker) keeps the fire
 //     pinned to the wall-clock hour across DST transitions.
 //
@@ -160,7 +178,8 @@ func (s *Scheduler) Run(ctx context.Context) {
 }
 
 // runCatchUp performs the current-day catch-up described on Run. It runs at most
-// one pass and only for TODAY — it never backfills historical missed days.
+// one slot — one pass plus that slot's bounded retries — and only for TODAY: it
+// never backfills historical missed days.
 func (s *Scheduler) runCatchUp(ctx context.Context) {
 	now := s.now()
 	today := now.In(s.config.Location).Format(dateLayout)
@@ -185,43 +204,97 @@ func (s *Scheduler) runCatchUp(ctx context.Context) {
 	s.runScheduledPass(ctx)
 }
 
-// runScheduledPass runs exactly one notify pass with panic isolation, then marks
-// today ON SUCCESS ONLY. A panic is recovered so the scheduler survives; the day
-// is NOT marked on panic so the next fire retries (and #124's per-reminder
-// watermark still prevents any double-send). now is resolved once so the pass
-// clock and the marked date agree.
+// runScheduledPass runs the notify pass for one scheduled slot, with panic
+// isolation, and marks today ON SUCCESS or once the retry budget is spent.
+//
+// A pass-level error is NOT a completed day: the only error RunOnce raises at
+// pass level is the owner listing failing, which returns before a single owner
+// is processed, so zero reminders went out. Marking the day on it recorded an
+// attempt as a success — the local day was then closed for good, and a same-day
+// restart hit the marker-equals-today early return and made no call at all.
+// Instead the marker is left alone and the pass is retried after
+// passRetryDelay, up to maxPassAttempts attempts in this slot. Marking the day
+// after the LAST failed attempt is what keeps the original anti-busy-loop
+// property: a broken database costs a bounded number of attempts, then the
+// scheduler waits for the next scheduled fire rather than spinning. #124's
+// per-reminder watermark remains the authoritative idempotency guard, so an
+// attempt that overlaps a partially delivered earlier one still sends nothing
+// twice.
+//
+// A panic is a different failure class and keeps its own semantics: recovered so
+// the scheduler survives, day NOT marked so the next fire retries, and it does
+// not spend the error budget — an attempt is only worth repeating immediately
+// when the failure is the transient shape a returned error describes.
+//
+// now is resolved once per attempt so each attempt's pass clock and the date it
+// would mark agree.
 func (s *Scheduler) runScheduledPass(ctx context.Context) {
-	now := s.now()
-	if !s.runPassRecovered(ctx, now) {
-		// Panicked: leave the marker untouched so a retry is allowed.
-		return
+	for attempt := 1; ; attempt++ {
+		now := s.now()
+		completed, err := s.runPassRecovered(ctx, now)
+		if !completed {
+			// Panicked: leave the marker untouched so the next fire retries.
+			return
+		}
+		if err == nil {
+			s.markRan(ctx, now)
+			return
+		}
+		// The error itself is logged by reason only; RunOnce already logged the
+		// per-owner detail and never surfaces reminder contents.
+		if attempt >= maxPassAttempts {
+			log.Printf("reminder scheduler: notify pass failed %d times (see prior notify logs), marking today and giving up until the next scheduled run", attempt)
+			s.markRan(ctx, now)
+			return
+		}
+		log.Printf("reminder scheduler: notify pass returned an error (see prior notify logs), attempt %d of %d, retrying in %s", attempt, maxPassAttempts, passRetryDelay)
+		if !s.waitBeforeRetry(ctx) {
+			// Shutting down mid-backoff: leave the marker untouched so the next
+			// start's catch-up re-runs today's pass.
+			return
+		}
 	}
-	s.markRan(ctx, now)
+}
+
+// waitBeforeRetry waits passRetryDelay before the next attempt in this slot,
+// through the same injected timer seam the main loop uses, and reports whether
+// the retry may proceed. It returns false when the signal context is cancelled
+// during (or in the same round as) the backoff, so a shutdown never starts a
+// pass the caller is trying to drain.
+func (s *Scheduler) waitBeforeRetry(ctx context.Context) bool {
+	timer := s.newTimer(passRetryDelay)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C():
+	}
+	// The same re-check the main loop makes after its own fire, for the same
+	// reason: a backoff elapsing in the round that cancels must not start a pass.
+	return ctx.Err() == nil
 }
 
 // runPassRecovered calls RunOnce inside a recover() so a panic in the batch pass
 // (or anything it calls) is contained to this goroutine instead of crashing the
 // process — fiber's recover middleware only covers request handlers. It returns
-// true when the pass completed without panicking (a returned error is a normal,
-// logged pass outcome, not a panic). The recovery logs only a stable reason and
-// a scrubbed stack — NEVER per-owner reminder contents (RunOnce itself never
-// surfaces them).
-func (s *Scheduler) runPassRecovered(ctx context.Context, now time.Time) (completed bool) {
+// completed=true when the pass ran to completion without panicking, together
+// with whatever error the pass itself returned: a pass-level error is an
+// expected-transient outcome, and what to do about it (retry, then give up for
+// the day) is the caller's decision, not this function's. The recovery logs only
+// a stable reason and a scrubbed stack — NEVER per-owner reminder contents
+// (RunOnce itself never surfaces them).
+func (s *Scheduler) runPassRecovered(ctx context.Context, now time.Time) (completed bool, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			completed = false
+			err = nil
 			log.Printf("reminder scheduler: notify pass panicked, recovered and continuing; stack:\n%s", debug.Stack())
 		}
 	}()
 
-	if _, err := s.runner.RunOnce(ctx, now, s.config.Location, false); err != nil {
-		// A pass-level error (e.g. listing owners failed) is expected-transient and
-		// safe to log by reason; RunOnce already contains per-owner failures. We
-		// still mark today so a broken DB does not busy-loop the scheduler — the
-		// watermark guarantees no double-send if it recovers before the next day.
-		log.Printf("reminder scheduler: notify pass returned an error (see prior notify logs)")
-	}
-	return true
+	_, err = s.runner.RunOnce(ctx, now, s.config.Location, false)
+	return true, err
 }
 
 // markRan records today's local date as the last successful run. A write failure

--- a/internal/reminders/scheduler_test.go
+++ b/internal/reminders/scheduler_test.go
@@ -15,10 +15,14 @@ import (
 // told to panic on the Nth call, and signals every call on a channel so a test
 // can block until a pass has actually run without sleeping.
 type fakeRunner struct {
-	mu         sync.Mutex
-	calls      int
-	panicOn    int // 1-based call index to panic on; 0 = never
-	returnErr  error
+	mu        sync.Mutex
+	calls     int
+	panicOn   int // 1-based call index to panic on; 0 = never
+	returnErr error
+	// errCalls limits returnErr to the FIRST n calls, so a test can make a pass
+	// fail and then recover on a retry. 0 (the zero value) means returnErr is
+	// returned by every call — a permanently broken pass.
+	errCalls   int
 	called     chan struct{}
 	perCallNow []time.Time
 }
@@ -33,6 +37,9 @@ func (r *fakeRunner) RunOnce(_ context.Context, now time.Time, _ *time.Location,
 	current := r.calls
 	shouldPanic := r.panicOn == current
 	err := r.returnErr
+	if r.errCalls > 0 && current > r.errCalls {
+		err = nil
+	}
 	r.perCallNow = append(r.perCallNow, now)
 	r.mu.Unlock()
 
@@ -593,5 +600,250 @@ func TestMarkerWriteFailureIsLoggedNotFatal(t *testing.T) {
 	// we exercised the error branch rather than a silent success.
 	if _, ok := marker.get(markerKey + "::written"); ok {
 		t.Fatal("unexpected sentinel")
+	}
+}
+
+// retryTimerCeiling separates the two kinds of timer the scheduler arms from its
+// single newTimer seam. The next-run timer is always the hours from now to the
+// next local run hour (every fixture below sits at least three hours from its
+// run hour); the in-slot retry timer is passRetryDelay, minutes. Anything at or
+// below this ceiling is therefore a retry timer, which lets one factory drive
+// retries deterministically without a wall-clock wait.
+const retryTimerCeiling = time.Hour
+
+// slotTimerFactory is a schedulerTimer factory that tells the two timers apart by
+// their duration (see retryTimerCeiling). Retry timers fire IMMEDIATELY when
+// fireRetries is set — that is how a retry test runs in microseconds instead of
+// passRetryDelay — and stay parked otherwise, which is the "shutdown arrives
+// mid-backoff" case. Next-run timers never fire, so every pass a test observes is
+// one it drove itself. Each armed duration is recorded and announced on armed.
+type slotTimerFactory struct {
+	fireRetries bool
+
+	mu        sync.Mutex
+	durations []time.Duration
+	armed     chan time.Duration
+}
+
+func newSlotTimerFactory(fireRetries bool) *slotTimerFactory {
+	return &slotTimerFactory{fireRetries: fireRetries, armed: make(chan time.Duration, 16)}
+}
+
+func (f *slotTimerFactory) newTimer(d time.Duration) schedulerTimer {
+	f.mu.Lock()
+	f.durations = append(f.durations, d)
+	f.mu.Unlock()
+
+	ch := make(chan time.Time, 1)
+	if d <= retryTimerCeiling && f.fireRetries {
+		ch <- time.Now()
+	}
+	select {
+	case f.armed <- d:
+	default:
+	}
+	return fakeTimer{ch: ch}
+}
+
+// retryDelays returns every armed duration the ceiling classifies as a retry
+// backoff, in arming order.
+func (f *slotTimerFactory) retryDelays() []time.Duration {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var out []time.Duration
+	for _, d := range f.durations {
+		if d <= retryTimerCeiling {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+// waitForRetryTimer blocks until the factory has armed a timer the ceiling
+// classifies as a retry backoff, or the deadline elapses.
+func (f *slotTimerFactory) waitForRetryTimer(t *testing.T, within time.Duration) {
+	t.Helper()
+	deadline := time.After(within)
+	for {
+		select {
+		case d := <-f.armed:
+			if d <= retryTimerCeiling {
+				return
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting for the scheduler to arm a retry timer; armed so far: %v", f.durations)
+		}
+	}
+}
+
+// TestPassErrorRetriesInTheSameSlotAndMarksOnlyOnceItSucceeds is the core guard
+// for the record's claim: a pass-level error (the owner listing failed, so ZERO
+// reminders went out) must not be recorded as today's completed run. The first
+// attempt errors, the in-slot retry succeeds, and only that success advances the
+// marker — exactly one marker write for the day.
+func TestPassErrorRetriesInTheSameSlotAndMarksOnlyOnceItSucceeds(t *testing.T) {
+	utc := time.UTC
+	today := time.Date(2026, 7, 6, 12, 0, 0, 0, utc) // H=9, so catch-up fires
+	runner := newFakeRunner()
+	runner.returnErr = errors.New("listing owners failed")
+	runner.errCalls = 1 // only the first attempt fails; the retry succeeds
+	marker := newFakeMarker()
+	marker.values[markerKey] = "2026-07-05" // yesterday
+
+	timers := newSlotTimerFactory(true)
+	scheduler := newTestScheduler(runner, marker, 9, utc, func() time.Time { return today }, timers.newTimer)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := scheduler.Start(ctx)
+
+	waitForCalls(t, runner, 2, 2*time.Second)
+	cancel()
+	<-done
+
+	if got := runner.callCount(); got != 2 {
+		t.Fatalf("expected the failed pass to be retried once inside its slot (2 attempts), got %d", got)
+	}
+	if v, ok := marker.get(markerKey); !ok || v != "2026-07-06" {
+		t.Fatalf("expected the successful retry to mark today 2026-07-06, got %q ok=%v", v, ok)
+	}
+	if marker.setCalls != 1 {
+		t.Fatalf("expected exactly one marker write, made by the retry that actually succeeded, got %d", marker.setCalls)
+	}
+}
+
+// TestRestartBeforeTheRetryStillCatchesUpToday is the record's second half: a
+// process that dies between a failed attempt and its retry must not have left
+// today marked, so the next start's catch-up re-runs the day. The first
+// scheduler's retry timer never fires and the context is cancelled while the
+// backoff is pending; a fresh scheduler over the SAME marker store then fires a
+// catch-up pass.
+func TestRestartBeforeTheRetryStillCatchesUpToday(t *testing.T) {
+	utc := time.UTC
+	today := time.Date(2026, 7, 6, 12, 0, 0, 0, utc)
+	clock := func() time.Time { return today }
+	marker := newFakeMarker()
+	marker.values[markerKey] = "2026-07-05" // yesterday -> catch-up fires
+
+	failing := newFakeRunner()
+	failing.returnErr = errors.New("listing owners failed")
+	timers := newSlotTimerFactory(false) // the retry backoff stays pending
+
+	first := newTestScheduler(failing, marker, 9, utc, clock, timers.newTimer)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := first.Start(ctx)
+
+	waitForCalls(t, failing, 1, 2*time.Second)
+	timers.waitForRetryTimer(t, 2*time.Second)
+	cancel() // the process dies while the retry is still waiting
+	<-done
+
+	if v, ok := marker.get(markerKey); !ok || v != "2026-07-05" {
+		t.Fatalf("a pass that failed and has not retried yet must leave the marker at yesterday, got %q ok=%v", v, ok)
+	}
+
+	// The restart: a new scheduler over the same marker store, same local day.
+	recovered := newFakeRunner()
+	second := newTestScheduler(recovered, marker, 9, utc, clock, neverFireTimerFactory())
+	restartCtx, restartCancel := context.WithCancel(context.Background())
+	restartDone := second.Start(restartCtx)
+
+	waitForCalls(t, recovered, 1, 2*time.Second)
+	restartCancel()
+	<-restartDone
+
+	if got := recovered.callCount(); got != 1 {
+		t.Fatalf("expected the restart to catch up today's unfinished pass exactly once, got %d", got)
+	}
+	if v, ok := marker.get(markerKey); !ok || v != "2026-07-06" {
+		t.Fatalf("expected the caught-up pass to mark today 2026-07-06, got %q ok=%v", v, ok)
+	}
+}
+
+// TestRetryBudgetIsBoundedThenTheDayIsMarked guards the other half of the trade:
+// the retry is BOUNDED. A permanently failing pass is attempted exactly
+// maxPassAttempts times in its slot, each attempt separated by a non-zero
+// backoff, and only then is the day marked — so a broken database can never
+// busy-loop the scheduler, which is the property the pre-existing "mark on
+// error" behaviour bought at the cost of the whole day's reminders.
+func TestRetryBudgetIsBoundedThenTheDayIsMarked(t *testing.T) {
+	utc := time.UTC
+	today := time.Date(2026, 7, 6, 12, 0, 0, 0, utc)
+	runner := newFakeRunner()
+	runner.returnErr = errors.New("listing owners failed") // errCalls 0 -> every attempt fails
+	marker := newFakeMarker()
+	marker.values[markerKey] = "2026-07-05" // yesterday -> catch-up fires
+
+	timers := newSlotTimerFactory(true)
+	scheduler := newTestScheduler(runner, marker, 9, utc, func() time.Time { return today }, timers.newTimer)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := scheduler.Start(ctx)
+
+	waitForCalls(t, runner, maxPassAttempts, 2*time.Second)
+	cancel()
+	<-done
+
+	if got := runner.callCount(); got != maxPassAttempts {
+		t.Fatalf("expected exactly %d attempts in one slot, got %d", maxPassAttempts, got)
+	}
+	if v, ok := marker.get(markerKey); !ok || v != "2026-07-06" {
+		t.Fatalf("expected the spent budget to mark today 2026-07-06 (anti-busy-loop), got %q ok=%v", v, ok)
+	}
+	delays := timers.retryDelays()
+	if len(delays) != maxPassAttempts-1 {
+		t.Fatalf("expected %d retry backoffs between %d attempts, got %d (%v)", maxPassAttempts-1, maxPassAttempts, len(delays), delays)
+	}
+	for i, d := range delays {
+		if d <= 0 {
+			t.Fatalf("retry backoff %d was %s: a zero delay is the busy loop the budget exists to prevent", i+1, d)
+		}
+	}
+}
+
+// TestPanickingPassDoesNotSpendTheErrorRetryBudget keeps the two failure classes
+// distinct. A panic leaves the pass in a state the in-slot retry cannot reason
+// about, so it keeps its original semantics — recovered, day not marked, retried
+// by the NEXT fire — and must not be re-entered immediately as a transient error
+// would be. Retry timers here fire instantly, so an in-slot retry would show up
+// as a second call; the next-run timer never fires, so nothing else can.
+func TestPanickingPassDoesNotSpendTheErrorRetryBudget(t *testing.T) {
+	utc := time.UTC
+	today := time.Date(2026, 7, 6, 12, 0, 0, 0, utc)
+	runner := newFakeRunner()
+	runner.panicOn = 1 // the catch-up pass panics
+	marker := newFakeMarker()
+	marker.values[markerKey] = "2026-07-05" // yesterday -> catch-up fires
+
+	timers := newSlotTimerFactory(true)
+	scheduler := newTestScheduler(runner, marker, 9, utc, func() time.Time { return today }, timers.newTimer)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := scheduler.Start(ctx)
+
+	// Wait until the loop has armed its next-run timer: that happens strictly
+	// after the panicking catch-up pass returned, so any in-slot retry would
+	// already have been armed and (firing instantly) already have called RunOnce.
+	deadline := time.After(2 * time.Second)
+	for armedNextRun := false; !armedNextRun; {
+		select {
+		case d := <-timers.armed:
+			if d > retryTimerCeiling {
+				armedNextRun = true
+			}
+		case <-deadline:
+			t.Fatal("scheduler never reached its next-run timer after the panicking pass")
+		}
+	}
+	cancel()
+	<-done
+
+	if got := runner.callCount(); got != 1 {
+		t.Fatalf("a panicking pass must not be retried inside its slot; expected 1 attempt, got %d", got)
+	}
+	if delays := timers.retryDelays(); len(delays) != 0 {
+		t.Fatalf("a panicking pass must arm no retry backoff, got %v", delays)
+	}
+	if marker.setCalls != 0 {
+		t.Fatalf("a panicking pass must leave the marker untouched so the next fire retries, got %d write(s)", marker.setCalls)
 	}
 }

--- a/internal/reminders/scheduler_test.go
+++ b/internal/reminders/scheduler_test.go
@@ -847,3 +847,52 @@ func TestPanickingPassDoesNotSpendTheErrorRetryBudget(t *testing.T) {
 		t.Fatalf("a panicking pass must leave the marker untouched so the next fire retries, got %d write(s)", marker.setCalls)
 	}
 }
+
+// advancingClock is a now() seam that moves forward by step on every call, so a
+// test can put the wall clock across local midnight WHILE one slot is retrying.
+// The scheduler runs in its own goroutine, hence the mutex.
+type advancingClock struct {
+	mu   sync.Mutex
+	at   time.Time
+	step time.Duration
+}
+
+func (c *advancingClock) now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	at := c.at
+	c.at = c.at.Add(c.step)
+	return at
+}
+
+// TestSpentBudgetMarksTheSlotsOwnDayNotTheDayItsRetriesRanInto pins the date the
+// spent budget writes. Marking is a giving-up record for the slot that failed,
+// so it must name THAT slot's local day. Resolving it from the last attempt's
+// clock instead lets a slot whose retries cross local midnight mark TOMORROW —
+// a day whose pass has not run and whose scheduled hour has not arrived — and a
+// restart on that day then reads marker == today and skips its catch-up, losing
+// the very day of reminders this retry exists to save.
+func TestSpentBudgetMarksTheSlotsOwnDayNotTheDayItsRetriesRanInto(t *testing.T) {
+	utc := time.UTC
+	// 23:50 on 2026-07-06: the run hour (9) is long past, so catch-up fires, and
+	// the slot's remaining backoff lands the later attempts on 2026-07-07.
+	clock := &advancingClock{at: time.Date(2026, 7, 6, 23, 50, 0, 0, utc), step: passRetryDelay}
+	runner := newFakeRunner()
+	runner.returnErr = errors.New("listing owners failed") // every attempt fails
+	marker := newFakeMarker()
+	marker.values[markerKey] = "2026-07-05" // yesterday -> catch-up fires
+
+	timers := newSlotTimerFactory(true)
+	scheduler := newTestScheduler(runner, marker, 9, utc, clock.now, timers.newTimer)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := scheduler.Start(ctx)
+
+	waitForCalls(t, runner, maxPassAttempts, 2*time.Second)
+	cancel()
+	<-done
+
+	if v, ok := marker.get(markerKey); !ok || v != "2026-07-06" {
+		t.Fatalf("expected the spent budget to mark the slot's own day 2026-07-06, got %q ok=%v — marking 2026-07-07 closes a day that never ran", v, ok)
+	}
+}


### PR DESCRIPTION
## Failed scheduled notify passes were marked complete for the day

`runPassRecovered` logged a pass-level error and returned `true` unconditionally, so
`runScheduledPass` fell through to `markRan`. The only error the notify pass raises at pass level is
the owner listing failing (`internal/services/webhook_notify_service.go:157-159`), which returns
before a single owner is processed — so a day on which **zero** reminders went out was recorded as a
completed day, and a same-day restart hit the marker-equals-today early return in `runCatchUp` and
made no call at all. Owners lost every due reminder for that local day after one transient database
hiccup at the scheduled hour.

### What this does not do

The comment at the old `scheduler.go:219-221` was right about *why* the marker was written: without
it a permanently broken database busy-loops the scheduler. Simply not marking on error trades a
missed-reminder bug for a spin bug. That property is kept, not removed.

### The change — `internal/reminders/scheduler.go`

One scheduled slot now attempts the pass up to `maxPassAttempts` (3) times, `passRetryDelay`
(5 minutes) apart:

- attempt succeeds → mark the day (unchanged);
- attempt returns an error → **do not** mark, wait the backoff, attempt again;
- budget spent → log by reason, mark the day, and wait for the next scheduled fire. This is the
  anti-busy-loop bound: a broken database costs three attempts per slot, never an unbounded spin;
- ctx cancelled during a backoff → return **without** marking, so the next start's catch-up re-runs
  today's pass. That is the "restart before the retry" case in the record;
- **panic keeps its own semantics**: recovered, day not marked, retried by the NEXT fire, and it does
  not spend the error budget — a panicked pass is not the transient shape an in-slot retry is for.

`runPassRecovered` now returns `(completed bool, err error)` — it reports whether the pass panicked
and hands the pass's own error up; what to do about that error is the caller's decision. The backoff
goes through the existing injected `newTimer` seam (`waitBeforeRetry`), so the scheduler stays fully
deterministic under test and the tests never touch the wall clock.

**Why an overlapping retry is safe:** #124's per-reminder watermark is the authoritative idempotency
guard and it is claimed *before* delivery. A retry that re-runs after an attempt that partially
delivered sees the advanced watermarks and suppresses those reminders — the retry can only cover what
the failed attempt did not send. The scheduler's day marker was never the double-send guard; it is a
trigger-level "already ran today" flag.

### Guard first — red before the fix

Four guards added to `internal/reminders/scheduler_test.go`. The record's own scratch repro
(`TestW5ReproPassErrorMarksDayAndSuppressesRestartCatchUp`) asserted the *bug* and passed on the
broken tree; these assert the correct behaviour, so three of them fail on it. Run against the
unfixed tree (the two new constants declared, behaviour untouched):

```
=== RUN   TestPassErrorRetriesInTheSameSlotAndMarksOnlyOnceItSucceeds
2026/08/25 18:32:43 reminder scheduler: notify pass returned an error (see prior notify logs)
    scheduler_test.go:699: timed out waiting for 2 RunOnce call(s); got 1
--- FAIL: TestPassErrorRetriesInTheSameSlotAndMarksOnlyOnceItSucceeds (2.00s)
=== RUN   TestRestartBeforeTheRetryStillCatchesUpToday
2026/08/25 18:32:45 reminder scheduler: notify pass returned an error (see prior notify logs)
    scheduler_test.go:736: timed out waiting for the scheduler to arm a retry timer; armed so far: [21h0m0s]
--- FAIL: TestRestartBeforeTheRetryStillCatchesUpToday (2.00s)
=== RUN   TestRetryBudgetIsBoundedThenTheDayIsMarked
2026/08/25 18:32:47 reminder scheduler: notify pass returned an error (see prior notify logs)
    scheduler_test.go:782: timed out waiting for 3 RunOnce call(s); got 1
--- FAIL: TestRetryBudgetIsBoundedThenTheDayIsMarked (2.00s)
=== RUN   TestPanickingPassDoesNotSpendTheErrorRetryBudget
--- PASS: TestPanickingPassDoesNotSpendTheErrorRetryBudget (0.00s)   (panic path was already correct)
FAIL	github.com/ovumcy/ovumcy-web/internal/reminders	8.254s
```

After the fix, all four pass (`ok github.com/ovumcy/ovumcy-web/internal/reminders 1.799s`).

### One induced red per assertion the defect could not reach

The assertions the unfixed tree never reached (it failed earlier in the same test) were each proved
falsifiable by a mutant of the fix, applied and reverted one at a time:

| mutant of `scheduler.go` | red |
| --- | --- |
| `if !completed { err = errors.New(...) }` — panic folded into the error class | `TestPanickingPassDoesNotSpendTheErrorRetryBudget`: `a panicking pass must not be retried inside its slot; expected 1 attempt, got 2` |
| `passRetryDelay = 0` | `TestRetryBudgetIsBoundedThenTheDayIsMarked`: `retry backoff 1 was 0s: a zero delay is the busy loop the budget exists to prevent` |
| drop `markRan` after the budget is spent | same test: `expected the spent budget to mark today 2026-07-06 (anti-busy-loop), got "2026-07-05"` |
| retry without arming a backoff timer | same test: `expected 2 retry backoffs between 3 attempts, got 0 ([])`; and `TestRestartBeforeTheRetryStillCatchesUpToday`: `timed out waiting for the scheduler to arm a retry timer` |
| `markRan` on every failed attempt (the original defect kept beside the retry) | `TestPassErrorRetriesInTheSameSlotAndMarksOnlyOnceItSucceeds`: `expected exactly one marker write, made by the retry that actually succeeded, got 2`; and `TestRestartBeforeTheRetryStillCatchesUpToday`: `a pass that failed and has not retried yet must leave the marker at yesterday, got "2026-07-06"` |

### Also in the diff

`docs/notifications.md` — the scheduler notes said catch-up runs "at most one pass for the current
day" and said nothing about failure. One bullet now states the retry, the three-attempt bound, that a
restart in between still catches the day up, and that the watermark prevents a re-send.

### Verification

`go build ./...` · `go test ./internal/reminders` (also `-count=5`, no flake) · `go test ./scripts/...`
(webhookdocs and changelogd read the docs) · `go test ./internal/i18n/...` ·
`go test ./internal/services -run 'TestCalendarDay.*Barrier'` (the sweep's allowlist names a
`internal/reminders` site) · `golangci-lint run ./internal/reminders/...` → 0 issues ·
`go run ./scripts/changelogd check` → OK. `-race` could not run locally (no gcc on this host); CI's
race lane covers it.

Single-commit revert; no persisted data, schema or public contract is touched.
