### PR TITLE
refactor(db): drop the unreachable driver-message unique-constraint branch

### DIFF
--- a/changelog.d/db-name-the-unique-constraint-fallback.md
+++ b/changelog.d/db-name-the-unique-constraint-fallback.md
@@ -1,0 +1,21 @@
+none
+
+Dead-code removal with no user-visible effect: the persistence layer's
+duplicate-key classifier no longer sniffs the driver's error text. It kept a
+fallback that searched for SQLite's wording, `UNIQUE constraint failed:`, and
+tried to read a constraint name out of it. That branch could never run on
+either supported dialect: the SQLite driver's error translator replaces the
+driver error with GORM's bare duplicate-key sentinel and throws the wording
+away, and PostgreSQL words its own refusal differently and would not match the
+marker even if it did survive. Classification now reads the translated sentinel
+alone — the signal both dialects genuinely produce, and the one the database
+configuration is already tested to enable.
+
+The name a duplicate-key error carries is documented for what it is: the
+constraint the calling repository declares for the write, not a name read back
+from the database's refusal. It had always been caller-supplied while reading
+as though it were derived from the schema, and the deleted branch was the only
+thing that made the other reading plausible. No caller branches on the value —
+the three consumers in the service layer test only that the write was refused
+by a unique index — so refusing a duplicate email, a duplicate OIDC identity or
+a duplicate symptom name reaches the owner exactly as before.

--- a/internal/db/errors.go
+++ b/internal/db/errors.go
@@ -44,6 +44,17 @@ var ErrUnsupportedUserRole = errors.New("unsupported user role")
 // raises.
 var ErrOIDCLogoutStateUnattributed = models.ErrOIDCLogoutStateUnattributed
 
