### PR TITLE
fix(services): close the stats and webhook view-model divergences

### DIFF
--- a/changelog.d/services-close-the-view-model-divergences.md
+++ b/changelog.d/services-close-the-view-model-divergences.md
@@ -1,0 +1,19 @@
+### Fixed
+
+- **The stats reliability card no longer describes two states of one account.** An owner in
+  irregular-cycle mode with exactly two completed cycles read the heading "Early estimate" beside the
+  hint written for a variable pattern. The heading and the hint now come from one reliability tier,
+  so a "variable pattern" hint appears only where the "Variable pattern" heading does — at three
+  completed cycles, the same minimum every other pattern statement on the page uses.
+- **`ovumcy webhook show` reports the reminder lead window that is actually in force.** For a stored
+  lead-day value outside 0–14 — a hand-edited row, a restored backup, or a row written before the
+  bound existed — `show` printed the raw column, so it named a window no reminder would ever fire on
+  and a no-op `set` looked like a change. Both the show and the set views now print the clamped value
+  the reminder decision uses.
+
+### Internal
+
+- The stats page's view model no longer carries predicted next-period, ovulation or fertile-window
+  values for an owner whose predictions are suppressed. Suppression was a template obligation — one
+  boolean beside the full statistics it was meant to hide — so a new partial or a serialization of
+  the struct could publish an estimate the page itself refuses to show.

