### PR TITLE
fix(services): order the date and user guards before the reads they protect

### DIFF
--- a/changelog.d/services-order-the-date-guards.md
+++ b/changelog.d/services-order-the-date-guards.md
@@ -1,0 +1,19 @@
+none
+
+Two preconditions in `internal/services` now refuse the input they were written
+for, and two tests now assert what their names promise. Neither production
+change is reachable from a request: the manual cycle-start policy's zero-day
+refusal ran on the day already projected into the request's zone, where a zero
+`time.Time` is an ordinary year-1 calendar day, so it fired in UTC only — every
+other zone computed the policy against a year-1 calendar instead — and the
+viewer reads dereferenced the acting owner with no branch in front, so a read
+that arrived without a resolved session would have panicked rather than
+refused. The transport layer parses the date and resolves the session before
+either is reached, so no operator or owner sees a difference today.
+
+On the test side, the auto-fill previous-day fixture agreed with every offset
+mutant it named (the recent-period lookback already covers those days and
+decides the answer alone); it now says what it pins and points at the test that
+pins the offset. Two error-propagation tests asserted only that some error came
+back, which a pre-transaction refusal or a cause-dropping wrap also satisfies;
+they now assert the injected error itself.

--- a/internal/services/cycle_start_policy.go
+++ b/internal/services/cycle_start_policy.go
@@ -49,11 +49,15 @@ func ResolveManualCycleStartPolicy(user *models.User, logs []models.DailyLog, da
 		location = time.UTC
 	}
 
-	targetDay := DateAtLocation(day.In(location), location)
-	if targetDay.IsZero() {
+	// The refusal reads the RAW input, like IsAllowedManualCycleStartDate
+	// above: DateAtLocation has no zero short-circuit, so a projected zero day
+	// is an ordinary year-1 calendar day in every zone with a non-zero offset
+	// and IsZero() answers false there.
+	if day.IsZero() {
 		return ManualCycleStartPolicy{}
 	}
 
+	targetDay := DateAtLocation(day, location)
 	policy := ManualCycleStartPolicy{
 		ConflictDate: findCompetingCycleStart(logs, targetDay, location),
 	}

--- a/internal/services/cycle_start_policy_boundary_test.go
+++ b/internal/services/cycle_start_policy_boundary_test.go
@@ -223,3 +223,47 @@ func TestPotentialImplantationGapDays_CrossTimezone(t *testing.T) {
 		})
 	}
 }
+
+// TestResolveManualCycleStartPolicy_ZeroDayIsRefusedInEveryLocation pins the
+// zero-day guard onto the RAW input, the way IsAllowedManualCycleStartDate
+// already tests it. The guard used to run on the projected day, and
+// DateAtLocation has no zero short-circuit: a zero time.Time is 0001-01-01 in
+// UTC, but projected into any zone with a non-zero offset it is an ordinary
+// calendar day (0001-01-01 east of UTC, 0000-12-31 west of it) whose IsZero()
+// is false. The refusal therefore fired only in UTC, and everywhere else the
+// policy was computed against a year-1 calendar — empty by accident whenever
+// no log sits there, and, as the fixture below shows, not empty when one does.
+func TestResolveManualCycleStartPolicy_ZeroDayIsRefusedInEveryLocation(t *testing.T) {
+	// Two period days at the very start of the calendar, the second one a
+	// cycle start: the only fixture a year-1 target day can reach.
+	logs := []models.DailyLog{
+		{Date: time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), IsPeriod: true},
+		{Date: time.Date(1, time.January, 2, 0, 0, 0, 0, time.UTC), IsPeriod: true, CycleStart: true},
+	}
+	now := mustParseCycleStartPolicyDay(t, "2026-03-03")
+
+	cases := []struct {
+		name     string
+		location *time.Location
+	}{
+		{"UTC", time.UTC},
+		{"east of UTC", time.FixedZone("UTC+1", 1*60*60)},
+		{"west of UTC", time.FixedZone("UTC-5", -5*60*60)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			policy := ResolveManualCycleStartPolicy(&models.User{}, logs, time.Time{}, now, tc.location)
+			if !policy.ConflictDate.IsZero() {
+				t.Fatalf("zero day yielded a conflict date %s", CalendarDayKey(policy.ConflictDate))
+			}
+			if !policy.PreviousStart.IsZero() || policy.ShortGapDays != 0 {
+				t.Fatalf("zero day yielded a previous start %s / short gap %d",
+					CalendarDayKey(policy.PreviousStart), policy.ShortGapDays)
+			}
+			if policy.PotentialImplantation || policy.ImplantationGapDays != 0 {
+				t.Fatalf("zero day yielded an implantation flag (%t, %d days)",
+					policy.PotentialImplantation, policy.ImplantationGapDays)
+			}
+		})
+	}
+}