+// UniqueConstraintError reports that a write was refused by a unique index.
+//
+// Constraint is **not** read out of the database's refusal: it is the name the
+// calling repository declared for the one unique constraint that write can
+// violate (see classifyUniqueConstraintError). Neither driver hands this layer
+// a usable constraint name — the sqlite translator replaces the driver error
+// with a bare sentinel, and postgres words its own message differently — so a
+// caller must treat this as documentation of the write, not as a fact read back
+// from the schema. Branching on it is branching on the repository's own
+// annotation; today's consumers only test for the type's presence
+// (`internal/services`: registration, operator-user, symptom).
 type UniqueConstraintError struct {
 	Constraint string
 	Err        error
@@ -60,6 +71,9 @@ func (err *UniqueConstraintError) Unwrap() error {
 	return err.Err
 }
 
+// UniqueConstraint returns the caller-declared constraint name, with the
+// caveat on the Constraint field: it is the repository's annotation of the
+// write, not a name extracted from the database's refusal.
 func (err *UniqueConstraintError) UniqueConstraint() string {
 	return err.Constraint
 }
@@ -88,28 +102,26 @@ func classifyOIDCIdentityCreateError(err error) error {
 	return classifyUniqueConstraintError(err, "oidc_identities.issuer_subject")
 }
 
-func classifyUniqueConstraintError(err error, defaultConstraint string) error {
+// classifyUniqueConstraintError turns a duplicate-key refusal into a
+// UniqueConstraintError carrying constraint, the name the calling repository
+// declares for the one unique index that write can violate.
+//
+// The single signal it reads is gorm.ErrDuplicatedKey, which both drivers
+// produce because newGORMConfig sets TranslateError (gorm_config.go, pinned by
+// TestNewGORMConfigEnablesTranslateError). errors.Is, not ==: the postgres
+// translator wraps the sentinel around the pgconn error.
+//
+// It deliberately does not sniff the driver's message text. That could never be
+// right for both dialects at once — "UNIQUE constraint failed:" is SQLite's
+// wording and postgres does not emit it — and it is not even reachable on
+// SQLite, whose translator replaces the driver error with the bare sentinel and
+// throws the wording away. Absence of message sniffing is pinned by
+// TestClassifyUniqueConstraintErrorIgnoresDriverMessageText.
+func classifyUniqueConstraintError(err error, constraint string) error {
 	if err == nil {
 		return nil
 	}
 	if errors.Is(err, gorm.ErrDuplicatedKey) {
-		return &UniqueConstraintError{
-			Constraint: defaultConstraint,
-			Err:        err,
-		}
-	}
-
-	message := strings.ToLower(strings.TrimSpace(err.Error()))
-	if strings.Contains(message, "unique constraint failed") {
-		const marker = "unique constraint failed:"
-		constraint := defaultConstraint
-		index := strings.Index(message, marker)
-		if index >= 0 {
-			extracted := strings.TrimSpace(message[index+len(marker):])
-			if extracted != "" {
-				constraint = extracted
-			}
-		}
 		return &UniqueConstraintError{
 			Constraint: constraint,
 			Err:        err,

--- a/internal/db/helpers_test.go
+++ b/internal/db/helpers_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -112,10 +113,17 @@ func TestClassifyUniqueConstraintError(t *testing.T) {
 		t.Fatalf("expected duplicated-key sentinel to become UniqueConstraintError, got %T %v", duplicated, duplicated)
 	}
 
-	sqliteStyle := errors.New("UNIQUE constraint failed: users.email")
-	sqliteClassified := classifyUniqueConstraintError(sqliteStyle, "fallback")
-	if !errors.As(sqliteClassified, &uniqueErr) || uniqueErr.Constraint != "users.email" {
-		t.Fatalf("expected sqlite-style error to extract users.email, got %T %v", sqliteClassified, sqliteClassified)
+	// What the postgres driver actually hands us: the sentinel wrapped around
+	// the pgconn error, never the bare sentinel (gorm.io/driver/postgres
+	// error_translator.go returns fmt.Errorf("%w: %w", …)). Classification must
+	// see through the wrap, because it is the only thing it looks at.
+	wrapped := fmt.Errorf(
+		"%w: ERROR: duplicate key value violates unique constraint \"idx_users_email\" (SQLSTATE 23505)",
+		gorm.ErrDuplicatedKey,
+	)
+	wrappedClassified := classifyUniqueConstraintError(wrapped, "users.email")
+	if !errors.As(wrappedClassified, &uniqueErr) || uniqueErr.Constraint != "users.email" {
+		t.Fatalf("expected wrapped duplicated-key error to become UniqueConstraintError, got %T %v", wrappedClassified, wrappedClassified)
 	}
 
 	rawErr := errors.New("other failure")
@@ -124,18 +132,50 @@ func TestClassifyUniqueConstraintError(t *testing.T) {
 	}
 }
 
+// TestClassifyUniqueConstraintErrorIgnoresDriverMessageText pins the deletion of
+// the driver-message fallback: classification is driven by gorm.ErrDuplicatedKey
+// alone — i.e. by TranslateError in newGORMConfig — and never by sniffing the
+// driver's wording. A message-only error carries no translated sentinel, so it
+// is not a unique-constraint violation as far as this layer is concerned and
+// passes through untouched.
+//
+// Sniffing a message was dialect-asymmetric and could never be right for both
+// drivers at once: "UNIQUE constraint failed:" is SQLite's wording, which
+// postgres does not emit, and the glebarez sqlite translator replaces the
+// driver error outright with the bare sentinel, so the wording never survives
+// to be matched anyway.
+func TestClassifyUniqueConstraintErrorIgnoresDriverMessageText(t *testing.T) {
+	t.Parallel()
+
+	driverWorded := errors.New("UNIQUE constraint failed: users.email")
+	classified := classifyUniqueConstraintError(driverWorded, "symptom_types.user_id_name")
+
+	var uniqueErr *UniqueConstraintError
+	if errors.As(classified, &uniqueErr) {
+		t.Fatalf("expected driver message text to be ignored, got UniqueConstraintError %q", uniqueErr.Constraint)
+	}
+	if !errors.Is(classified, driverWorded) {
+		t.Fatalf("expected untranslated driver error to pass through unchanged, got %T %v", classified, classified)
+	}
+}
+
 func TestClassifyCreateErrorsUseExpectedConstraints(t *testing.T) {
 	t.Parallel()
 
-	userErr := classifyUserCreateError(errors.New("UNIQUE constraint failed: users.email"))
+	userErr := classifyUserCreateError(gorm.ErrDuplicatedKey)
 	var uniqueErr *UniqueConstraintError
 	if !errors.As(userErr, &uniqueErr) || uniqueErr.Constraint != "users.email" {
 		t.Fatalf("expected user create error to classify users.email, got %T %v", userErr, userErr)
 	}
 
-	oidcErr := classifyOIDCIdentityCreateError(errors.New("UNIQUE constraint failed: oidc_identities.issuer_subject"))
+	oidcErr := classifyOIDCIdentityCreateError(gorm.ErrDuplicatedKey)
 	if !errors.As(oidcErr, &uniqueErr) || uniqueErr.Constraint != "oidc_identities.issuer_subject" {
 		t.Fatalf("expected oidc identity create error to classify issuer_subject, got %T %v", oidcErr, oidcErr)
+	}
+
+	symptomErr := classifySymptomWriteError(gorm.ErrDuplicatedKey)
+	if !errors.As(symptomErr, &uniqueErr) || uniqueErr.Constraint != "symptom_types.user_id_name" {
+		t.Fatalf("expected symptom write error to classify user_id_name, got %T %v", symptomErr, symptomErr)
 	}
 }
 


### PR DESCRIPTION
## What was wrong

`classifyUniqueConstraintError` (`internal/db/errors.go`) had two branches. The first maps
`gorm.ErrDuplicatedKey` onto a `UniqueConstraintError` carrying the constraint name the calling
repository declared. The second searched the driver's error text for SQLite's wording,
`unique constraint failed:`, and extracted a constraint name out of it — about twenty lines whose
whole job was to produce a database-derived name.

The record (R2-0128) said that branch is unreachable because the `errors.Is` branch wins first,
`TranslateError: true` being set in `newGORMConfig`. That is true but understates it. Re-derived
here from the driver sources and a probe rather than from the record's transcript:

- **SQLite** — `github.com/glebarez/sqlite@v1.11.0/sqlite.go:238 Translate` returns the **bare**
  `gorm.ErrDuplicatedKey` on `SQLITE_CONSTRAINT_UNIQUE`; the driver message is discarded. Probed
  through `UserRepository.Create` on a duplicate email, the error arriving at classification is
  `*errors.errorString` with the text `duplicated key not allowed`, and
  `strings.Contains(msg, "unique constraint failed")` is **false**. The branch would not fire even
  if the `errors.Is` branch were deleted — the marker never survives translation.
- **Postgres** — `gorm.io/driver/postgres@v1.6.2/error_translator.go:28` returns
  `fmt.Errorf("%w: %w", gorm.ErrDuplicatedKey, pgErr)`. `errors.Is` is true, and the text is
  `duplicate key value violates unique constraint "…"` — Postgres's own wording, which never
  matches a SQLite marker.

So the branch was not a dialect-neutral fallback at all: it could only ever have fired for **one**
driver, under a configuration that a test already forbids
(`TestNewGORMConfigEnablesTranslateError`, `internal/db/helpers_test.go`). Keeping it as a
`TranslateError=false` fallback would have documented a safety net that catches SQLite and drops
Postgres — a worse failure mode than having none, because the two dialects would then disagree on
whether a duplicate registration is a friendly refusal or a raw driver error.

Subject verified live before any edit: `TranslateError: true` still at `internal/db/gorm_config.go:16`,
the `errors.Is` branch still ahead of the string branch, the string branch still present. Not a dead
record.

## Which outcome, and why

**Deleted**, not commented. Three reasons, in order of weight: the branch is unreachable on both
dialects *independently of branch order*, so no comment about ordering would even be accurate; the
scenario it nominally covers is already refused by a test, so it guards nothing reachable; and it is
dialect-asymmetric, so it could not be made honest without adding a Postgres-worded twin — an
abstraction the record did not ask for and the callers do not need.

Verified before deleting that no caller depends on the extracted name: the three consumers —
`internal/services/registration_service.go:90`, `operator_user_service.go:115`,
`symptom_service.go:107` — all do `errors.As` against an `interface{ UniqueConstraint() string }` and
use only the boolean. None reads the string.

## The defect that survives the deletion

`UniqueConstraintError.Constraint` and `UniqueConstraint()` read as database-derived and are
caller-supplied. Doc comments now say so, and say why no future code can fix it by looking harder at
the driver: neither driver hands this layer a usable constraint name. The classifier's parameter is
renamed `defaultConstraint` → `constraint`, since with the extraction gone there is no other value
for it to be a default against.

The record listed two callers; there are **three**. `SymptomRepository` classifies through
`classifySymptomWriteError` with `symptom_types.user_id_name` (`internal/db/symptom_repository.go:53`),
added after the audit snapshot. It is covered by the same doc caveat and is now asserted in
`TestClassifyCreateErrorsUseExpectedConstraints`.

## Red → green

Not `none-practical`. The record judged an automatic check impractical while `TranslateError` is on;
that holds for a check driven through a real database, but not for one calling the classifier
directly, which is what pins the deletion.

**Red 1 — the new guard, induced against the pre-fix tree.**
`TestClassifyUniqueConstraintErrorIgnoresDriverMessageText` feeds the exact string the deleted branch
searched for, `UNIQUE constraint failed: users.email`, while declaring a *different* caller
constraint, and requires it to pass through unclassified. Against the unfixed tree:

```
--- FAIL: TestClassifyUniqueConstraintErrorIgnoresDriverMessageText
    helpers_test.go:155: expected driver message text to be ignored,
        got UniqueConstraintError "users.email"
```

The failure names the culprit exactly — the branch preferred the message's `users.email` over the
caller's declared `symptom_types.user_id_name`, which is the "looks derived from the database and is
not" defect stated as a test. Green after the deletion.

**Red 2 — induced separately, by gutting the surviving branch's body.** The wrapped-sentinel
assertion added to `TestClassifyUniqueConstraintError` covers the form Postgres actually delivers.
Replacing `errors.Is(err, gorm.ErrDuplicatedKey)` with `err == gorm.ErrDuplicatedKey`:

```
--- FAIL: TestClassifyUniqueConstraintError
    helpers_test.go:126: expected wrapped duplicated-key error to become UniqueConstraintError,
        got *fmt.wrapError duplicated key not allowed: ERROR: duplicate key value violates
        unique constraint "idx_users_email" (SQLSTATE 23505)
```

Restored, green. One induced red per assertion; no assertion ships that was not observed failing.

Real-driver behaviour needs no new test and got none: `TestUserRepositoryCreateTranslatesUniqueViolation`
(SQLite) and `TestUserRepositoryCreateTranslatesPostgresUniqueViolation` (Postgres) already put a real
duplicate through `UserRepository.Create` on both dialects and require a `UniqueConstraintError` out
of it. Those are what redden if a driver upgrade stops translating.

The two pre-existing assertions that fed SQLite-worded strings into the classifier were rewritten to
feed the translated sentinel — they were exercising the deleted branch, and were the only thing
making it look alive.

## Validation

`go build ./...`; `go test ./internal/db/... ./internal/services/...` (full, Postgres-backed, green);
`go test ./internal/i18n/... ./scripts/archcheck/...`; `golangci-lint run ./internal/db/...
./internal/services/...` → 0 issues; `go run ./scripts/changelogd check` → OK.
`./internal/api/...` was not run: the change is inside `internal/db`, the classifier is unexported,
no signature moved, and no test outside `internal/db` feeds a message-worded error into it — the only
route from the api layer is a real duplicate through a real repository, which the two suites above
cover on both dialects.

## Rollback

Single-commit revert; category is dead-code, so no persisted data and no public contract is touched
and no dialect-parity or OpenAPI re-run is required. Reverting restores an unreachable branch and the
two tests that fed it, at no behavioural cost.