--- a/internal/services/calendar_feed_ics.go
+++ b/internal/services/calendar_feed_ics.go
@@ -92,7 +92,7 @@ type calendarFeedEvent struct {
 //
 // The decision, in order (mirrors DecideDueReminders' medical-safety gate):
 //   - Build cycle stats from the owner's logs via the SAME path the dashboard
-//     uses (StatsService.BuildCycleStatsFromLogs, which needs no repositories).
+//     uses (BuildCycleStatsFromLogs, which needs no repositories).
 //   - If in-app predictions are suppressed (DashboardPredictionDisabled — the
 //     owner's unpredictable-cycle mode — stats.PregnancyPaused, or
 //     DashboardCycleOverdue), emit ZERO events. This is the hard medical-safety
@@ -116,10 +116,11 @@ func calendarFeedEvents(input CalendarFeedICSInput) []calendarFeedEvent {
 		return nil
 	}
 
-	// Reuse the exact dashboard prediction path — a zero-dependency StatsService
-	// runs precisely the dashboard's stats derivation (baseline + pregnancy-pause
-	// resolution) without a store, exactly as DecideDueReminders does.
-	stats := NewStatsService(nil, nil).BuildCycleStatsFromLogs(user, input.Logs, input.Now, input.Location)
+	// Reuse the exact dashboard prediction path — package-level
+	// BuildCycleStatsFromLogs runs precisely the dashboard's stats derivation
+	// (baseline + pregnancy-pause resolution) without a store, exactly as
+	// DecideDueReminders does.
+	stats := BuildCycleStatsFromLogs(user, input.Logs, input.Now, input.Location)
 
 	// Medical-safety suppression gate: if the app suppresses predictions, emit
 	// nothing. Unpredictable-cycle mode, a pregnancy pause, OR an overdue cycle

--- a/internal/services/stats_page_view_service.go
+++ b/internal/services/stats_page_view_service.go
@@ -150,7 +150,7 @@ func (service *StatsService) BuildStatsPageViewData(ctx context.Context, user *m
 	predictionExplanation := BuildOwnerPredictionExplanation(user, cycleContext, hasCycleFactorExplanation && len(cycleFactorExplanation.HintFactorKeys) > 0)
 
 	return StatsPageViewData{
-		Stats:                               baseData.stats,
+		Stats:                               publishedStatsForOwner(user, baseData.stats),
 		ChartData:                           baseData.chartData,
 		ChartBaseline:                       baseData.chartBaseline,
 		TrendPointCount:                     baseData.trendPointCount,
@@ -195,6 +195,46 @@ func (service *StatsService) BuildStatsPageViewData(ctx context.Context, user *m
 		IsIrregularMode:                     isIrregularMode,
 		IsOwner:                             isOwner,
 	}, nil
+}
+
+// publishedStatsForOwner returns the CycleStats this page PUBLISHES: the
+// computed stats with every forward-looking value the display policy refuses
+// cleared, so the data cannot outlive the decision. Suppression on this surface
+// used to be a template obligation — one boolean beside the full CycleStats it
+// was supposed to hide — and a template that forgets the boolean, a new partial,
+// a JSON view or a debug dump of the struct then publishes a claim the product
+// has decided it must not make. Cleared here, the same forgetful template
+// renders nothing instead of a suppressed estimate.
+//
+// The two shared predicates decide, never a signal recombined here, and they
+// clear different sets because they answer different questions:
+// FertilityProjectionSuppressed also covers the zero-cycles floor, where the
+// projected next period legitimately stays because its anchor is a recorded
+// start and only the length falls back.
+//
+// RECORDED history — observed cycle lengths, the last period start, the current
+// cycle day — is never touched: it is fact, not projection, and the page's
+// "facts only" mode exists precisely to keep showing it. Only the PUBLISHED copy
+// is cleared; every builder above reads the full stats, because the ribbon, the
+// factor context and the cycle context each apply their own suppression rule to
+// it.
+func publishedStatsForOwner(user *models.User, stats CycleStats) CycleStats {
+	// Both verdicts are read off the UNCLEARED stats, so the second predicate
+	// cannot be answered from fields the first one has already emptied.
+	fertilitySuppressed := FertilityProjectionSuppressed(user, stats)
+	predictionsSuppressed := PredictionsSuppressed(user, stats)
+
+	if fertilitySuppressed {
+		stats.OvulationDate = time.Time{}
+		stats.OvulationExact = false
+		stats.FertilityWindowStart = time.Time{}
+		stats.FertilityWindowEnd = time.Time{}
+		stats.CurrentFertility = FertilityStatusUnknown
+	}
+	if predictionsSuppressed {
+		stats.NextPeriodStart = time.Time{}
+	}
+	return stats
 }
 
 func (service *StatsService) buildStatsPageBaseData(ctx context.Context, user *models.User, cycleLabelPattern string, now time.Time, location *time.Location, maxTrendPoints int) (statsPageBaseData, error) {
@@ -334,12 +374,22 @@ func shouldShowStatsLongCycleNotice(user *models.User, completedCycleLengths []i
 	return long >= shortCycleNoticeMinimumOccurrences
 }
 
-// shouldShowStatsPerimenopauseHint surfaces a STRAW+10-aligned educational
-// note for users aged 45+, where within-individual cycle variability rises
-// sharply (Gibson et al., npj Digital Medicine 2023, Apple Women's Health
-// Study, n=12,608) and persistent ≥7-day differences between consecutive
-// cycles mark entry into the menopausal transition (Harlow et al., the
-// ReSTAGE collaboration, median entry age 45.5 years).
+// shouldShowStatsPerimenopauseHint surfaces a STRAW+10-aligned educational note
+// for users aged 45+, where within-individual cycle variability rises sharply
+// (Gibson et al., npj Digital Medicine 2023, Apple Women's Health Study,
+// n=12,608).
+//
+// THE AGE BRACKET IS THE WHOLE RULE — no cycle data is consulted, and that is
+// deliberate, not an omission. The copy is an invitation to look, not a verdict:
+// it tells the owner that persistent ≥7-day differences between consecutive
+// cycles are what marks entry into the menopausal transition (Harlow et al., the
+// ReSTAGE collaboration, median entry age 45.5 years) and asks them to notice
+// it. Gating the hint on that criterion would turn the invitation into a claim
+// the app makes about the account, and would withhold it from exactly the owners
+// with too little history to measure variability at all. It is why this function
+// is unlike the two siblings above it, which DO make pattern statements and are
+// therefore gated at 3 occurrences. Regression:
+// TestStatsPerimenopauseHintFollowsTheAgeBracketAlone.
 func shouldShowStatsPerimenopauseHint(user *models.User) bool {
 	return user != nil && NormalizeAgeGroup(user.AgeGroup) == models.AgeGroup45Plus
 }
@@ -361,21 +411,47 @@ func buildStatsPredictionReliability(user *models.User, flags StatsFlags, stats 
 	}
 
 	variablePattern := user != nil && (user.IrregularCycle || (flags.CompletedCycleCount >= minimumPhaseInsightCycles && IsIrregularCycleSpread(stats)))
-	labelKey := "stats.reliability.early"
+	tier := resolveStatsReliabilityTier(variablePattern, sampleCount)
 
+	return sampleCount, usesRecentWindow, tier.labelKey, tier.hintKey, true
+}
+
+// statsReliabilityTier is the single reliability verdict the card renders. The
+// heading and the hint are two sentences about ONE state of the account, so
+// they are read off one tier rather than derived from two independent
+// expressions: the label was gated at minimumPhaseInsightCycles and the hint was
+// not, which paired "the pattern is still early" with the hint written for a
+// variable pattern for an irregular-cycle owner at exactly two completed cycles
+// — the case HasPersonalCycleRange admits and both statements describe
+// differently.
+type statsReliabilityTier struct {
+	labelKey string
+	hintKey  string
+}
+
+var (
+	// statsReliabilityEarly is the floor: enough cycles for basic insights, not
+	// enough to characterize a pattern. It says nothing about variability in
+	// either sentence, which is what "conservative with sparse data" means here.
+	statsReliabilityEarly    = statsReliabilityTier{labelKey: "stats.reliability.early", hintKey: "stats.reliability.hint"}
+	statsReliabilityBuilding = statsReliabilityTier{labelKey: "stats.reliability.building", hintKey: "stats.reliability.hint"}
+	statsReliabilityStable   = statsReliabilityTier{labelKey: "stats.reliability.stable", hintKey: "stats.reliability.hint"}
+	statsReliabilityVariable = statsReliabilityTier{labelKey: "stats.reliability.variable", hintKey: "stats.reliability.hint_variable"}
+)
+
+// resolveStatsReliabilityTier picks the tier from the sample the card is about.
+// A variable pattern needs minimumPhaseInsightCycles behind it exactly as every
+// other pattern claim on this page does; below that the account is early,
+// whichever mode it is in.
+func resolveStatsReliabilityTier(variablePattern bool, sampleCount int) statsReliabilityTier {
 	switch {
 	case variablePattern && sampleCount >= minimumPhaseInsightCycles:
-		labelKey = "stats.reliability.variable"
+		return statsReliabilityVariable
 	case sampleCount >= cyclePredictionWindow:
-		labelKey = "stats.reliability.stable"
+		return statsReliabilityStable
 	case sampleCount >= minimumPhaseInsightCycles:
-		labelKey = "stats.reliability.building"
+		return statsReliabilityBuilding
+	default:
+		return statsReliabilityEarly
 	}
-
-	hintKey := "stats.reliability.hint"
-	if variablePattern {
-		hintKey = "stats.reliability.hint_variable"
-	}
-
-	return sampleCount, usesRecentWindow, labelKey, hintKey, true
 }

--- a/internal/services/stats_page_view_service_test.go
+++ b/internal/services/stats_page_view_service_test.go
@@ -508,3 +508,171 @@ func TestShouldShowStatsLongCycleNotice(t *testing.T) {
 		})
 	}
 }
