### PR TITLE
docs(reminders): name the strict rollover, not the marker, as what blocks the repeated DST hour

### DIFF
--- a/changelog.d/reminders-name-what-blocks-the-repeated-hour.md
+++ b/changelog.d/reminders-name-what-blocks-the-repeated-hour.md
@@ -1,0 +1,13 @@
+none
+
+Internal-only correction with no behaviour change: the reminder scheduler's
+documentation named the wrong mechanism for a real safety property. On a DST
+fall-back day the local run hour occurs twice, and the comments claimed the
+once-per-local-day "ran today" marker was what kept the repeated hour from
+firing a second notify pass. It is not: the marker is read only by the startup
+catch-up, never by the timer loop. What actually prevents the second fire is the
+schedule math rebuilding its candidate strictly after the instant that just
+fired, which rolls the next fire to the following calendar day. The three places
+that repeated the claim now name the rollover, and a new regression drives the
+scheduler loop itself across a repeated wall-clock hour and pins exactly one
+pass.

--- a/internal/reminders/idempotency_layering_test.go
+++ b/internal/reminders/idempotency_layering_test.go
@@ -10,13 +10,16 @@ import (
 	"github.com/ovumcy/ovumcy-web/internal/services"
 )
 
-// This file proves the idempotency LAYERING the design mandates: the once-per-
-// local-day marker stops the TRIGGER from firing more than once per day, but
-// #124's per-reminder watermark is the authoritative backstop — even if two
-// passes run in the same fake day (marker failed, or an operator `ovumcy notify`
-// cron ran alongside), each reminder ships at most once. It drives the REAL
-// services.WebhookNotifyService (not the scheduler's stub PassRunner) so the
-// actual claim-before-delivery + decision-suppression path is exercised.
+// This file proves the idempotency LAYERING the design mandates: the TRIGGER
+// aims at one pass per local day — the timer loop recomputes its next fire
+// strictly after the instant that just fired (nextRun), and the once-per-local-
+// day marker adds restart safety on top, being read by runCatchUp only — but
+// #124's per-reminder watermark is the authoritative backstop. Even if two
+// passes run in the same fake day (a restart the marker did not cover, or an
+// operator `ovumcy notify` cron running alongside), each reminder ships at most
+// once. It drives the REAL services.WebhookNotifyService (not the scheduler's
+// stub PassRunner) so the actual claim-before-delivery + decision-suppression
+// path is exercised.
 //
 // Two shapes of "twice" live here and neither implies the other: the passes may
 // run one after the other (the second reads what the first wrote), or they may
@@ -202,8 +205,8 @@ func (s stubLogReader) ListByUser(_ context.Context, userID uint) ([]models.Dail
 }
 
 // TestIdempotencyLayeringTwoFiresSameDaySendOnce is the layering proof: the
