### PR TITLE
build(lint): enforce the layer directions and ban inline suppressions

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -9,8 +9,8 @@
 # can disappear without a diff is the failure mode this whole surface exists to
 # close.
 #
-# This is the REFUSING surface of three. An edit-time guard flags the same two
-# invariants as they are written and cannot refuse a fragment it never sees
+# This is the REFUSING surface of three. An edit-time guard flags two of the
+# same invariants as they are written and cannot refuse a fragment it never sees
 # whole; CI is the backstop that no local skip reaches. The decision behind the
 # split, and the instrument all three run, are in scripts/archcheck.
 #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -534,12 +534,12 @@ jobs:
         run: go vet ./cmd/... ./internal/... ./migrations/... ./scripts/... ./web/...
 
       # The architecture contract asked of the TREE: transport imports no
-      # persistence, and no schema is migrated at runtime. The same two
-      # invariants are also refused at the moment of an edit and again at
-      # commit, and this is the backstop neither a local skip nor a hook that
-      # was never installed reaches. What it decides, and why syntax answers one
-      # invariant while types are needed for the other, is in the command's own
-      # doc comment.
+      # persistence, the layers import in one direction only, and no schema is
+      # migrated at runtime. Two of those are also refused at the moment of an
+      # edit and all three again at commit, and this is the backstop neither a
+      # local skip nor a hook that was never installed reaches. What it decides,
+      # and why syntax answers the import rules while types are needed for the
+      # schema one, is in the command's own doc comment.
       - name: Architecture invariants
         run: go run ./scripts/archcheck
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,9 @@
 #     at the default, matching the codebase's existing spelling.
 #   - unconvert: removes type conversions that are no-ops; they only obscure
 #     the actual types in security-relevant code.
+#   - nolintlint: the zero-suppression line below, asked of the tree rather
+#     than of a reviewer. What it reaches and what it does not is in the
+#     paragraph on that line, further down.
 #
 # Evaluated against the codebase and deliberately NOT enabled:
 #   - gocritic: its default set flags intentional test patterns here (mapKey
@@ -28,6 +31,22 @@
 # The repo carries zero //nolint directives; keep it that way. If a new
 # finding is a false positive, prefer narrowing the linter's settings here
 # (with a comment) over inline suppressions.
+#
+# nolintlint is what now stands behind that line, and being exact about how far
+# it reaches matters more than the fact it is on. It reports a directive that is
+# bare, that carries no explanation, or that is unused — and "unused" is judged
+# against the linters THIS config runs. Two consequences follow, both measured
+# against v2.12.2 rather than read off the documentation:
+#   - a well-formed directive for an enabled linter that really does suppress a
+#     finding passes; there is no setting that refuses one.
+#   - a directive naming a linter golangci-lint does not run is invisible to it.
+#     `//nolint:gosec` is that case here: gosec is not enabled below, it runs in
+#     its own workflow, and two such directives had accumulated in the tree
+#     suppressing nothing on either path. They were removed by hand in the same
+#     change that added this linter, because the linter would not have found
+#     them.
+# So the last step from "no junk suppressions" to "none at all" stays a reading
+# of the diff. What is no longer a reading of the diff is everything below it.
 version: "2"
 
 linters:
@@ -36,6 +55,7 @@ linters:
     - copyloopvar
     - intrange
     - misspell
+    - nolintlint
     - unconvert
   exclusions:
     # `npm ci` installs at least one package that ships Go sources of its own
@@ -48,6 +68,16 @@ linters:
     paths:
       - node_modules
   settings:
+    nolintlint:
+      # Every knob the linter has, all pointing the same way: a directive must
+      # name its linters, explain itself, and actually suppress something.
+      # allow-unused stays at its default rather than being dropped as noise: a
+      # directive that suppresses nothing is the shape an inline suppression
+      # decays into once the finding it was written for is fixed elsewhere, and
+      # it outlives the reviewer who would have caught it going in.
+      require-specific: true
+      require-explanation: true
+      allow-unused: false
     misspell:
       # Localized copy asserted by backend regressions is not English prose:
       # "successivo" is Italian for "next" (it.json month-navigation label),

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,11 +21,17 @@ npm run lint:js
 npm run build
 ```
 
-`scripts/archcheck` reads the whole tree and answers two architecture
+`scripts/archcheck` reads the whole tree and answers three architecture
 questions: nothing under `internal/api` or `internal/apideps` imports
-persistence, and no schema is migrated at runtime. It asks about the tree
-rather than about a diff, so it answers the same way however the code got
-there. CI runs it too.
+persistence, the layers of [docs/architecture.md](docs/architecture.md) import
+in one direction only (`internal/services` and `internal/db` never reach up into
+transport, `internal/db` never reaches up into `internal/services`, and
+`internal/models` depends on no other package in the module), and no schema is
+migrated at runtime. It asks about the tree rather than about a diff, so it
+answers the same way however the code got there — including for a file behind a
+build tag your platform does not select, which a package listing would not see.
+Test files are outside the two import rules on purpose: a fixture proves a
+repository against the service that owns it, and the reverse. CI runs it too.
 
 The same check refuses a commit, through `.githooks/pre-commit`. That file is
 tracked but git hooks are not, so it has to be installed once per clone:

--- a/changelog.d/lint-enforce-the-layer-directions-and-the-nolint-ban.md
+++ b/changelog.d/lint-enforce-the-layer-directions-and-the-nolint-ban.md
@@ -1,0 +1,15 @@
+### Internal
+
+- **The layer directions and the no-inline-suppression rule are checked mechanically instead of
+  by eye.** `scripts/archcheck` gained a `layer-imports` rule: `internal/services` and
+  `internal/db` may not import transport, `internal/db` may not import `internal/services`, and
+  `internal/models` may not import any other package in the module. It is stated as denials rather
+  than as an allow-list of what each layer may reach, so a new legitimate edge — `internal/i18n`
+  from a service, say — is not refused, and it reads every file in the tree rather than the
+  packages the current platform builds, so a file behind a build tag is covered too. Test files
+  stay outside it, because a fixture proves a repository against the service that owns it and the
+  reverse. Separately, `nolintlint` is enabled in `.golangci.yml`, which fails the lint job on a
+  `//nolint` directive that is bare, unexplained, or unused for a linter this config runs; two
+  directives naming `gosec` — a linter golangci-lint does not run here, so they suppressed nothing
+  on any path — were removed by hand, since the linter does not see that shape. No production
+  behaviour changes.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,7 +18,10 @@ the source of truth.
 ## Layered architecture
 
 Strict one-directional layering. Transport never reaches the database; domain
