### PR TITLE
refactor(services): name the cycle bounds and route day diffs through CalendarDaysBetween

### DIFF
--- a/changelog.d/cycles-name-the-bounds-and-day-diffs.md
+++ b/changelog.d/cycles-name-the-bounds-and-day-diffs.md
@@ -1,0 +1,17 @@
+none
+
+Internal hygiene in the cycle services, with no user-visible change: the three
+day-difference sites in `cycles.go` now measure calendar days through
+`CalendarDaysBetween` instead of an hour difference, and a new barrier refuses
+that shape anywhere in shipped Go outside `CalendarDaysBetween` itself. The
+calendar's projected-cycle loop now refuses a non-positive cycle-length step
+instead of trusting its callee for one, which is what the baseline projection
+already did; production stats cannot produce such a step, so nothing that
+renders today changes. The plausible-luteal ceiling used by the
+observed-luteal inference is a named constant beside its floor; a
+production-unreachable location fallback in the calendar month clamp is gone
+with the white-box test that was its only caller; the recent-cycles builder
+sorts a copy rather than its caller's slice; and the two arithmetically
+unreachable returns in `CalcOvulationDay` carry the `codecov:ignore` marker and
+the invariant that makes them unreachable, matching the sibling return below
+them. Every prediction, projected date and rendered cycle length is unchanged.

--- a/internal/services/calendar_day_diff_barrier_test.go
+++ b/internal/services/calendar_day_diff_barrier_test.go
@@ -1,0 +1,249 @@
+package services
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// Barrier for the "day difference computed as an hour difference" class, the
+// arithmetic sibling of the anchor class swept by
+// calendar_day_construction_barrier_test.go.
+//
+// Measuring the distance between two time.Time values through
+// `a.Sub(b).Hours()` asks how many HOURS separate two instants. Every caller in
+// this tree wants a different number: how many CALENDAR DAYS separate two dates.
+// The two answers agree only while both operands happen to be anchored at the
+// same midnight. They diverge in two independent ways:
+//
+//   - a DST transition makes a calendar day 23 or 25 hours long, so a two-day
+//     span across Europe/Berlin 2026-03-28 -> 2026-03-30 measures 47 hours and
+//     truncates to 1; and
+//   - a location midnight against a UTC midnight is a sub-day offset that
+//     truncates the same way on every ordinary day in every non-UTC zone.
+//
+// CalendarDaysBetween exists to be the one answer: it re-anchors both operands
+// to UTC midnight of their own calendar day first, so neither divergence can
+// reach the subtraction. A site that spells the subtraction out again is safe
+// only for as long as an unstated invariant about its CALLER holds, and nothing
+// at the site says which invariant that is.
+//
+// This sweep therefore refuses the SHAPE, not a spelling of the divisor: any
+// `<value>.Sub(<value>).Hours()` in shipped Go. Dividing by 24, by a named
+// constant, or comparing the hours against a literal are the same defect.
+//
+// Scope note (deliberate, not an oversight): _test.go files are not swept. A
+// test that computed its expectation with CalendarDaysBetween would be checking
+// CalendarDaysBetween against itself; an independent oracle spelled out in hours
+// is what makes such a test worth running.
+const calendarDayDiffPoint = "internal/services/day_utils.go:CalendarDaysBetween"
+
+// calendarDayDiffAllowlist carries the sites this sweep flags and tolerates,
+// each with its reason. The key is `<path>:<enclosing function>` so an
+// unrelated edit above a site does not turn the barrier red.
+//
+// An entry belongs here ONLY when the site is genuinely asking for elapsed
+// HOURS — a TTL, a freshness window, a rate-limit interval — because such a
+// site is not measuring a calendar-day span at all and CalendarDaysBetween
+// would be the wrong instrument for it. A site that wants days belongs in
+// CalendarDaysBetween, never here. The set must match the sweep EXACTLY: a
+// stale entry fails too, so a fixed site cannot leave its exemption behind.
+var calendarDayDiffAllowlist = map[string]string{}
+
+// calendarDayDiffBlindSpots is what this sweep provably cannot see, printed
+// with every failure so a green run is never read as a cleared tree.
+var calendarDayDiffBlindSpots = []string{
+	"only the direct `x.Sub(y).Hours()` chain is read: a Sub result stored in a local (or returned by a helper) and converted to hours somewhere else is invisible",
+	"other routes from a Duration to days are invisible too — Duration/(24*time.Hour), Duration.Truncate, UnixNano differences, a helper that hides either",
+	"_test.go files are out of scope on purpose (see the note above), so a test oracle spelled in hours never appears here",
+	"non-Go surfaces are out of scope: the JavaScript bundle and the templates are not parsed here",
+}
+
+// calendarDayDiffFileFloor guards the WALK against a vacuous pass: a broken
+// discovery would otherwise sweep an empty tree and report success.
+//
+// The MATCHER is guarded by a positive control instead of by a count, because
+// after this class is cleared the whole module holds only a handful of
+// `.Sub(...)` sites and a count that low proves nothing: CalendarDaysBetween
+// itself is a member of the shape, so if the sweep reports no finding at
+// calendarDayDiffPoint it has stopped reading the chain and the run fatals.
+const calendarDayDiffFileFloor = 200
+
+type calendarDayDiffFinding struct {
+	key      string
+	position string
+}
+
+type calendarDayDiffScan struct {
+	findings []calendarDayDiffFinding
+	files    int
+}
+
+// TestCalendarDayDiffBarrier refuses every shipped site that measures the
+// distance between two time values in hours, except CalendarDaysBetween itself.
+func TestCalendarDayDiffBarrier(t *testing.T) {
+	t.Parallel()
+
+	scan := scanCalendarDayDiffShapes(t)
+
+	if scan.files < calendarDayDiffFileFloor {
+		t.Fatalf("the sweep parsed %d shipped Go file(s), fewer than the floor of %d — discovery is broken, so a green verdict here would mean nothing", scan.files, calendarDayDiffFileFloor)
+	}
+	unexplained := make([]calendarDayDiffFinding, 0, len(scan.findings))
+	matched := map[string]bool{}
+	sanctioned := 0
+	for _, finding := range scan.findings {
+		if finding.key == calendarDayDiffPoint {
+			sanctioned++
+			continue
+		}
+		if _, allowed := calendarDayDiffAllowlist[finding.key]; allowed {
+			matched[finding.key] = true
+			continue
+		}
+		unexplained = append(unexplained, finding)
+	}
+
+	if sanctioned == 0 {
+		t.Fatalf("nothing was found at %s — the single sanctioned day-difference site moved or was renamed, and this sweep is now exempting a function that no longer exists", calendarDayDiffPoint)
+	}
+
+	if len(unexplained) > 0 {
+		lines := make([]string, 0, len(unexplained))
+		for _, finding := range unexplained {
+			lines = append(lines, fmt.Sprintf("  %s\n    key: %s", finding.position, finding.key))
+		}
+		sort.Strings(lines)
+		t.Errorf("%d site(s) measure a day difference in hours:\n%s\n%s", len(unexplained), strings.Join(lines, "\n"), calendarDayDiffGuidance())
+	}
+
+	stale := make([]string, 0, len(calendarDayDiffAllowlist))
+	for key := range calendarDayDiffAllowlist {
+		if !matched[key] {
+			stale = append(stale, key)
+		}
+	}
+	if len(stale) > 0 {
+		sort.Strings(stale)
+		t.Errorf("%d allowlist entr(y/ies) match nothing in the tree:\n  %s\nA site that was fixed, moved or renamed must not leave its exemption behind — a stale line makes the list read shorter than it is.", len(stale), strings.Join(stale, "\n  "))
+	}
+}
+
+func calendarDayDiffGuidance() string {
+	var builder strings.Builder
+	builder.WriteString("How to clear a finding:\n")
+	builder.WriteString("  - the site wants CALENDAR DAYS (a cycle length, a gap between period days, a countdown to a predicted date): call CalendarDaysBetween(from, to), which re-anchors both operands to UTC midnight of their own calendar day before subtracting. It is exactly `int(hours/24)` on operands a DST transition and a location midnight can no longer reach.\n")
+	builder.WriteString("  - the site really wants elapsed HOURS (a TTL, a freshness window, a rate-limit interval): it is not a calendar-day span at all, so say so in calendarDayDiffAllowlist. Adding a line there is a deliberate act and owes a one-line reason, not a bare path.\n")
+	builder.WriteString("What this sweep cannot see, so a green run is not a cleared tree:\n")
+	for _, blindSpot := range calendarDayDiffBlindSpots {
+		builder.WriteString("  - " + blindSpot + "\n")
+	}
+	return builder.String()
+}
+
+// scanCalendarDayDiffShapes parses every shipped (non-test) Go file in the
+// module and reports each `x.Sub(y).Hours()` chain.
+func scanCalendarDayDiffShapes(t *testing.T) calendarDayDiffScan {
+	t.Helper()
+
+	root := calendarDayDiffRepoRoot(t)
+	fileSet := token.NewFileSet()
+	scan := calendarDayDiffScan{}
+
+	walkErr := filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			name := entry.Name()
+			if path != root && (strings.HasPrefix(name, ".") || name == "node_modules") {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+
+		parsed, parseErr := parser.ParseFile(fileSet, path, nil, 0)
+		if parseErr != nil {
+			t.Fatalf("parse %s: %v", path, parseErr)
+		}
+		relative, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			t.Fatalf("relative path of %s: %v", path, relErr)
+		}
+		scan.files++
+		inspectCalendarDayDiffFile(fileSet, parsed, filepath.ToSlash(relative), &scan)
+		return nil
+	})
+	if walkErr != nil {
+		t.Fatalf("walk %s: %v", root, walkErr)
+	}
+	return scan
+}
+
+// calendarDayDiffRepoRoot climbs to the directory holding go.mod, so the sweep
+// covers the whole module rather than the package it happens to live in.
+func calendarDayDiffRepoRoot(t *testing.T) string {
+	t.Helper()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("working directory: %v", err)
+	}
+	for {
+		if _, statErr := os.Stat(filepath.Join(dir, "go.mod")); statErr == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("no go.mod found above %s", dir)
+		}
+		dir = parent
+	}
+}
+
+func inspectCalendarDayDiffFile(fileSet *token.FileSet, file *ast.File, relative string, scan *calendarDayDiffScan) {
+	ranges := calendarDayFunctionRanges(file)
+
+	ast.Inspect(file, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		selector, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || selector.Sel.Name != "Hours" || len(call.Args) != 0 {
+			return true
+		}
+		inner, ok := selector.X.(*ast.CallExpr)
+		if !ok || !calendarDayDiffIsSubCall(inner) {
+			return true
+		}
+
+		position := fileSet.Position(call.Pos())
+		scan.findings = append(scan.findings, calendarDayDiffFinding{
+			key:      relative + ":" + calendarDayEnclosingFunction(ranges, call.Pos()),
+			position: fmt.Sprintf("%s:%d:%d", relative, position.Line, position.Column),
+		})
+		return true
+	})
+}
+
+// calendarDayDiffIsSubCall reports the one-argument call shape `<expr>.Sub(<expr>)`,
+// which is what time.Time.Sub looks like. Only the `.Hours()` chain on top of it
+// produces a finding, so a one-argument Sub on some other type is inert here.
+func calendarDayDiffIsSubCall(call *ast.CallExpr) bool {
+	selector, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	return selector.Sel.Name == "Sub" && len(call.Args) == 1
+}