+
+// TestBuildStatsPageViewDataDropsSuppressedPredictionsFromThePublishedStats
+// pins that the view model this page publishes carries no forward-looking value
+// the display policy refuses. Suppression used to be a template obligation — one
+// boolean beside the full CycleStats it was supposed to hide — so a new partial,
+// a JSON view or a debug dump of the struct could publish a predicted next
+// period for an owner whose whole page says no prediction can be made.
+//
+// Both anchors are fixtures this test owns: the identical regular owner must
+// come back POPULATED and the unpredictable one EMPTY, so the case cannot pass
+// by clearing (or by never computing) everything.
+func TestBuildStatsPageViewDataDropsSuppressedPredictionsFromThePublishedStats(t *testing.T) {
+	// Explicit cycle starts, so the owner has a real anchor and the projection
+	// this test is about is the baseline path's, not a detection leftover.
+	logs := []models.DailyLog{
+		{Date: mustParseStatsServiceDay(t, "2026-01-01"), IsPeriod: true, CycleStart: true},
+		{Date: mustParseStatsServiceDay(t, "2026-01-29"), IsPeriod: true, CycleStart: true},
+		{Date: mustParseStatsServiceDay(t, "2026-02-26"), IsPeriod: true, CycleStart: true},
+		{Date: mustParseStatsServiceDay(t, "2026-03-26"), IsPeriod: true, CycleStart: true},
+	}
+	now := mustParseStatsServiceDay(t, "2026-04-05")
+	build := func(user *models.User) StatsPageViewData {
+		t.Helper()
+		service := NewStatsService(&stubStatsDayReader{logsForRange: logs}, &stubStatsSymptomReader{})
+		viewData, err := service.BuildStatsPageViewData(context.Background(), user, "en", "Cycle %d", now, time.UTC, 12)
+		if err != nil {
+			t.Fatalf("BuildStatsPageViewData() unexpected error: %v", err)
+		}
+		return viewData
+	}
+
+	regular := build(&models.User{ID: 300, Role: models.RoleOwner, CycleLength: 28})
+	if regular.Stats.NextPeriodStart.IsZero() || regular.Stats.OvulationDate.IsZero() ||
+		regular.Stats.FertilityWindowStart.IsZero() || regular.Stats.FertilityWindowEnd.IsZero() {
+		t.Fatalf("anchor: a regular owner must receive projected dates, got %+v", regular.Stats)
+	}
+
+	suppressed := build(&models.User{ID: 301, Role: models.RoleOwner, CycleLength: 28, UnpredictableCycle: true})
+	if !suppressed.PredictionDisabled {
+		t.Fatalf("expected PredictionDisabled=true for an unpredictable owner")
+	}
+	for name, value := range map[string]time.Time{
+		"NextPeriodStart":      suppressed.Stats.NextPeriodStart,
+		"OvulationDate":        suppressed.Stats.OvulationDate,
+		"FertilityWindowStart": suppressed.Stats.FertilityWindowStart,
+		"FertilityWindowEnd":   suppressed.Stats.FertilityWindowEnd,
+	} {
+		if !value.IsZero() {
+			t.Fatalf("expected Stats.%s to be cleared under suppression, got %s", name, value.Format("2006-01-02"))
+		}
+	}
+	if suppressed.Stats.CurrentFertility == FertilityStatusFertile {
+		t.Fatalf("expected no fertile claim in the published stats under suppression")
+	}
+	if suppressed.Stats.MedianCycleLength != regular.Stats.MedianCycleLength || suppressed.Stats.LastPeriodStart.IsZero() {
+		t.Fatalf("expected the RECORDED history to survive suppression, got %+v", suppressed.Stats)
+	}
+}
+
+// TestBuildStatsPageViewDataPairsTheReliabilityLabelAndHint pins that the
+// reliability heading and its hint describe ONE state of the account. They used
+// to come from two independent expressions gated at different cycle counts, so
+// an irregular-cycle owner at exactly two completed cycles read "Early estimate"
+// beside the hint written for a variable pattern.
+func TestBuildStatsPageViewDataPairsTheReliabilityLabelAndHint(t *testing.T) {
+	testCases := []struct {
+		name            string
+		completedCycles int
+		irregularSpread bool
+		irregularMode   bool
+		wantLabelKey    string
+		wantHintKey     string
+	}{
+		{
+			name:            "irregular mode at the basic-insights floor stays early",
+			completedCycles: 2,
+			irregularMode:   true,
+			wantLabelKey:    "stats.reliability.early",
+			wantHintKey:     "stats.reliability.hint",
+		},
+		{
+			name:            "irregular mode at the pattern minimum turns variable",
+			completedCycles: 3,
+			irregularMode:   true,
+			wantLabelKey:    "stats.reliability.variable",
+			wantHintKey:     "stats.reliability.hint_variable",
+		},
+		{
+			name:            "observed spread at the pattern minimum turns variable",
+			completedCycles: 3,
+			irregularSpread: true,
+			wantLabelKey:    "stats.reliability.variable",
+			wantHintKey:     "stats.reliability.hint_variable",
+		},
+		{
+			name:            "regular history below the recent window is building",
+			completedCycles: 4,
+			wantLabelKey:    "stats.reliability.building",
+			wantHintKey:     "stats.reliability.hint",
+		},
+		{
+			name:            "regular history at the recent window is stable",
+			completedCycles: 6,
+			wantLabelKey:    "stats.reliability.stable",
+			wantHintKey:     "stats.reliability.hint",
+		},
+	}
+
+	for index, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			logs := statspageviewserviceCovLogsWithNCompletedCycles(t, testCase.completedCycles)
+			if testCase.irregularSpread {
+				// The spread fixture already carries two completed cycles (14d, 35d).
+				logs = statspageviewserviceCovIrregularSpreadLogs(t, testCase.completedCycles-2)
+			}
+			service := NewStatsService(&stubStatsDayReader{logsForRange: logs}, &stubStatsSymptomReader{})
+			now := logs[len(logs)-1].Date.AddDate(0, 0, 5)
+
+			viewData, err := service.BuildStatsPageViewData(context.Background(),
+				&models.User{ID: uint(400 + index), Role: models.RoleOwner, CycleLength: 28, IrregularCycle: testCase.irregularMode},
+				"en", "Cycle %d", now, time.UTC, 12,
+			)
+			if err != nil {
+				t.Fatalf("BuildStatsPageViewData() unexpected error: %v", err)
+			}
+			if !viewData.ShowPredictionReliability {
+				t.Fatalf("expected the reliability block to be shown at %d completed cycles", testCase.completedCycles)
+			}
+			if viewData.PredictionReliabilityLabelKey != testCase.wantLabelKey ||
+				viewData.PredictionReliabilityHintKey != testCase.wantHintKey {
+				t.Fatalf("reliability pair = (%q, %q), want (%q, %q)",
+					viewData.PredictionReliabilityLabelKey, viewData.PredictionReliabilityHintKey,
+					testCase.wantLabelKey, testCase.wantHintKey)
+			}
+		})
+	}
+}
+
+// TestStatsPerimenopauseHintFollowsTheAgeBracketAlone pins the rule the hint
+// actually implements. Its copy is educational and conditional — it ASKS the
+// owner to watch for persistent 7-day differences — so the bracket is the whole
+// gate, and no amount of regular cycle data withdraws it. A variability gate
+// added here would turn an invitation to look into a claim about the account.
+func TestStatsPerimenopauseHintFollowsTheAgeBracketAlone(t *testing.T) {
+	regularLogs := statspageviewserviceCovLogsWithNCompletedCycles(t, 6)
+	variableLogs := statspageviewserviceCovIrregularSpreadLogs(t, 3)
+
+	build := func(user *models.User, logs []models.DailyLog) StatsPageViewData {
+		t.Helper()
+		service := NewStatsService(&stubStatsDayReader{logsForRange: logs}, &stubStatsSymptomReader{})
+		now := logs[len(logs)-1].Date.AddDate(0, 0, 5)
+		viewData, err := service.BuildStatsPageViewData(context.Background(), user, "en", "Cycle %d", now, time.UTC, 12)
+		if err != nil {
+			t.Fatalf("BuildStatsPageViewData() unexpected error: %v", err)
+		}
+		return viewData
+	}
+
+	steady45Plus := build(&models.User{ID: 500, Role: models.RoleOwner, CycleLength: 28, AgeGroup: models.AgeGroup45Plus}, regularLogs)
+	if !steady45Plus.ShowPerimenopauseHint {
+		t.Fatalf("expected the hint for a 45+ owner whose cycles are perfectly regular")
+	}
+
+	variableUnder40 := build(&models.User{ID: 501, Role: models.RoleOwner, CycleLength: 28, AgeGroup: models.AgeGroupUnder40}, variableLogs)
+	if variableUnder40.ShowPerimenopauseHint {
+		t.Fatalf("expected no hint below the 45+ bracket however variable the cycles are")
+	}
+}