-logic never depends on HTTP; persisted types stay transport-free.
+logic never depends on HTTP; persisted types stay transport-free. All three are
+checked mechanically against the whole tree by `scripts/archcheck`, which CI
+runs on every change; test files are outside the check, because a fixture
+legitimately reaches across a layer boundary to prove the layer below it.
 
 ```mermaid
 flowchart TB

--- a/internal/templates/dom_attribute_consumers_test.go
+++ b/internal/templates/dom_attribute_consumers_test.go
@@ -314,7 +314,9 @@ func domAttrConsumerTemplateHooks(t *testing.T, templateDir, root string) map[st
 		if entry.IsDir() || filepath.Ext(path) != ".html" {
 			return nil
 		}
-		content, readErr := os.ReadFile(path) //nolint:gosec // walked path under the repository's own template tree
+		// The path is one WalkDir handed back from the repository's own template
+		// tree, not input.
+		content, readErr := os.ReadFile(path)
 		if readErr != nil {
 			return readErr
 		}
@@ -384,7 +386,9 @@ func domAttrConsumerConsumerIndex(t *testing.T, root string) (map[string]bool, m
 		if !domAttrConsumerSourceExtensions[extension] {
 			return nil
 		}
-		content, readErr := os.ReadFile(path) //nolint:gosec // walked path under the repository root
+		// The path is one WalkDir handed back from under the repository root,
+		// not input.
+		content, readErr := os.ReadFile(path)
 		if readErr != nil {
 			return readErr
 		}

--- a/scripts/archcheck/main.go
+++ b/scripts/archcheck/main.go
@@ -1,7 +1,9 @@
-// Command archcheck answers two architecture questions about the TREE, not
-// about one edit.
+// Command archcheck answers three architecture questions about the TREE, not
+// about one edit: transport imports no persistence, the layers of
+// docs/architecture.md import in one direction only, and no schema is migrated
+// at runtime.
 //
-// The distinction is the whole reason it exists. The same two invariants are
+// The distinction is the whole reason it exists. Two of those invariants are
 // also guarded at the moment of an edit, and that guard sees one tool call and
 // never the file the call produced: `db.AutoMigr` plus `ate(...)` written as two
 // edits passes any pattern, and so does an import split across two. Widening the
@@ -13,8 +15,12 @@
 // Two passes, cheapest first:
 //
 //   - Syntax (go/parser), over every Go file in the module. This alone decides
-//     the import rule exactly — an import graph IS syntax — and it is what makes
-//     the common case cost a parse and nothing more.
+//     the two import rules exactly — an import graph IS syntax — and it is what
+//     makes the common case cost a parse and nothing more. Parsing the files
+//     rather than listing the packages is also what makes those rules see a
+//     file behind a build tag this platform does not select: internal/services
+//     holds one (the `gofuzz` libFuzzer harness), and `go list` answers about
+//     the build it was asked for, never about the tree.
 //   - Types (golang.org/x/tools/go/packages), over only those packages the
 //     syntactic pass found a candidate in. It is what makes the AutoMigrate rule
 //     exact rather than name-matched: a local variable named db with an
@@ -55,10 +61,15 @@ import (
 // handle a rule file, a test or a message can name — the text of a message may
 // be improved, the identifier may not.
 const (
-	ruleAPIImports  = "api-imports"
-	ruleAutoMigrate = "automigrate"
-	ruleUnreadable  = "unreadable"
+	ruleAPIImports   = "api-imports"
+	ruleLayerImports = "layer-imports"
+	ruleAutoMigrate  = "automigrate"
+	ruleUnreadable   = "unreadable"
 )
+
+// modulePath is this module's import prefix. The layer rules deny package paths
+// under it, so it is spelled once here rather than once per entry.
+const modulePath = "github.com/ovumcy/ovumcy-web"
 
 // gormPkgPath is compared against the package that DECLARES the method reached
 // by the call, never against the spelling of the receiver.
@@ -87,6 +98,54 @@ var forbiddenImports = []string{
 var transportDirs = []string{
 	"internal/api",
 	"internal/apideps",
+}
+
+// layerRule is one direction of the layering drawn in docs/architecture.md:
+// the package tree it constrains, and the module-local packages that tree may
+// not import. api -> services -> db -> models runs one way, so each layer's
+// rule is the set of layers ABOVE it.
+//
+// Denials, not an allow-list of what a layer may reach. The allowed set grows
+// with ordinary work — internal/services imports internal/i18n today, which it
+// did not when the layers were first drawn — so a list transcribed from the
+// graph as it stands would refuse the first legitimate edge someone adds, and
+// the refusal would land on a contributor who did nothing wrong. What the
+// contract fixes is the direction; a denial states the direction and nothing
+// else.
+//
+// Only module-local paths, and that is the division of labour with
+// ruleAPIImports above rather than an omission: transport is denied the
+// persistence surface itself (gorm, the drivers, database/sql) because
+// "transport never reaches the database" is about the database. "Domain logic
+// never depends on HTTP" and "persisted types stay transport-free" are about
+// this module's own layers — internal/services legitimately dials net/http to
+// deliver a webhook, and denying it that would be a rule the contract does not
+// state.
+type layerRule struct {
+	dir    string   // the package tree the rule constrains, relative to the module root
+	denied []string // package paths it may not import; each covers its own subtree
+	remedy string   // what to do instead, printed with every finding
+}
+
+var layerRules = []layerRule{
+	{
+		dir:    "internal/services",
+		denied: []string{modulePath + "/internal/api", modulePath + "/internal/apideps"},
+		remedy: "domain logic sits below transport: transport calls a service, and a service answers with domain data and sentinel errors.",
+	},
+	{
+		dir:    "internal/db",
+		denied: []string{modulePath + "/internal/api", modulePath + "/internal/apideps", modulePath + "/internal/services"},
+		remedy: "persistence sits below domain logic: a repository takes what it needs as arguments and returns models, and internal/services is what calls it.",
+	},
+	{
+		// The bottom of the layering, which is why its denial is the module
+		// itself: internal/models has no outgoing edge inside this module at
+		// all, and that is the property "transport-free types" names.
+		dir:    "internal/models",
+		denied: []string{modulePath},
+		remedy: "persisted types depend on no other layer: keep the type here and put the behaviour that needs a neighbour in internal/services.",
+	},
 }
 
 // skippedDirs never hold source this module builds. testdata is excluded by the
@@ -184,6 +243,7 @@ func run(root string) ([]finding, error) {
 			return nil
 		}
 		findings = append(findings, importFindings(fset, abs, path, file)...)
+		findings = append(findings, layerFindings(fset, abs, path, file)...)
 		if hasAutoMigrateCall(file) {
 			candidates = append(candidates, path)
 		}
@@ -275,17 +335,50 @@ func importFindings(fset *token.FileSet, root, path string, file *ast.File) []fi
 	return out
 }
 
+// layerFindings applies the one-directional layering to one parsed file.
+//
+// Test files are exempt, on the same reading that exempts them from
+// ruleAPIImports, and here the exemption is load-bearing rather than a courtesy:
+// internal/db's tests import internal/services and internal/services' tests
+// import internal/db, both by construction — a repository is proved against the
+// service that owns it and vice versa. A rule covering them would refuse
+// ordinary test work on its first day, and the way out of it would be to route
+// tests around the database, which costs more than the rule is worth.
+func layerFindings(fset *token.FileSet, root, path string, file *ast.File) []finding {
+	rel, ok := productionFile(root, path)
+	if !ok {
+		return nil
+	}
+	var out []finding
+	for _, rule := range layerRules {
+		if !strings.HasPrefix(rel, rule.dir+"/") {
+			continue
+		}
+		for _, spec := range file.Imports {
+			imported, err := strconv.Unquote(spec.Path.Value)
+			if err != nil {
+				continue
+			}
+			if !matchesAny(imported, rule.denied) {
+				continue
+			}
+			out = append(out, finding{
+				rule: ruleLayerImports,
+				pos:  fset.Position(spec.Pos()),
+				msg:  rule.dir + " must not import " + imported + ". " + rule.remedy,
+			})
+		}
+	}
+	return out
+}
+
 // inTransportLayer reports whether path is production source under a
 // transport-only package. The comparison runs on the path relative to the module
 // root and in slash form, so the same file answers the same way whichever
 // platform and whichever checkout it is read from.
 func inTransportLayer(root, path string) bool {
-	rel, err := filepath.Rel(root, path)
-	if err != nil {
-		return false
-	}
-	rel = filepath.ToSlash(rel)
-	if strings.HasSuffix(rel, "_test.go") {
+	rel, ok := productionFile(root, path)
+	if !ok {
 		return false
 	}
 	for _, dir := range transportDirs {
@@ -296,9 +389,35 @@ func inTransportLayer(root, path string) bool {
 	return false
 }
 
+// productionFile names path the way a reader at the module root would — relative
+// and in slash form — and reports false for a file no import rule covers: one
+// outside the root, or a test file.
+//
+// Both import rules ask this single question, and they have to answer it the
+// same way. Two copies of the test-file check is how one of them ends up
+// covering _test.go by accident on the day the other is edited.
+func productionFile(root, path string) (string, bool) {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return "", false
+	}
+	rel = filepath.ToSlash(rel)
+	if strings.HasSuffix(rel, "_test.go") {
+		return "", false
+	}
+	return rel, true
+}
+
 func isForbiddenImport(imported string) bool {
-	for _, f := range forbiddenImports {
-		if imported == f || strings.HasPrefix(imported, f+"/") {
+	return matchesAny(imported, forbiddenImports)
+}
+
+// matchesAny reports whether imported is one of paths or lives under one. The
+// prefix is taken on a path SEGMENT and never on the raw string, so
+// "database/sqlx" is not "database/sql".
+func matchesAny(imported string, paths []string) bool {
+	for _, p := range paths {
+		if imported == p || strings.HasPrefix(imported, p+"/") {
 			return true
 		}
 	}

--- a/scripts/archcheck/main_test.go
+++ b/scripts/archcheck/main_test.go
@@ -167,6 +167,151 @@ func TestTransportProductionCodeMayNotImportPersistence(t *testing.T) {
 	}
 }
 
+// The layering rule, one direction per case. The negatives carry the weight
+// here: this rule denies upward edges and says nothing about the cross-cutting
+// packages or about net/http, and a rule that quietly widened to either would
+// refuse work the contract permits.
+func TestTheLayersImportInOneDirectionOnly(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+		body string
+		want bool
+	}{
+		{
+			name: "services reaching up into transport",
+			path: "internal/services/cycle.go",
+			body: "package services\n\nimport \"github.com/ovumcy/ovumcy-web/internal/api\"\n\nvar _ = api.New\n",
+			want: true,
+		},
+		{
+			name: "services reaching up into the port surface",
+			path: "internal/services/cycle.go",
+			body: "package services\n\nimport \"github.com/ovumcy/ovumcy-web/internal/apideps\"\n\nvar _ = apideps.X\n",
+			want: true,
+		},
+		{
+			name: "persistence reaching up into domain logic",
+			path: "internal/db/repo.go",
+			body: "package db\n\nimport \"github.com/ovumcy/ovumcy-web/internal/services\"\n\nvar _ = services.New\n",
+			want: true,
+		},
+		{
+			name: "persistence reaching up into transport",
+			path: "internal/db/repo.go",
+			body: "package db\n\nimport \"github.com/ovumcy/ovumcy-web/internal/api\"\n\nvar _ = api.New\n",
+			want: true,
+		},
+		{
+			name: "a persisted type reaching sideways into a cross-cutting package",
+			path: "internal/models/day.go",
+			body: "package models\n\nimport \"github.com/ovumcy/ovumcy-web/internal/security\"\n\nvar _ = security.Seal\n",
+			want: true,
+		},
+		{
+			name: "a persisted type reaching down into the migrations",
+			path: "internal/models/day.go",
+			body: "package models\n\nimport \"github.com/ovumcy/ovumcy-web/migrations\"\n\nvar _ = migrations.FS\n",
+			want: true,
+		},
+		{
+			name: "the direction the contract allows: transport calls a service",
+			path: "internal/api/handler.go",
+			body: "package api\n\nimport \"github.com/ovumcy/ovumcy-web/internal/services\"\n\nvar _ = services.New\n",
+			want: false,
+		},
+		{
+			name: "the direction the contract allows: persistence maps rows to models",
+			path: "internal/db/repo.go",
+			body: "package db\n\nimport \"github.com/ovumcy/ovumcy-web/internal/models\"\n\nvar _ models.Day\n",
+			want: false,
+		},
+		{
+			name: "a cross-cutting package, which the layering does not order",
+			path: "internal/services/locale.go",
+			body: "package services\n\nimport \"github.com/ovumcy/ovumcy-web/internal/i18n\"\n\nvar _ = i18n.T\n",
+			want: false,
+		},
+		{
+			name: "the standard library, which the rule is not about",
+			path: "internal/services/webhook.go",
+			body: "package services\n\nimport \"net/http\"\n\nvar _ = http.Post\n",
+			want: false,
+		},
+		{
+			name: "another module whose path merely begins with this one",
+			path: "internal/models/day.go",
+			body: "package models\n\nimport \"github.com/ovumcy/ovumcy-web-extras/thing\"\n\nvar _ = thing.X\n",
+			want: false,
+		},
+		{
+			name: "a test file, where a repository is proved against its own service",
+			path: "internal/db/repo_test.go",
+			body: "package db\n\nimport \"github.com/ovumcy/ovumcy-web/internal/services\"\n\nvar _ = services.New\n",
+			want: false,
+		},
+		{
+			name: "a test file on the other side of the same seam",
+			path: "internal/services/cycle_test.go",
+			body: "package services\n\nimport \"github.com/ovumcy/ovumcy-web/internal/api\"\n\nvar _ = api.New\n",
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := scan(t, writeTree(t, map[string]string{tc.path: tc.body}))
+			if tc.want && len(got) == 0 {
+				t.Fatalf("expected a %s finding, got none", ruleLayerImports)
+			}
+			if !tc.want && len(got) != 0 {
+				t.Fatalf("expected no finding, got %v: %v", rulesIn(got), got)
+			}
+			for _, f := range got {
+				if f.rule != ruleLayerImports {
+					t.Fatalf("expected only %s findings, got %s: %v", ruleLayerImports, f.rule, f)
+				}
+			}
+		})
+	}
+}
+
+// A build-tagged file is the hole a package-listing instrument cannot see:
+// `go list` answers about the build it was asked for, and internal/services
+// really does hold a file (the gofuzz libFuzzer harness) that no ordinary GOOS
+// selects. The parse-every-file pass is what closes it, so the closure is
+// asserted rather than assumed.
+func TestAFileBehindABuildTagIsStillRead(t *testing.T) {
+	dir := writeTree(t, map[string]string{
+		"internal/services/harness.go": "//go:build gofuzz\n\npackage services\n\nimport \"github.com/ovumcy/ovumcy-web/internal/api\"\n\nvar _ = api.New\n",
+	})
+	got := scan(t, dir)
+	if len(got) != 1 || got[0].rule != ruleLayerImports {
+		t.Fatalf("expected one %s finding behind the build tag, got %v: %v", ruleLayerImports, rulesIn(got), got)
+	}
+}
+
+// A finding has to say which direction was crossed and what to do instead: the
+// reader of the refusal is someone who just wrote the import and believes it is
+// reasonable.
+func TestALayerFindingNamesTheDirectionAndTheRemedy(t *testing.T) {
+	dir := writeTree(t, map[string]string{
+		"internal/db/repo.go": "package db\n\nimport \"github.com/ovumcy/ovumcy-web/internal/services\"\n\nvar _ = services.New\n",
+	})
+	got := scan(t, dir)
+	if len(got) != 1 {
+		t.Fatalf("expected one finding, got %v: %v", rulesIn(got), got)
+	}
+	for _, want := range []string{
+		"internal/db must not import github.com/ovumcy/ovumcy-web/internal/services",
+		"internal/services is what calls it",
+	} {
+		if !strings.Contains(got[0].msg, want) {
+			t.Fatalf("the finding should carry %q, got %q", want, got[0].msg)
+		}
+	}
+}
+
 // The class this command exists for. Each half of the file, taken alone, is text
 // no pattern for the forbidden import can match — which is exactly what an
 // event-shaped rule sees when the two halves arrive as two edits. The tree is


### PR DESCRIPTION
## What this closes

Board group **T0002** — records **R2-0002** (the four layer directions hold but nothing automatic
enforces them) and **R2-0005** (`.golangci.yml` states a zero-`//nolint` invariant with no check
behind it).