--- a/internal/services/calendar_days.go
+++ b/internal/services/calendar_days.go
@@ -305,6 +305,22 @@ func appendPredictedCycles(predictedPeriodMap map[string]bool, preFertileMap map
 	}
 
 	predictedCycleLength := predictedCycleLength(stats.MedianCycleLength, stats.AverageCycleLength)
+	if predictedCycleLength <= 0 {
+		// The loop below advances the cursor by exactly this value, so a
+		// non-positive step never moves it, never falsifies the bound, and
+		// fills the prediction maps until the process dies. Zero is a real
+		// return of predictedCycleLength (an average under 0.5 rounds to it),
+		// and its other stepping caller, applyProjectedBaseline, guards it too
+		// — the termination of this loop is this function's business, not the
+		// callee's.
+		//
+		// codecov:ignore -- defensive: unreachable from production stats today.
+		// Both writers of NextPeriodStart derive median and average from the
+		// same observed lengths, so either both are zero (and the default
+		// applies) or both describe at least one real cycle.
+		// Regression: TestAppendPredictedCyclesTerminatesOnANonPositiveStep.
+		return
+	}
 	predictedPeriodLength := predictedPeriodLength(stats.AveragePeriodLength)
 	// The bound is a CALENDAR-DAY comparison, not an instant one: cycleStart
 	// comes from CalendarDay and gridEnd from plain AddDate arithmetic, and in

--- a/internal/services/calendar_view_policy.go
+++ b/internal/services/calendar_view_policy.go
@@ -118,9 +118,14 @@ func parseCalendarDayParam(raw string, location *time.Location) (time.Time, erro
 	return ParseDayDate(raw, location)
 }
 
+// clampCalendarMonthToMinimum raises monthStart to minMonth when it falls
+// before it. location is always non-nil: the sole caller,
+// ResolveCalendarMonthAndSelectedDateWithinBounds, substitutes time.UTC for a
+// nil one before any of this runs, so the clamped month is anchored in the
+// request zone and never in minMonth's own.
 func clampCalendarMonthToMinimum(monthStart time.Time, minMonth time.Time, location *time.Location) time.Time {
 	if calendarMonthBefore(monthStart, minMonth) {
-		return calendarMonthAnchor(minMonth, resolveCalendarLocation(location, minMonth))
+		return calendarMonthAnchor(minMonth, location)
 	}
 	return monthStart
 }
@@ -136,14 +141,4 @@ func calendarMonthBefore(month time.Time, minMonth time.Time) bool {
 		return monthYear < minYear
 	}
 	return monthNumber < minNumber
-}
-
-func resolveCalendarLocation(location *time.Location, fallback time.Time) *time.Location {
-	if location != nil {
-		return location
-	}
-	if fallback.Location() != nil {
-		return fallback.Location()
-	}
-	return time.UTC
 }