--- a/internal/services/stats_service.go
+++ b/internal/services/stats_service.go
@@ -65,15 +65,34 @@ func (service *StatsService) BuildCycleStatsForRange(ctx context.Context, user *
 }
 
 // BuildCycleStatsFromLogs computes cycle stats from already-fetched logs, for
-// callers that have the relevant range in memory and want to avoid a
-// redundant daily_logs query.
-func (service *StatsService) BuildCycleStatsFromLogs(user *models.User, logs []models.DailyLog, now time.Time, location *time.Location) CycleStats {
+// callers that have the relevant range in memory and want to avoid a redundant
+// daily_logs query.
+//
+// It is package-level because it consults NO repositories: the whole derivation
+// is BuildCycleStats + ApplyUserCycleBaseline + ResolvePregnancyPause over the
+// logs it is handed. The repository-free callers — the webhook decision pass and
+// the .ics feed — used to say that in a comment and reach it through
+// NewStatsService(nil, nil), a service whose two fields exist only to be not
+// dereferenced. Here the property is structural: there is no receiver to hold a
+// nil store, so a future line that needs one cannot compile into this function
+// unnoticed.
+func BuildCycleStatsFromLogs(user *models.User, logs []models.DailyLog, now time.Time, location *time.Location) CycleStats {
 	stats := BuildCycleStats(logs, now)
 	stats = ApplyUserCycleBaseline(user, logs, stats, now, location)
 	if _, paused := ResolvePregnancyPause(logs); paused {
 		stats.PregnancyPaused = true
 	}
 	return stats
+}
+
+// BuildCycleStatsFromLogs is the method form, kept because the dashboard view
+// service depends on this derivation through an interface seam
+// (DashboardStatsProvider) that its tests substitute. It adds nothing: the
+// method IS the package function, so the two can never disagree about what the
+// dashboard's stats are. Regression:
+// TestStatsServiceBuildCycleStatsFromLogsIsThePackageFunction.
+func (service *StatsService) BuildCycleStatsFromLogs(user *models.User, logs []models.DailyLog, now time.Time, location *time.Location) CycleStats {
+	return BuildCycleStatsFromLogs(user, logs, now, location)
 }
 
 func StatsOverviewRange(now time.Time) (time.Time, time.Time) {

--- a/internal/services/stats_service_test.go
+++ b/internal/services/stats_service_test.go
@@ -327,6 +327,46 @@ func TestBuildSymptomFrequenciesForUserPropagatesErrors(t *testing.T) {
 	}
 }
 
+// TestStatsServiceBuildCycleStatsFromLogsIsThePackageFunction pins that the
+// method the dashboard's interface seam depends on adds nothing to the
+// package-level derivation. The repository-free callers (the webhook decision
+// pass, the .ics feed) now call the function directly; a method that started
+// computing something of its own would silently give the dashboard a different
+// prediction from the two egress surfaces.
+//
+// It also pins that the function needs no service at all — it is called here on
+// a receiver-less path, which is the "consults no repositories" property the
+// egress callers used to assert in a comment and buy with NewStatsService(nil,
+// nil).
+func TestStatsServiceBuildCycleStatsFromLogsIsThePackageFunction(t *testing.T) {
+	// The fixture drives all three steps of the derivation, so agreeing on it is
+	// not the same as agreeing on raw BuildCycleStats: the owner's non-default
+	// luteal phase only reaches the stats through ApplyUserCycleBaseline, and the
+	// pregnancy flag only through ResolvePregnancyPause.
+	logs := []models.DailyLog{
+		{Date: mustParseStatsServiceDay(t, "2026-01-01"), IsPeriod: true, CycleStart: true},
+		{Date: mustParseStatsServiceDay(t, "2026-01-29"), IsPeriod: true, CycleStart: true},
+		{Date: mustParseStatsServiceDay(t, "2026-02-26"), IsPeriod: true, CycleStart: true},
+		{Date: mustParseStatsServiceDay(t, "2026-03-08"), PregnancyTest: models.PregnancyTestPositive},
+	}
+	user := &models.User{ID: 9, Role: models.RoleOwner, CycleLength: 28, LutealPhase: 11}
+	now := mustParseStatsServiceDay(t, "2026-03-10")
+
+	direct := BuildCycleStatsFromLogs(user, logs, now, time.UTC)
+	raw := BuildCycleStats(logs, now)
+	if direct == raw {
+		t.Fatalf("anchor: the fixture must exercise the baseline and pause steps, got the raw derivation %+v", raw)
+	}
+	if !direct.PregnancyPaused || direct.LutealPhase != 11 {
+		t.Fatalf("anchor: expected the pause flag and the owner's luteal phase, got %+v", direct)
+	}
+
+	viaMethod := NewStatsService(&stubStatsDayReader{}, &stubStatsSymptomReader{}).BuildCycleStatsFromLogs(user, logs, now, time.UTC)
+	if viaMethod != direct {
+		t.Fatalf("method result %+v differs from the package function's %+v", viaMethod, direct)
+	}
+}
+
 func mustParseStatsServiceDay(t *testing.T, raw string) time.Time {
 	t.Helper()
 	parsed, err := time.ParseInLocation("2006-01-02", raw, time.UTC)

--- a/internal/services/webhook_notify_service_test.go
+++ b/internal/services/webhook_notify_service_test.go
@@ -334,12 +334,26 @@ func TestNotifyCrossOwnerHealthDataStaysScoped(t *testing.T) {
 }
 
 // TestNotifyDisclaimerPresentInEveryPayload proves the mandatory medical-safety
-// disclaimer rides in every delivered payload.
+// disclaimer rides in every delivered payload. It is the invariant's only
+// carrier — buildPayload sets Disclaimer unconditionally, and there is no
+// per-reminder flag a producer could forget — so it drives BOTH reminder kinds:
+// one owner whose next period is inside the lead window and one whose ovulation
+// is, with the kinds asserted present so the sweep cannot go quiet by delivering
+// only one of them.
 func TestNotifyDisclaimerPresentInEveryPayload(t *testing.T) {
 	now := time.Date(2026, 3, 12, 9, 0, 0, 0, time.UTC)
-	record := dueRecord(1, "https://a.example/hook", now, 26)
-	repo := &stubNotifyRepo{records: []models.WebhookNotifyRecord{record}}
-	logs := stubLogReader{byUser: map[uint][]models.DailyLog{1: {periodStartLog(1, *record.LastPeriodStart)}}}
+	periodOwner := dueRecord(1, "https://a.example/hook", now, 26)
+	periodOwner.WebhookNotifyOvulation = true
+	ovulationOwner := dueRecord(2, "https://b.example/hook", now, 12)
+	ovulationOwner.WebhookNotifyOvulation = true
+
+	repo := &stubNotifyRepo{records: []models.WebhookNotifyRecord{periodOwner, ovulationOwner}}
+	logs := stubLogReader{byUser: map[uint][]models.DailyLog{
+		1: {periodStartLog(1, *periodOwner.LastPeriodStart)},
+		// The ovulation reminder is withheld until one cycle has been observed
+		// (FertilityProjectionSuppressed), so this owner carries a completed one.
+		2: completedCycleStartLogs(2, *ovulationOwner.LastPeriodStart),
+	}}
 	deliverer := &stubDeliverer{}
 	service := newTestNotifyService(repo, logs, stubDecryptor{}, deliverer)
 
@@ -347,12 +361,16 @@ func TestNotifyDisclaimerPresentInEveryPayload(t *testing.T) {
 		t.Fatalf("RunOnce: %v", err)
 	}
 	deliveries := deliverer.deliveries()
-	if len(deliveries) == 0 {
-		t.Fatal("expected at least one delivery")
-	}
+	seenKinds := map[string]bool{}
 	for _, delivery := range deliveries {
+		seenKinds[delivery.payload.Type] = true
 		if !strings.Contains(delivery.payload.Disclaimer, "not medical advice or a method of contraception") {
-			t.Fatalf("payload missing disclaimer: %q", delivery.payload.Disclaimer)
+			t.Fatalf("payload of type %q missing disclaimer: %q", delivery.payload.Type, delivery.payload.Disclaimer)
+		}
+	}
+	for _, kind := range []string{DueReminderTypePeriod, DueReminderTypeOvulation} {
+		if !seenKinds[kind] {
+			t.Fatalf("anchor: expected a %q delivery, got kinds %v", kind, seenKinds)
 		}
 	}
 }

--- a/internal/services/webhook_reminder.go
+++ b/internal/services/webhook_reminder.go
@@ -45,15 +45,21 @@ const (
 //     watermark already equals it.
 //   - LeadDays echoes the window that was in force (settings.ReminderLeadDays,
 //     clamped), for observability by the caller.
-//   - Estimate is always true: a predicted period/ovulation date is an estimate,
-//     never fact (medical-safety invariant), so any surface rendering this must
-//     carry the estimate qualifier + non-medical-advice disclaimer.
+//
+// EVERY EventDate here is an estimate, never fact (medical-safety invariant), so
+// every surface rendering one must carry the estimate qualifier and the
+// non-medical-advice disclaimer. That obligation used to be spelled as an
+// Estimate field set to a literal true by both producers and read by nothing: a
+// constant cannot distinguish a case, so no consumer could branch on it and the
+// invariant travelled as prose wearing the shape of data. It travels as data
+// where it is actually enforced — buildPayload sets WebhookPayload.Disclaimer on
+// every payload unconditionally, and reminderCopy words the date as an estimate.
+// Regression: TestNotifyDisclaimerPresentInEveryPayload.
 type DueReminder struct {
 	Type        string
 	EventDate   time.Time
 	CycleAnchor time.Time
 	LeadDays    int
-	Estimate    bool
 }
 
 // WebhookReminderSettings is the transport-free webhook decision input: the
@@ -111,7 +117,7 @@ func WebhookReminderSettingsFromNotifyRecord(record models.WebhookNotifyRecord) 
 //
 //   - Webhook delivery disabled ⇒ nothing.
 //   - Build cycle stats from the owner's logs via the SAME path the dashboard
-//     uses (StatsService.BuildCycleStatsFromLogs, which needs no repositories).
+//     uses (BuildCycleStatsFromLogs, which needs no repositories).
 //   - In-app predictions suppressed (DashboardPredictionDisabled — the owner's
 //     unpredictable-cycle mode — stats.PregnancyPaused, or DashboardCycleOverdue
 //     — the running cycle is past the account's reference length by more than a
@@ -173,11 +179,12 @@ func decideDueReminders(user *models.User, settings WebhookReminderSettings, log
 		return nil, 0
 	}
 
-	// Reuse the exact dashboard prediction path. BuildCycleStatsFromLogs is a
-	// StatsService method but consults no repositories, so a zero-dependency
-	// service is the pure, allocation-cheap way to run precisely the dashboard's
-	// stats derivation (baseline + pregnancy-pause resolution) without a store.
-	stats := NewStatsService(nil, nil).BuildCycleStatsFromLogs(user, logs, now, location)
+	// Reuse the exact dashboard prediction path. BuildCycleStatsFromLogs is
+	// package-level precisely because it consults no repositories, so this pass
+	// runs the dashboard's stats derivation (baseline + pregnancy-pause
+	// resolution) without constructing — and without depending on never
+	// dereferencing — a store-less service.
+	stats := BuildCycleStatsFromLogs(user, logs, now, location)
 
 	// Medical-safety gate: if the app suppresses predictions, emit nothing. The
 	// three signals are read through the predicate every surface shares.
@@ -246,7 +253,6 @@ func decidePeriodReminder(settings WebhookReminderSettings, prediction Dashboard
 		EventDate:   eventDate,
 		CycleAnchor: anchor,
 		LeadDays:    leadDays,
-		Estimate:    true,
 	}, true, false
 }
 
@@ -283,7 +289,6 @@ func decideOvulationReminder(stats CycleStats, settings WebhookReminderSettings,
 		EventDate:   eventDate,
 		CycleAnchor: anchor,
 		LeadDays:    leadDays,
-		Estimate:    true,
 	}, true, false
 }
 

--- a/internal/services/webhook_reminder_test.go
+++ b/internal/services/webhook_reminder_test.go
@@ -167,9 +167,6 @@ func TestDecideDueRemindersOvulationWindowBoundaries(t *testing.T) {
 			if ovulation.LeadDays != leadDays {
 				t.Fatalf("ovulation lead days = %d, want %d", ovulation.LeadDays, leadDays)
 			}
-			if !ovulation.Estimate {
-				t.Fatalf("expected Estimate=true (a predicted date is never fact)")
-			}
 		})
 	}
 }