Both records ask for an enforcement mechanism where none exists, so there is no failing test to
write first. Each rule was instead landed and then **deliberately broken** to watch it go red;
every red below was induced by this branch, none of them occurred naturally.

## Two corrections to the records first

**R2-0002 is half wrong.** `scripts/archcheck` already exists, already reads the import graph of
the whole tree, and already runs as the CI step `Architecture invariants` — its `api-imports` rule
covers direction 1 (`internal/api` and `internal/apideps` never reach persistence). That is exactly
the counter-evidence the record names ("a CI step that reads the import graph"); the grep in the
evidence looked for `depguard`/`importas`/`gomodguard`/`packages.Load`/`go/build`, and archcheck
matches none of those spellings. Directions 2-4 really were unenforced, and those are what this PR
adds.

**R2-0005's "the tree currently honours it" is stale.** `grep -rn '//nolint' --include='*.go'`
returns **2**, not 0, at `c0bbb235`:

```
internal/templates/dom_attribute_consumers_test.go:317: os.ReadFile(path) //nolint:gosec // ...
internal/templates/dom_attribute_consumers_test.go:387: os.ReadFile(path) //nolint:gosec // ...
```

They arrived with `e130f0f9`, after the record was written.

## The import graph on this tree, re-drawn before any rule was written