--- a/internal/services/calendar_view_policy_coverage_test.go
+++ b/internal/services/calendar_view_policy_coverage_test.go
@@ -200,19 +200,18 @@ func TestCalendarViewPolicyMonthBeforeSameYearLaterMonth(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Line 119 — location != nil guard in resolveCalendarLocation
-// Line 122 — fallback.Location() return path (not covered)
+// Which zone a CLAMPED month is anchored in
 // ---------------------------------------------------------------------------
 
-// resolveCalendarLocation is an unexported function; we exercise it indirectly
-// through clampCalendarMonthToMinimum, which is called inside
-// ResolveCalendarMonthAndSelectedDateWithinBounds when the month is before minMonth.
+// The three tests below fix the zone of a clamped month at the public entry
+// point, ResolveCalendarMonthAndSelectedDateWithinBounds, which substitutes UTC
+// for a nil location before clamping runs. minMonth carries a zone of its own
+// (it is built from the account's CreatedAt), and it must never be the one the
+// result is anchored in.
 //
-// calendarviewpolicyCovResolveLocationNonNilReturnsIt verifies that when a
-// non-nil location is supplied alongside a minMonth that has a different
-// embedded location, the non-nil explicit location wins.
-// Mutation on line 119: changing != nil to == nil would invert this, returning
-// the fallback location instead of the supplied one — the result location would differ.
+// TestCalendarViewPolicyResolveLocationNonNilReturnsIt: a supplied location wins
+// over the zone embedded in minMonth. A clamp that anchored in minMonth's zone
+// instead would fail here.
 func TestCalendarViewPolicyResolveLocationNonNilReturnsIt(t *testing.T) {
 	berlinLoc := time.FixedZone("Berlin", 2*60*60)
 	tokyoLoc := time.FixedZone("Tokyo", 9*60*60)
@@ -235,26 +234,19 @@ func TestCalendarViewPolicyResolveLocationNonNilReturnsIt(t *testing.T) {
 	}
 }
 
-// calendarviewpolicyCovResolveLocationNilUseFallback exercises line 122:
-// resolveCalendarLocation is called with a nil location; the fallback time has a
-// non-UTC location embedded in it, so the fallback's Location() must be returned.
-// This is the NOT COVERED path on line 122.
-//
-// This test pins the wrapper's behaviour: line 18's nil guard converts nil → UTC
-// *before* clamping runs, so the public entry point always hands
-// resolveCalendarLocation a non-nil (UTC) location and the clamped month carries
-// UTC. The unexported helper's own fallback branch (line 122) is reachable
-// directly in a white-box test and is covered by
-// TestCalendarViewPolicyResolveLocationNilDirectFallback below.
+// TestCalendarViewPolicyResolveLocationNilUseFallback pins the nil-location
+// contract: the entry point's own guard converts nil → UTC *before* clamping
+// runs, so a clamped month carries UTC and not the Tokyo zone embedded in
+// minMonth. This is the only nil-location path there is — clamping is reached
+// from nowhere else.
 func TestCalendarViewPolicyResolveLocationNilUseFallback(t *testing.T) {
 	tokyoLoc := time.FixedZone("Tokyo", 9*60*60)
 	minMonth := time.Date(2023, time.June, 1, 0, 0, 0, 0, tokyoLoc)
 	now := time.Date(2026, time.February, 21, 0, 0, 0, 0, time.UTC)
 
-	// Pass nil location — line 18 guard replaces it with UTC.
-	// Month 2022-01 is before minMonth, so clamping fires.
-	// resolveCalendarLocation receives UTC (not nil) so line 122 is not reached
-	// in this path; the returned month must carry UTC.
+	// Pass nil location — the entry point's guard replaces it with UTC.
+	// Month 2022-01 is before minMonth, so clamping fires and the returned
+	// month must carry UTC, not minMonth's Tokyo zone.
 	gotMonth, _, err := ResolveCalendarMonthAndSelectedDateWithinBounds("2022-01", "", now, nil, minMonth)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -268,9 +260,9 @@ func TestCalendarViewPolicyResolveLocationNilUseFallback(t *testing.T) {
 	}
 }
 
-// calendarviewpolicyCovResolveLocationNonNilPreferred confirms the non-nil branch
-// (line 119–120) with a concrete timezone change so a mutation flipping the
-// condition from != to == would return the wrong location and fail this assertion.
+// TestCalendarViewPolicyResolveLocationNonNilPreferred repeats the check with a
+// second, opposite-sign zone, so a clamp that anchored in minMonth's zone rather
+// than the request's fails on a concrete offset rather than by luck.
 func TestCalendarViewPolicyResolveLocationNonNilPreferred(t *testing.T) {
 	tokyoLoc := time.FixedZone("Tokyo", 9*60*60)
 	pacificLoc := time.FixedZone("PST", -8*60*60)
@@ -285,25 +277,11 @@ func TestCalendarViewPolicyResolveLocationNonNilPreferred(t *testing.T) {
 	}
 	// The explicit pacificLoc must win over the Tokyo location embedded in minMonth.
 	if gotMonth.Location() != pacificLoc {
-		t.Errorf("resolveCalendarLocation should prefer non-nil explicit location: got %v, want PST",
+		t.Errorf("clamped month should carry the supplied location: got %v, want PST",
 			gotMonth.Location())
 	}
 	// And the clamped month itself must be 2023-06.
 	if gotMonth.Format("2006-01") != "2023-06" {
 		t.Errorf("clamped month = %s, want 2023-06", gotMonth.Format("2006-01"))
-	}
-}
-
-// TestCalendarViewPolicyResolveLocationNilDirectFallback exercises line 122
-// directly: resolveCalendarLocation is an unexported helper this white-box test
-// can call with a nil location. The fallback time carries a concrete zone, so
-// its Location() must be returned (line 123). A mutation flipping line 122's
-// `!= nil` to `== nil` would fall through to the time.UTC default and fail here.
-func TestCalendarViewPolicyResolveLocationNilDirectFallback(t *testing.T) {
-	tokyo := time.FixedZone("Tokyo", 9*60*60)
-	fallback := time.Date(2024, time.January, 1, 0, 0, 0, 0, tokyo)
-
-	if got := resolveCalendarLocation(nil, fallback); got != tokyo {
-		t.Fatalf("resolveCalendarLocation(nil, fallback) = %v, want %v (fallback zone)", got, tokyo)
 	}
 }

--- a/internal/services/cycle_bounds_and_day_diff_test.go
+++ b/internal/services/cycle_bounds_and_day_diff_test.go
@@ -129,7 +129,7 @@ func eggWhiteLutealLogs(lutealLength int) []models.DailyLog {
 
 	origin := time.Date(2026, time.January, 5, 0, 0, 0, 0, time.UTC)
 	logs := make([]models.DailyLog, 0, cycleCount*3)
-	for cycle := 0; cycle < cycleCount; cycle++ {
+	for cycle := range cycleCount {
 		start := origin.AddDate(0, 0, cycle*cycleLength)
 		logs = append(logs,
 			models.DailyLog{Date: start, IsPeriod: true, CycleStart: true},

--- a/internal/services/cycle_bounds_and_day_diff_test.go
+++ b/internal/services/cycle_bounds_and_day_diff_test.go
@@ -1,0 +1,316 @@
+package services
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+)
+
+// TestCycleLengthsCountsCalendarDaysAcrossADSTTransition pins the arithmetic at
+// cycleLengths, the one day-difference site of the three in cycles.go whose
+// operands do NOT pass through dateOnly inside the function: `starts` arrives as
+// a parameter, so the anchor is the caller's business.
+//
+// Europe/Berlin springs forward on 2026-03-29, so local midnight on 2026-03-28
+// and local midnight on 2026-03-30 are 47 hours apart, not 48. Measured in
+// hours, `int(47/24)` reports a 1-day cycle; measured in calendar days it is 2.
+// The same shortfall shows up with no transition involved whenever one operand
+// is a location midnight and the other a UTC one.
+func TestCycleLengthsCountsCalendarDaysAcrossADSTTransition(t *testing.T) {
+	t.Parallel()
+
+	berlin, err := time.LoadLocation("Europe/Berlin")
+	if err != nil {
+		t.Fatalf("load Europe/Berlin: %v", err)
+	}
+
+	starts := []time.Time{
+		time.Date(2026, time.March, 28, 0, 0, 0, 0, berlin),
+		time.Date(2026, time.March, 30, 0, 0, 0, 0, berlin),
+	}
+	if hours := starts[1].Sub(starts[0]).Hours(); hours != 47 {
+		t.Fatalf("fixture does not cross the spring-forward day: %.2f hours between the two starts, want 47", hours)
+	}
+
+	lengths := cycleLengths(starts)
+	if len(lengths) != 1 {
+		t.Fatalf("cycleLengths returned %d length(s), want 1", len(lengths))
+	}
+	if lengths[0] != 2 {
+		t.Errorf("cycleLengths across the spring-forward day = %d, want 2 calendar days — the hour difference is 47, which truncates to 1", lengths[0])
+	}
+}
+
+// TestDetectCycleStartsGapIsACalendarDayGap pins the gap arithmetic in
+// DetectCycleStarts. Both operands pass through dateOnly first, so this is a
+// characterization: it holds before and after the switch to CalendarDaysBetween
+// and exists so the replacement cannot quietly change the off-by-one (`- 1`,
+// the count of days BETWEEN two period days) while it changes the instrument.
+func TestDetectCycleStartsGapIsACalendarDayGap(t *testing.T) {
+	t.Parallel()
+
+	day := func(month time.Month, dayOfMonth int) time.Time {
+		return time.Date(2026, month, dayOfMonth, 0, 0, 0, 0, time.UTC)
+	}
+
+	cases := []struct {
+		name       string
+		secondDay  time.Time
+		wantStarts int
+	}{
+		// gapDays = 4: below the >= 5 threshold, so the second period day
+		// belongs to the same cycle.
+		{name: "four clear days between period days", secondDay: day(time.March, 6), wantStarts: 1},
+		// gapDays = 5: exactly the threshold, so a new cycle starts.
+		{name: "five clear days between period days", secondDay: day(time.March, 7), wantStarts: 2},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			logs := periodLogsOn(day(time.March, 1), testCase.secondDay)
+			if got := len(DetectCycleStarts(logs)); got != testCase.wantStarts {
+				t.Errorf("DetectCycleStarts found %d start(s), want %d", got, testCase.wantStarts)
+			}
+		})
+	}
+}
+
+// TestBuildPeriodClustersGapIsACalendarDayGap is the same characterization for
+// the second gap site, inside buildPeriodClusters. Reached through
+// BuildCycleStats, whose PeriodLength counts the days of the first cluster.
+func TestBuildPeriodClustersGapIsACalendarDayGap(t *testing.T) {
+	t.Parallel()
+
+	day := func(month time.Month, dayOfMonth int) time.Time {
+		return time.Date(2026, month, dayOfMonth, 0, 0, 0, 0, time.UTC)
+	}
+
+	cases := []struct {
+		name         string
+		secondDay    time.Time
+		wantClusters int
+	}{
+		{name: "four clear days between period days", secondDay: day(time.March, 6), wantClusters: 1},
+		{name: "five clear days between period days", secondDay: day(time.March, 7), wantClusters: 2},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			logs := periodLogsOn(day(time.March, 1), testCase.secondDay)
+			if got := len(buildPeriodClusters(logs)); got != testCase.wantClusters {
+				t.Errorf("buildPeriodClusters found %d cluster(s), want %d", got, testCase.wantClusters)
+			}
+		})
+	}
+}
+
+// periodLogsOn builds one period-flagged log per supplied calendar day.
+func periodLogsOn(days ...time.Time) []models.DailyLog {
+	logs := make([]models.DailyLog, 0, len(days))
+	for _, day := range days {
+		logs = append(logs, models.DailyLog{Date: day, IsPeriod: true})
+	}
+	return logs
+}
+
+// eggWhiteLutealLogs builds four 30-day cycles whose only ovulation signal is
+// egg-white mucus, placed so every cycle's inferred luteal phase is exactly
+// lutealLength days. Ovulation is estimated at peak day + 1, so the peak sits
+// lutealLength+1 days before the next cycle start. No BBT values are recorded,
+// which keeps the thermal detector out of the inference.
+func eggWhiteLutealLogs(lutealLength int) []models.DailyLog {
+	const cycleLength = 30
+	const cycleCount = 4
+
+	origin := time.Date(2026, time.January, 5, 0, 0, 0, 0, time.UTC)
+	logs := make([]models.DailyLog, 0, cycleCount*3)
+	for cycle := 0; cycle < cycleCount; cycle++ {
+		start := origin.AddDate(0, 0, cycle*cycleLength)
+		logs = append(logs,
+			models.DailyLog{Date: start, IsPeriod: true, CycleStart: true},
+			models.DailyLog{Date: start.AddDate(0, 0, 1), IsPeriod: true},
+		)
+		if cycle == cycleCount-1 {
+			continue
+		}
+		nextStart := start.AddDate(0, 0, cycleLength)
+		peak := nextStart.AddDate(0, 0, -(lutealLength + 1))
+		logs = append(logs, models.DailyLog{Date: peak, CervicalMucus: models.CervicalMucusEggWhite})
+	}
+	return logs
+}
+
+// TestAppendPredictedCyclesTerminatesOnANonPositiveStep is the termination
+// guard for the projection loop in appendPredictedCycles, which advances by
+// `cycleStart.AddDate(0, 0, predictedCycleLength)`. A zero step never moves the
+// cursor, so the loop bound stays satisfied and the calendar page fills its
+// prediction maps until the process dies.
+//
+// Zero is a real return of predictedCycleLength, not a hypothetical: the average
+// branch tests the raw average and returns the rounded one, so 0.4 yields 0.
+// Its other stepping caller, applyProjectedBaseline (cycle_baseline.go), reads
+// that as "no usable length" and declines to project — this loop had no such
+// guard and simply trusted the callee.
+//
+// Production cannot reach the state (both writers of NextPeriodStart derive
+// median and average from the same observed lengths), so the stats below are
+// crafted. The call runs in a goroutine behind a deadline because the failure
+// mode being guarded is non-termination, which no assertion can observe from
+// inside the call.
+func TestAppendPredictedCyclesTerminatesOnANonPositiveStep(t *testing.T) {
+	t.Parallel()
+
+	if step := predictedCycleLength(0, 0.4); step > 0 {
+		t.Fatalf("fixture no longer produces a non-positive step: predictedCycleLength(0, 0.4) = %d — this test would pass without exercising the guard", step)
+	}
+
+	stats := CycleStats{
+		MedianCycleLength:  0,
+		AverageCycleLength: 0.4,
+		NextPeriodStart:    time.Date(2026, time.March, 1, 0, 0, 0, 0, time.UTC),
+	}
+	gridEnd := time.Date(2026, time.April, 11, 0, 0, 0, 0, time.UTC)
+
+	predictedPeriod := map[string]bool{}
+	preFertile := map[string]bool{}
+	fertilityEdge := map[string]bool{}
+	fertilityPeak := map[string]bool{}
+	ovulation := map[string]bool{}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		appendPredictedCycles(predictedPeriod, preFertile, fertilityEdge, fertilityPeak, ovulation, stats, gridEnd, time.UTC, true)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatalf("appendPredictedCycles did not return within 10s on a zero cycle-length step: the projection loop advances by predictedCycleLength and a non-positive step never moves its cursor")
+	}
+
+	for name, painted := range map[string]map[string]bool{
+		"predicted period": predictedPeriod,
+		"pre-fertile":      preFertile,
+		"fertility edge":   fertilityEdge,
+		"fertility peak":   fertilityPeak,
+		"ovulation":        ovulation,
+	} {
+		if len(painted) != 0 {
+			t.Errorf("%s map holds %d day(s); a cycle length that resolves to nothing must paint no projected cycle at all", name, len(painted))
+		}
+	}
+}
+
+// TestCalcOvulationDayAlwaysProducesADayOnceAdmitted proves the claim the two
+// `codecov:ignore -- defensive invariant` comments in CalcOvulationDay make.
+// Both mark a `return 0, false` that the arithmetic above them makes
+// unreachable, and a comment asserting unreachability is worth no more than the
+// run behind it: this walks the whole admitted domain and refuses a zero day.
+//
+// The entry guard admits cycleLen >= minLutealPhaseDays+minOvulationCycleDay,
+// so maxSupportedLutealPhase = cycleLen-minOvulationCycleDay is always at least
+// minLutealPhaseDays (the first ignored return), and the clamp below it caps
+// resolvedLutealPhase at that value, so ovDay is always at least
+// minOvulationCycleDay (the second). Deleting the clamp turns the second into a
+// live refusal for any luteal phase longer than the cycle supports.
+func TestCalcOvulationDayAlwaysProducesADayOnceAdmitted(t *testing.T) {
+	t.Parallel()
+
+	const lowestAdmittedCycleLength = minLutealPhaseDays + minOvulationCycleDay
+
+	for cycleLen := lowestAdmittedCycleLength; cycleLen <= 400; cycleLen++ {
+		for lutealPhase := -5; lutealPhase <= 60; lutealPhase++ {
+			ovDay, _ := CalcOvulationDay(cycleLen, lutealPhase)
+			if ovDay < minOvulationCycleDay {
+				t.Fatalf("CalcOvulationDay(%d, %d) = %d: a cycle the entry guard already admitted was refused by one of the two defensive returns marked codecov:ignore, so the invariant those comments state does not hold", cycleLen, lutealPhase, ovDay)
+			}
+			if ovDay >= cycleLen {
+				t.Fatalf("CalcOvulationDay(%d, %d) = %d, which is not inside the cycle", cycleLen, lutealPhase, ovDay)
+			}
+		}
+	}
+}
+
+// TestBuildStatsCycleFactorRecentCyclesLeavesItsArgumentUntouched pins the
+// argument as read-only. Both builders in buildStatsCycleFactorExplanation are
+// handed the SAME slice inside one composite literal, so a sort in place makes
+// the order of two struct fields load-bearing: reordering them — an edit that
+// reads as pure formatting — would hand the pattern builder a different
+// sequence. Nothing at either call site says so.
+func TestBuildStatsCycleFactorRecentCyclesLeavesItsArgumentUntouched(t *testing.T) {
+	t.Parallel()
+
+	day := func(dayOfMonth int) time.Time {
+		return time.Date(2026, time.March, dayOfMonth, 0, 0, 0, 0, time.UTC)
+	}
+
+	snapshots := []statsCycleFactorCycleSnapshot{
+		{Start: day(1), End: day(28), CycleLength: 28, ComparisonKind: "variable"},
+		{Start: day(29), End: day(31), CycleLength: 21, ComparisonKind: "shorter"},
+		{Start: day(10), End: day(20), CycleLength: 40, ComparisonKind: "longer"},
+	}
+	before := make([]time.Time, len(snapshots))
+	for index, snapshot := range snapshots {
+		before[index] = snapshot.Start
+	}
+
+	if summaries := buildStatsCycleFactorRecentCycles(snapshots); len(summaries) != len(snapshots) {
+		t.Fatalf("buildStatsCycleFactorRecentCycles returned %d summar(y/ies), want %d", len(summaries), len(snapshots))
+	}
+
+	for index, snapshot := range snapshots {
+		if !snapshot.Start.Equal(before[index]) {
+			t.Fatalf("buildStatsCycleFactorRecentCycles reordered its argument: element %d starts on %s, was %s. Sort a copy — the caller passes this same slice to buildStatsCycleFactorPatternSummaries in the same composite literal.", index, snapshot.Start.Format("2006-01-02"), before[index].Format("2006-01-02"))
+		}
+	}
+}
+
+// TestInferUserLutealPhaseRejectsAnImplausiblyLongLutealPhase pins both ends of
+// the plausibility window the observed-luteal inference filters on. The floor
+// is minLutealPhaseDays and the ceiling maxPlausibleLutealPhaseDays; a cycle
+// whose inferred luteal length falls outside either is dropped from the sample,
+// so with too few surviving cycles the inference reports the default and
+// declines to claim it was refined.
+func TestInferUserLutealPhaseRejectsAnImplausiblyLongLutealPhase(t *testing.T) {
+	t.Parallel()
+
+	if minLutealPhaseDays >= maxPlausibleLutealPhaseDays {
+		t.Fatalf("the plausible-luteal window is empty: floor %d, ceiling %d", minLutealPhaseDays, maxPlausibleLutealPhaseDays)
+	}
+
+	cases := []struct {
+		name         string
+		lutealLength int
+		wantRefined  bool
+	}{
+		{name: "at the ceiling", lutealLength: maxPlausibleLutealPhaseDays, wantRefined: true},
+		{name: "one day past the ceiling", lutealLength: maxPlausibleLutealPhaseDays + 1, wantRefined: false},
+		{name: "at the floor", lutealLength: minLutealPhaseDays, wantRefined: true},
+		{name: "one day below the floor", lutealLength: minLutealPhaseDays - 1, wantRefined: false},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			logs := eggWhiteLutealLogs(testCase.lutealLength)
+			got, refined := InferUserLutealPhase(logs, time.UTC)
+			if refined != testCase.wantRefined {
+				t.Fatalf("InferUserLutealPhase reported refined=%v for a %d-day luteal phase, want %v", refined, testCase.lutealLength, testCase.wantRefined)
+			}
+			want := testCase.lutealLength
+			if !testCase.wantRefined {
+				want = defaultLutealPhaseDays
+			}
+			if got != want {
+				t.Errorf("InferUserLutealPhase = %d for a %d-day luteal phase, want %d", got, testCase.lutealLength, want)
+			}
+		})
+	}
+}