@@ -213,9 +210,6 @@ func TestDecideDueRemindersPeriodWindow(t *testing.T) {
 			}
 			if got := period.CycleAnchor.Format("2006-01-02"); got != tc.wantEvent {
 				t.Fatalf("period cycle anchor = %s, want %s (anchor is the next cycle start)", got, tc.wantEvent)
-			}
-			if !period.Estimate {
-				t.Fatalf("expected Estimate=true")
 			}
 		})
 	}

--- a/internal/services/webhook_settings_cli.go
+++ b/internal/services/webhook_settings_cli.go
@@ -37,8 +37,12 @@ type WebhookSettingsView struct {
 	// no endpoint is configured. It is the single form of a webhook URL that may
 	// appear in operator output — never the scheme/path/query/token.
 	Host             string
-	NotifyPeriod     bool
-	NotifyOvulation  bool
+	NotifyPeriod    bool
+	NotifyOvulation bool
+	// ReminderLeadDays is the lead window IN FORCE — always clamped through
+	// NormalizeReminderLeadDays, the same value DecideDueReminders applies —
+	// never the raw stored column. Both builders of this struct clamp, so `show`
+	// and `set` cannot report two different readings of one window.
 	ReminderLeadDays int
 }
 
@@ -205,12 +209,17 @@ func (service *WebhookSettingsCLIService) resolveOwner(ctx context.Context, emai
 	}
 
 	view := WebhookSettingsView{
-		Configured:       configured,
-		Enabled:          owner.WebhookEnabled,
-		Host:             host,
-		NotifyPeriod:     owner.WebhookNotifyPeriod,
-		NotifyOvulation:  owner.WebhookNotifyOvulation,
-		ReminderLeadDays: owner.ReminderLeadDays,
+		Configured:      configured,
+		Enabled:         owner.WebhookEnabled,
+		Host:            host,
+		NotifyPeriod:    owner.WebhookNotifyPeriod,
+		NotifyOvulation: owner.WebhookNotifyOvulation,
+		// Clamped, exactly as viewFromUpdate and DecideDueReminders clamp it: the
+		// view reports the window IN FORCE, never the raw stored column. A row
+		// outside the bound — hand-edited, restored from a backup, or written
+		// before the bound existed — otherwise made `show` print a window no
+		// reminder can fire on, and a no-op `set` look like a change.
+		ReminderLeadDays: NormalizeReminderLeadDays(owner.ReminderLeadDays),
 	}
 	return owner, view, plaintextURL, nil
 }