-// scheduler fires the notify pass TWICE within one fake day (simulating a marker
-// that failed to persist, or a concurrent operator cron). The real service's
+// notify pass is run TWICE within one fake day (simulating a restart the marker
+// did not cover, or a concurrent operator cron). The real service's
 // per-reminder watermark must ensure the owner's period reminder ships exactly
 // ONCE across both fires — never twice.
 func TestIdempotencyLayeringTwoFiresSameDaySendOnce(t *testing.T) {
@@ -225,8 +228,10 @@ func TestIdempotencyLayeringTwoFiresSameDaySendOnce(t *testing.T) {
 		t.Fatalf("first pass should send exactly one reminder, sent=%d", report1.Sent)
 	}
 
-	// Fire 2 in the SAME day: the marker did NOT stop this (we bypass it here on
-	// purpose). The watermark, now advanced, must suppress the second send.
+	// Fire 2 in the SAME day: the trigger's once-per-day layer is bypassed here on
+	// purpose — this case calls the service directly, so neither the loop's
+	// rollover nor the marker is in the path. The watermark, now advanced, must
+	// suppress the second send.
 	report2, err := service.RunOnce(context.Background(), now, time.UTC, false)
 	if err != nil {
 		t.Fatalf("second pass: %v", err)

--- a/internal/reminders/next_run.go
+++ b/internal/reminders/next_run.go
@@ -37,9 +37,16 @@ const markerKey = models.AppStateKeyLastReminderRunDate
 //     fires at once, and a full notify pass over every owner repeats until the
 //     transition. fireOnCalendarDay keeps the pass on its intended day instead.
 //   - Fall-back (a local hour repeats, e.g. 02:00 occurs twice): time.Date
-//     resolves the target to one concrete instant; the pass fires once for that
-//     local date. The once-per-local-day marker guarantees the repeated wall-
-//     clock hour cannot trigger a second pass.
+//     resolves the target to one concrete instant — the FIRST occurrence, at the
+//     offset in effect before the transition — and the pass fires there. What
+//     stops the second occurrence from firing again is the loop below being
+//     STRICT: recomputed from the instant that just fired, today's candidate is
+//     not After(now), so it is rebuilt one calendar day later. The scheduler's
+//     once-per-local-day marker does NOT do this and cannot: it is read only by
+//     runCatchUp, on startup, and the timer loop never consults it. The marker
+//     covers a different case on the same day — a RESTART during the repeated
+//     hour, where catch-up would otherwise re-fire a day that already ran.
+//     Guard: TestSchedulerLoopFiresOnceAcrossTheRepeatedFallBackHour.
 //
 // Because each call recomputes from the actual current instant in location, a
 // scheduler that recomputes every cycle stays pinned to the local hour across a

--- a/internal/reminders/next_run_test.go
+++ b/internal/reminders/next_run_test.go
@@ -194,9 +194,12 @@ func TestNextRunDSTSpringForward(t *testing.T) {
 
 // TestNextRunDSTFallBack pins the fall-back edge in America/New_York: on
 // 2026-11-01 local clocks fall 02:00 -> 01:00, so local 01:00 occurs twice.
-// nextRun must resolve the target to ONE concrete future instant (the once-per-
-// local-day marker, tested elsewhere, prevents the repeated hour from firing a
-// second pass).
+// nextRun must resolve the target to ONE concrete future instant, and — the
+// second half below — must roll to the next calendar day once that instant has
+// passed, which is what keeps the repeated hour from firing a second pass. This
+// case tests nextRun alone; the same property driven through the scheduler loop
+// is TestSchedulerLoopFiresOnceAcrossTheRepeatedFallBackHour. The once-per-local-
+// day marker is not involved in either: the timer loop never reads it.
 func TestNextRunDSTFallBack(t *testing.T) {
 	ny := mustLoadLocation(t, "America/New_York")
 

--- a/internal/reminders/scheduler_test.go
+++ b/internal/reminders/scheduler_test.go
@@ -62,6 +62,15 @@ func (r *fakeRunner) callCount() int {
 	return r.calls
 }
 
+// passInstants returns the clock each pass was handed, in call order — what a
+// case needs when the question is not only HOW MANY passes ran but WHICH instant
+// each one ran for.
+func (r *fakeRunner) passInstants() []time.Time {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]time.Time(nil), r.perCallNow...)
+}
+
 // fakeMarker is an in-memory MarkerStore. It optionally fails reads to exercise
 // the fail-safe catch-up skip.
 type fakeMarker struct {
@@ -69,6 +78,7 @@ type fakeMarker struct {
 	values   map[string]string
 	getErr   error
 	setErr   error
+	getCalls int
 	setCalls int
 }
 
@@ -79,6 +89,7 @@ func newFakeMarker() *fakeMarker {
 func (m *fakeMarker) Get(_ context.Context, key string) (string, bool, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	m.getCalls++
 	if m.getErr != nil {
 		return "", false, m.getErr
 	}
@@ -95,6 +106,15 @@ func (m *fakeMarker) Set(_ context.Context, key string, value string) error {
 	}
 	m.values[key] = value
 	return nil
+}
+
+// getCount returns how many times the scheduler asked the store for the marker.
+// It is what lets a case assert WHICH code path consults the marker, not merely
+// what the marker holds afterwards.
+func (m *fakeMarker) getCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.getCalls
 }
 
 func (m *fakeMarker) get(key string) (string, bool) {
@@ -894,5 +914,147 @@ func TestSpentBudgetMarksTheSlotsOwnDayNotTheDayItsRetriesRanInto(t *testing.T) 
 
 	if v, ok := marker.get(markerKey); !ok || v != "2026-07-06" {
 		t.Fatalf("expected the spent budget to mark the slot's own day 2026-07-06, got %q ok=%v — marking 2026-07-07 closes a day that never ran", v, ok)
+	}
+}
+
+// virtualClock is a clock the scheduler moves itself. Reading it never advances
+// it (unlike advancingClock above); only a fired timer does, by exactly the
+// delay the scheduler asked that timer for. Every instant the scheduler then
+// sees is one its own schedule math produced, which is what lets a case walk the
+// timer loop across a real DST transition in microseconds.
+type virtualClock struct {
+	mu sync.Mutex
+	at time.Time
+}
+
+func (c *virtualClock) now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.at
+}
+
+// advance moves the clock forward by d and returns the instant it lands on.
+func (c *virtualClock) advance(d time.Duration) time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.at = c.at.Add(d)
+	return c.at
+}
+
+// virtualTimerFactory fires every timer the scheduler arms, having first moved
+// the virtualClock forward by that timer's own delay — until the next fire would
+// carry the clock past horizon, or the fire budget is spent. It then parks (a
+// timer that never fires) and announces the park, which is a case's signal that
+// the loop has left the window under test and can be cancelled.
+//
+// maxFires is not decoration: a schedule that returns an instant NOT strictly
+// after now arms a ZERO delay, which never passes any horizon, so without a
+// budget that shape would spin here instead of failing the case.
+type virtualTimerFactory struct {
+	clock    *virtualClock
+	horizon  time.Time
+	maxFires int
+
+	mu     sync.Mutex
+	fires  int
+	parked chan struct{}
+}
+
+func newVirtualTimerFactory(clock *virtualClock, horizon time.Time, maxFires int) *virtualTimerFactory {
+	return &virtualTimerFactory{
+		clock:    clock,
+		horizon:  horizon,
+		maxFires: maxFires,
+		parked:   make(chan struct{}, 1),
+	}
+}
+
+func (f *virtualTimerFactory) newTimer(d time.Duration) schedulerTimer {
+	f.mu.Lock()
+	fire := f.fires < f.maxFires && !f.clock.now().Add(d).After(f.horizon)
+	if fire {
+		f.fires++
+	}
+	f.mu.Unlock()
+
+	ch := make(chan time.Time, 1)
+	if !fire {
+		select {
+		case f.parked <- struct{}{}:
+		default:
+		}
+		return fakeTimer{ch: ch}
+	}
+	ch <- f.clock.advance(d)
+	return fakeTimer{ch: ch}
+}
+
+// TestSchedulerLoopFiresOnceAcrossTheRepeatedFallBackHour drives the SCHEDULER
+// LOOP — not nextRun in isolation, not runCatchUp — across a local hour that
+// occurs twice, and pins that exactly one pass fires for it.
+//
+// The zone is America/New_York on 2026-11-01, where clocks fall 02:00 -> 01:00,
+// so local 01:00 happens once at -04:00 and again an hour later at -05:00. The
+// run hour is 1. The loop walks a virtual clock that only its own armed delays
+// move, so every instant under test comes from the schedule math itself.
+//
+// What makes the second occurrence a non-event is nextRun's STRICT rollover:
+// recomputed from the instant that just fired, today's candidate is not
+// After(now), so it is rebuilt on the next calendar day (25h out, past this
+// case's horizon). The once-per-local-day marker is NOT what does it — the loop
+// never reads it (asserted below), and this case starts before the run hour, so
+// runCatchUp, the only marker reader, returns without a pass whatever the marker
+// holds. Induced red: relaxing next_run.go's `!candidate.After(now)` to
+// `candidate.Before(now)` re-fires the same hour and fails this case; making
+// markRan a no-op leaves it green.
+func TestSchedulerLoopFiresOnceAcrossTheRepeatedFallBackHour(t *testing.T) {
+	ny := mustLoadLocation(t, "America/New_York")
+
+	// Premise, asserted rather than assumed: both halves come from tzdata and the
+	// stdlib, and a change in either must fail loudly here instead of quietly
+	// turning this case into a non-DST one. time.Date answers the ambiguous wall
+	// clock with its FIRST occurrence, and an hour later the clock reads 01:00
+	// again.
+	firstFire := time.Date(2026, 11, 1, 1, 0, 0, 0, ny)
+	if _, offset := firstFire.Zone(); offset != -4*60*60 {
+		t.Fatalf("premise broken: time.Date resolved local 01:00 to offset %ds, want -14400 (the pre-transition occurrence)", offset)
+	}
+	if hour := firstFire.Add(time.Hour).In(ny).Hour(); hour != 1 {
+		t.Fatalf("premise broken: an hour after the first local 01:00 the clock reads %02d:00, so this date is no longer a fall-back edge", hour)
+	}
+
+	start := time.Date(2026, 11, 1, 0, 15, 0, 0, ny) // before the run hour: no catch-up
+	// The window ends before the next legitimate fire (2026-11-02 01:00, 25h after
+	// the first), so ANY second fire inside it is the repeated hour firing twice.
+	horizon := time.Date(2026, 11, 1, 23, 59, 0, 0, ny)
+	clock := &virtualClock{at: start}
+	timers := newVirtualTimerFactory(clock, horizon, 4)
+
+	runner := newFakeRunner()
+	marker := newFakeMarker()
+	scheduler := newTestScheduler(runner, marker, 1, ny, clock.now, timers.newTimer)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := scheduler.Start(ctx)
+
+	select {
+	case <-timers.parked:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the loop never armed a fire beyond the fall-back day, so it is still firing inside it")
+	}
+	cancel()
+	<-done
+
+	instants := runner.passInstants()
+	if len(instants) != 1 {
+		t.Fatalf("the repeated local hour must drive exactly ONE scheduled pass, got %d at %v — the strict rollover in nextRun is what prevents the second fire", len(instants), instants)
+	}
+	if !instants[0].Equal(firstFire) {
+		t.Fatalf("expected the single pass at the first occurrence of local 01:00 (%s), got %s", firstFire.Format(time.RFC3339), instants[0].In(ny).Format(time.RFC3339))
+	}
+	// The other half of the claim: the timer loop does not gate on the marker. The
+	// only read is runCatchUp's, at startup.
+	if got := marker.getCount(); got != 1 {
+		t.Fatalf("the marker must be read exactly once, by runCatchUp at startup, got %d read(s) — the timer loop does not consult it", got)
 	}
 }


### PR DESCRIPTION
## What was wrong

R2-0136 CONFIRMED on the live tree. `internal/reminders/next_run.go:39-42` said the
once-per-local-day marker "guarantees the repeated wall-clock hour cannot trigger a second
pass" on a DST fall-back day. It does not and cannot: the marker is read in exactly one
place, `runCatchUp` (`internal/reminders/scheduler.go:187`), and `Run`'s timer loop
(`internal/reminders/scheduler.go:162-177`) calls `runScheduledPass` without ever consulting
it. The record's own grep, re-run on this tree, still returns two marker call sites —
`scheduler.go:187` (Get, in `runCatchUp`) and `scheduler.go:316` (Set, in `markRan`).

What actually prevents the second fire is the strict rollover in `nextRun`
(`internal/reminders/next_run.go:62`, `for !candidate.After(now)`): recomputed from the
instant that just fired, today's candidate is not strictly in the future, so it is rebuilt
one calendar day later. `time.Date` resolves the ambiguous local hour to its first
occurrence, so the day's fire happens once at that instant and the next one is 25h out.

The claim was made in three places, and all three are corrected:

- `internal/reminders/next_run.go:39-49` — the fall-back bullet on `nextRun`.
- `internal/reminders/next_run_test.go:195-202` — `TestNextRunDSTFallBack`'s header.
- `internal/reminders/idempotency_layering_test.go:13-22` — the file header ("the marker
  stops the TRIGGER from firing more than once per day"), plus its two in-file
  restatements at the two-fires case.

The corrected text also says what the marker *does* cover on that same day: a restart during
the repeated hour, where catch-up would otherwise re-fire a day that already ran.

## The guard

`TestSchedulerLoopFiresOnceAcrossTheRepeatedFallBackHour`
(`internal/reminders/scheduler_test.go:1010`) drives the scheduler LOOP — not `nextRun` in
isolation, not `runCatchUp` — across America/New_York 2026-11-01, where local 01:00 occurs at
-04:00 and again at -05:00. Run hour 1, start 00:15 local (before the run hour, so catch-up
cannot fire whatever the marker holds). Two new seams make the loop testable without a real
clock: `virtualClock` (`scheduler_test.go:925`), which only the scheduler's own armed delays
move, and `virtualTimerFactory` (`scheduler_test.go:953`), which fires each armed timer after
advancing the clock by that timer's delay until the next fire would pass a horizon set at
23:59 local — 25h short of the next legitimate fire — then parks and says so. Its fire budget
exists because a non-strict schedule arms a ZERO delay, which no horizon stops.

Assertions: exactly one pass, at the first occurrence of local 01:00; and exactly one marker
read, `runCatchUp`'s (`fakeMarker.getCount`, `scheduler_test.go:114`). Both halves of the
corrected sentence, one induction each. The tzdata/stdlib premises (which occurrence
`time.Date` picks, that the hour really repeats) are asserted, not assumed. Zone loading uses
the package's existing `mustLoadLocation` skip (`next_run_test.go:11`) rather than a new
spelling.

## Red -> green: three mutations, two induced reds and one deliberate green

The subject is latent — the scheduler behaves correctly today and only the stated reason was
wrong — so every red here had to be induced.

1. **Rollover gutted** — `next_run.go:62` `!candidate.After(now)` -> `candidate.Before(now)`:
   `the repeated local hour must drive exactly ONE scheduled pass, got 4 at [2026-11-01
   01:00:00 -0400 EDT x4]`. Re-run after the fix landed: red again, same message.
2. **Marker gutted** — `markRan`'s body emptied so the marker records nothing: the guard stays
   GREEN, while eight marker-owning cases in the same package go red, so the mutant is real.
   This is the pair the PR rests on: breaking the marker does not touch the fall-back
   property; breaking the rollover does.
3. **Loop made to consult the marker** — a `marker.Get` + same-day `continue` inserted in
   `Run`'s loop: `the marker must be read exactly once, by runCatchUp at startup, got 2
   read(s)`. Proves the second assertion is live, and that today the loop truly does not read
   it.

Each mutation was snapshotted before and diffed byte-for-byte against the snapshot after
restoring; `git diff` on the production files shows comment-only changes.

## Validation

`go build ./...`, `go test ./internal/reminders/...`, `go test ./internal/i18n/...
./internal/templates/...`, `golangci-lint run ./internal/reminders/...` (0 issues), `go run
./scripts/changelogd check`. Also `TestCalendarDayConstructionBarrier` in `internal/services`,
which parses `internal/reminders/next_run.go` — green (it is AST-based and skips comments and
test files). `./internal/api/...` was NOT run: no production statement changed anywhere in the
tree, nothing outside `cmd/ovumcy` imports `internal/reminders`, and the transport lane cannot
observe a comment.

## Rollback

Single-commit revert. Comments and one test only; no behaviour, no schema, no public
interface, nothing persisted.