--- a/internal/services/cycle_bounds_and_day_diff_test.go
+++ b/internal/services/cycle_bounds_and_day_diff_test.go
@@ -17,12 +17,22 @@ import (
 // hours, `int(47/24)` reports a 1-day cycle; measured in calendar days it is 2.
 // The same shortfall shows up with no transition involved whenever one operand
 // is a location midnight and the other a UTC one.
+//
+// A missing zone database SKIPS this test rather than failing it, which is the
+// answer the other five tz-dependent tests in this package already give
+// (cycle_baseline_coverage_test.go, cycle_projection_reference_test.go,
+// cycle_signals_mutation_round2_test.go, dashboard_cycle_test.go,
+// dashboard_reminder_banner_test.go). The module imports time/tzdata nowhere, so
+// zones come from the host: on one without zoneinfo this demonstration goes
+// quiet. What does NOT go quiet there is TestCalendarDayDiffBarrier, which reads
+// the source rather than the clock and refuses the shape with no zone database
+// at all — so the class stays barred even where this proof of it cannot run.
 func TestCycleLengthsCountsCalendarDaysAcrossADSTTransition(t *testing.T) {
 	t.Parallel()
 
 	berlin, err := time.LoadLocation("Europe/Berlin")
 	if err != nil {
-		t.Fatalf("load Europe/Berlin: %v", err)
+		t.Skipf("tz database unavailable: %v", err)
 	}
 
 	starts := []time.Time{

--- a/internal/services/cycle_signals.go
+++ b/internal/services/cycle_signals.go
@@ -25,6 +25,18 @@ const (
 	bbtThirdDayMarginCelsius = 0.2
 )
 
+// maxPlausibleLutealPhaseDays is the ceiling of the plausibility window the
+// observed-luteal inference filters its per-cycle samples through; the floor is
+// minLutealPhaseDays. It belongs to this file rather than to the luteal-phase
+// const family in cycles.go because it is an outlier-rejection threshold owned
+// by the inference, not a property of the cycle model: a length past it means
+// the ovulation signal was misread (a stray egg-white day early in the cycle, a
+// thermal shift picked up from a disturbed reading), so the cycle is dropped
+// from the sample rather than clamped into it. The prediction-time bound is a
+// different quantity — maxSupportedLutealPhase (cycles.go), computed from the
+// cycle length.
+const maxPlausibleLutealPhaseDays = 20
+
 func InferUserLutealPhase(logs []models.DailyLog, location *time.Location) (int, bool) {
 	if location == nil {
 		location = time.UTC
@@ -45,7 +57,7 @@ func InferUserLutealPhase(logs []models.DailyLog, location *time.Location) (int,
 		}
 
 		lutealLength := CalendarDaysBetween(ovulationDate, nextStart)
-		if lutealLength < minLutealPhaseDays || lutealLength > 20 {
+		if lutealLength < minLutealPhaseDays || lutealLength > maxPlausibleLutealPhaseDays {
 			continue
 		}
 		lutealLengths = append(lutealLengths, lutealLength)

--- a/internal/services/cycles.go
+++ b/internal/services/cycles.go
@@ -103,6 +103,10 @@ func CalcOvulationDay(cycleLen, lutealPhase int) (int, bool) {
 	ovulationExact := true
 	maxSupportedLutealPhase := cycleLen - minOvulationCycleDay
 	if maxSupportedLutealPhase < minLutealPhaseDays {
+		// codecov:ignore -- defensive invariant: the guard above admits only
+		// cycleLen >= minLutealPhaseDays+minOvulationCycleDay, so
+		// maxSupportedLutealPhase is always at least minLutealPhaseDays.
+		// Regression: TestCalcOvulationDayAlwaysProducesADayOnceAdmitted.
 		return 0, false
 	}
 	if resolvedLutealPhase > maxSupportedLutealPhase {
@@ -112,6 +116,10 @@ func CalcOvulationDay(cycleLen, lutealPhase int) (int, bool) {
 
 	ovDay := cycleLen - resolvedLutealPhase
 	if ovDay < minOvulationCycleDay {
+		// codecov:ignore -- defensive invariant: the clamp above caps
+		// resolvedLutealPhase at maxSupportedLutealPhase = cycleLen-minOvulationCycleDay,
+		// so ovDay is always at least minOvulationCycleDay.
+		// Regression: TestCalcOvulationDayAlwaysProducesADayOnceAdmitted.
 		return 0, false
 	}
 	return ovDay, ovulationExact
@@ -188,7 +196,13 @@ func DetectCycleStarts(logs []models.DailyLog) []time.Time {
 			continue
 		}
 
-		gapDays := int(day.Sub(previousPeriodDay).Hours()/24) - 1
+		// The gap is the count of clear days BETWEEN the two period days, so
+		// the calendar-day span minus one. CalendarDaysBetween rather than a
+		// spelled-out hour difference: the operands are dateOnly values today,
+		// but nothing at this site says so, and an hour difference reads a
+		// DST-shortened day, or a location midnight against a UTC one, as one
+		// day fewer than it is.
+		gapDays := CalendarDaysBetween(previousPeriodDay, day) - 1
 		if gapDays >= 5 {
 			starts = append(starts, day)
 		}
@@ -265,7 +279,9 @@ func buildPeriodClusters(logs []models.DailyLog) []periodCluster {
 			clusters = append(clusters, periodCluster{Start: day, End: day})
 		} else {
 			lastIndex := len(clusters) - 1
-			gapDays := int(day.Sub(clusters[lastIndex].End).Hours()/24) - 1
+			// Same clear-days-between count as in DetectCycleStarts, against
+			// the running cluster's last day.
+			gapDays := CalendarDaysBetween(clusters[lastIndex].End, day) - 1
 			if gapDays >= 5 {
 				clusters = append(clusters, periodCluster{Start: day, End: day})
 			} else if day.After(clusters[lastIndex].End) {
@@ -364,6 +380,13 @@ func predictedCycleLength(median int, average float64) int {
 	// and push every downstream prediction late, but leaves the median unmoved.
 	// The mean is only a fallback for the degenerate case where no median is
 	// available (it never is when at least one cycle length exists).
+	//
+	// A ZERO return is part of the contract, not an accident: the average branch
+	// tests the raw average but returns the ROUNDED one, so an average under 0.5
+	// yields 0, and applyProjectedBaseline (cycle_baseline.go) reads that 0 as
+	// "no usable length" and falls back to the owner's configured cycle length
+	// before declining to project at all. A caller that instead STEPS by this
+	// value must guard it for itself — appendPredictedCycles does.
 	if median > 0 {
 		return median
 	}
@@ -515,6 +538,13 @@ func buildCycles(starts []time.Time, logs []models.DailyLog) []detectedCycle {
 	return cycles
 }
 
+// cycleLengths returns the calendar-day span between each pair of consecutive
+// cycle starts. The anchor of the supplied instants is the caller's business --
+// they arrive as a parameter, unlike the two gap sites above -- so the span is
+// measured with CalendarDaysBetween, which re-anchors both operands first. An
+// hour difference would report a DST-crossing two-day span as one day
+// (Europe/Berlin 2026-03-28 -> 2026-03-30 is 47 hours) and every span between a
+// location midnight and a UTC one as a day short.
 func cycleLengths(starts []time.Time) []int {
 	if len(starts) < 2 {
 		return nil
@@ -522,7 +552,7 @@ func cycleLengths(starts []time.Time) []int {
 
 	lengths := make([]int, 0, len(starts)-1)
 	for i := 1; i < len(starts); i++ {
-		lengths = append(lengths, int(starts[i].Sub(starts[i-1]).Hours()/24))
+		lengths = append(lengths, CalendarDaysBetween(starts[i-1], starts[i]))
 	}
 	return lengths
 }

--- a/internal/services/stats_cycle_factor_context.go
+++ b/internal/services/stats_cycle_factor_context.go
@@ -194,15 +194,23 @@ func buildStatsCycleFactorRecentCycles(snapshots []statsCycleFactorCycleSnapshot
 		return nil
 	}
 
-	sort.Slice(snapshots, func(i, j int) bool {
-		return snapshots[i].Start.After(snapshots[j].Start)
+	// Sort a COPY. The caller hands the same slice to
+	// buildStatsCycleFactorPatternSummaries inside one composite literal, so
+	// sorting the argument in place would reorder what that builder sees and
+	// make the order of two struct fields load-bearing — an edit that reads as
+	// pure formatting. Regression:
+	// TestBuildStatsCycleFactorRecentCyclesLeavesItsArgumentUntouched.
+	ordered := make([]statsCycleFactorCycleSnapshot, len(snapshots))
+	copy(ordered, snapshots)
+	sort.Slice(ordered, func(i, j int) bool {
+		return ordered[i].Start.After(ordered[j].Start)
 	})
-	if len(snapshots) > statsCycleFactorRecentCycleLimit {
-		snapshots = snapshots[:statsCycleFactorRecentCycleLimit]
+	if len(ordered) > statsCycleFactorRecentCycleLimit {
+		ordered = ordered[:statsCycleFactorRecentCycleLimit]
 	}
 
-	summaries := make([]StatsCycleFactorRecentCycleSummary, 0, len(snapshots))
-	for _, snapshot := range snapshots {
+	summaries := make([]StatsCycleFactorRecentCycleSummary, 0, len(ordered))
+	for _, snapshot := range ordered {
 		summaries = append(summaries, StatsCycleFactorRecentCycleSummary{
 			Start:          snapshot.Start,
 			End:            snapshot.End,


### PR DESCRIPTION
## What this is

Group **T0042** — six audit records in `internal/services`, all P3, none a live defect. Each was
verified against the live tree before anything was written, and each ships with a guard that was
observed failing first. **Two** records produced a **natural** red — three assertions that failed on
the unfixed tree with no edit at all (R2-0066 twice, R2-0093 once). The other four, plus the two
characterization pins under R2-0066, needed an **induced** red; each induction is described below,
and each was fed the exact input the assertion it proves names. R2-0447's deletion carries
`none-practical` for a behavioural assertion, and says why.

Two of the six records carried **wrong evidence**. Both corrections are below, under the record.

## Per record

### R2-0066 — three day-difference sites — **implemented**

`cycles.go` spelled a calendar-day span as `Sub().Hours()/24` at three sites. Verified arithmetically
identical at each before replacing:

- `DetectCycleStarts` (`internal/services/cycles.go:205`) and `buildPeriodClusters`
  (`internal/services/cycles.go:284`): both operands already pass through `dateOnly` in the same
  function, so `CalendarDaysBetween(prev, day) - 1` is bit-identical today. The `- 1` (clear days
  *between* two period days, not the span) is preserved at both.
- `cycleLengths` (`internal/services/cycles.go:555`): operands arrive as a **parameter**, so the
  anchor is the caller's business and the two expressions genuinely differ.

**Red → green.** Natural, two of them:

1. `TestCycleLengthsCountsCalendarDaysAcrossADSTTransition` — Europe/Berlin 2026-03-28 → 2026-03-30
   local midnights are 47 hours apart. Unfixed tree: `cycleLengths ... = 1, want 2`. This is the one
   site of the three that was behaviourally wrong for a reachable input.
2. `TestCalendarDayDiffBarrier` — new sweep, unfixed tree flagged exactly the three sites by
   `path:function` key and printed the guidance block.

The two `dateOnly`-anchored sites cannot be made to fail behaviourally, so they are pinned by
characterization tests (`TestDetectCycleStartsGapIsACalendarDayGap`,
`TestBuildPeriodClustersGapIsACalendarDayGap`) whose non-vacuity was proven by **induced** red:
changing `- 1` to `- 2` at each site reddened its own test and only its own
(`found 1 start(s), want 2` / `found 1 cluster(s), want 2`).

**The barrier is N-of-N, not N-of-N+1.** `git grep '\.Sub(' -- '*.go'` over shipped (non-test) Go
returns four sites module-wide before this change and one after: `CalendarDaysBetween` itself
(`internal/services/day_utils.go:147`), which the sweep names as its single sanctioned point and
asserts it still finds — that assertion is the anti-vacuity control for the matcher, since a count
that low proves nothing. The walk gets a file floor of 200. The allowlist ships **empty**; an entry
is admissible only for a site genuinely measuring elapsed hours (a TTL, a freshness window), which is
derived from the guard's subject — a calendar-day span — not restated beside it. `_test.go` files are
out of scope on purpose: a test that computed its expectation with `CalendarDaysBetween` would be
checking `CalendarDaysBetween` against itself, and the two existing hour-spelled test oracles
(`cycles_property_test.go:17`, `cycles_pipeline_property_test.go:151`) are what makes those tests
worth running. Stated in the sweep's blind-spot list, which prints with every failure.

### R2-0042 — `appendPredictedCycles` loop step — **implemented, and the record's evidence is wrong**

The record classifies this false-positive on the ground that "No path returns <= 0" from
`predictedCycleLength`. **That is false.** The average branch tests the *raw* average and returns the
*rounded* one, so `predictedCycleLength(0, 0.4) == 0`.

I first "fixed" that — guard the rounded value, as the sibling `predictedPeriodLength` does — and the
final package run caught it: `TestCycleBaseline_NoProjectionWhenResolvedCycleLengthIsZero` went red.
A zero return is **part of the contract**: `applyProjectedBaseline` (`internal/services/cycle_baseline.go:74-80`)
reads it as "no usable length", falls back to the owner's configured cycle length, and declines to
project. Fixing the callee would have silently killed a live guard and its mutation test. Reverted;
`predictedCycleLength` is unchanged apart from a comment naming the contract.

The guard therefore lands where the loop is, at `internal/services/calendar_days.go:308-324`: a
non-positive step returns before the loop, matching what the other stepping caller already does. It
carries `codecov:ignore` and the reachability argument (both writers of `NextPeriodStart` derive
median and average from the same observed lengths, so the state is not reachable from production
stats).

**Red → green.** **Induced**, by gutting the guard's body (`return` → `_ = predictedCycleLength`,
leaving the call site wired):
`TestAppendPredictedCyclesTerminatesOnANonPositiveStep` → *"appendPredictedCycles did not return
within 10s on a zero cycle-length step"* after exactly 10.00s. The test runs the call behind a
deadline because the failure mode is non-termination, which no assertion can observe from inside the
call, and it asserts up front that the fixture still produces a zero step so it cannot pass
vacuously.

### R2-0045 — bare literal `20` luteal ceiling — **implemented**

Verified: `grep` confirms no `max*LutealPhaseDays` counterpart existed. Named
`maxPlausibleLutealPhaseDays = 20` in `internal/services/cycle_signals.go:38` — in that file, not
beside the cycle-model consts in `cycles.go`, on the record's own counter-evidence: it is an
outlier-rejection threshold owned by the inference (a cycle past it is *dropped* from the sample, not
clamped into it), unrelated to the computed prediction-time `maxSupportedLutealPhase`.

**Red → green.** **Induced.** Naming a literal is behaviour-preserving, so the induction is the exact
drift the name prevents: put the bare `20` back at the comparison and let the const read 19.
`TestInferUserLutealPhaseRejectsAnImplausiblyLongLutealPhase/one_day_past_the_ceiling` →
*"reported refined=true for a 20-day luteal phase, want false"*. The test drives the real
`InferUserLutealPhase` through egg-white peak-day fixtures at floor, floor−1, ceiling and ceiling+1.

### R2-0093 — `buildStatsCycleFactorRecentCycles` sorts its caller's slice — **implemented**

Confirmed on the live tree at `internal/services/stats_cycle_factor_context.go:65-70` and `:192`.
Now sorts a copy.

**Red → green.** Natural: `TestBuildStatsCycleFactorRecentCyclesLeavesItsArgumentUntouched` →
*"reordered its argument: element 0 starts on 2026-03-29, was 2026-03-01"* on the unfixed tree.

**A correction to the task's suggested method.** The brief proposed swapping the two field
initialisers and watching an existing test go red. I checked: that produces **no** red. The pattern
builder aggregates into a map and emits in a fixed `statsCycleFactorPatternOrder`, so it is
order-independent — which is precisely why the record calls this latent. The assertion that can fail
is the one on the argument itself, so that is the one shipped.

### R2-0447 — `resolveCalendarLocation` — **implemented**

Verified end to end: `clampCalendarMonthToMinimum` has exactly one caller
(`calendar_view_policy.go:38`), which is nil-guarded at `:18-20`; `time.Time.Location()` never
returns nil (it substitutes UTC), so `return time.UTC` was unreachable outright. Collapsed into the
caller; the invariant is now stated on `clampCalendarMonthToMinimum`. The only thing reaching the nil
arm was the white-box test, which is deleted. The three sibling tests that go through the public
entry point are kept and their now-stale line-number commentary rewritten to say what they actually
assert (which zone a clamped month is anchored in).

**Red → green.** For the deletion itself: `none-practical` — removing a provably unreachable branch
is behaviour-preserving, and no assertion can distinguish the trees. What *is* guarded is the
invariant the collapsed function now relies on directly, and that was proven by **induced** red:
deleting the entry point's `if location == nil { location = time.UTC }` makes
`TestCalendarViewPolicyNilLocationUsesUTC` panic with `time: missing Location in call to Date` at
`StartOfCalendarDay`.

### R2-0448 — two unreachable guards in `CalcOvulationDay` — **implemented**

Both verified unreachable on the live tree. Marked `// codecov:ignore -- defensive invariant` with
the arithmetic that makes each unreachable, matching the sibling at `cycles.go:151`.

**Consistency with R2-0042, since the brief asks.** One direction throughout: **keep the defensive
guard, name the invariant, and prove the claim rather than assert it.** Both returns here are marked
(never one and not the other), and the new guard added in R2-0042 is written the same way — a
`codecov:ignore` with its reachability argument.

**Red → green.** **Induced.** A `codecov:ignore` comment makes a claim, so the claim is tested:
`TestCalcOvulationDayAlwaysProducesADayOnceAdmitted` walks the whole admitted domain
(cycleLen 15..400 × lutealPhase −5..60) and refuses a zero day. Gutting the clamp above the second
guard →*"CalcOvulationDay(15, -5) = 0: a cycle the entry guard already admitted was refused by one of
the two defensive returns marked codecov:ignore"*. The first guard's unreachability is algebraic
(`cycleLen - minOvulationCycleDay >= minLutealPhaseDays` follows from the entry threshold) and is
exercised, not separately induced, by the same domain walk — stated here rather than implied.

## Review follow-up: one answer to a missing zone database

Review found `TestCycleLengthsCountsCalendarDaysAcrossADSTTransition` answering a failed
`time.LoadLocation("Europe/Berlin")` with `t.Fatalf` while the five other tz-dependent tests in the
package answer with `t.Skipf`. Correct, and the split is the defect: the module imports `time/tzdata`
nowhere, so on a host without zoneinfo — scratch or distroless container, trimmed `GOROOT` — five
would skip and one would redden the package over a missing OS data file.

**Taken: match the convention** (`t.Skipf("tz database unavailable: %v", err)`), so
`git grep -c 'tz database unavailable' -- internal/services` now returns six files, one answer each.
Two reasons over importing `time/tzdata`:

1. Importing it would make the five existing skips unreachable, and leaving them is exactly the
   N-of-N+1 split this repo treats as a new defect rather than a partial fix — sweeping them is a
   change wider than this group of six records, and it belongs to its own PR with its own reasoning
   about a production binary that would then carry the zone database.
2. The cost of skipping is smaller here than it looks. The load-bearing guard for R2-0066 is
   `TestCalendarDayDiffBarrier`, which parses the source rather than reading a clock and needs no
   zone database at all: on a zoneless host the *class* is still refused, and only this
   demonstration of it goes quiet. That reasoning is written into the test's comment, not just here.

Not exercised: the skip branch itself. Go falls back to `$GOROOT/lib/time/zoneinfo.zip`, so a bogus
`ZONEINFO` does not force it on this host — the line is character-identical to the five siblings.

## Verification

`go build ./...`; `go test ./internal/services/` (full, green, 147s); `./internal/i18n/...` and
`./internal/templates/...`; `golangci-lint run ./...` → `0 issues`;
`go run ./scripts/changelogd check` → OK; `go test ./internal/api/... -timeout 20m` → `ok 508.8s`,
run once at the end.

Review follow-up re-validated with `go test ./internal/services/ -run
TestCycleLengthsCountsCalendarDaysAcrossADSTTransition` → PASS. The change is test-only and touches
no import, so `./internal/api/...` was not re-run: nothing in that lane can observe it.

## Rollback

Single-commit revert. Every item in this register is a test, guard, doc or local-code change; none
alters persisted data or a public contract except where category is migration-parity or api-contract,
which additionally require re-running the dialect-parity and OpenAPI contract suites after revert.