--- a/internal/services/webhook_settings_cli_test.go
+++ b/internal/services/webhook_settings_cli_test.go
@@ -399,3 +399,62 @@ func TestApplyWebhookSettingsDryRunDisabledNoURL(t *testing.T) {
 		t.Fatalf("expected a disabled, not-configured view, got %+v", view)
 	}
 }
+
+// TestWebhookSettingsViewsReportTheLeadWindowInForce pins that `show` and `set`
+// print the SAME lead window, the clamped one the decision layer actually uses.
+// The show path used to publish the raw stored column, so a value outside
+// [MinReminderLeadDays, MaxReminderLeadDays] — a hand-edited row, a restored
+// backup, a row written before the bound existed — made `show` report a window
+// no reminder would ever fire on, and a no-op `set` look like a change.
+func TestWebhookSettingsViewsReportTheLeadWindowInForce(t *testing.T) {
+	testCases := []struct {
+		name   string
+		stored int
+		want   int
+	}{
+		{name: "below the lower bound", stored: -5, want: MinReminderLeadDays},
+		{name: "above the upper bound", stored: 90, want: MaxReminderLeadDays},
+		{name: "inside the bound is untouched", stored: 3, want: 3},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			const userID = uint(77)
+			reader := &stubWebhookReader{
+				found: true,
+				user: models.User{
+					ID:                  userID,
+					WebhookEnabled:      true,
+					WebhookURL:          encryptTestWebhookURL(t, "https://ntfy.example.io/topic", userID),
+					WebhookNotifyPeriod: true,
+					ReminderLeadDays:    testCase.stored,
+				},
+			}
+			svc, _ := newWebhookCLIServiceForTest(reader)
+
+			shown, err := svc.ResolveWebhookSettings(context.Background(), "owner@example.com")
+			if err != nil {
+				t.Fatalf("ResolveWebhookSettings: %v", err)
+			}
+			if shown.ReminderLeadDays != testCase.want {
+				t.Fatalf("show reported lead window %d, want the clamped %d", shown.ReminderLeadDays, testCase.want)
+			}
+			// The value in force, straight from the decision layer's own clamp.
+			inForce := NormalizeReminderLeadDays(reader.user.ReminderLeadDays)
+			if shown.ReminderLeadDays != inForce {
+				t.Fatalf("show reported %d, but the lead window in force is %d", shown.ReminderLeadDays, inForce)
+			}
+
+			// A flag-only patch that leaves the lead day alone must print the same
+			// number the show path just printed.
+			enabled := true
+			applied, err := svc.ApplyWebhookSettings(context.Background(), "owner@example.com", WebhookSettingsPatch{Enabled: &enabled}, true)
+			if err != nil {
+				t.Fatalf("ApplyWebhookSettings: %v", err)
+			}
+			if applied.ReminderLeadDays != shown.ReminderLeadDays {
+				t.Fatalf("set reported lead window %d, show reported %d", applied.ReminderLeadDays, shown.ReminderLeadDays)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What was wrong

Six technical-debt records against `internal/services`, all of the same shape: a view model
publishing something other than the decision behind it. Five confirmed as described, one confirmed
only in its narrow reading — the details are under each record below. Reasoning lives in the code
comments; this body is the evidence and the red→green trail.

## Per record

### R2-0082 — the stats view model outlives the suppression decision — CONFIRMED (latent)

`BuildStatsPageViewData` emitted `Stats: baseData.stats` — the full `CycleStats` including
`NextPeriodStart`, `OvulationDate`, `FertilityWindow*`, `CurrentFertility` — beside
`PredictionDisabled: predictionDisabled`. Nothing zeroes those fields: `ApplyUserCycleBaseline`'s
`applyProjectedBaseline` (`internal/services/cycle_baseline.go:69`) sets them without consulting any
suppression signal. Both counter-evidence clauses in the record were checked and neither dissolves
it: `stats.html` gates the phase card on `.PredictionDisabled` but never reads the projected dates
at all, and `CycleStats` does not zero itself.

The record's line numbers are stale (`:134` derives from `DashboardPredictionDisabled(user)`; the
live tree reads `cycleContext.PredictionDisabled` at `:145`). The shape is unchanged.

Fixed in `internal/services/stats_page_view_service.go:200` — `publishedStatsForOwner` clears the
refused fields on the PUBLISHED copy only, through the two shared predicates rather than a signal
recombined at the call site. The two clear different sets because they answer different questions
the zero-cycles floor suppresses fertility but keeps the projected next period, whose anchor is a
recorded start.

Red was **induced** twice, one per leg, each by gutting the predicate call in the fix's own body:

- `fertilitySuppressed := false` → `expected Stats.FertilityWindowEnd to be cleared under
  suppression, got 2026-04-08`
- `predictionsSuppressed := false` → `expected Stats.NextPeriodStart to be cleared under
  suppression, got 2026-04-23`

Both restored and `diff`-verified against a pre-induction snapshot. Guard:
`TestBuildStatsPageViewDataDropsSuppressedPredictionsFromThePublishedStats`, which carries both
anchors — the identical regular owner must come back populated, and the recorded history (median
cycle length, last period start) must survive — so it cannot pass by clearing everything.

**Behaviour change, transport-observable:** an owner in the zero-cycles tier has
`PredictionDisabled == false` but `FertilityProjectionSuppressed == true`, so
`stats.html:110`'s `{{if eq .Stats.CurrentFertility "fertile"}}` and the
`data-fertility-status` hook no longer publish a fertile claim sourced only from the onboarding
slider. That is the first-cycle floor applied where it was missing, not a regression.

### R2-0083 — reliability label and hint gated differently — CONFIRMED

`buildStatsPredictionReliability` chose the label through a switch requiring
`sampleCount >= minimumPhaseInsightCycles` (3) for `variable`, and the hint through a bare
`if variablePattern`. `HasPersonalCycleRange` admits an owner at 2 completed cycles
(`statsMinimumInsightsCycles = 2`), and `variablePattern` is true at 2 via `user.IrregularCycle`, so
the pair rendered was `stats.reliability.early` + `stats.reliability.hint_variable`.

Settled against the live locales rather than inheriting the record's hedge: en/ru read
"Early estimate" / "Ранняя оценка" beside "Predictions may vary more when cycle length changes from
cycle to cycle." — two different statements about one account's history, on the surface whose job is
to say how much to trust the numbers. Resolved toward the conservative side (the label's existing
gate wins) because every other pattern statement on this page is gated at 3.

Fixed at `internal/services/stats_page_view_service.go:414` — one `statsReliabilityTier` carrying
both keys, resolved once by `resolveStatsReliabilityTier`. No locale key added or removed.

Red observed against the **unfixed** tree, exactly one row of five:

```
--- FAIL: .../irregular_mode_at_the_basic-insights_floor_stays_early
    reliability pair = ("stats.reliability.early", "stats.reliability.hint_variable"),
    want ("stats.reliability.early", "stats.reliability.hint")
```

Guard: `TestBuildStatsPageViewDataPairsTheReliabilityLabelAndHint`, a table over
(completedCycleCount, irregular mode, observed spread) asserting the pair, with the four
already-correct tiers as anchors.

### R2-0084 — perimenopause hint cites a criterion it does not use — CONFIRMED in the narrow reading, wrong-gate reading REFUTED

The doc comment argued from Harlow et al.'s persistent ≥7-day criterion for a function that reads
only `NormalizeAgeGroup(user.AgeGroup)`. The record's counter-evidence is the one that holds, and
the copy settles it: `stats.perimenopause_hint` is conditional and educational — "If you notice
persistent differences of 7 or more days between consecutive cycles, that can be an early sign…" —
an invitation to look, not a claim the app makes about the account. Gating on measured variability
would make it diagnostic and would withhold it from exactly the owners with too little history to
measure. So the defect is the comment, and the comment now states that the bracket is the whole rule
and why.

Red **induced**, one per assertion, since the code was already correct:

- call site gated on `IsIrregularCycleSpread(baseData.stats)` — the criterion the old comment named
  → `expected the hint for a 45+ owner whose cycles are perfectly regular`
- bracket check dropped (`return user != nil`) →
  `expected no hint below the 45+ bracket however variable the cycles are`

Both restored, file `diff`-verified identical to the snapshot. Guard:
`TestStatsPerimenopauseHintFollowsTheAgeBracketAlone`.

### R2-0105 — `DueReminder.Estimate` is a write-only constant — CONFIRMED (one file reference stale)

`grep '\.Estimate\b'` over `internal/` excluding tests returns nothing; both producers wrote
`Estimate: true` literally. The record names `webhook_notify_service.go:265-276` as a second
producer — that is stale, both producers are in `webhook_reminder.go` (`:249`, `:286`). The
substance holds.

Dropped rather than wired into `buildPayload`. Deriving the disclaimer from the field would create a
path where `Estimate: false` silently drops it, which weakens the invariant the field only claimed
to carry. The obligation is stated where it is enforced: the `DueReminder` doc now says every
`EventDate` is an estimate and points at `buildPayload`'s unconditional `Disclaimer`.

That makes `TestNotifyDisclaimerPresentInEveryPayload` the invariant's sole carrier, so it was
widened from one period-only owner to both reminder kinds, with the kinds asserted present so it
cannot go quiet by delivering only one. Red **induced** by gutting the fix's own body —
`disclaimer := ""` in `buildPayload` → `payload of type "period-soon" missing disclaimer: ""` —
then restored and `diff`-verified.

### R2-0106 — `NewStatsService(nil, nil)` as a purity claim — CONFIRMED

`webhook_reminder.go:180` built a nil-fielded service to call a method whose body never touches
`service.days` or `service.symptoms`. The comment asserted the property; nothing kept it true.

**Callers named before landing, as asked.** `BuildCycleStatsFromLogs` has no `internal/api` caller —
the ripple does not reach the transport lane. Production callers are `stats_service.go:64`
(`BuildCycleStatsForRange`), `dashboard_view_service.go:420` **through the `DashboardStatsProvider`
interface** (`dashboard_view_service.go:23`), `webhook_reminder.go:180` and
`calendar_feed_ics.go:122`.

Chosen shape: package-level function + thin method delegate. The interface seam is real — the
dashboard's own tests substitute a capturing stub for it — so removing the method would force a
redesign of a collaborator this PR has no business touching. The delegate costs one line and cannot
drift, which is what the new guard pins.

`calendar_feed_ics.go:122` is outside the record's file list and was converted anyway: it is the
same class at the only other production site, and fixing N of N+1 leaves the two sites diverging.
Nobody else in this wave owns that file. Test call sites still use the method form and were left
alone.

Red **induced** by making the delegate diverge (`return BuildCycleStats(logs, now)`) →
`method result {… LutealPhase:14 … PregnancyPaused:false} differs from the package function's
{… LutealPhase:11 … PregnancyPaused:true}`. Note the first fixture attempt did **not** kill this
mutant — three explicit cycle starts alone make the baseline path a no-op — so the fixture carries a
non-default luteal phase and a positive pregnancy test, and asserts up front that it differs from
the raw `BuildCycleStats` derivation. Guard:
`TestStatsServiceBuildCycleStatsFromLogsIsThePackageFunction`.

### R2-0108 — `show` prints the raw lead-day column — CONFIRMED

`resolveOwner` built the view with `ReminderLeadDays: owner.ReminderLeadDays`; `viewFromUpdate` and
`DecideDueReminders` both clamp through `NormalizeReminderLeadDays`. For a stored value outside
0..14, `ovumcy webhook show` named a window no reminder can fire on and a no-op `set` looked like a
change.

Fixed by clamping in `resolveOwner` too, with the field's doc comment stating that the view carries
the window IN FORCE. No persistence change: `SaveWebhookSettings` already clamped on the way in.

Red observed against the **unfixed** tree, two of three rows:

```
below the lower bound: show reported lead window -5, want the clamped 0
above the upper bound: show reported lead window 90, want the clamped 14
```

Guard: `TestWebhookSettingsViewsReportTheLeadWindowInForce`, which also asserts the show and set
views agree, so the two builders cannot diverge again silently.

## Validation

`go build ./...`; `go test ./internal/services/` (full package, 350 s); `go test ./internal/i18n/...
./internal/templates/...`; `golangci-lint run ./internal/services/...` → 0 issues;
`go run ./scripts/changelogd check` after commit.

`./internal/api/... ./cmd/...` was run once, **9 min 26 s** wall clock, both green. It was earned:
R2-0082 changes `data-fertility-status` and the fertile-window line for owners in the zero-cycles
tier, and R2-0108 is reached from `cmd/ovumcy webhook show`.

No Postgres test failed in a full run and passed under `-run`.

## Rollback

Single commit, `git revert`. No persisted data is altered and no schema is touched. The two
`api-contract` records mean the OpenAPI contract suite is re-run after a revert.
