### PR TITLE
fix(dashboard): suppress every fertility claim the shared gate already refuses

### DIFF
--- a/changelog.d/dashboard-suppress-what-the-gate-already-knows.md
+++ b/changelog.d/dashboard-suppress-what-the-gate-already-knows.md
@@ -1,0 +1,22 @@
+### Fixed
+
+- **The dashboard no longer states a fertility verdict for an account whose predictions are
+  suppressed.** The header's fertility gate carried one of the four suppression signals — the
+  zero-completed-cycle floor — so an owner in unpredictable-cycle mode, on a pregnancy pause, or
+  past their own reference cycle length still read "Fertile window" on the status line, and the
+  header still declared "fertile" or "not fertile" as its fertility state. In unpredictable-cycle
+  mode that line sat next to the notice saying predictions are off. All four signals now decide it,
+  through the same gate the calendar grid, the `.ics` feed and the reminder banner already use: in
+  those states the status line shows no fertile-window item and the header declares no fertility
+  state at all, while the cycle day, the phase and recorded observations are untouched.
+- **The journal grid stops publishing that verdict too.** The grid below the status header carried
+  the raw fertility classification with no gate on it whatsoever, so it stayed readable to scripts
+  and styling in every suppressed state, including before the first completed cycle. It now reads
+  the same single verdict the header does.
+- **An overdue cycle no longer names a next-period date to an owner with irregular cycles and
+  little history.** Withholding the estimate past reference + 7 days reached everyone except the
+  one group tracking irregular cycles with fewer than three completed: they kept seeing a projected
+  date captioned "needs more cycles" — a date rolled a whole cycle forward from a period that
+  should already have started. That owner now gets the same "estimate paused" notice everyone else
+  past that point gets. Owners inside their reference length still see the estimate with its
+  caption.

--- a/changelog.d/dashboard-suppress-what-the-gate-already-knows.md
+++ b/changelog.d/dashboard-suppress-what-the-gate-already-knows.md
@@ -20,3 +20,11 @@
   should already have started. That owner now gets the same "estimate paused" notice everyone else
   past that point gets. Owners inside their reference length still see the estimate with its
   caption.
+- **An owner tracking to conceive whose first cycle runs long is told when the fertile window
+  arrives, instead of nothing.** Before the first completed cycle the status line carries one
+  dateless sentence — "your fertile window appears after your first completed cycle" — in place of
+  an ovulation estimate. Once that first cycle passed the reference length the sentence disappeared
+  too and the slot was simply empty, at the point the owner has the most reason to wonder. Pausing
+  a projection withholds a date; this line names none, so it now stays for as long as the first
+  cycle is open. It still goes when predictions are off altogether — unpredictable-cycle mode or a
+  pregnancy pause — where promising a future window would contradict the rest of the page.