Probe (module `github.com/ovumcy/ovumcy-web`), run once per GOOS:

```sh
GOOS=windows go list -deps=false \
  -f '{{$p := .ImportPath}}{{range .Imports}}{{$p}} -> {{.}}{{"\n"}}{{end}}' \
  ./cmd/... ./internal/... ./migrations/... ./web/... | grep -- '-> github.com/ovumcy/ovumcy-web'
```

Internal edges (prefix stripped), `exit 0`:

```
cmd/ovumcy        -> internal/api, bootstrap, cli, db, i18n, reminders, security, services, web
internal/api      -> internal/apideps, httpx, i18n, models, security, services, templates
internal/apideps  -> internal/models, security, services
internal/bootstrap-> internal/apideps, db, i18n, security, services
internal/cli      -> internal/bootstrap, db, i18n, services
internal/db       -> internal/models, migrations
internal/reminders-> internal/models, services
internal/services -> internal/i18n, internal/models, internal/security
internal/models   -> (no outgoing project edge)
```

`diff` of the `windows` and `linux` graphs is empty — the internal edges are identical on both.
No violation of any of the four directions.

**One correction to the record's evidence:** R2-0002 says `internal/services -> models,security
only`. On this tree it is `i18n, models, security` — `internal/i18n` is a real, legitimate edge.
That single fact is why the new rule is written as **denials** and not as an allow-list of what
each layer may reach: an allow-list transcribed from the graph as recorded would have refused an
edge that is already in `main`, and would keep refusing the next legitimate one.

**The hole the record names, measured.** Six files carry `//go:build` constraints, and one of them
is inside a layer this PR rules on: `internal/services/policy_fuzz_libfuzzer.go` (`//go:build
gofuzz`), which no ordinary `GOOS` selects and which `go list` therefore never reports. Its imports
(`net/mail`, `strings`, `time`, `unicode`, `unicode/utf8`, `github.com/AdamKorcz/go-118-fuzz-build/testing`)
are clean; the other five are `internal/cli` platform shims and clean too.

