### PR TITLE
refactor(api): resolve the onboarding step-2 timezone once

### DIFF
--- a/changelog.d/onboarding-resolve-the-timezone-once.md
+++ b/changelog.d/onboarding-resolve-the-timezone-once.md
@@ -1,0 +1,13 @@
+none
+
+Internal only: the onboarding step-2 handler resolved the request timezone
+twice — once discarding the result, once inside the completion call — and now
+resolves it once into a named variable that both uses. Behaviour is unchanged
+on every path: the resolver's only side effect is writing the `ovumcy_tz`
+response cookie, it reads the request and never its own response, so the two
+calls always took the same branch and returned the same zone. What the discard
+bought is that the cookie is written before step 2 can refuse the submission,
+which the named variable keeps by staying where the discard was; a regression
+now pins it, so the resolution cannot drift down to the completion call site.
+On the urlencoded path this also stops the request body being materialized and
+re-parsed a second time per submission.

--- a/internal/api/handlers_onboarding_steps.go
+++ b/internal/api/handlers_onboarding_steps.go
@@ -59,7 +59,13 @@ func (handler *Handler) OnboardingStep2(c fiber.Ctx) error {
 		return redirectOrJSON(c, "/dashboard")
 	}
 
-	_ = handler.requestLocationFromOnboardingForm(c)
+	// Resolved before the refusals below, not at the CompleteOnboardingForUser
+	// call site: requestLocationFromOnboardingForm also writes the ovumcy_tz
+	// cookie, and the client that submitted client_timezone keeps it even when
+	// the step is refused. Resolving once also keeps the urlencoded path from
+	// re-materializing and re-parsing the request body a second time.
+	// Regression: TestOnboardingStep2SetsTheFormFallbackTimezoneCookieOnARefusedStep.
+	location := handler.requestLocationFromOnboardingForm(c)
 
 	values, validationError := handler.parseOnboardingStep2Input(c)
 	if validationError != "" {
@@ -77,7 +83,7 @@ func (handler *Handler) OnboardingStep2(c fiber.Ctx) error {
 	if err != nil {
 		return handler.failMutation(c, onboardingCycleMutation, onboardingSaveStepErrorSpec())
 	}
-	if _, err := handler.onboardingSvc.CompleteOnboardingForUser(c.Context(), user.ID, handler.requestLocationFromOnboardingForm(c)); err != nil {
+	if _, err := handler.onboardingSvc.CompleteOnboardingForUser(c.Context(), user.ID, location); err != nil {
 		if errors.Is(err, services.ErrOnboardingStepsRequired) {
 			// The step-2 columns are persisted at this point; only the completion
 			// (which seeds the first period's day entries) did not run, so the

--- a/internal/api/onboarding_request_timezone_regression_test.go
+++ b/internal/api/onboarding_request_timezone_regression_test.go
@@ -136,6 +136,41 @@ func TestOnboardingPersistsLastPeriodStartUsingFormTimezoneFallback(t *testing.T
 	}
 }
 
+// TestOnboardingStep2SetsTheFormFallbackTimezoneCookieOnARefusedStep pins the
+// side effect that keeps step 2's timezone resolution at the TOP of the handler
+// rather than at the CompleteOnboardingForUser call site: the resolver writes
+// the ovumcy_tz cookie, and it has to run before the validation refusal
+// returns, not only on the success path that consumes the location. Deleting
+// the resolution (it reads as an unused result) or inlining it into the
+// CompleteOnboardingForUser argument drops the cookie on every early return
+// out of step 2.
+//
+// Form-fallback case, deliberately narrower than the default both-signals
+// convention: neither X-Ovumcy-Timezone nor an ovumcy_tz cookie is sent, so
+// client_timezone is the only source and the cookie write is the only
+// observable trace the resolver leaves. It says nothing about the header or
+// cookie branches, which never write on this path.
+func TestOnboardingStep2SetsTheFormFallbackTimezoneCookieOnARefusedStep(t *testing.T) {
+	app, database := newOnboardingTestApp(t)
+	user := createOnboardingTestUser(t, database, "step2-refused-tz@example.com", "StrongPass1", false)
+	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
+
+	timezoneName, _ := timezoneWithDifferentCalendarDay(t, time.Now().UTC())
+
+	refusedForm := url.Values{
+		"cycle_length":              {"not-a-number"},
+		"period_length":             {"5"},
+		onboardingTimezoneFieldName: {timezoneName},
+	}
+	response := onboardingHTMXResponse(t, app, http.MethodPost, "/api/v1/onboarding/steps/2", authCookie, "", refusedForm)
+	assertStatusCode(t, response, http.StatusBadRequest)
+
+	timezoneCookie := responseCookie(response.Cookies(), timezoneCookieName)
+	if timezoneCookie == nil || strings.TrimSpace(timezoneCookie.Value) != timezoneName {
+		t.Fatalf("expected timezone cookie %q=%q on the refused step-2 submission, got %#v", timezoneCookieName, timezoneName, timezoneCookie)
+	}
+}
+
 func submitOnboardingStep1WithTimezone(t *testing.T, app *fiber.App, authCookie string, timezoneName string, form url.Values) {
 	t.Helper()
 


### PR DESCRIPTION
# refactor(api): resolve the onboarding step-2 timezone once

Register T0022, record `R2-0022` (confirmed-debt, P3, complexity).

## What was wrong

`OnboardingStep2` resolved the request timezone twice.

- `internal/api/handlers_onboarding_steps.go:62` — `_ = handler.requestLocationFromOnboardingForm(c)`, a bare discard with no comment.
- `internal/api/handlers_onboarding_steps.go:80` — the same call again, inline as the `CompleteOnboardingForUser` argument.

The discard was load-bearing and said so nowhere. `requestLocationFromOnboardingForm`
(`internal/api/handlers_onboarding_input_helpers.go:29-48`) writes the `ovumcy_tz` response
cookie on two of its four branches, and running it at the TOP of the handler is what makes
that cookie reach a client whose submission is then refused — by `parseOnboardingStep2Input`
(`:66`) or by a failing `SaveStep2` (`:78`), both of which return before the completion call
ever runs. A reader deleting the discard as an unused result would silently have dropped the
cookie on those paths. On the urlencoded path the second call also re-materializes and
re-parses the whole request body (`handlers_onboarding_input_helpers.go:22`,
`url.ParseQuery(string(c.Body()))`).

## What changed

One line each side: resolve once into a named `location`, left exactly where the discard was,
and pass it to `CompleteOnboardingForUser`. Plus a comment stating why the resolution sits
above the refusals, and the regression's name.

Behaviour-preserving on every path (see "Refuted" for the proof that it is).

## Verified against the live tree — the record was accurate, its explanation was not

The double call is still there, at the exact lines the record names, and there is no reader of
the timezone cookie between `:62` and `:80` (`parseOnboardingStep2Input` and `SaveStep2` touch
neither cookie nor location). So the finding stands.

**Refuted:** the record's `recurring_cost` claims the second call "only agrees with the first
because the first call already wrote the cookie the second one now reads." That is false.
Fiber v3's `Res.Cookie` writes a **response** cookie (`res.go:314`) and `Req.Cookies` reads the
**request** header (`req.go:387`, `fasthttp.Request.Header.Cookie(key)`) — the resolver never
reads back its own write. The resolver is therefore idempotent with respect to an unchanged
request: both calls took the same branch and returned the same `*time.Location`. This matters
for the fix's safety: resolving once cannot change which zone is used, only how many times the
cookie is stamped (fasthttp replaces a same-named response cookie, so the wire is identical
either way) and how many times the body is parsed.

**Also refuted:** the record's `counter_evidence` offers deletion as the alternative fix ("the
second one writes the same cookie before it is needed"). Deletion is NOT equivalent — the
second call is downstream of two early returns, so deleting `:62` removes the cookie from the
refusal paths. That is what the guard below catches.

## Red -> green (one assertion, red INDUCED twice)

Guard: `TestOnboardingStep2SetsTheFormFallbackTimezoneCookieOnARefusedStep`,
`internal/api/onboarding_request_timezone_regression_test.go:139-172`. Step-2 submission carrying
only `client_timezone` (no `X-Ovumcy-Timezone`, no `ovumcy_tz` cookie — an explicitly named
form-fallback case, as the repository's timezone regressions require of anything that does not
send both signals) and an unparsable `cycle_length`; asserts 400 **and**
`Set-Cookie: ovumcy_tz=<zone>`. Its docblock states the limit: it says nothing about the header
or request-cookie branches, which do not write on this path.

The subject is a shape, not a live bug: the guard is GREEN on the unfixed tree. So the red was
induced, twice, and the second induction is the one that matters because it is the mutant that
lives in the tree **after** this change:

1. Pre-fix mutant — delete the `_ =` discard at `:62` (the deletion the record predicts a
   reader makes):
   `expected timezone cookie "ovumcy_tz"="Pacific/Kiritimati" on the refused step-2 submission, got (*http.Cookie)(nil)` — FAIL.
2. Post-fix mutant — inline the resolution back into the `CompleteOnboardingForUser` argument
   (the named variable removes "delete as dead code" as a reachable mistake; "move it down to
   its only use" replaces it): same failure — FAIL.

Both reverted; guard green with the fix in place.

## Deliberate residuals

- **No linter rule.** The record suggests banning a bare `_ = f(...)` discard of a getter-named
  method. Declined: the point fix is two lines, the class fix needs a name heuristic ("reads as
  a getter") that no existing linter expresses, and a repo-wide ban on `_ = method()` would
  refuse legitimate deliberate discards. The class here is one site.
- **No static/AST assertion** that the resolver is called exactly once in this handler. One
  induced red proves one assertion; the behavioural guard already kills both mutants, and a
  call-count check would restate the diff rather than the invariant.
- `OnboardingStep1` (`handlers_onboarding_steps.go:32`) already resolved once into `location`;
  untouched. `handlers_onboarding_complete.go` not inspected beyond confirming it is out of scope.

## Validation

`go build ./...`; `go test ./internal/api/... -count=1 -timeout 20m` -> ok, 684 s;
`go test ./internal/i18n/... ./internal/templates/... ./scripts/... -count=1` -> all ok;
`golangci-lint run ./internal/api/...` -> 0 issues; `go run ./scripts/changelogd check` -> OK.

## Rollback

Single-commit revert. Category is `complexity`: no persisted data, no migration, no public
contract, no wire format. Neither the dialect-parity nor the OpenAPI contract suite needs
re-running after a revert.