--- a/internal/api/dashboard_suppression_render_regression_test.go
+++ b/internal/api/dashboard_suppression_render_regression_test.go
@@ -1,0 +1,186 @@
+package api
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+	"github.com/ovumcy/ovumcy-web/internal/services"
+	"gorm.io/gorm"
+)
+
+// The dashboard publishes its fertility verdict three times — the status
+// header's `data-fertility-status`, the fertile-window item beside the phase,
+// and the journal grid's `data-fertility` — and only the first two were gated
+// at all. The gate they shared carried one disjunct of the shared predicate
+// (the zero-completed-cycle floor), so an owner in unpredictable-cycle mode or
+// on a pregnancy pause read "Fertile window" on the same line as the notice
+// saying the account's predictions are off, and the grid published the raw
+// classification for every tier.
+//
+// This is the render half of the fix: the three hooks are asserted together,
+// against an account that genuinely classifies as fertile, so a suppression
+// that only reached the attribute the previous regression named cannot pass.
+
+// dashboardSuppressionSeed is the shared baseline: a 28-day account whose
+// running cycle is on day 12 — inside the fertile window (ovulation day 14,
+// window days 9-14) with a day of timezone slack on either side — with two
+// completed cycles behind it.
+func dashboardSuppressionSeed(t *testing.T, database *gorm.DB, userID uint, columns map[string]any) {
+	t.Helper()
+
+	today := services.DateAtLocation(time.Now().UTC(), time.UTC)
+	updates := map[string]any{
+		"cycle_length":      28,
+		"period_length":     5,
+		"luteal_phase":      14,
+		"last_period_start": today.AddDate(0, 0, -11),
+	}
+	for column, value := range columns {
+		updates[column] = value
+	}
+	if err := database.Model(&models.User{}).Where("id = ?", userID).Updates(updates).Error; err != nil {
+		t.Fatalf("seed cycle baseline: %v", err)
+	}
+	for _, offsetDays := range []int{-67, -39, -11} {
+		if err := database.Create(&models.DailyLog{
+			UserID:     userID,
+			Date:       today.AddDate(0, 0, offsetDays),
+			IsPeriod:   true,
+			CycleStart: true,
+		}).Error; err != nil {
+			t.Fatalf("seed cycle start %d: %v", offsetDays, err)
+		}
+	}
+}
+
+func TestDashboardWithholdsEveryFertilityClaimTheSharedGateSuppresses(t *testing.T) {
+	for name, testCase := range map[string]struct {
+		account         string
+		columns         map[string]any
+		pregnancyPaused bool
+		wantFertile     bool
+	}{
+		"nothing suppressed: the measured window renders": {
+			account:     "anchor",
+			wantFertile: true,
+		},
+		"unpredictable-cycle mode": {
+			account: "unpredictable",
+			columns: map[string]any{"unpredictable_cycle": true},
+		},
+		"pregnancy pause": {
+			account:         "pregnancy-pause",
+			pregnancyPaused: true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			app, database := newOnboardingTestApp(t)
+			user := createOnboardingTestUser(t, database, "dashboard-suppression-"+testCase.account+"@example.com", "StrongPass1", true)
+			dashboardSuppressionSeed(t, database, user.ID, testCase.columns)
+			if testCase.pregnancyPaused {
+				// A positive test after the running cycle's start with no later
+				// start: ResolvePregnancyPause reports an active pause.
+				if err := database.Create(&models.DailyLog{
+					UserID:        user.ID,
+					Date:          services.DateAtLocation(time.Now().UTC(), time.UTC).AddDate(0, 0, -2),
+					PregnancyTest: models.PregnancyTestPositive,
+				}).Error; err != nil {
+					t.Fatalf("seed positive pregnancy test: %v", err)
+				}
+			}
+
+			authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
+			document := mustParseHTMLDocument(t, mustRenderDashboard(t, app, authCookie, "en"))
+
+			header := dashboardElementByDataAttr(document, "data-dashboard-status-header")
+			if header == nil {
+				t.Fatal("expected the dashboard status header")
+			}
+			wantStatus := "unknown"
+			if testCase.wantFertile {
+				wantStatus = "fertile"
+			}
+			if got := htmlAttr(header, "data-fertility-status"); got != wantStatus {
+				t.Errorf("status header declares fertility %q, want %q", got, wantStatus)
+			}
+
+			statusLine := dashboardElementByDataAttr(document, "data-dashboard-status-line")
+			if statusLine == nil {
+				t.Fatal("expected the dashboard status line")
+			}
+			if got := htmlFindElement(statusLine, htmlNodeHasAttr("data-fertile-window")) != nil; got != testCase.wantFertile {
+				t.Errorf("fertile-window item rendered = %v, want %v", got, testCase.wantFertile)
+			}
+
+			// The journal grid republishes the same classification for the
+			// scripts and stylesheet rules that read it, and had no gate at all.
+			editor := dashboardElementByDataAttr(document, "data-dashboard-editor")
+			if editor == nil {
+				t.Fatal("expected the dashboard journal grid")
+			}
+			if got := htmlAttr(editor, "data-fertility"); got != wantStatus {
+				t.Errorf("journal grid publishes data-fertility=%q, want %q", got, wantStatus)
+			}
+		})
+	}
+}
+
+// TestDashboardPausesTheNextPeriodEstimateForAnOverdueIrregularAccount is the
+// render regression for the branch-order half. An overdue cycle carries no
+// evidence about when the next one starts, so the header names no date — but
+// the thin-history "needs more cycles" branch claimed the display first for an
+// irregular account with fewer than three completed cycles, and that account
+// read a named date with a qualifier where the floor is suppression.
+//
+// The account inside its reference length is the positive anchor: the
+// needs-data message is a real state and must survive the fix.
+func TestDashboardPausesTheNextPeriodEstimateForAnOverdueIrregularAccount(t *testing.T) {
+	for name, testCase := range map[string]struct {
+		account     string
+		startOffset int
+		wantPaused  bool
+	}{
+		"overdue past the reference length": {account: "overdue", startOffset: -54, wantPaused: true},
+		"inside the reference length":       {account: "current", startOffset: -11},
+	} {
+		t.Run(name, func(t *testing.T) {
+			app, database := newOnboardingTestApp(t)
+			user := createOnboardingTestUser(t, database, "dashboard-overdue-irregular-"+testCase.account+"@example.com", "StrongPass1", true)
+			today := services.DateAtLocation(time.Now().UTC(), time.UTC)
+			// Irregular mode with a single completed 28-day cycle behind it:
+			// fewer than three, so dashboardNeedsNextPeriodData is armed.
+			if err := database.Model(&models.User{}).Where("id = ?", user.ID).Updates(map[string]any{
+				"irregular_cycle":   true,
+				"cycle_length":      28,
+				"period_length":     5,
+				"luteal_phase":      14,
+				"last_period_start": today.AddDate(0, 0, testCase.startOffset),
+			}).Error; err != nil {
+				t.Fatalf("seed cycle baseline: %v", err)
+			}
+			for _, offsetDays := range []int{testCase.startOffset - 28, testCase.startOffset} {
+				if err := database.Create(&models.DailyLog{
+					UserID:     user.ID,
+					Date:       today.AddDate(0, 0, offsetDays),
+					IsPeriod:   true,
+					CycleStart: true,
+				}).Error; err != nil {
+					t.Fatalf("seed cycle start %d: %v", offsetDays, err)
+				}
+			}
+
+			authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
+			document := mustParseHTMLDocument(t, mustRenderDashboard(t, app, authCookie, "en"))
+
+			paused := htmlFindElement(document, htmlNodeHasAttr("data-dashboard-next-period-paused"))
+			if got := paused != nil; got != testCase.wantPaused {
+				t.Errorf("paused next-period notice rendered = %v, want %v", got, testCase.wantPaused)
+			}
+			named := htmlFindElement(document, htmlNodeHasAttr("data-dashboard-next-period"))
+			if got := named != nil; got == testCase.wantPaused {
+				t.Errorf("named next-period estimate rendered = %v while paused = %v; an overdue cycle may name no date", got, testCase.wantPaused)
+			}
+		})
+	}
+}

--- a/internal/services/dashboard_cycle.go
+++ b/internal/services/dashboard_cycle.go
@@ -408,11 +408,26 @@ func buildDashboardPredictionDisplay(user *models.User, stats CycleStats, today 
 		ovulationExact:      prediction.OvulationExact,
 		ovulationImpossible: prediction.OvulationImpossible,
 	}
-	if display.nextPeriodPrompt || display.nextPeriodNeedsData {
+	// The prompt is not a projection: with no recorded start there is no date
+	// to withhold and nothing for the overdue signal to be about, so it answers
+	// first — and DashboardCycleOverdue reads false there anyway, the cycle day
+	// being derived from the same absent anchor.
+	if display.nextPeriodPrompt {
 		return finalizeDashboardPredictionDisplay(display)
 	}
+	// Suppression is the floor, so overdue outranks the thin-history branch
+	// below rather than following it. Both describe a weak estimate, but they
+	// answer with different strengths: nextPeriodNeedsData still NAMES the
+	// projected date and captions it "needs more cycles", which is exactly the
+	// qualifier the medical-safety invariant refuses to accept in place of
+	// withholding. Ordered the other way round, the one cohort that met both —
+	// an irregular account with fewer than three completed cycles, overdue —
+	// was the only one still reading a date past its own reference length.
 	if DashboardCycleOverdue(user, stats) {
 		return pauseDashboardPredictionDisplay(display)
+	}
+	if display.nextPeriodNeedsData {
+		return finalizeDashboardPredictionDisplay(display)
 	}
 	return finalizeDashboardPredictionDisplay(applyDashboardPredictionRanges(display, user, stats, location))
 }

--- a/internal/services/dashboard_view_service.go
+++ b/internal/services/dashboard_view_service.go
@@ -263,37 +263,44 @@ type dashboardTimingFrame struct {
 }
 
 // resolveDashboardTimingFrame decides that frame from the resolved usage goal.