## Why archcheck and not depguard

Picked archcheck; did not do both.

1. **depguard cannot see the build-tagged file above.** golangci-lint analyses the packages the
   current build context selects, so the `gofuzz` harness inside `internal/services` is outside its
   view. archcheck's first pass is `go/parser` over *every* `.go` file in the tree — build
   constraints are invisible to it, which is precisely what makes it read that file. R2-0002's own
   `minimal_regression_guard` offers this shape for exactly this reason ("which also covers
   build-tagged files").
2. **One invariant, one home.** Direction 1 is already `api-imports` in archcheck. Putting 2-4 in
   `.golangci.yml` would split one contract across two mechanisms with two different test-file
   policies and two different failure messages — the N-of-N+1 shape the contributor guidance warns about.
3. **The test-file decision is already made and documented there**, so the new rule inherits it
   rather than re-litigating it.

`.golangci.yml` still changes — for R2-0005, which is a linter question.

## How test files are treated, and why

**Exempt, explicitly, and it is load-bearing rather than a convenience.** The test-import graph
(`go list -f '{{.TestImports}}'`) shows the seam runs both ways by construction:

```
internal/api      TEST -> internal/db, internal/bootstrap, internal/services, internal/models, ...
internal/db       TEST -> internal/services, internal/models, internal/testdb, migrations
internal/services TEST -> internal/db, internal/templates, internal/testdb
```

A fixture proves a repository against the service that owns it, and the reverse. A rule covering
`_test.go` would refuse all three on its first day, and the only way out would be to route tests
around the database — a real regression in the repo's ability to test itself. The exemption lives
in one function, `productionFile`, which **both** import rules call, so they cannot drift apart;
gutting it reddens a negative case in each rule's suite (transcript below).

## What the rule says

`scripts/archcheck`, new rule id `layer-imports` (the existing `api-imports` and `automigrate` are
untouched):

| tree | may not import |
|---|---|
| `internal/services` | `internal/api`, `internal/apideps` |
| `internal/db` | `internal/api`, `internal/apideps`, `internal/services` |
| `internal/models` | anything under `github.com/ovumcy/ovumcy-web` |

Only module-local paths. `docs/architecture.md`'s "transport never reaches the database" is about
the database, and `api-imports` already denies transport the persistence surface itself (gorm, the
drivers, `database/sql`). "Domain logic never depends on HTTP" and "persisted types stay
transport-free" are statements about this module's own layers — `internal/services` legitimately
dials `net/http` to deliver a webhook, and denying it that would be a rule the contract does not
state.

## Induced red → green #1: the layering rule, against the real tree

**Induced** by adding one import line to a real production file,
`internal/services/settings_service.go:10` — an upward edge into transport:

```
$ go run ./scripts/archcheck
internal/services/settings_service.go:10:2: layer-imports: internal/services must not import
  github.com/ovumcy/ovumcy-web/internal/api. domain logic sits below transport: transport calls a
  service, and a service answers with domain data and sentinel errors.
archcheck: 1 finding(s). The layer contract is docs/architecture.md; running this check is in CONTRIBUTING.md.
exit status 1                                                              # archcheck-exit=1
```

Import line removed again:

```
$ git status --porcelain          # only scripts/archcheck/* modified — the induced edit is gone
$ go run ./scripts/archcheck
                                  # archcheck-exit=0
```

Three further inductions, each gutting the body that owns **one** assertion, so no assertion in the
new suite is left unproven:

| gutted | reddens | verdict |
|---|---|---|
| `layerFindings` body → `return nil` | all three new tests, naming `layer-imports` | `expected a layer-imports finding, got none` (×6 subtests) |
| walk skips files starting `//go:build` | `TestAFileBehindABuildTagIsStillRead` **only** | `expected one layer-imports finding behind the build tag, got []` |
| finding `msg` → `"layering violation"` | `TestALayerFindingNamesTheDirectionAndTheRemedy` **only** | `should carry "internal/db must not import .../internal/services", got "layering violation"` |
| the `_test.go` check in `productionFile` | one negative case in **each** rule's suite | `expected no finding, got [api-imports]` / `got [layer-imports]` (×2) |

The first attempt at the build-tag induction was a no-op and said so: the walk parses with
`parser.SkipObjectResolution` and no `parser.ParseComments`, so `file.Comments` is empty and a
comment-based skip never fired — the suite stayed green. Re-induced by reading the raw bytes, which
did redden exactly the one test. That is also the mechanism proof that build constraints are
invisible to this pass.

All restored; `go test ./scripts/archcheck/` → `ok`.

## Induced red → green #2: `nolintlint`

Enabled with every knob it has: `require-specific: true`, `require-explanation: true`,
`allow-unused: false`. Three separate inductions, one per knob, each fed the exact shape it names —
all at `internal/templates/dom_attribute_consumers_test.go:319`:

```
# induced: a bare directive                                     -> require-specific
:319:41: directive `//nolint` should mention specific linter such as `//nolint:my-linter` (nolintlint)
# induced: //nolint:errcheck on a real errcheck finding, no reason -> require-explanation
:319:37: directive `//nolint:errcheck` should provide explanation such as `//nolint:errcheck // this is why`
# induced: //nolint:errcheck // reason where errcheck finds nothing -> allow-unused
:319:41: directive `//nolint:errcheck // induced probe` is unused for linter "errcheck"
```

Each `lint-exit=1`; after reverting each, `0 issues.` / `lint-exit=0`.

**A fourth probe found the linter's edge, and it changed the change.** The tree's actual directives
were `//nolint:gosec`, and replaying that exact text produced **`0 issues.`** — `allow-unused`
judges "unused" only against linters *this config runs*, and `gosec` is not one of them. So the two
directives already in `main` would have sailed through the very guard being added here. They are inert on
both paths (`gosec` runs in `security.yml` over `./cmd/... ./internal/...` with no `-tests`, so it
never reads that file, and standalone gosec honours `#nosec`, not `//nolint:`), so they are
**removed by hand** here, with the reason written into `.golangci.yml` rather than left implicit.
The config comment states plainly that the last step from "no junk suppressions" to "none at all"
remains a reading of the diff — the linter has no setting for it.

## Cost to the branches open in parallel

`golangci-lint run --max-issues-per-linter=0 --max-same-issues=0 ./cmd/... ./internal/...
./migrations/... ./scripts/... ./web/...` → **`0 issues.`**, and `go run ./scripts/archcheck` →
**exit 0**. Nothing was added beyond what the contract states: no unrelated linters, no deny entry
the architecture doc does not name, no rule over the cross-cutting packages (`security`, `i18n`,
`templates`, `httpx`, `bootstrap`), which the layering does not order. The only way a sibling
branch reddens on this is by writing an upward import or an inline suppression.

## Docs kept in step

`CONTRIBUTING.md`, `.github/workflows/ci.yml` (step comment), `.githooks/pre-commit` (comment) and
the archcheck doc comment all said "two invariants"; they now say three, and the pre-commit comment
is corrected to "two of the same invariants" because the edit-time guard still covers only two.
`docs/architecture.md` gains one sentence saying the layering is checked mechanically and that test
files are outside the check — archcheck's own refusal points readers at that file as the contract.

## Verification

| command | verdict |
|---|---|
| `go build ./...` | OK |
| `go vet ./cmd/... ./internal/... ./migrations/... ./scripts/... ./web/...` | OK |
| `golangci-lint config verify` | exit 0 |
| `golangci-lint run --max-issues-per-linter=0 --max-same-issues=0 <5 trees>` | `0 issues.` |
| `go run ./scripts/archcheck` | exit 0 |
| `go test ./scripts/archcheck/` | ok |
| `go test ./internal/templates/` | ok (5.7s) |
| `go test ./internal/i18n/` | ok (1.8s) |
| `actionlint .github/workflows/ci.yml` | exit 0 |
| `go run ./scripts/changelogd check` | `changelog fragment check OK.` |

`./internal/api/...` was not run: this branch touches no file under it, and the record's own scope
is config and one script. `internal/templates` and `internal/i18n` were run because the branch edits
a test in the former and the latter's external test reads templates.

## Deliberately not done

- No `depguard`, `importas` or `gomodguard` — see "Why archcheck and not depguard"; adding one now would be the second home
  for the same invariant.
- No rule forbidding `internal/services` → `internal/db`. `docs/architecture.md` draws that edge as
  allowed (`services --> db`); the tree happens not to use it today (repositories are reached
  through ports), and encoding today's accident as a rule would contradict a tracked diagram.
- No rule over the cross-cutting packages or over `internal/cli`, `internal/bootstrap`,
  `internal/reminders` — the contract does not order them.
- The zero-`//nolint` line is now *mostly* mechanical, not fully: golangci-lint ships no setting
  that refuses a well-formed, explained, load-bearing directive. Said so in the config rather than
  letting the comment overclaim.

## Rollback

Single-commit revert. No persisted data, no public contract, no runtime behaviour touched.
