### PR TITLE
fix(stats): gate the fertile-window card on the pregnancy pause

### DIFF
--- a/changelog.d/stats-gate-fertile-card-on-pregnancy-pause.md
+++ b/changelog.d/stats-gate-fertile-card-on-pregnancy-pause.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- **The statistics page no longer claims a fertile window while cycle predictions
+  are paused by a positive pregnancy test.** The phase card there decided whether
+  to show estimates from the unpredictable-cycle setting alone, so it was the one
+  prediction surface the pregnancy pause never reached: the calendar grid, the
+  calendar feed and the outbound reminders all withheld their projections while
+  the statistics page kept showing "Fertile window", derived from the cycle
+  length set during onboarding rather than from anything recorded. It now reads
+  the same paused-or-off decision the dashboard already resolves, and shows the
+  logged-history view instead. Nothing changes for an owner without a pause.

--- a/internal/api/dashboard_regressions_test.go
+++ b/internal/api/dashboard_regressions_test.go
@@ -380,6 +380,108 @@ func TestDashboardAndStatsAgreeOnPhaseAndFertilityOnAFertileWindowDay(t *testing
 	}
 }
 
+// TestStatsFertileWindowCardIsSuppressedByAPregnancyPause is the render
+// regression for the one prediction surface the pregnancy pause did not reach.
+// /stats resolved the flag its phase card gates on from
+// DashboardPredictionDisabled — the owner's unpredictable-cycle setting alone —
+// while the calendar grid, the .ics feed and the webhook pass all gate on the
+// shared suppression predicate, so an owner whose latest fertility signal is a
+// positive pregnancy test still read "Fertile window" on /stats: a claim
+// projected from the onboarding cycle-length slider, which the medical-safety
+// invariant says must be suppressed rather than captioned.
+//
+// Both accounts sit on day 12 of a 28-day baseline with two completed cycles
+// behind them — the tier the card lives in (HasInsights, >= 2) and a
+// fertile-window day by the same math the test above uses — and differ only in
+// the positive pregnancy test. The unpaused case is the positive anchor for the
+// paused one: it proves the two hooks asserted absent under the pause are the
+// hooks this surface actually renders, so the suppression case cannot pass by
+// naming an attribute that no longer exists.
+//
+// Deliberately narrower than its subject: it pins the pregnancy pause only. The
+// zero-completed-cycle tier never reaches this card (HasInsights excludes it)
+// and an overdue cycle is already caught by the stronger CycleDataStale branch
+// above the card's fertility line.
+func TestStatsFertileWindowCardIsSuppressedByAPregnancyPause(t *testing.T) {
+	for name, testCase := range map[string]struct {
+		account         string
+		pregnancyPaused bool
+	}{
+		"no pregnancy test: the fertile-window claim renders": {account: "unpaused"},
+		"positive pregnancy test: the claim is withheld":      {account: "paused", pregnancyPaused: true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			app, database := newOnboardingTestApp(t)
+			user := createOnboardingTestUser(t, database, "stats-pregnancy-pause-"+testCase.account+"@example.com", "StrongPass1", true)
+			today := services.DateAtLocation(time.Now().UTC(), time.UTC)
+			if err := database.Model(&models.User{}).Where("id = ?", user.ID).Updates(map[string]any{
+				"cycle_length":      28,
+				"period_length":     5,
+				"last_period_start": today.AddDate(0, 0, -11),
+			}).Error; err != nil {
+				t.Fatalf("seed cycle baseline: %v", err)
+			}
+			// Three recorded starts 28 days apart: two completed cycles, and the
+			// running one on day 12 — inside the fertile window (ovulation day 14,
+			// window days 9-14) with a day of timezone slack on either side.
+			for _, offsetDays := range []int{-67, -39, -11} {
+				if err := database.Create(&models.DailyLog{
+					UserID:     user.ID,
+					Date:       today.AddDate(0, 0, offsetDays),
+					IsPeriod:   true,
+					CycleStart: true,
+				}).Error; err != nil {
+					t.Fatalf("seed cycle start %d: %v", offsetDays, err)
+				}
+			}
+			if testCase.pregnancyPaused {
+				// Positive test after the running cycle's start, with no later cycle
+				// start: ResolvePregnancyPause reports an active pause.
+				if err := database.Create(&models.DailyLog{
+					UserID:        user.ID,
+					Date:          today.AddDate(0, 0, -2),
+					PregnancyTest: models.PregnancyTestPositive,
+				}).Error; err != nil {
+					t.Fatalf("seed positive pregnancy test: %v", err)
+				}
+			}
+
+			authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
+			request := httptest.NewRequest(http.MethodGet, "/stats", nil)
+			request.Header.Set("Accept-Language", "en")
+			request.Header.Set("Cookie", authCookie)
+			response, err := app.Test(request, testConfigNoTimeout)
+			if err != nil {
+				t.Fatalf("stats request failed: %v", err)
+			}
+			defer func() { _ = response.Body.Close() }()
+
+			document := mustParseHTMLDocument(t, mustReadBodyString(t, response.Body))
+			fertilityStatus := ""
+			if statusValue := dashboardElementByDataAttr(document, "data-fertility-status"); statusValue != nil {
+				fertilityStatus = htmlAttr(statusValue, "data-fertility-status")
+			}
+			fertileWindowLine := dashboardElementByDataAttr(document, "data-fertile-window")
+
+			if !testCase.pregnancyPaused {
+				if fertilityStatus != "fertile" {
+					t.Errorf("anchor: expected /stats to declare fertility %q on a fertile-window day, got %q", "fertile", fertilityStatus)
+				}
+				if fertileWindowLine == nil {
+					t.Error("anchor: expected /stats to render the fertile-window line on a fertile-window day")
+				}
+				return
+			}
+			if fertilityStatus == "fertile" {
+				t.Errorf("expected /stats to withhold the fertility status under a pregnancy pause, got data-fertility-status=%q", fertilityStatus)
+			}
+			if fertileWindowLine != nil {
+				t.Error("expected /stats to withhold the fertile-window line under a pregnancy pause, got data-fertile-window rendered")
+			}
+		})
+	}
+}
+
 // TestDashboardHeaderWithholdsFertilityUntilTheFirstCompletedCycle is the
 // render regression for the first reliability tier. Both accounts below sit on
 // cycle day 12 of a 28-day baseline — a fertile-window day by the same math the