--- a/internal/services/day_service_coverage_test.go
+++ b/internal/services/day_service_coverage_test.go
@@ -276,27 +276,29 @@ func TestDayService_ShouldAutoFill_ReturnsFalseWhenWasPeriod(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Line 554 — ShouldAutoFillPeriodDays: previousDay offset
+// ShouldAutoFillPeriodDays with a period the day before
 //
-//   previousDay := dayStart.AddDate(0, 0, -1)
+//	return !previousEntry.IsPeriod && !hasRecentPeriod, nil
 //
-// A mutant changing -1 to 0 (or 1) would make the check look at the wrong
-// day. We need a test where the EXACT previous day is a period but no other
-// nearby day is, so the correct day being checked matters.
+// A period on day-1 makes BOTH terms refuse, so this fixture pins the
+// behaviour and not the previousDay offset that produces it: hasPeriodInRecentDays
+// already covers day-1..day-3, so it answers false whether the offset reads
+// -1, -2, -3 or 0. Any fixture that would separate -1 from -2 has to put a
+// period in that span, which re-arms the lookback and forces false on both
+// sides — -2 and -3 are equivalent mutants of this function. The offset is
+// pinned instead by TestDayService_ShouldAutoFill_UsesPreviousDayNotFollowingDay
+// (day_service_mutation_test.go), whose fixture keeps the lookback empty and
+// puts the periods on dayStart and day+1 so only offset -1 answers true.
 // ---------------------------------------------------------------------------
 
-// TestDayService_ShouldAutoFill_ChecksExactPreviousDay verifies that the
-// function looks at day-1 (not day itself or day-2) when deciding whether to
-// autofill.
-func TestDayService_ShouldAutoFill_ChecksExactPreviousDay(t *testing.T) {
+// TestDayService_ShouldAutoFill_RefusesWhenThePreviousDayIsAPeriod verifies
+// that a day whose predecessor is already a period day does not start a second
+// auto-fill run.
+func TestDayService_ShouldAutoFill_RefusesWhenThePreviousDayIsAPeriod(t *testing.T) {
 	logs := newDayLogRepositoryStub()
 	service := dayserviceCovNewService(logs, &dayserviceCovUserStub{})
 	day := time.Date(2026, time.February, 10, 0, 0, 0, 0, time.UTC)
 
-	// Put a period entry exactly one day before dayStart. If the function
-	// looks at the right day it should detect previousEntry.IsPeriod=true and
-	// return false. If it uses offset 0 (checks dayStart itself, which has no
-	// entry) or -2 it would return true.
 	logs.entries["2026-02-09"] = models.DailyLog{
 		ID:       1,
 		UserID:   10,
@@ -309,7 +311,7 @@ func TestDayService_ShouldAutoFill_ChecksExactPreviousDay(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if should {
-		t.Fatal("expected false because the exact previous day is a period day")
+		t.Fatal("expected false because the previous day is already a period day")
 	}
 }
 
@@ -415,14 +417,18 @@ func TestDayService_AutoFill_SaveErrorPropagatesForExistingEntry(t *testing.T) {
 		SexActivity: models.SexActivityNone,
 	}
 	// Inject the Save error for that day.
-	logs.saveErrByDay["2026-02-11"] = errors.New("save failed")
+	saveErr := errors.New("save failed")
+	logs.saveErrByDay["2026-02-11"] = saveErr
 
 	service := dayserviceCovNewService(logs, &dayserviceCovUserStub{})
 	now := start.AddDate(0, 0, 5)
 
 	err := service.AutoFillFollowingPeriodDays(context.Background(), 10, start, 3, models.FlowLight, now, time.UTC)
-	if err == nil {
-		t.Fatal("expected error to propagate from Save, got nil")
+	// The Save error itself, not merely some error: this path has a Fetch
+	// above it and a Create below it that can each fail too, and an opaque
+	// sentinel in its place would hide which one refused.
+	if !errors.Is(err, saveErr) {
+		t.Fatalf("expected the injected Save error to propagate, got: %v", err)
 	}
 }
 
@@ -735,10 +741,13 @@ func TestDayService_MarkCycleStartManually_TxErrorPropagates(t *testing.T) {
 	service := NewDayServiceWithTx(logs, users, failingRunner)
 
 	err := service.MarkCycleStartManually(context.Background(), 10, targetDay, targetDay, time.UTC, ManualCycleStartOptions{})
-	// The error wraps txErr (via wrapManualCycleStartFailure if it reaches the
-	// inner return, or directly if it short-circuits earlier). Either way,
-	// we expect a non-nil error.
-	if err == nil {
-		t.Fatal("expected error from failing TxRunner, got nil")
+	// The injected error itself must come back. `err != nil` would also be
+	// satisfied by the pre-transaction refusals this function can return
+	// before the runner is ever reached (ErrManualCycleStartDateInvalid,
+	// ErrDayEntryLoadFailed, ErrManualCycleStartReplaceRequired), so it would
+	// pass on a fixture that never exercised the runner at all — and by any
+	// wrapping that drops the cause.
+	if !errors.Is(err, txErr) {
+		t.Fatalf("expected the injected TxRunner error to propagate, got: %v", err)
 	}
 }

--- a/internal/services/viewer_service.go
+++ b/internal/services/viewer_service.go
@@ -2,10 +2,19 @@ package services
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/ovumcy/ovumcy-web/internal/models"
 )
+
+// ErrViewerUserRequired is returned when a read is asked for with no resolved
+// owner. Every caller sits behind the session middleware, so this is a
+// precondition rather than a flow: it exists so that the path which is
+// currently unreachable fails as an error instead of a panic, and so that it
+// can never be answered with empty data — a read scoped to a missing id must
+// refuse, not report that the owner has nothing.
+var ErrViewerUserRequired = errors.New("viewer read requires a resolved user")
 
 type ViewerDayReader interface {
 	FetchLogByDate(ctx context.Context, userID uint, day time.Time, location *time.Location) (models.DailyLog, error)
@@ -28,15 +37,29 @@ func NewViewerService(days ViewerDayReader, symptoms ViewerSymptomReader) *Viewe
 	}
 }
 
+// The three methods below are every site in this file that reads user.ID, and
+// each refuses before it does: the guard belongs where the dereference is, not
+// on one method of the three. FetchDayLogForViewer needs none of its own — it
+// holds no id and its first call is one of these.
+
 func (service *ViewerService) FetchSymptomsForViewer(ctx context.Context, user *models.User, selectedIDs []uint) ([]models.SymptomType, error) {
+	if user == nil {
+		return nil, ErrViewerUserRequired
+	}
 	return service.symptoms.FetchPickerSymptoms(ctx, user.ID, selectedIDs)
 }
 
 func (service *ViewerService) FetchLogsForViewer(ctx context.Context, user *models.User, from time.Time, to time.Time, location *time.Location) ([]models.DailyLog, error) {
+	if user == nil {
+		return nil, ErrViewerUserRequired
+	}
 	return service.days.FetchLogsForUser(ctx, user.ID, from, to, location)
 }
 
 func (service *ViewerService) FetchLogByDateForViewer(ctx context.Context, user *models.User, day time.Time, location *time.Location) (models.DailyLog, error) {
+	if user == nil {
+		return models.DailyLog{}, ErrViewerUserRequired
+	}
 	return service.days.FetchLogByDate(ctx, user.ID, day, location)
 }
 

--- a/internal/services/viewer_service_test.go
+++ b/internal/services/viewer_service_test.go
@@ -17,9 +17,13 @@ type stubViewerDayReader struct {
 	// Captured userID arguments — used to prove reads are owner-scoped.
 	byDateUserID  uint
 	forUserUserID uint
+	// Call counter — a captured id of 0 is also the zero value, so proving a
+	// read never happened needs its own signal.
+	calls int
 }
 
 func (stub *stubViewerDayReader) FetchLogByDate(_ context.Context, userID uint, _ time.Time, _ *time.Location) (models.DailyLog, error) {
+	stub.calls++
 	stub.byDateUserID = userID
 	if stub.err != nil {
 		return models.DailyLog{}, stub.err
@@ -28,6 +32,7 @@ func (stub *stubViewerDayReader) FetchLogByDate(_ context.Context, userID uint, 
 }
 
 func (stub *stubViewerDayReader) FetchLogsForUser(_ context.Context, userID uint, _ time.Time, _ time.Time, _ *time.Location) ([]models.DailyLog, error) {
+	stub.calls++
 	stub.forUserUserID = userID
 	if stub.err != nil {
 		return nil, stub.err
@@ -44,9 +49,12 @@ type stubViewerSymptomReader struct {
 
 	// Captured userID argument — used to prove reads are owner-scoped.
 	symptomUserID uint
+	// Call counter, for the same reason as stubViewerDayReader.calls.
+	calls int
 }
 
 func (stub *stubViewerSymptomReader) FetchPickerSymptoms(_ context.Context, userID uint, selectedIDs []uint) ([]models.SymptomType, error) {
+	stub.calls++
 	stub.symptomUserID = userID
 	if stub.err != nil {
 		return nil, stub.err
@@ -55,6 +63,59 @@ func (stub *stubViewerSymptomReader) FetchPickerSymptoms(_ context.Context, user
 	result := make([]models.SymptomType, len(stub.symptoms))
 	copy(result, stub.symptoms)
 	return result, nil
+}
+
+// TestViewerServiceRefusesANilUser pins the precondition every method here
+// carries: the acting owner is resolved before the service is reached. Each
+// one used to dereference user.ID with no branch in front of it, so the
+// unreachable transport path — a handler that reached a read with no resolved
+// session — was a panic rather than an error, and a guard that answered with
+// empty data instead would read as "this owner has nothing", which is the one
+// answer a read scoped to a missing id must never give. The collaborators must
+// not be touched at all: a read issued for user_id 0 is an unscoped read.
+func TestViewerServiceRefusesANilUser(t *testing.T) {
+	dayReader := &stubViewerDayReader{
+		entry: models.DailyLog{Notes: "owner-note"},
+		logs:  []models.DailyLog{{Notes: "n1"}},
+	}
+	symptomReader := &stubViewerSymptomReader{symptoms: []models.SymptomType{{Name: "Headache"}}}
+	service := NewViewerService(dayReader, symptomReader)
+	moment := time.Now().UTC()
+
+	cases := []struct {
+		name string
+		call func() error
+	}{
+		{"FetchSymptomsForViewer", func() error {
+			_, err := service.FetchSymptomsForViewer(context.Background(), nil, []uint{4})
+			return err
+		}},
+		{"FetchLogsForViewer", func() error {
+			_, err := service.FetchLogsForViewer(context.Background(), nil, moment, moment, time.UTC)
+			return err
+		}},
+		{"FetchLogByDateForViewer", func() error {
+			_, err := service.FetchLogByDateForViewer(context.Background(), nil, moment, time.UTC)
+			return err
+		}},
+		{"FetchDayLogForViewer", func() error {
+			_, _, err := service.FetchDayLogForViewer(context.Background(), nil, moment, time.UTC)
+			return err
+		}},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			dayReader.calls = 0
+			symptomReader.calls = 0
+			if err := testCase.call(); !errors.Is(err, ErrViewerUserRequired) {
+				t.Fatalf("%s(nil user) error = %v, want ErrViewerUserRequired", testCase.name, err)
+			}
+			if dayReader.calls != 0 || symptomReader.calls != 0 {
+				t.Fatalf("%s(nil user) reached its collaborators: %d day reads, %d symptom reads",
+					testCase.name, dayReader.calls, symptomReader.calls)
+			}
+		})
+	}
 }
 
 func TestViewerServiceFetchSymptomsForViewerLoadsOwnerSymptoms(t *testing.T) {


### PR DESCRIPTION
Group T0048 — five records verified against the tree: four implemented, one refuted.

## R2-0048 — CONFIRMED — the zero-day refusal ran after the projection

`ResolveManualCycleStartPolicy` computed `targetDay := DateAtLocation(day.In(location), location)`
and then tested `targetDay.IsZero()`. `DateAtLocation` has no zero short-circuit (unlike
`CalendarDay`), so a zero `time.Time` projects to an ordinary year-1 calendar day — 0001-01-01
east of UTC, 0000-12-31 west of it — and `IsZero()` answers false there. The refusal fired in
UTC only. The sibling `IsAllowedManualCycleStartDate` already tests the raw input; the guard now
does the same, and `targetDay` is built from `day` (the `.In(location)` was a no-op —
`DateAtLocation` applies it itself).

red→green, **not induced**: `TestResolveManualCycleStartPolicy_ZeroDayIsRefusedInEveryLocation`
(`internal/services/cycle_start_policy_boundary_test.go:236`) seeds the only fixture a year-1
target day can reach — two period days at 0001-01-01/02, the second a cycle start — and asks for
a zero day in three zones. Against the unfixed tree: UTC PASS, `east of UTC` and `west of UTC`
FAIL with `zero day yielded a conflict date 0001-01-02`. So the policy was not merely "empty by
accident": with a log there it came back non-empty, and which happened depended on the request's
time zone. Green in all three after the reorder.

## R2-0490 — CONFIRMED — the fixture agreed with the mutant it named

`TestDayService_ShouldAutoFill_ChecksExactPreviousDay` seeded a period on day-1 and asserted
`false`. `ShouldAutoFillPeriodDays` returns `!previousEntry.IsPeriod && !hasRecentPeriod`
(`internal/services/day_service.go:614`) and `hasPeriodInRecentDays(…, 3, …)` covers day-1..day-3,
so that fixture answers `false` whether the offset reads -1, -2, -3 or 0 — the test could not fail
for the reason in its name.

Measured, **induced**: with `dayStart.AddDate(0, 0, -1)` mutated to `0` in `day_service.go`, the
test PASSED, while `TestDayService_ShouldAutoFill_UsesPreviousDayNotFollowingDay`
(`day_service_mutation_test.go:31`) FAILED — the offset is already pinned there, by the only
fixture that can pin it (lookback empty, periods on dayStart and day+1). The mutant was reverted
and `day_service.go` verified byte-identical to a pre-mutation snapshot; it is not in this diff.

So the guard the record proposed exists. Duplicating it would add nothing, and offsets -2/-3 are
equivalent mutants of this function — any fixture separating them re-arms the lookback and forces
`false` on both sides. The fix is therefore the claim, not a new assertion: the test is renamed to
what it verifies (`…_RefusesWhenThePreviousDayIsAPeriod`) and its header states the limit and
names the test that covers the offset. **`none-practical` for a new killing assertion**, for that
reason.

## R2-0496 — CONFIRMED — two propagation tests accepted any error

Both asserted `err == nil` only. `MarkCycleStartManually` returns
`ErrManualCycleStartDateInvalid` / `ErrDayEntryLoadFailed` / `ErrManualCycleStartReplaceRequired`
before the runner is reached (`day_service.go:463-480`), so the tx test passed on a fixture that
never entered the transaction; the test's own comment conceded it. Both now use `errors.Is`
against the injected sentinel.

red→green, **induced** (three mutants, each reverted, `day_service.go` restored from snapshot):
- `return err` → `return wrapManualCycleStartFailure(err)` (a `%w: %v` wrap that drops the cause):
  `got: manual cycle start failed: tx commit failed`.
- the pre-transaction date guard forced to refuse: `got: manual cycle start date invalid` — the
  record's exact hazard.
- the auto-fill `Save` error replaced by `ErrDayEntryUpdateFailed`: `got: update day entry failed`.

Each was green under the old `err != nil`.

## R2-0562 — REFUTED — both halves already landed

The record quotes `case left < right` comparing untrimmed operands. `compareISODate`
(`internal/services/settings_view_service.go:377-387`) trims once into `leftDate`/`rightDate` and
every arm reads those; its comment describes the asymmetry in the past tense. The padded-left
ordering cases the record asks for exist too —
`TestCompareISODateComparesTheSameOperandsInBothArms`
(`internal/services/settings_view_service_test.go:147-148`): `{" 2024-01-05", "2024-01-02", 1}`
and `{" 2024-01-02", "2024-01-05", -1}`. Nothing was changed here, and the defect was not
re-created to give the fix a target. (The four single-branch tests at
`settings_view_service_coverage_test.go:139-171` are now subsumed by that table; removing them is
out of scope.)

## R2-0589 — CONFIRMED — the viewer reads dereferenced the owner unguarded

All four methods took `*models.User` and read `user.ID` immediately, with no nil branch — unlike
`TrackingVisibilityForUser`. Every caller is behind the session middleware, so the path is
unreachable today; reached, it was a panic. Each of the three sites that reads `user.ID` now
refuses with `ErrViewerUserRequired`; `FetchDayLogForViewer` holds no id and inherits the refusal
from its first call. It is an error, never empty data — an empty success reads as "this owner has
nothing", which is the one answer a read scoped to a missing id must not give.

red→green, mixed: `TestViewerServiceRefusesANilUser` (`viewer_service_test.go:76`) failed on the
unfixed tree with `panic: runtime error: invalid memory address or nil pointer dereference`, in
the `FetchSymptomsForViewer` dereference — real, not induced. Its second assertion (the collaborators are not
touched at all, since a read issued for `user_id` 0 is an unscoped read) cannot fail on that
mutant, so it was proved separately, **induced**: with the guard moved below the read in
`FetchLogsForViewer`, the sentinel still came back and the test failed with
`FetchLogsForViewer(nil user) reached its collaborators: 1 day reads, 0 symptom reads`. Reverted;
`viewer_service.go` `diff`ed clean against its snapshot.

The layering question about these four pass-through methods is T0049's and is untouched — nothing
renamed, deleted or restructured.

## Validation

`go build ./...`, `go vet ./...`; `go test ./internal/services/` (214.8 s), the locale suites,
and `db` / `security` / `bootstrap` / `reminders` / `httpx` / `scripts/...`; `golangci-lint run`
repo-wide, 0 issues; `go run ./scripts/changelogd check` after the commit. `./internal/api/...`
was run once, green in 852 s, because both production changes sit on transport-reachable call
paths (`handlers_days_read.go:19,38`, `handlers_days_write.go:167`) even though neither can change
what a request produces.

`internal/db` failed once while that api run was in flight and passed alone on either side of it
(312 s, 147 s) — contention, not a defect; it shares no code with this diff.

`gofmt -l internal/services/` reports `day_service.go`, `settings_view_service.go` and
`webhook_reminder.go` — pre-existing struct-alignment drift on files this PR does not modify.

## Rollback

Single-commit revert. Tests, one guard reorder and one nil precondition; no persisted data, no
schema, no signature and no public contract changed. `ErrViewerUserRequired` is a new exported
sentinel with no caller outside the service and its test.