-// The ovulation estimate follows the next-period item's gating exactly: a
-// suppressed prediction (unpredictable cycle, pregnancy pause) stays suppressed
-// here too, and so does a cycle overdue enough that the next-period window is
-// withheld (NextPeriodEstimatePaused) — the ovulation estimate is derived from
-// the same projection, so an account trying to conceive would otherwise be the
-// one cohort still reading a placeholder where the window used to be. The third
-// condition is of the same kind and answers the same question from the other
-// end: before the first completed cycle (AwaitingFirstCycle) the projection has
-// nothing but the onboarding slider to project from, so the estimate is
-// manufactured rather than measured. That state alone gets the bridge line in
-// place of the estimate — a promise about data, not a date. BBT keeps existing
-// only where the tracking settings grant it, and its placement is a property of
-// the goal alone: a late cycle is when a morning reading matters most, so
-// nothing about the cycle demotes the field.
+// The ovulation estimate is withheld wherever the next-period window is: an
+// unpredictable cycle, a pregnancy pause, and a cycle overdue past its own
+// reference length — it is derived from the same projection, so an account
+// trying to conceive would otherwise be the one cohort still reading a
+// placeholder where the window used to be. Before the first completed cycle
+// (AwaitingFirstCycle) the projection has nothing but the onboarding slider to
+// project from, so the estimate is manufactured rather than measured; that state
+// gets the bridge line in place of the estimate — a promise about data, not a
+// date. BBT keeps existing only where the tracking settings grant it, and its
+// placement is a property of the goal alone: a late cycle is when a morning
+// reading matters most, so nothing about the cycle demotes the field.
 //
-// The two items read DIFFERENT gates on purpose. The ovulation estimate is a
-// fertility claim, so it reads the decision the context already resolved
-// (FertilitySuppressed = FertilityProjectionSuppressed) rather than rebuilding
-// it from PredictionDisabled/NextPeriodEstimatePaused/AwaitingFirstCycle. The
-// bridge line needs the three shared signals WITHOUT the first-cycle floor —
-// it is the line shown IN that floor, so a gate that included it would gate the
-// bridge on its own state — and the context carries no field for that half, so
-// the pair below is still resolved here.
+// The two items read DIFFERENT gates, and the difference is about what each one
+// SAYS, not about which signals happen to be at hand.
+//
+// The ovulation estimate names a date, so it is a fertility claim and reads the
+// decision the context already resolved (FertilitySuppressed =
+// FertilityProjectionSuppressed) rather than rebuilding it from the disjuncts.
+//
+// The bridge line names NO date — it says the fertile window arrives once the
+// first cycle closes. Suppression exists to withhold a claim, and there is no
+// claim here to withhold, so the bridge asks only whether the account has
+// predictions at all: PredictionDisabled (unpredictable-cycle mode, pregnancy
+// pause), where a line promising a future window would contradict the page. It
+// deliberately does NOT read NextPeriodEstimatePaused. That flag means "this
+// projection is paused", which is a fact about a date the bridge does not name;
+// reading it withdrew the line for an account whose FIRST cycle had run past the
+// reference length — the moment the owner most needs to be told when the window
+// arrives — and left the status slot empty instead. Nor does it read
+// FertilitySuppressed: the bridge is the line shown IN the first-cycle floor, so
+// a gate carrying that floor would gate the bridge on its own state.
 func resolveDashboardTimingFrame(user *models.User, cycleContext DashboardCycleContext, visibility dashboardOwnerVisibility) dashboardTimingFrame {
 	if !IsOwnerUser(user) || NormalizeUsageGoal(user.UsageGoal) != models.UsageGoalTrying {
 		return dashboardTimingFrame{}
 	}
-	predictionSuppressed := cycleContext.PredictionDisabled || cycleContext.NextPeriodEstimatePaused
 	return dashboardTimingFrame{
 		ShowOvulationEstimate: !cycleContext.FertilitySuppressed,
-		ShowFirstCycleBridge:  !predictionSuppressed && cycleContext.AwaitingFirstCycle,
+		ShowFirstCycleBridge:  !cycleContext.PredictionDisabled && cycleContext.AwaitingFirstCycle,
 		BBTInVisibleTier:      visibility.ShowBBTField,
 	}
 }