--- a/internal/services/stats_page_view_service.go
+++ b/internal/services/stats_page_view_service.go
@@ -131,12 +131,22 @@ func (service *StatsService) BuildStatsPageViewData(ctx context.Context, user *m
 	showShortCycleNotice := shouldShowStatsShortCycleNotice(user, completedCycleLengths)
 	showLongCycleNotice := shouldShowStatsLongCycleNotice(user, completedCycleLengths)
 	showPerimenopauseHint := shouldShowStatsPerimenopauseHint(user)
-	predictionDisabled := DashboardPredictionDisabled(user)
+	cycleContext := BuildDashboardCycleContext(user, baseData.stats, DateAtLocation(now, location), location)
+	// The stats phase card reads the suppression the cycle context already
+	// resolved, not DashboardPredictionDisabled(user) on its own: the
+	// unpredictable-cycle setting is one signal among several, and a pregnancy
+	// pause left this surface — the last prediction surface without the gate the
+	// calendar grid, the .ics feed and the webhook pass all carry — still
+	// claiming a fertile window whose only source is the onboarding
+	// cycle-length slider. Reading the resolved decision rather than
+	// recombining the signals here keeps /stats moving with the dashboard on
+	// every later reliability change. Regression:
+	// TestStatsFertileWindowCardIsSuppressedByAPregnancyPause.
+	predictionDisabled := cycleContext.PredictionDisabled
 	isIrregularMode := isStatsIrregularMode(user)
 	isOwner := IsOwnerUser(user)
 	predictionSampleCount, predictionSampleUsesRecentWindow, predictionReliabilityLabelKey, predictionReliabilityHintKey, showPredictionReliability := buildStatsPredictionReliability(user, baseData.flags, baseData.stats)
 	cycleFactorExplanation, hasCycleFactorExplanation := buildStatsCycleFactorExplanation(user, baseData.logs, baseData.stats, now, location)
-	cycleContext := BuildDashboardCycleContext(user, baseData.stats, DateAtLocation(now, location), location)
 	predictionExplanation := BuildOwnerPredictionExplanation(user, cycleContext, hasCycleFactorExplanation && len(cycleFactorExplanation.HintFactorKeys) > 0)
 
 	return StatsPageViewData{


### PR DESCRIPTION
## Why

`/stats` was the one prediction surface a pregnancy pause never reached.

The phase card at `internal/templates/stats.html:99` gates on `PredictionDisabled`, and
`BuildStatsPageViewData` filled that flag from `DashboardPredictionDisabled(user)` — literally
`user.UnpredictableCycle`, one signal out of several. `stats.PregnancyPaused` never clears
`CurrentFertility` or the window, so an owner whose latest fertility signal is a positive pregnancy
test still read **"Fertile window"** on the statistics page while the calendar grid
(`buildCalendarPredictionMaps`), the `.ics` feed (`BuildCalendarFeedICS`) and the outbound reminder
pass (`webhook_reminder.go`) all withheld their projections through the shared
`PredictionsSuppressed` predicate.

The window shown there has nothing behind it but the onboarding cycle-length slider projected
forward, which the medical-safety invariant says must be suppressed, not captioned.

## What changed

One line of business logic, in the layer that owns it.

`internal/services/stats_page_view_service.go:134` now reads the suppression the cycle context has
already resolved:

```go
cycleContext := BuildDashboardCycleContext(user, baseData.stats, DateAtLocation(now, location), location)
predictionDisabled := cycleContext.PredictionDisabled
```

`BuildDashboardCycleContext` returns `PredictionDisabled: true` on both its pregnancy-pause branch
and its unpredictable-cycle branch, so the page keeps its previous behaviour for the
unpredictable-cycle setting and gains the pause. The context was already being built a few lines
below for the prediction explainer — it is only hoisted, not added — so no extra work is done per
request. Neither `internal/templates/stats.html` nor `internal/api/stats_page_helpers.go` changed:
the signals are not recombined on the surface, which is what `prediction-display.md` asks for
("a surface calls the predicate, or reads the decision the context already resolved").

Scope kept to the surviving leg of the register item. The zero-completed-cycle tier cannot reach
this card — it sits in the `HasInsights` arm, and `HasInsights` needs two completed cycles — and an
overdue cycle is already caught by the strictly stronger `CycleDataStale` branch immediately above
the card's fertility line (`rawCycleDay > referenceLength` versus `> referenceLength + 7`). Both were
re-derived on this tree and left alone.

## Guard

`TestStatsFertileWindowCardIsSuppressedByAPregnancyPause`
(`internal/api/dashboard_regressions_test.go`), beside the positive-case sibling
`TestDashboardAndStatsAgreeOnPhaseAndFertilityOnAFertileWindowDay` that it mirrors.

Two owners, both on day 12 of a 28-day baseline with two completed cycles behind them — a
fertile-window day in the tier where the card renders — differing only in a positive `pregnancy_test`
log two days back with no later cycle start. The paused one must not carry
`data-fertility-status="fertile"` and must not render `data-fertile-window`; the unpaused one is the
positive anchor **in the same test**, proving those two hooks are what this surface really renders,
so the suppression case cannot pass by naming an attribute that no longer exists.

The defect is latent — it needs the seeded pause — so the red below is induced by the fixture, not by
gutting production code.

**Red, against the tree before the fix:**

```
$ go test ./internal/api -run 'TestStatsFertileWindowCardIsSuppressedByAPregnancyPause' -timeout 20m -v
=== RUN   TestStatsFertileWindowCardIsSuppressedByAPregnancyPause
=== RUN   TestStatsFertileWindowCardIsSuppressedByAPregnancyPause/no_pregnancy_test:_the_fertile-window_claim_renders
=== RUN   TestStatsFertileWindowCardIsSuppressedByAPregnancyPause/positive_pregnancy_test:_the_claim_is_withheld
    dashboard_regressions_test.go:476: expected /stats to withhold the fertility status under a pregnancy pause, got data-fertility-status="fertile"
    dashboard_regressions_test.go:479: expected /stats to withhold the fertile-window line under a pregnancy pause, got data-fertile-window rendered
--- FAIL: TestStatsFertileWindowCardIsSuppressedByAPregnancyPause (3.64s)
    --- PASS: .../no_pregnancy_test:_the_fertile-window_claim_renders (1.86s)
    --- FAIL: .../positive_pregnancy_test:_the_claim_is_withheld (1.78s)
FAIL	github.com/ovumcy/ovumcy-web/internal/api	13.442s
```

Both assertions redden, and the anchor case passes in the same run — the two hooks are live.

**Mutant, re-run after the fix landed** (`predictionDisabled` put back to
`DashboardPredictionDisabled(user)`, the fix's body gutted rather than its call site unwired) —
identical failure at `dashboard_regressions_test.go:476` and `:479`, then restored.

**Green:**

```
$ go test ./internal/api -run 'TestStatsFertileWindowCardIsSuppressedByAPregnancyPause|TestDashboardAndStatsAgreeOnPhaseAndFertilityOnAFertileWindowDay|TestDashboardHeaderWithholdsFertilityUntilTheFirstCompletedCycle' -timeout 20m
ok  	github.com/ovumcy/ovumcy-web/internal/api	13.773s
```

## Validation

| Command | Verdict |
| --- | --- |
| `go build ./...` | ok |
| `go test ./internal/api/... -timeout 20m` | ok, 692.9s |
| `go test ./internal/services/... -timeout 20m` | ok, 225.3s |
| `go test ./internal/i18n/... ./internal/templates/...` | ok |
| `golangci-lint run ./internal/services/... ./internal/api/...` | 0 issues |
| `go run ./scripts/changelogd check` | OK |

## Notes

- Under a pause the card now shows the existing "facts only / predictions off" block. No new copy
  was added: the page already names the reason through
  `prediction.explainer.pregnancy_paused`, which `BuildOwnerPredictionExplanation` selects from the
  same context, so the pause is stated rather than merely blank.
- `buildStatsPredictionReliability` and `buildStatsCycleFactorExplanation` still read
  `user.UnpredictableCycle` directly. They gate a sample-size label and a retrospective factor
  summary, not a projected window, so they are outside this item's class and are left untouched.
- Rollback is a single-commit revert; nothing persisted and no public contract is touched.