--- a/internal/services/dashboard_view_service.go
+++ b/internal/services/dashboard_view_service.go
@@ -40,11 +40,19 @@ type DashboardViewService struct {
 
 // DashboardViewData is everything the dashboard page renders.
 //
-// ShowFertilityStatus gates the slider-derived fertility half of the status
-// header — the fertile-window item and the status the header declares — on the
-// first completed cycle (DashboardAwaitingFirstCycle), for every goal: until one
-// cycle has been observed that window is the onboarding cycle length projected
-// forward, whatever the account is tracking for.
+// ShowFertilityStatus gates the fertility half of the status header — the
+// fertile-window item and the status the header declares — on the decision the
+// cycle context already resolved (DashboardCycleContext.FertilitySuppressed,
+// which is FertilityProjectionSuppressed). It used to name the first-cycle
+// floor alone, one disjunct of the four, so unpredictable-cycle mode, a
+// pregnancy pause and an overdue cycle all rendered "Fertile window" — the last
+// two beside the very notice saying the account's predictions are off.
+//
+// Stats is the PUBLISHED copy, cleared by publishedStatsForOwner: the gate and
+// the data behind it move together, so a partial that forgets the gate renders
+// nothing rather than the raw classification. Every builder in
+// BuildDashboardViewData still reads the uncleared stats, because each applies
+// its own suppression rule to them.
 type DashboardViewData struct {
 	Stats                             CycleStats
 	CycleContext                      DashboardCycleContext
@@ -172,8 +180,13 @@ func (service *DashboardViewService) BuildDashboardViewData(ctx context.Context,
 		reminderBanner = BuildDashboardReminderBanner(cycleContext, today, user.ReminderLeadDays)
 	}
 
+	// The same helper the stats page publishes through, so the two surfaces
+	// cannot drift apart on what a suppressed tier is allowed to carry. Every
+	// builder above still reads the uncleared stats.
+	publishedStats := publishedStatsForOwner(user, stats)
+
 	return DashboardViewData{
-		Stats:                             stats,
+		Stats:                             publishedStats,
 		CycleContext:                      cycleContext,
 		CycleHero:                         BuildDashboardCycleHero(user, stats, cycleContext, dashboardCycleHeroInput{Logs: logs, Today: today, Location: location}),
 		ReminderBanner:                    reminderBanner,
@@ -198,7 +211,7 @@ func (service *DashboardViewService) BuildDashboardViewData(ctx context.Context,
 		MoreFieldsOpen:                    dashboardMoreFieldsHoldData(todayLog, visibility, timingFrame.BBTInVisibleTier),
 		ShowOvulationEstimate:             timingFrame.ShowOvulationEstimate,
 		ShowFirstCycleBridge:              timingFrame.ShowFirstCycleBridge,
-		ShowFertilityStatus:               !cycleContext.AwaitingFirstCycle,
+		ShowFertilityStatus:               !cycleContext.FertilitySuppressed,
 		ShowBBTInVisibleTier:              timingFrame.BBTInVisibleTier,
 		AllowManualCycleStart:             visibility.AllowManualCycleStart,
 		ManualCycleStartPolicy:            cycleStart.Policy,
@@ -264,13 +277,22 @@ type dashboardTimingFrame struct {
 // only where the tracking settings grant it, and its placement is a property of
 // the goal alone: a late cycle is when a morning reading matters most, so
 // nothing about the cycle demotes the field.
+//
+// The two items read DIFFERENT gates on purpose. The ovulation estimate is a
+// fertility claim, so it reads the decision the context already resolved
+// (FertilitySuppressed = FertilityProjectionSuppressed) rather than rebuilding
+// it from PredictionDisabled/NextPeriodEstimatePaused/AwaitingFirstCycle. The
+// bridge line needs the three shared signals WITHOUT the first-cycle floor —
+// it is the line shown IN that floor, so a gate that included it would gate the
+// bridge on its own state — and the context carries no field for that half, so
+// the pair below is still resolved here.
 func resolveDashboardTimingFrame(user *models.User, cycleContext DashboardCycleContext, visibility dashboardOwnerVisibility) dashboardTimingFrame {
 	if !IsOwnerUser(user) || NormalizeUsageGoal(user.UsageGoal) != models.UsageGoalTrying {
 		return dashboardTimingFrame{}
 	}
 	predictionSuppressed := cycleContext.PredictionDisabled || cycleContext.NextPeriodEstimatePaused
 	return dashboardTimingFrame{
-		ShowOvulationEstimate: !predictionSuppressed && !cycleContext.AwaitingFirstCycle,
+		ShowOvulationEstimate: !cycleContext.FertilitySuppressed,
 		ShowFirstCycleBridge:  !predictionSuppressed && cycleContext.AwaitingFirstCycle,
 		BBTInVisibleTier:      visibility.ShowBBTField,
 	}

--- a/internal/services/dashboard_view_service_suppression_test.go
+++ b/internal/services/dashboard_view_service_suppression_test.go
@@ -1,0 +1,208 @@
+package services
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+)
+
+// The dashboard is the surface the medical-safety floor is easiest to lose on,
+// because it publishes the same claim three times: the gate the header reads
+// (ShowFertilityStatus), the classification the status attribute carries, and
+// the raw CycleStats copy the page hands to every partial below it. This file
+// pins all three to the SHARED predicates rather than to any recombination of
+// their disjuncts — the gate carried only the first-cycle floor, so an account
+// in unpredictable-cycle mode, on a pregnancy pause, or past its own reference
+// length read "Fertile window" beside the very notice saying its predictions
+// are off.
+//
+// Each case names the tier and what it costs, and the unsuppressed row is the
+// positive anchor: without it a guard that simply blanked every projection
+// would read as green.
+
+// dashboardSuppressionDay is the fixture's today. The window below is built
+// around it so that the unsuppressed row genuinely classifies as fertile —
+// a suppression assertion against a row that was never fertile proves nothing.
+const dashboardSuppressionDay = "2026-03-09"
+
+// dashboardSuppressionStats is a two-completed-cycle history whose projection
+// puts today inside the fertile window: every field a suppressed tier must
+// withhold is populated before the tier is applied.
+func dashboardSuppressionStats(t *testing.T) CycleStats {
+	t.Helper()
+	return CycleStats{
+		CompletedCycleCount:  2,
+		CurrentCycleDay:      10,
+		CurrentPhase:         "follicular",
+		CurrentFertility:     FertilityStatusFertile,
+		AverageCycleLength:   28,
+		MedianCycleLength:    28,
+		AveragePeriodLength:  5,
+		LutealPhase:          14,
+		LastPeriodStart:      mustParseDashboardServiceDay(t, "2026-02-28"),
+		NextPeriodStart:      mustParseDashboardServiceDay(t, "2026-03-28"),
+		OvulationDate:        mustParseDashboardServiceDay(t, "2026-03-13"),
+		OvulationExact:       true,
+		FertilityWindowStart: mustParseDashboardServiceDay(t, "2026-03-08"),
+		FertilityWindowEnd:   mustParseDashboardServiceDay(t, "2026-03-13"),
+	}
+}
+
+func TestBuildDashboardViewDataWithholdsEveryFertilityClaimTheSharedGateSuppresses(t *testing.T) {
+	today := mustParseDashboardServiceDay(t, dashboardSuppressionDay)
+
+	for name, testCase := range map[string]struct {
+		mutateUser  func(*models.User)
+		mutateStats func(*CycleStats)
+		// wantFertility is the fertility half — the window, the ovulation date
+		// and the classification the header declares.
+		wantFertility bool
+		// wantNextPeriod is the next-period half, which the first-cycle floor
+		// deliberately does NOT withhold: its anchor is a recorded start and
+		// only the length falls back to the onboarding slider.
+		wantNextPeriod bool
+	}{
+		"nothing suppressed: the measured window is published": {
+			wantFertility:  true,
+			wantNextPeriod: true,
+		},
+		"unpredictable-cycle mode: the owner turned projections off": {
+			mutateUser:     func(user *models.User) { user.UnpredictableCycle = true },
+			wantNextPeriod: false,
+		},
+		"pregnancy pause: the latest fertility signal is a positive test": {
+			mutateStats:    func(stats *CycleStats) { stats.PregnancyPaused = true },
+			wantNextPeriod: false,
+		},
+		"cycle overdue past its own reference length": {
+			mutateStats:    func(stats *CycleStats) { stats.CurrentCycleDay = 54 },
+			wantNextPeriod: false,
+		},
+		"awaiting the first completed cycle": {
+			mutateStats:    func(stats *CycleStats) { stats.CompletedCycleCount = 0 },
+			wantNextPeriod: true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			user := &models.User{ID: 11, Role: models.RoleOwner, CycleLength: 28, PeriodLength: 5, LutealPhase: 14, UsageGoal: models.UsageGoalAvoid}
+			if testCase.mutateUser != nil {
+				testCase.mutateUser(user)
+			}
+			stats := dashboardSuppressionStats(t)
+			if testCase.mutateStats != nil {
+				testCase.mutateStats(&stats)
+			}
+			// The fixture must be a live fertility claim before the tier is
+			// applied, or every "withheld" assertion below is vacuous.
+			if stats.CurrentFertility != FertilityStatusFertile {
+				t.Fatalf("fixture: expected a fertile classification to suppress, got %q", stats.CurrentFertility)
+			}
+
+			service := NewDashboardViewService(
+				&stubDashboardStatsProvider{stats: stats},
+				&stubDashboardViewerProvider{logEntry: models.DailyLog{Date: today}},
+				&stubDashboardDayStateProvider{},
+			)
+			viewData, err := service.BuildDashboardViewData(context.Background(), user, "en", today, time.UTC)
+			if err != nil {
+				t.Fatalf("BuildDashboardViewData() unexpected error: %v", err)
+			}
+
+			// The gate is the shared predicate's answer, not a fourth
+			// recombination of its disjuncts, and it is the same answer the
+			// cycle context already resolved for the banner.
+			if want := !FertilityProjectionSuppressed(user, stats); viewData.ShowFertilityStatus != want {
+				t.Errorf("ShowFertilityStatus = %v, want the shared predicate's %v", viewData.ShowFertilityStatus, want)
+			}
+			if want := !viewData.CycleContext.FertilitySuppressed; viewData.ShowFertilityStatus != want {
+				t.Errorf("ShowFertilityStatus = %v, want the context's already-resolved %v", viewData.ShowFertilityStatus, want)
+			}
+			if viewData.ShowFertilityStatus != testCase.wantFertility {
+				t.Errorf("ShowFertilityStatus = %v, want %v for this tier", viewData.ShowFertilityStatus, testCase.wantFertility)
+			}
+
+			// The published copy carries the same decision, so a partial that
+			// forgets the gate renders nothing instead of the raw claim.
+			wantClassification := FertilityStatusUnknown
+			if testCase.wantFertility {
+				wantClassification = FertilityStatusFertile
+			}
+			if viewData.Stats.CurrentFertility != wantClassification {
+				t.Errorf("published Stats.CurrentFertility = %q, want %q", viewData.Stats.CurrentFertility, wantClassification)
+			}
+			if got := !viewData.Stats.FertilityWindowStart.IsZero(); got != testCase.wantFertility {
+				t.Errorf("published Stats.FertilityWindowStart present = %v, want %v", got, testCase.wantFertility)
+			}
+			if got := !viewData.Stats.FertilityWindowEnd.IsZero(); got != testCase.wantFertility {
+				t.Errorf("published Stats.FertilityWindowEnd present = %v, want %v", got, testCase.wantFertility)
+			}
+			if got := !viewData.Stats.OvulationDate.IsZero(); got != testCase.wantFertility {
+				t.Errorf("published Stats.OvulationDate present = %v, want %v", got, testCase.wantFertility)
+			}
+			if got := !viewData.Stats.NextPeriodStart.IsZero(); got != testCase.wantNextPeriod {
+				t.Errorf("published Stats.NextPeriodStart present = %v, want %v", got, testCase.wantNextPeriod)
+			}
+
+			// RECORDED history is fact, not projection: no tier touches it.
+			if viewData.Stats.CurrentCycleDay != stats.CurrentCycleDay {
+				t.Errorf("published Stats.CurrentCycleDay = %d, want the recorded %d", viewData.Stats.CurrentCycleDay, stats.CurrentCycleDay)
+			}
+			if !viewData.Stats.LastPeriodStart.Equal(stats.LastPeriodStart) {
+				t.Errorf("published Stats.LastPeriodStart = %v, want the recorded %v", viewData.Stats.LastPeriodStart, stats.LastPeriodStart)
+			}
+			if viewData.Stats.CompletedCycleCount != stats.CompletedCycleCount {
+				t.Errorf("published Stats.CompletedCycleCount = %d, want the recorded %d", viewData.Stats.CompletedCycleCount, stats.CompletedCycleCount)
+			}
+		})
+	}
+}
+
+// TestBuildDashboardCycleContextPausesTheNextPeriodEstimateForAnOverdueIrregularAccount
+// pins the branch ORDER inside buildDashboardPredictionDisplay. The overdue
+// signal reached NextPeriodEstimatePaused only when no earlier branch claimed
+// the display first, and dashboardNeedsNextPeriodData claimed it for exactly the
+// cohort with the least evidence: an irregular account with fewer than three
+// completed cycles. That account read a named date carrying a "needs more
+// cycles" qualifier while overdue — a qualifier where the floor is suppression.
+//
+// The not-overdue row is the positive anchor: the needs-data message is a real
+// state and must survive, so the fix may not be "pause everything".
+func TestBuildDashboardCycleContextPausesTheNextPeriodEstimateForAnOverdueIrregularAccount(t *testing.T) {
+	today := mustParseDashboardServiceDay(t, dashboardSuppressionDay)
+
+	for name, testCase := range map[string]struct {
+		currentCycleDay int
+		wantOverdue     bool
+	}{
+		"overdue past the reference length": {currentCycleDay: 54, wantOverdue: true},
+		"inside the reference length":       {currentCycleDay: 10, wantOverdue: false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			user := &models.User{ID: 12, Role: models.RoleOwner, CycleLength: 28, PeriodLength: 5, LutealPhase: 14, IrregularCycle: true}
+			stats := dashboardSuppressionStats(t)
+			stats.CurrentCycleDay = testCase.currentCycleDay
+
+			// Fixture invariants: this is the exact collision — the thin-history
+			// branch is armed AND the overdue signal is set.
+			if !dashboardNeedsNextPeriodData(user, stats, stats.NextPeriodStart) {
+				t.Fatal("fixture: expected the thin-history next-period branch to be armed")
+			}
+			if got := DashboardCycleOverdue(user, stats); got != testCase.wantOverdue {
+				t.Fatalf("fixture: DashboardCycleOverdue = %v, want %v", got, testCase.wantOverdue)
+			}
+
+			cycleContext := BuildDashboardCycleContext(user, stats, today, time.UTC)
+			if cycleContext.NextPeriodEstimatePaused != testCase.wantOverdue {
+				t.Errorf("NextPeriodEstimatePaused = %v, want %v", cycleContext.NextPeriodEstimatePaused, testCase.wantOverdue)
+			}
+			if got := !cycleContext.DisplayNextPeriodStart.IsZero(); got == testCase.wantOverdue {
+				t.Errorf("DisplayNextPeriodStart present = %v while overdue = %v; an overdue cycle may name no date", got, testCase.wantOverdue)
+			}
+			if got := cycleContext.DisplayNextPeriodNeedsData; got == testCase.wantOverdue {
+				t.Errorf("DisplayNextPeriodNeedsData = %v while overdue = %v; the qualifier may not stand in for suppression", got, testCase.wantOverdue)
+			}
+		})
+	}
+}

--- a/internal/services/dashboard_view_service_test.go
+++ b/internal/services/dashboard_view_service_test.go
@@ -504,42 +504,64 @@ func TestFirstMissingTrackedDayFindsTrackedGap(t *testing.T) {
 // answers a question about the goal, but the estimate it adds is a prediction:
 // it must disappear wherever the next-period window does — an unpredictable
 // cycle, a pregnancy pause, and a cycle overdue past reference + 7, where the
-// projection has nothing left to say. The temperature's placement answers the
-// goal question alone and is unmoved by any of them.
+// projection has nothing left to say — and also before the first completed
+// cycle, where the bridge line stands in for it. The temperature's placement
+// answers the goal question alone and is unmoved by any of them.
+//
+// The cases feed a (user, stats) pair through BuildDashboardCycleContext rather
+// than hand-building the context, because the frame no longer recombines the
+// suppression signals: the ovulation estimate reads the FertilitySuppressed
+// decision the context resolved once. A hand-built context can set
+// PredictionDisabled without the decision that follows from it, which is a state
+// the builder never emits — asserting against one would pin the frame to a
+// fixture rather than to the policy.
 func TestResolveDashboardTimingFrameGatesTheOvulationEstimateOnEverySuppression(t *testing.T) {
-	user := &models.User{Role: models.RoleOwner, UsageGoal: models.UsageGoalTrying}
+	today := mustParseDashboardServiceDay(t, dashboardSuppressionDay)
 	visibility := dashboardOwnerVisibility{ShowBBTField: true}
 
 	for name, testCase := range map[string]struct {
-		cycleContext DashboardCycleContext
+		mutateUser   func(*models.User)
+		mutateStats  func(*CycleStats)
 		wantEstimate bool
 		wantBridge   bool
 	}{
 		"stable cycle": {
-			cycleContext: DashboardCycleContext{},
 			wantEstimate: true,
 		},
 		"predictions suppressed": {
-			cycleContext: DashboardCycleContext{PredictionDisabled: true},
+			mutateUser:   func(user *models.User) { user.UnpredictableCycle = true },
+			wantEstimate: false,
+		},
+		"pregnancy pause": {
+			mutateStats:  func(stats *CycleStats) { stats.PregnancyPaused = true },
 			wantEstimate: false,
 		},
 		"cycle overdue": {
-			cycleContext: DashboardCycleContext{NextPeriodEstimatePaused: true},
+			mutateStats:  func(stats *CycleStats) { stats.CurrentCycleDay = 54 },
 			wantEstimate: false,
 		},
 		"awaiting the first completed cycle": {
-			cycleContext: DashboardCycleContext{AwaitingFirstCycle: true},
+			mutateStats:  func(stats *CycleStats) { stats.CompletedCycleCount = 0 },
 			wantEstimate: false,
 			wantBridge:   true,
 		},
 		"awaiting the first cycle with predictions off": {
-			cycleContext: DashboardCycleContext{AwaitingFirstCycle: true, PredictionDisabled: true},
+			mutateUser:   func(user *models.User) { user.UnpredictableCycle = true },
+			mutateStats:  func(stats *CycleStats) { stats.CompletedCycleCount = 0 },
 			wantEstimate: false,
 			wantBridge:   false,
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			frame := resolveDashboardTimingFrame(user, testCase.cycleContext, visibility)
+			user := &models.User{ID: 13, Role: models.RoleOwner, UsageGoal: models.UsageGoalTrying, CycleLength: 28, PeriodLength: 5, LutealPhase: 14}
+			if testCase.mutateUser != nil {
+				testCase.mutateUser(user)
+			}
+			stats := dashboardSuppressionStats(t)
+			if testCase.mutateStats != nil {
+				testCase.mutateStats(&stats)
+			}
+			frame := resolveDashboardTimingFrame(user, BuildDashboardCycleContext(user, stats, today, time.UTC), visibility)
 			if frame.ShowOvulationEstimate != testCase.wantEstimate {
 				t.Fatalf("expected ovulation estimate=%v, got %v", testCase.wantEstimate, frame.ShowOvulationEstimate)
 			}

--- a/internal/services/dashboard_view_service_test.go
+++ b/internal/services/dashboard_view_service_test.go
@@ -551,6 +551,31 @@ func TestResolveDashboardTimingFrameGatesTheOvulationEstimateOnEverySuppression(
 			wantEstimate: false,
 			wantBridge:   false,
 		},
+		// The two rows below are the bridge's own boundary, and they are here
+		// because a shared boolean moved under it. The bridge names NO date —
+		// it says the window arrives after the first cycle closes — so a paused
+		// projection has nothing to withhold from it, and an overdue first cycle
+		// is exactly when the owner most needs to be told that. Both the
+		// irregular and the regular account reach it: they differ only in which
+		// branch of buildDashboardPredictionDisplay claims the display, which is
+		// not a fact about the copy.
+		"awaiting the first cycle, overdue": {
+			mutateStats: func(stats *CycleStats) {
+				stats.CompletedCycleCount = 0
+				stats.CurrentCycleDay = 54
+			},
+			wantEstimate: false,
+			wantBridge:   true,
+		},
+		"awaiting the first cycle, overdue, irregular": {
+			mutateUser: func(user *models.User) { user.IrregularCycle = true },
+			mutateStats: func(stats *CycleStats) {
+				stats.CompletedCycleCount = 0
+				stats.CurrentCycleDay = 54
+			},
+			wantEstimate: false,
+			wantBridge:   true,
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			user := &models.User{ID: 13, Role: models.RoleOwner, UsageGoal: models.UsageGoalTrying, CycleLength: 28, PeriodLength: 5, LutealPhase: 14}

--- a/internal/services/stats_page_view_service.go
+++ b/internal/services/stats_page_view_service.go
@@ -197,14 +197,20 @@ func (service *StatsService) BuildStatsPageViewData(ctx context.Context, user *m
 	}, nil
 }
 
-// publishedStatsForOwner returns the CycleStats this page PUBLISHES: the
-// computed stats with every forward-looking value the display policy refuses
-// cleared, so the data cannot outlive the decision. Suppression on this surface
-// used to be a template obligation — one boolean beside the full CycleStats it
-// was supposed to hide — and a template that forgets the boolean, a new partial,
-// a JSON view or a debug dump of the struct then publishes a claim the product
-// has decided it must not make. Cleared here, the same forgetful template
-// renders nothing instead of a suppressed estimate.
+// publishedStatsForOwner returns the CycleStats a page PUBLISHES: the computed
+// stats with every forward-looking value the display policy refuses cleared, so
+// the data cannot outlive the decision. Suppression on these surfaces used to be
+// a template obligation — one boolean beside the full CycleStats it was supposed
+// to hide — and a template that forgets the boolean, a new partial, a JSON view
+// or a debug dump of the struct then publishes a claim the product has decided
+// it must not make. Cleared here, the same forgetful template renders nothing
+// instead of a suppressed estimate.
+//
+// It serves BOTH owner surfaces that hand a CycleStats to a template — /stats
+// and the dashboard, whose journal grid republished the raw classification with
+// no gate on it at all. It stays one function rather than one per surface: a
+// second implementation of the clearing rule is precisely how the two came to
+// disagree in the first place.
 //
 // The two shared predicates decide, never a signal recombined here, and they
 // clear different sets because they answer different questions:

--- a/internal/templates/dashboard.html
+++ b/internal/templates/dashboard.html
@@ -3,11 +3,20 @@
   <h1 class="sr-only" data-title-key="nav.dashboard">{{t .Messages "nav.dashboard"}}</h1>
   <section class="space-y-3" data-dashboard-shell data-phase="{{.Stats.CurrentPhase}}" data-usage-goal="{{.CurrentUser.UsageGoal}}">
     {{$phase := .Stats.CurrentPhase}}{{if .CycleDataStale}}{{$phase = "unknown"}}{{else if .CycleHero.Visible}}{{$phase = .CycleHero.CurrentPhase}}{{end}}
+    {{/* The page's ONE fertility verdict, resolved once and read by every site
+         that publishes it below. The classification arrives already cleared for
+         the tiers the shared gate suppresses (ShowFertilityStatus is read too,
+         so gate and data must both fail before a claim escapes); a stale anchor
+         is the extra display signal the gate does not carry, and it is the
+         reason the phase above reads "unknown" as well. Written out per site,
+         this expression disagreed with itself: the journal grid carried no gate
+         at all and published the raw classification for every suppressed tier. */}}
+    {{$fertilityStatus := .Stats.CurrentFertility}}{{if or .CycleDataStale (not .ShowFertilityStatus)}}{{$fertilityStatus = "unknown"}}{{end}}
     <section
       class="card dashboard-status-header reveal"
       data-dashboard-status-header
       data-dashboard-phase="{{$phase}}"
-      data-fertility-status="{{if or .CycleDataStale (not .ShowFertilityStatus)}}unknown{{else}}{{.Stats.CurrentFertility}}{{end}}"
+      data-fertility-status="{{$fertilityStatus}}"
       {{if .CycleHero.Approximate}}data-cycle-hero-approximate="true"{{end}}>
       <div class="dashboard-status-top">
         <p class="dashboard-cycle-lead">
@@ -20,10 +29,11 @@
             <span aria-hidden="true">{{template "icon" (phaseIcon $phase)}}</span>
             <span>{{phaseLabel .Messages $phase}}</span>
           </span>
-          {{/* The fertile window is read off the projected cycle, so before the
-               first completed cycle it says the onboarding slider back to the
-               owner. It waits for the data that makes it a measurement. */}}
-          {{if and .ShowFertilityStatus (not .CycleDataStale) (eq .Stats.CurrentFertility "fertile")}}
+          {{/* The fertile window is read off the projected cycle, so it says
+               the onboarding slider back to the owner wherever the projection
+               has nothing observed behind it. It waits for the data that makes
+               it a measurement — the verdict resolved above already knows. */}}
+          {{if eq $fertilityStatus "fertile"}}
           <span class="dashboard-status-separator" aria-hidden="true">·</span>
           <span class="dashboard-status-item" data-fertile-window>{{t .Messages "dashboard.fertile_window"}}</span>
           {{end}}
@@ -233,7 +243,7 @@
     </section>
   </section>
 
-  <div class="grid gap-6" data-dashboard-editor data-phase="{{.Stats.CurrentPhase}}" data-fertility="{{.Stats.CurrentFertility}}" data-usage-goal="{{.CurrentUser.UsageGoal}}">
+  <div class="grid gap-6" data-dashboard-editor data-phase="{{.Stats.CurrentPhase}}" data-fertility="{{$fertilityStatus}}" data-usage-goal="{{.CurrentUser.UsageGoal}}">
     <section class="card p-4 sm:p-5">
       {{/* The title and the day it edits are one line: the date is what the
            title is about, not a second heading. */}}


### PR DESCRIPTION
## What was wrong

The medical-safety invariant puts **suppression** — not a qualifier — as the floor for a window or
fertility claim whose only source is configuration defaults or a projection past its own reference
range. The dashboard breached it in three independent places.

**1. The fertility gate carried one disjunct of four.** `ShowFertilityStatus` was
`!cycleContext.AwaitingFirstCycle` — the zero-completed-cycle floor alone. `PredictionsSuppressed`'s
three signals (unpredictable-cycle mode, pregnancy pause, `DashboardCycleOverdue`) went straight
through, and `DashboardCycleContext.FertilitySuppressed` — the right answer, already resolved at that
call site — was not read. An owner with 2 completed cycles in unpredictable mode, today inside the
projected window, rendered the fertile-window item and declared `data-fertility-status="fertile"` on
the same status line as the notice saying their predictions are off.

**2. A third site had no gate at all.** The journal grid's `data-fertility` published the raw
`Stats.CurrentFertility` — no gate, no stale check — for every suppressed tier, including before the
first completed cycle, where the header had already been withholding it.

**3. The next-period estimate missed overdue by branch ORDER.** In
`buildDashboardPredictionDisplay`, `nextPeriodPrompt || nextPeriodNeedsData` returned before the
`DashboardCycleOverdue` check, so `estimatePaused` stayed false for the one cohort that met both:
`dashboardNeedsNextPeriodData` is `IrregularCycle && CompletedCycleCount < 3`. That owner, at cycle
day 54 against a 28-day reference, read a projected date captioned "needs more cycles" — a date
`ProjectCycleStart` had rolled a whole cycle forward from a period that should already have started.

## What changed

- `ShowFertilityStatus` reads `cycleContext.FertilitySuppressed`; `ShowOvulationEstimate` reads it
  too, instead of recombining the signals a fourth time.
- The dashboard's **published** `Stats` goes through `publishedStatsForOwner` — the same helper
  `/stats` publishes through, unmoved and unduplicated (same package, one function, doc comment now
  names both callers). Every builder inside `BuildDashboardViewData` still reads the uncleared stats;
  only the copy handed to the template is cleared. Gate and data move together.
- `internal/templates/dashboard.html` resolves **one** fertility verdict beside the phase and all
  three sites read it; the journal grid gains the gate it never had.
- Branch order: the prompt branch stays first (no recorded start, so no date to withhold, and
  `DashboardCycleOverdue` reads false there anyway); `DashboardCycleOverdue` now outranks
  `nextPeriodNeedsData`.

## Decision on (3): **paused**, not the prompt

The overdue account gets `dashboard.next_period_estimate_paused`, not
`dashboard.next_period_need_cycles`. The two are different messages and the floor settles it, not the
order they happened to be written in: the needs-data message still **names the projected date** and
captions it — which is exactly the shape the invariant refuses ("there, suppression is the floor; a
qualifier is not enough"). The paused message names no date. The prompt branch (`LastPeriodStart`
zero) is untouched and stays first: it is not a projection, so there is nothing for the overdue
signal to be about. Owners inside their reference length keep the needs-data estimate — pinned as the
positive anchor in both new guards, so "pause everything" could not have passed.

## `dashboard_view_service.go`'s hand-recombination: half redundant, half not — kept, split

`predictionSuppressed := PredictionDisabled || NextPeriodEstimatePaused` fed two fields.
`ShowOvulationEstimate` became redundant and now reads `FertilitySuppressed` directly: after the
branch-order fix `!predictionSuppressed && !AwaitingFirstCycle` and `!FertilitySuppressed` agree, and
the field is strictly safer (it cannot diverge on the prompt edge). `ShowFirstCycleBridge` did **not**
become redundant, so the local is kept for it: the bridge needs the three shared signals *without*
the first-cycle floor, because it is the line shown **in** that floor — gating it on
`FertilitySuppressed` would gate it on its own state — and `DashboardCycleContext` carries no field
for that half. The comment above the function now says which gate each item reads and why they differ.

## Red → green (all reds REAL; none induced)

| Leg | Guard | Red on today's `main` | Green |
|---|---|---|---|
| Fertility gate | `TestBuildDashboardViewDataWithholdsEveryFertilityClaimTheSharedGateSuppresses` | `ShowFertilityStatus = true, want the shared predicate's false` × unpredictable / pregnancy pause / overdue | ok |
| Published data | same test | `published Stats.CurrentFertility = "fertile", want "unknown"`; `FertilityWindowStart/End`, `OvulationDate` present; `NextPeriodStart present = true, want false` on the three whole-projection tiers | ok |
| Branch order | `TestBuildDashboardCycleContextPausesTheNextPeriodEstimateForAnOverdueIrregularAccount` | `NextPeriodEstimatePaused = false, want true`; `DisplayNextPeriodStart present = true while overdue = true` | ok |
| DOM, fertility | `TestDashboardWithholdsEveryFertilityClaimTheSharedGateSuppresses` (api) | `status header declares fertility "fertile", want "unknown"` · `fertile-window item rendered = true, want false` · `journal grid publishes data-fertility="fertile", want "unknown"` — under unpredictable mode **and** pregnancy pause | ok |
| DOM, next period | `TestDashboardPausesTheNextPeriodEstimateForAnOverdueIrregularAccount` (api) | `paused next-period notice rendered = false, want true`; `named next-period estimate rendered = true` | ok |

Every table carries an unsuppressed positive anchor that was green before and after, so a guard that
merely blanked every projection could not have read as green.

`TestResolveDashboardTimingFrameGatesTheOvulationEstimateOnEverySuppression` changed its expectation:
its cases now feed a `(user, stats)` pair through `BuildDashboardCycleContext` instead of
hand-building a `DashboardCycleContext`. The new expectation is that the frame reads the context's
resolved `FertilitySuppressed`, so a hand-built context that sets `PredictionDisabled` without the
decision that follows from it is a state the builder never emits — asserting against one would pin
the frame to a fixture rather than to the policy. Its doc comment says so, and it gained a pregnancy-
pause row it never had.

## What an owner stops seeing

In unpredictable-cycle mode, on a pregnancy pause, and past their own reference cycle length: no
fertile-window item on the status line, and no fertility state declared anywhere on the page — header
or journal grid. Before the first completed cycle the journal grid stops publishing it too (the
header already withheld it). An owner tracking irregular cycles with fewer than three completed sees
"estimate paused" instead of a next-period date once overdue. The cycle day, the phase, the late-cycle
notice and every recorded observation (including the egg-white badge) are untouched — recorded facts
are not projections.

`SECURITY.md` and `docs/SECURITY_INVARIANTS.md` make no claim about dashboard suppression (their
prediction rows cover the persistent disclaimer and `.ics` suppression), so neither moves with this.

## Validation

`go build ./...`; `go test ./internal/services/` (191s); `go test ./internal/i18n/... ./internal/templates/...`;
`golangci-lint run` → 0 issues; `go run ./scripts/changelogd check` → OK; `go test ./internal/api/... -timeout 20m`
→ ok, 682s.

## Rollback

Revert the single commit. The three parts land together on purpose — the gate without the data leaves
the raw struct published for the next partial to read, the data without the gate leaves a clean shop
window on a broken lock — but each is independently revertible: `ShowFertilityStatus` back to
`!cycleContext.AwaitingFirstCycle`, `Stats` back to the uncleared `stats`, and the two branches back
into one `if`. No schema, no migration, no stored state; the change is display-only and takes effect
on the next render.
