### PR TITLE
test(db): pin the part-way migration failure and the hot single-file copy

### DIFF
--- a/changelog.d/test-db-partial-migration-and-hot-copy-guards.md
+++ b/changelog.d/test-db-partial-migration-and-hot-copy-guards.md
@@ -1,13 +1,17 @@
 none
 
 Test-only guards for two persistence properties that held with nothing pinning
-them. The first drives the migration runner with a three-statement migration
-whose middle statement the engine rejects, and requires that the failure leave
-neither the first statement's table nor a `schema_migrations` row claiming the
-migration applied — a row without the schema change would make every later boot
-skip that migration for good. The neighbouring failure cases stop earlier: they
-fail an injected catalog read, or are refused by the runner's own post-condition
-after every statement has already run. The second pins the backup hazard the
-self-hosting runbook warns about: copying `ovumcy.db` alone while the instance
-runs restores a database that opens cleanly, reports no error, and is missing
-every day still resident in `ovumcy.db-wal`. No production code changed.
+them. The first drives the migration runner with a four-statement migration the
+engine rejects part-way through, and requires that the failure leave nothing
+behind: not the table an earlier statement created, not the health field an
+earlier statement overwrote, not a `schema_migrations` row claiming the
+migration applied, and not one row fewer in the rest of that ledger. A row
+recorded without the schema change would make every later boot skip that
+migration for good; rows lost from the rest of the ledger would make the next
+boot re-apply the whole set against a schema that already has it. The
+neighbouring failure cases stop earlier: they fail an injected catalog read, or
+are refused by the runner's own post-condition after every statement has already
+run. The second pins the backup hazard the self-hosting runbook warns about:
+copying `ovumcy.db` alone while the instance runs restores a database that opens
+cleanly, reports no error, and is missing every day still resident in
+`ovumcy.db-wal`. No production code changed.

--- a/changelog.d/test-db-partial-migration-and-hot-copy-guards.md
+++ b/changelog.d/test-db-partial-migration-and-hot-copy-guards.md
@@ -1,0 +1,13 @@
+none
+
+Test-only guards for two persistence properties that held with nothing pinning
+them. The first drives the migration runner with a three-statement migration
+whose middle statement the engine rejects, and requires that the failure leave
+neither the first statement's table nor a `schema_migrations` row claiming the
+migration applied — a row without the schema change would make every later boot
+skip that migration for good. The neighbouring failure cases stop earlier: they
+fail an injected catalog read, or are refused by the runner's own post-condition
+after every statement has already run. The second pins the backup hazard the
+self-hosting runbook warns about: copying `ovumcy.db` alone while the instance
+runs restores a database that opens cleanly, reports no error, and is missing
+every day still resident in `ovumcy.db-wal`. No production code changed.

--- a/internal/db/migrations_destructive_replay_test.go
+++ b/internal/db/migrations_destructive_replay_test.go
@@ -748,6 +748,15 @@ func assertSentinelDayIntact(t *testing.T, databasePath string) {
 	reader := openSQLiteFileForReplayTest(t, databasePath)
 	defer closeReplayDatabase(t, reader)
 
+	assertSentinelDayIntactOn(t, reader)
+}
+
+// assertSentinelDayIntactOn is the same check against a non-migrating reader the
+// caller already holds. A case that has opened one to read the schema back does
+// not need a second connection to read the row.
+func assertSentinelDayIntactOn(t *testing.T, reader *gorm.DB) {
+	t.Helper()
+
 	rows := readDailyLogRowsForReplayTest(t, reader)
 	if len(rows) != 1 {
 		t.Fatalf("expected the seeded day to survive, found %d daily_logs rows", len(rows))

--- a/internal/db/migrations_partial_failure_test.go
+++ b/internal/db/migrations_partial_failure_test.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 
 	"gorm.io/gorm"
@@ -29,7 +30,7 @@ import (
 //     a health field of the seeded sentinel day, which is why this file seeds
 //     one at all — a rollback that reverts a fixture's own two tables while
 //     leaving a rewritten health row behind is the failure worth catching, and
-//     assertSentinelDayIntact is the sibling helper that names it);
+//     assertSentinelDayIntactOn is the sibling helper that names it);
 //   - the LEDGER is untouched — no row for this migration, and no row lost or
 //     gained anywhere else in it. The second half is not decoration: a rollback
 //     that reverted everything above while dropping the rows of the migrations
@@ -64,16 +65,22 @@ const (
 	// into schema_migrations and the version counted afterwards cannot drift
 	// apart. Spelling the number a second time would let the failing case count
 	// rows for a version nobody wrote and pass on a zero it earned by asking the
-	// wrong question. It is above every embedded version so nothing in the
-	// embedded set can collide with it.
+	// wrong question.
+	//
+	// It has to be a version the embedded set does not contain, or the seeded
+	// database already holds a ledger row for it and the case would read that
+	// row as this fixture's own. partialFailureFixtureMigration CHECKS that
+	// rather than trusting this sentence.
 	partialFailureFixtureName = "900_partial_failure.sql"
 
-	// The two tables bracket the failure: the first statement's table proves the
-	// rollback undid what had already executed, the last statement's table
+	// The three tables bracket the failure: the first statement's table proves
+	// the rollback undid what had already executed, the middle one belongs to
+	// the statement that separates the two cases, and the last statement's table
 	// proves the runner stopped at the failing statement instead of running past
 	// it.
-	partialFailureFirstTable = "partial_failure_first"
-	partialFailureLastTable  = "partial_failure_last"
+	partialFailureFirstTable  = "partial_failure_first"
+	partialFailureMiddleTable = "partial_failure_middle"
+	partialFailureLastTable   = "partial_failure_last"
 
 	// partialFailureRewrittenMood is what the fixture's data statement writes
 	// over every daily_logs row. It differs from the sentinel's own mood, so the
@@ -89,7 +96,7 @@ const (
 	// searches the migration for.
 	partialFailureMissingTable    = "partial_failure_no_such_table"
 	partialFailureBreakingMiddle  = "INSERT INTO " + partialFailureMissingTable + " (id) VALUES (1)"
-	partialFailureCompletedMiddle = "CREATE TABLE partial_failure_middle (id INTEGER)"
+	partialFailureCompletedMiddle = "CREATE TABLE " + partialFailureMiddleTable + " (id INTEGER)"
 )
 
 // partialFailureFixtureSQL is the four-statement migration: create a table,
@@ -145,7 +152,7 @@ func TestAMigrationThatFailsPartWayRecordsNeitherItsSchemaChangeNorItsLedgerRow(
 
 		// The health row the failed migration had already rewritten, read back
 		// through the sibling helper that names every column a bad replay costs.
-		assertSentinelDayIntact(t, databasePath)
+		assertSentinelDayIntactOn(t, reader)
 	})
 
 	t.Run("anchor: the same migration with a middle statement that works", func(t *testing.T) {
@@ -160,6 +167,12 @@ func TestAMigrationThatFailsPartWayRecordsNeitherItsSchemaChangeNorItsLedgerRow(
 
 		assertFixtureTablePresence(t, reader, partialFailureFirstTable, true,
 			"statement 1 left nothing behind even though the migration succeeded — the failing case above would then be asserting nothing")
+		// The statement in the position under test. Without this the anchor
+		// proves every statement of the fixture lands EXCEPT the one the two
+		// cases differ in, and a runner that silently skipped it — an off-by-one
+		// in the loop, a splitter dropping a chunk — would stay green here.
+		assertFixtureTablePresence(t, reader, partialFailureMiddleTable, true,
+			"the third statement of four left nothing behind even though the migration succeeded: the runner skipped the very statement the failing case relies on reaching")
 		assertFixtureTablePresence(t, reader, partialFailureLastTable, true,
 			"the last statement left nothing behind even though the migration succeeded — the failing case above would then be asserting nothing")
 		assertLedgerRowCount(t, reader, fixture.Version, 1,
@@ -184,6 +197,12 @@ func TestAMigrationThatFailsPartWayRecordsNeitherItsSchemaChangeNorItsLedgerRow(
 // its version and order out of the file name with migrationFilePattern — the
 // runner's own detection, so the fixture is versioned exactly as an embedded
 // migration would be and the caller has one value to both run and query.
+//
+// It also refuses a version the embedded set already uses. The database every
+// case here starts from is fully migrated, so a collision would have the ledger
+// assertions counting a row the seed wrote as if the fixture had written it: the
+// failing case would report a migration recorded that never was, and the total
+// would be off beside it. That was a sentence in a comment until it was this.
 func partialFailureFixtureMigration(t *testing.T, sqlText string) embeddedMigration {
 	t.Helper()
 
@@ -191,10 +210,20 @@ func partialFailureFixtureMigration(t *testing.T, sqlText string) embeddedMigrat
 	if len(matches) != 2 {
 		t.Fatalf("the fixture name %q is not one the runner would load as a migration", partialFailureFixtureName)
 	}
-	order, err := strconv.Atoi(matches[1])
+	version := matches[1]
+	order, err := strconv.Atoi(version)
 	requireNoErr(t, err, "read the fixture's order out of its name")
 
-	return embeddedMigration{Version: matches[1], Order: order, Name: partialFailureFixtureName, SQL: sqlText}
+	for _, embedded := range embeddedSQLiteMigrations(t) {
+		if embedded.Version == version {
+			t.Fatalf(
+				"the fixture's version %s is now taken by embedded migration %s: the seeded database already holds a ledger row for it, so this case would read that row as the fixture's own and report a failure that never happened — renumber %s above the embedded set",
+				version, embedded.Name, partialFailureFixtureName,
+			)
+		}
+	}
+
+	return embeddedMigration{Version: version, Order: order, Name: partialFailureFixtureName, SQL: sqlText}
 }
 
 // applyPartialFailureFixture runs the fixture through the real applyMigration on
@@ -233,21 +262,35 @@ func assertLedgerRowCount(t *testing.T, reader *gorm.DB, version string, want in
 
 // assertLedgerHoldsOnlyTheEmbeddedSet pins the rest of the ledger, which the
 // per-version count above cannot see. The expected total is DERIVED from the
-// embedded migration set at runtime rather than written down: the database was
-// seeded by booting the real opener, so it holds one row per embedded migration,
-// plus extra for whatever the case under test is expected to have added.
+// embedded migration set rather than written down: the database was seeded by
+// booting the real opener, so it holds one row per embedded migration, plus
+// extra for whatever the case under test is expected to have added.
 func assertLedgerHoldsOnlyTheEmbeddedSet(t *testing.T, reader *gorm.DB, extra int64, complaint string) {
 	t.Helper()
 
-	embedded, err := loadEmbeddedMigrations(DriverSQLite)
-	requireNoErr(t, err, "load the embedded sqlite migration set")
-	if len(embedded) == 0 {
-		t.Fatal("loaded no embedded migrations — the expected ledger total would assert nothing")
-	}
-
 	var total int64
 	requireNoErr(t, reader.Raw(`SELECT COUNT(*) FROM schema_migrations`).Scan(&total).Error, "count schema_migrations rows")
-	if want := int64(len(embedded)) + extra; total != want {
+	if want := int64(len(embeddedSQLiteMigrations(t))) + extra; total != want {
 		t.Errorf("schema_migrations holds %d row(s) in total, want %d: %s", total, want, complaint)
 	}
+}
+
+// embeddedSQLiteMigrationSet reads and parses the embedded SQLite tree once per
+// process. Deriving both the collision check and the expected ledger total from
+// the live set is the point — a written-down count would agree with itself — but
+// the set does not change while a test binary runs, and this file asks for it
+// three times per case.
+var embeddedSQLiteMigrationSet = sync.OnceValues(func() ([]embeddedMigration, error) {
+	return loadEmbeddedMigrations(DriverSQLite)
+})
+
+func embeddedSQLiteMigrations(t *testing.T) []embeddedMigration {
+	t.Helper()
+
+	migrations, err := embeddedSQLiteMigrationSet()
+	requireNoErr(t, err, "load the embedded sqlite migration set")
+	if len(migrations) == 0 {
+		t.Fatal("loaded no embedded migrations — every expectation derived from the set would assert nothing")
+	}
+	return migrations
 }

--- a/internal/db/migrations_partial_failure_test.go
+++ b/internal/db/migrations_partial_failure_test.go
@@ -1,0 +1,140 @@
+package db
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A migration whose SECOND statement of three is rejected by the engine is the
+// state applyMigration's per-migration transaction exists for, and no case drove
+// it before this file. The neighbouring failure tests stop somewhere else: the
+// inspection cases (migrations_inspection_failure_test.go) fail an injected
+// CATALOG READ, the destructive-replay cases
+// (migrations_destructive_replay_test.go) are refused by the runner's own
+// post-condition after every statement has already run, and
+// TestOpenSQLiteReleasesTheConnectionWhenMigrationsFail aborts on the ledger
+// SELECT before applyMigration is ever reached. None of them is a statement the
+// engine refuses in the middle of the list.
+//
+// The ledger row is the half of that state which decides what the NEXT boot
+// does, and no case looked at it at all. It is written after the last statement
+// and inside the same transaction, so both halves stand or fall together: a row
+// recorded for a migration whose statements did not all run would make every
+// later boot skip that migration for good, and the instance would keep serving
+// on a schema missing whatever the migration was for — silently, since the
+// runner reports success for a version it believes is applied.
+//
+// Deliberately narrower than "the runner is atomic", and the limit is stated
+// here so no reader concludes the broader claim: this drives one synthetic
+// migration through the real applyMigration on SQLite, where DDL is
+// transactional. Postgres is not measured — the transaction is the runner's,
+// not the dialect's, but only SQLite is exercised here.
+
+const (
+	// partialFailureFixtureVersion is the version applyFixtureMigration stamps
+	// on every synthetic migration, above every embedded one.
+	partialFailureFixtureVersion = "900"
+	partialFailureFixtureName    = "900_partial_failure.sql"
+
+	// partialFailureFirstTable is created by statement 1, before the failure;
+	// partialFailureLastTable by statement 3, after it. The first proves the
+	// transaction rolled back what had already been executed, the second that
+	// the runner stopped at the failing statement instead of running past it.
+	partialFailureFirstTable = "partial_failure_first"
+	partialFailureLastTable  = "partial_failure_last"
+
+	// partialFailureMiddleStatement parses and cannot run: an INSERT into a
+	// table that does not exist. A statement the engine rejects at execution
+	// time is what a migration typo, a renamed column or a constraint the data
+	// does not satisfy all look like from the runner's side.
+	partialFailureMiddleStatement = "INSERT INTO partial_failure_no_such_table (id) VALUES (1)"
+	partialFailureWorkingMiddle   = "CREATE TABLE partial_failure_middle (id INTEGER)"
+)
+
+// partialFailureFixtureSQL is the three-statement migration, with middle as its
+// second statement.
+func partialFailureFixtureSQL(middle string) string {
+	return "CREATE TABLE " + partialFailureFirstTable + " (id INTEGER);\n" +
+		middle + ";\n" +
+		"CREATE TABLE " + partialFailureLastTable + " (id INTEGER);"
+}
+
+// TestAMigrationThatFailsPartWayRecordsNeitherItsSchemaChangeNorItsLedgerRow
+// runs that migration twice. The failing case is the subject; the case whose
+// middle statement works is the anchor, and it is what keeps every assertion
+// below able to fail: it proves the fixture's tables do get created and its
+// ledger row does get written when the migration completes, so their absence in
+// the failing case is the rollback and not the fixture doing nothing.
+func TestAMigrationThatFailsPartWayRecordsNeitherItsSchemaChangeNorItsLedgerRow(t *testing.T) {
+	t.Run("the middle statement is rejected by the engine", func(t *testing.T) {
+		databasePath := filepath.Join(t.TempDir(), "partial-failure.db")
+		seedFullyMigratedDatabaseWithSentinelDay(t, databasePath)
+
+		err := applyFixtureMigration(t, databasePath, partialFailureFixtureName, partialFailureFixtureSQL(partialFailureMiddleStatement))
+
+		// Reported with t.Error rather than t.Fatal: a runner that swallowed the
+		// statement error is exactly the shape whose effect on the schema and on
+		// the ledger the assertions below measure, and aborting here would hide
+		// both.
+		if err == nil {
+			t.Error("a migration whose statement the engine rejects must fail, got no error")
+		} else {
+			for _, expected := range []string{partialFailureFixtureName, partialFailureMiddleStatement, "no such table"} {
+				if !strings.Contains(err.Error(), expected) {
+					t.Errorf("the failure must name %q so an operator can find the statement that broke; got %v", expected, err)
+				}
+			}
+		}
+
+		assertFixtureTablePresence(t, databasePath, partialFailureFirstTable, false,
+			"statement 1 ran before the failure and its table is still there: the migration was not rolled back")
+		assertFixtureTablePresence(t, databasePath, partialFailureLastTable, false,
+			"statement 3 is after the failing one and its table is there: the runner ran past a statement the engine rejected")
+		assertLedgerRowCount(t, databasePath, partialFailureFixtureVersion, 0,
+			"the migration is recorded as applied although it failed part-way: every later boot will skip it and the schema change is lost for good")
+	})
+
+	t.Run("anchor: the same migration with a middle statement that works", func(t *testing.T) {
+		databasePath := filepath.Join(t.TempDir(), "partial-failure-anchor.db")
+		seedFullyMigratedDatabaseWithSentinelDay(t, databasePath)
+
+		err := applyFixtureMigration(t, databasePath, partialFailureFixtureName, partialFailureFixtureSQL(partialFailureWorkingMiddle))
+		requireNoErr(t, err, "a migration whose statements all succeed must apply")
+
+		assertFixtureTablePresence(t, databasePath, partialFailureFirstTable, true,
+			"statement 1 left nothing behind even though the migration succeeded — the failing case above would then be asserting nothing")
+		assertFixtureTablePresence(t, databasePath, partialFailureLastTable, true,
+			"statement 3 left nothing behind even though the migration succeeded — the failing case above would then be asserting nothing")
+		assertLedgerRowCount(t, databasePath, partialFailureFixtureVersion, 1,
+			"a migration that applied cleanly was not recorded — the failing case above would then be asserting nothing")
+	})
+}
+
+// assertFixtureTablePresence reads the schema back through a connection that
+// applies no migration, so the reader can never repair what it measures.
+func assertFixtureTablePresence(t *testing.T, databasePath string, tableName string, want bool, complaint string) {
+	t.Helper()
+
+	reader := openSQLiteFileForReplayTest(t, databasePath)
+	defer closeReplayDatabase(t, reader)
+
+	if got := reader.Migrator().HasTable(tableName); got != want {
+		t.Errorf("table %s present=%v, want %v: %s", tableName, got, want, complaint)
+	}
+}
+
+// assertLedgerRowCount counts the schema_migrations rows for one version, again
+// through a connection that runs no migration of its own.
+func assertLedgerRowCount(t *testing.T, databasePath string, version string, want int64, complaint string) {
+	t.Helper()
+
+	reader := openSQLiteFileForReplayTest(t, databasePath)
+	defer closeReplayDatabase(t, reader)
+
+	var count int64
+	requireNoErr(t, reader.Raw(`SELECT COUNT(*) FROM schema_migrations WHERE version = ?`, version).Scan(&count).Error, "count schema_migrations rows")
+	if count != want {
+		t.Errorf("schema_migrations holds %d row(s) for version %s, want %d: %s", count, version, want, complaint)
+	}
+}

--- a/internal/db/migrations_partial_failure_test.go
+++ b/internal/db/migrations_partial_failure_test.go
@@ -2,11 +2,14 @@ package db
 
 import (
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
+
+	"gorm.io/gorm"
 )
 
-// A migration whose SECOND statement of three is rejected by the engine is the
+// A migration whose statements are rejected part-way through the list is the
 // state applyMigration's per-migration transaction exists for, and no case drove
 // it before this file. The neighbouring failure tests stop somewhere else: the
 // inspection cases (migrations_inspection_failure_test.go) fail an injected
@@ -17,45 +20,84 @@ import (
 // SELECT before applyMigration is ever reached. None of them is a statement the
 // engine refuses in the middle of the list.
 //
-// The ledger row is the half of that state which decides what the NEXT boot
-// does, and no case looked at it at all. It is written after the last statement
-// and inside the same transaction, so both halves stand or fall together: a row
-// recorded for a migration whose statements did not all run would make every
-// later boot skip that migration for good, and the instance would keep serving
-// on a schema missing whatever the migration was for — silently, since the
-// runner reports success for a version it believes is applied.
+// Three things have to be true afterwards, and the fixture is built so that each
+// one is separately observable:
 //
-// Deliberately narrower than "the runner is atomic", and the limit is stated
-// here so no reader concludes the broader claim: this drives one synthetic
-// migration through the real applyMigration on SQLite, where DDL is
-// transactional. Postgres is not measured — the transaction is the runner's,
-// not the dialect's, but only SQLite is exercised here.
+//   - the SCHEMA the migration had already changed is back (its first statement
+//     creates a table);
+//   - the DATA it had already rewritten is back (its second statement overwrites
+//     a health field of the seeded sentinel day, which is why this file seeds
+//     one at all — a rollback that reverts a fixture's own two tables while
+//     leaving a rewritten health row behind is the failure worth catching, and
+//     assertSentinelDayIntact is the sibling helper that names it);
+//   - the LEDGER is untouched — no row for this migration, and no row lost or
+//     gained anywhere else in it. The second half is not decoration: a rollback
+//     that reverted everything above while dropping the rows of the migrations
+//     that ARE applied leaves a state worse than the one under test, since the
+//     next boot re-applies the whole set against a schema that already has it.
+//
+// The ledger row is what decides that next boot. It is written after the last
+// statement and inside the same transaction, so a row recorded for a migration
+// whose statements did not all run would make every later boot skip it for
+// good, and the instance would keep serving on a schema missing whatever the
+// migration was for — silently, since the runner reports success for a version
+// it believes is applied.
+//
+// Postgres is deliberately not measured here, and the reason is not "SQLite is
+// what this file happens to open". The transaction is the RUNNER's — one
+// dialect-neutral `database.Transaction` in applyMigration — and both supported
+// engines have transactional DDL, so the SQLite arm measures the runner itself.
+// A Postgres arm would cost a container per case on every run of this package
+// and would measure the same Go statement through an engine that ADDITIONALLY
+// refuses every command issued after a failed one inside a transaction block
+// (SQLSTATE 25P02, until the block is rolled back): a green there could not
+// distinguish the runner's rollback from the engine's own refusal, which makes
+// it the weaker of the two arms on exactly the axis under test. Add the arm if
+// the runner ever stops wrapping a migration in one transaction, or if an
+// engine without transactional DDL is supported.
 
 const (
-	// partialFailureFixtureVersion is the version applyFixtureMigration stamps
-	// on every synthetic migration, above every embedded one.
-	partialFailureFixtureVersion = "900"
-	partialFailureFixtureName    = "900_partial_failure.sql"
+	// partialFailureFixtureName is the ONE place the fixture's version is
+	// written down. partialFailureFixtureMigration reads it back out of this
+	// name with the runner's own migrationFilePattern, and the assertions query
+	// the ledger for the version off that same value, so the version stamped
+	// into schema_migrations and the version counted afterwards cannot drift
+	// apart. Spelling the number a second time would let the failing case count
+	// rows for a version nobody wrote and pass on a zero it earned by asking the
+	// wrong question. It is above every embedded version so nothing in the
+	// embedded set can collide with it.
+	partialFailureFixtureName = "900_partial_failure.sql"
 
-	// partialFailureFirstTable is created by statement 1, before the failure;
-	// partialFailureLastTable by statement 3, after it. The first proves the
-	// transaction rolled back what had already been executed, the second that
-	// the runner stopped at the failing statement instead of running past it.
+	// The two tables bracket the failure: the first statement's table proves the
+	// rollback undid what had already executed, the last statement's table
+	// proves the runner stopped at the failing statement instead of running past
+	// it.
 	partialFailureFirstTable = "partial_failure_first"
 	partialFailureLastTable  = "partial_failure_last"
 
-	// partialFailureMiddleStatement parses and cannot run: an INSERT into a
-	// table that does not exist. A statement the engine rejects at execution
-	// time is what a migration typo, a renamed column or a constraint the data
-	// does not satisfy all look like from the runner's side.
-	partialFailureMiddleStatement = "INSERT INTO partial_failure_no_such_table (id) VALUES (1)"
-	partialFailureWorkingMiddle   = "CREATE TABLE partial_failure_middle (id INTEGER)"
+	// partialFailureRewrittenMood is what the fixture's data statement writes
+	// over every daily_logs row. It differs from the sentinel's own mood, so the
+	// write is visible either way round: absent after the failed migration,
+	// present after the one that completes.
+	partialFailureRewrittenMood = "0"
+
+	// partialFailureMissingTable is the only part of the failing statement the
+	// assertions match on. Requiring the runner's whole statement echo would
+	// couple this test to that formatting — a change that truncates a long
+	// statement, normalises whitespace or quotes differently would redden it
+	// with no behaviour regressed — while the table name is what an operator
+	// searches the migration for.
+	partialFailureMissingTable    = "partial_failure_no_such_table"
+	partialFailureBreakingMiddle  = "INSERT INTO " + partialFailureMissingTable + " (id) VALUES (1)"
+	partialFailureCompletedMiddle = "CREATE TABLE partial_failure_middle (id INTEGER)"
 )
 
-// partialFailureFixtureSQL is the three-statement migration, with middle as its
-// second statement.
+// partialFailureFixtureSQL is the four-statement migration: create a table,
+// rewrite a health field, then middle — the statement whose success or failure
+// separates the two cases — and finally create a second table.
 func partialFailureFixtureSQL(middle string) string {
 	return "CREATE TABLE " + partialFailureFirstTable + " (id INTEGER);\n" +
+		"UPDATE daily_logs SET mood = " + partialFailureRewrittenMood + ";\n" +
 		middle + ";\n" +
 		"CREATE TABLE " + partialFailureLastTable + " (id INTEGER);"
 }
@@ -63,78 +105,149 @@ func partialFailureFixtureSQL(middle string) string {
 // TestAMigrationThatFailsPartWayRecordsNeitherItsSchemaChangeNorItsLedgerRow
 // runs that migration twice. The failing case is the subject; the case whose
 // middle statement works is the anchor, and it is what keeps every assertion
-// below able to fail: it proves the fixture's tables do get created and its
-// ledger row does get written when the migration completes, so their absence in
-// the failing case is the rollback and not the fixture doing nothing.
+// below able to fail: it proves the fixture's tables do get created, its health
+// write does land, and its ledger row does get written when the migration
+// completes — so their absence in the failing case is the rollback and not the
+// fixture doing nothing.
 func TestAMigrationThatFailsPartWayRecordsNeitherItsSchemaChangeNorItsLedgerRow(t *testing.T) {
-	t.Run("the middle statement is rejected by the engine", func(t *testing.T) {
+	t.Run("the third statement of four is rejected by the engine", func(t *testing.T) {
 		databasePath := filepath.Join(t.TempDir(), "partial-failure.db")
 		seedFullyMigratedDatabaseWithSentinelDay(t, databasePath)
 
-		err := applyFixtureMigration(t, databasePath, partialFailureFixtureName, partialFailureFixtureSQL(partialFailureMiddleStatement))
+		fixture := partialFailureFixtureMigration(t, partialFailureFixtureSQL(partialFailureBreakingMiddle))
+		err := applyPartialFailureFixture(t, databasePath, fixture)
 
 		// Reported with t.Error rather than t.Fatal: a runner that swallowed the
-		// statement error is exactly the shape whose effect on the schema and on
-		// the ledger the assertions below measure, and aborting here would hide
-		// both.
+		// statement error is exactly the shape whose effect on the schema, the
+		// health row and the ledger the assertions below measure, and aborting
+		// here would hide all three.
 		if err == nil {
 			t.Error("a migration whose statement the engine rejects must fail, got no error")
 		} else {
-			for _, expected := range []string{partialFailureFixtureName, partialFailureMiddleStatement, "no such table"} {
+			for _, expected := range []string{partialFailureFixtureName, partialFailureMissingTable, "no such table"} {
 				if !strings.Contains(err.Error(), expected) {
 					t.Errorf("the failure must name %q so an operator can find the statement that broke; got %v", expected, err)
 				}
 			}
 		}
 
-		assertFixtureTablePresence(t, databasePath, partialFailureFirstTable, false,
+		reader := openSQLiteFileForReplayTest(t, databasePath)
+		defer closeReplayDatabase(t, reader)
+
+		assertFixtureTablePresence(t, reader, partialFailureFirstTable, false,
 			"statement 1 ran before the failure and its table is still there: the migration was not rolled back")
-		assertFixtureTablePresence(t, databasePath, partialFailureLastTable, false,
-			"statement 3 is after the failing one and its table is there: the runner ran past a statement the engine rejected")
-		assertLedgerRowCount(t, databasePath, partialFailureFixtureVersion, 0,
+		assertFixtureTablePresence(t, reader, partialFailureLastTable, false,
+			"the last statement is after the failing one and its table is there: the runner ran past a statement the engine rejected")
+		assertLedgerRowCount(t, reader, fixture.Version, 0,
 			"the migration is recorded as applied although it failed part-way: every later boot will skip it and the schema change is lost for good")
+		assertLedgerHoldsOnlyTheEmbeddedSet(t, reader, 0,
+			"the rolled-back migration cost the ledger rows of migrations that ARE applied: the next boot re-applies the whole set against a schema that already has it")
+
+		// The health row the failed migration had already rewritten, read back
+		// through the sibling helper that names every column a bad replay costs.
+		assertSentinelDayIntact(t, databasePath)
 	})
 
 	t.Run("anchor: the same migration with a middle statement that works", func(t *testing.T) {
 		databasePath := filepath.Join(t.TempDir(), "partial-failure-anchor.db")
 		seedFullyMigratedDatabaseWithSentinelDay(t, databasePath)
 
-		err := applyFixtureMigration(t, databasePath, partialFailureFixtureName, partialFailureFixtureSQL(partialFailureWorkingMiddle))
-		requireNoErr(t, err, "a migration whose statements all succeed must apply")
+		fixture := partialFailureFixtureMigration(t, partialFailureFixtureSQL(partialFailureCompletedMiddle))
+		requireNoErr(t, applyPartialFailureFixture(t, databasePath, fixture), "a migration whose statements all succeed must apply")
 
-		assertFixtureTablePresence(t, databasePath, partialFailureFirstTable, true,
+		reader := openSQLiteFileForReplayTest(t, databasePath)
+		defer closeReplayDatabase(t, reader)
+
+		assertFixtureTablePresence(t, reader, partialFailureFirstTable, true,
 			"statement 1 left nothing behind even though the migration succeeded — the failing case above would then be asserting nothing")
-		assertFixtureTablePresence(t, databasePath, partialFailureLastTable, true,
-			"statement 3 left nothing behind even though the migration succeeded — the failing case above would then be asserting nothing")
-		assertLedgerRowCount(t, databasePath, partialFailureFixtureVersion, 1,
+		assertFixtureTablePresence(t, reader, partialFailureLastTable, true,
+			"the last statement left nothing behind even though the migration succeeded — the failing case above would then be asserting nothing")
+		assertLedgerRowCount(t, reader, fixture.Version, 1,
 			"a migration that applied cleanly was not recorded — the failing case above would then be asserting nothing")
+		assertLedgerHoldsOnlyTheEmbeddedSet(t, reader, 1,
+			"the ledger does not hold the embedded set plus this migration, so its row count says nothing about what a failed migration costs")
+
+		rows := readDailyLogRowsForReplayTest(t, reader)
+		if len(rows) != 1 {
+			t.Fatalf("expected the seeded day to survive a migration that applied, found %d daily_logs rows", len(rows))
+		}
+		if mood := rows[0]["mood"]; mood != partialFailureRewrittenMood {
+			t.Errorf(
+				"daily_logs.mood = %q after the migration applied, want %q: the fixture's health write never lands, so its absence in the failing case above is not the rollback",
+				mood, partialFailureRewrittenMood,
+			)
+		}
 	})
 }
 
-// assertFixtureTablePresence reads the schema back through a connection that
-// applies no migration, so the reader can never repair what it measures.
-func assertFixtureTablePresence(t *testing.T, databasePath string, tableName string, want bool, complaint string) {
+// partialFailureFixtureMigration builds the fixture the runner will see, reading
+// its version and order out of the file name with migrationFilePattern — the
+// runner's own detection, so the fixture is versioned exactly as an embedded
+// migration would be and the caller has one value to both run and query.
+func partialFailureFixtureMigration(t *testing.T, sqlText string) embeddedMigration {
 	t.Helper()
 
-	reader := openSQLiteFileForReplayTest(t, databasePath)
-	defer closeReplayDatabase(t, reader)
+	matches := migrationFilePattern.FindStringSubmatch(partialFailureFixtureName)
+	if len(matches) != 2 {
+		t.Fatalf("the fixture name %q is not one the runner would load as a migration", partialFailureFixtureName)
+	}
+	order, err := strconv.Atoi(matches[1])
+	requireNoErr(t, err, "read the fixture's order out of its name")
+
+	return embeddedMigration{Version: matches[1], Order: order, Name: partialFailureFixtureName, SQL: sqlText}
+}
+
+// applyPartialFailureFixture runs the fixture through the real applyMigration on
+// a connection of its own, which it closes again, so the assertions read the
+// file through a connection that never carried the migration.
+func applyPartialFailureFixture(t *testing.T, databasePath string, fixture embeddedMigration) error {
+	t.Helper()
+
+	database := openSQLiteFileForReplayTest(t, databasePath)
+	defer closeReplayDatabase(t, database)
+
+	return applyMigration(database, fixture)
+}
+
+// assertFixtureTablePresence reports whether one of the fixture's tables is in
+// the schema. The reader is passed in: it applies no migration, so it can never
+// repair what it measures, and one per case is enough.
+func assertFixtureTablePresence(t *testing.T, reader *gorm.DB, tableName string, want bool, complaint string) {
+	t.Helper()
 
 	if got := reader.Migrator().HasTable(tableName); got != want {
 		t.Errorf("table %s present=%v, want %v: %s", tableName, got, want, complaint)
 	}
 }
 
-// assertLedgerRowCount counts the schema_migrations rows for one version, again
-// through a connection that runs no migration of its own.
-func assertLedgerRowCount(t *testing.T, databasePath string, version string, want int64, complaint string) {
+// assertLedgerRowCount counts the schema_migrations rows for one version.
+func assertLedgerRowCount(t *testing.T, reader *gorm.DB, version string, want int64, complaint string) {
 	t.Helper()
-
-	reader := openSQLiteFileForReplayTest(t, databasePath)
-	defer closeReplayDatabase(t, reader)
 
 	var count int64
 	requireNoErr(t, reader.Raw(`SELECT COUNT(*) FROM schema_migrations WHERE version = ?`, version).Scan(&count).Error, "count schema_migrations rows")
 	if count != want {
 		t.Errorf("schema_migrations holds %d row(s) for version %s, want %d: %s", count, version, want, complaint)
+	}
+}
+
+// assertLedgerHoldsOnlyTheEmbeddedSet pins the rest of the ledger, which the
+// per-version count above cannot see. The expected total is DERIVED from the
+// embedded migration set at runtime rather than written down: the database was
+// seeded by booting the real opener, so it holds one row per embedded migration,
+// plus extra for whatever the case under test is expected to have added.
+func assertLedgerHoldsOnlyTheEmbeddedSet(t *testing.T, reader *gorm.DB, extra int64, complaint string) {
+	t.Helper()
+
+	embedded, err := loadEmbeddedMigrations(DriverSQLite)
+	requireNoErr(t, err, "load the embedded sqlite migration set")
+	if len(embedded) == 0 {
+		t.Fatal("loaded no embedded migrations — the expected ledger total would assert nothing")
+	}
+
+	var total int64
+	requireNoErr(t, reader.Raw(`SELECT COUNT(*) FROM schema_migrations`).Scan(&total).Error, "count schema_migrations rows")
+	if want := int64(len(embedded)) + extra; total != want {
+		t.Errorf("schema_migrations holds %d row(s) in total, want %d: %s", total, want, complaint)
 	}
 }

--- a/internal/db/sqlite_backup_restore_test.go
+++ b/internal/db/sqlite_backup_restore_test.go
@@ -2,7 +2,9 @@ package db
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -301,6 +303,11 @@ func TestAHotCopyOfTheMainDatabaseFileAloneRestoresWithoutTheWALResidentDay(t *t
 	// `ovumcy.db` itself, the second is only in the WAL beside it.
 	createBackupRaceDay(t, repos, user.ID, "2026-04-01")
 	checkpointWALTruncate(t, liveDB)
+
+	// `ovumcy.db` as it stands with 2026-04-01 folded in and nothing after it.
+	// The copy taken below has to still be exactly these bytes.
+	mainFileAtLastCheckpoint := hashFileForBackupTest(t, livePath)
+
 	createBackupRaceDay(t, repos, user.ID, "2026-04-02")
 	assertWALCarriesBytes(t, livePath)
 
@@ -310,14 +317,32 @@ func TestAHotCopyOfTheMainDatabaseFileAloneRestoresWithoutTheWALResidentDay(t *t
 	copyFileForBackupTest(t, livePath, copyPath)
 	assertNoWALSidecarsBesideTheCopy(t, copyPath)
 
-	// Nothing holds the WAL still across the residency check and the read of the
-	// main file, and a checkpoint landing in that window would fold 2026-04-02
-	// into the bytes just copied. Re-reading the WAL afterwards is what rules
-	// that out: nothing writes to this database between the two checks, so a WAL
-	// that still carries bytes was never folded away. Without it the absence
-	// below could fail on a race while telling the reader to go and relax a
-	// sentence in the runbook.
-	assertWALCarriesBytes(t, livePath)
+	// Nothing holds the database still across the residency check and the read
+	// of the main file, and a checkpoint landing in that window would fold
+	// 2026-04-02 into the bytes just copied — firing the absence assertion below
+	// on a race, with a message that sends the reader off to relax a sentence in
+	// the runbook.
+	//
+	// What this rules out, and no more: the copied bytes are byte-for-byte
+	// `ovumcy.db` as it stood at the last checkpoint, before 2026-04-02 was
+	// committed. A checkpoint anywhere in the window — before the copy, or torn
+	// across it — writes the write-ahead log's frames INTO the main file and
+	// changes those bytes, so equality is what says no checkpoint reached the
+	// copy.
+	//
+	// The write-ahead log's own size cannot say this, which is why re-reading it
+	// here would be worth nothing. SQLite's automatic checkpoint is PASSIVE: it
+	// copies frames into the main file and restarts the log at its beginning,
+	// REUSING the file at the size it already has. Only wal_checkpoint(TRUNCATE)
+	// — what this test calls deliberately, above — resets it to zero bytes. So a
+	// `-wal` that still carries bytes is exactly as consistent with a checkpoint
+	// having just run as without one.
+	if copied := hashFileForBackupTest(t, copyPath); copied != mainFileAtLastCheckpoint {
+		t.Fatalf(
+			"the copied ovumcy.db is not the file as it stood at the last checkpoint (sha256 %s, want %s): something wrote the main database file while the app was live — a checkpoint folding the write-ahead log into it, or a commit now reaching it directly — so what the restore below shows says nothing about copying a WAL-mode database's main file alone",
+			copied, mainFileAtLastCheckpoint,
+		)
+	}
 
 	restoredDays := restoredDayList(t, copyPath, user.ID)
 	if !slices.Contains(restoredDays, "2026-04-01") {
@@ -326,6 +351,19 @@ func TestAHotCopyOfTheMainDatabaseFileAloneRestoresWithoutTheWALResidentDay(t *t
 	if slices.Contains(restoredDays, "2026-04-02") {
 		t.Fatalf("the hot single-file copy restored %v, the WAL-resident day included, with the write-ahead log still carrying bytes on both sides of the copy: copying ovumcy.db alone on a running instance no longer loses the commits still in ovumcy.db-wal, so the last bullet of the Backup and Restore Contract in docs/self-hosted.md can be relaxed", restoredDays)
 	}
+}
+
+// hashFileForBackupTest is a file's exact content as a hex digest, so a case can
+// say "these are the same bytes" about a file the running application is free to
+// write to underneath it.
+func hashFileForBackupTest(t *testing.T, path string) string {
+	t.Helper()
+
+	content, err := os.ReadFile(path) // #nosec G304 -- a path this test built under t.TempDir()
+	if err != nil {
+		t.Fatalf("read %s to hash it: %v", filepath.Base(path), err)
+	}
+	return fmt.Sprintf("%x", sha256.Sum256(content))
 }
 
 // assertNoWALSidecarsBesideTheCopy is what keeps the test above about the copy

--- a/internal/db/sqlite_backup_restore_test.go
+++ b/internal/db/sqlite_backup_restore_test.go
@@ -310,12 +310,21 @@ func TestAHotCopyOfTheMainDatabaseFileAloneRestoresWithoutTheWALResidentDay(t *t
 	copyFileForBackupTest(t, livePath, copyPath)
 	assertNoWALSidecarsBesideTheCopy(t, copyPath)
 
+	// Nothing holds the WAL still across the residency check and the read of the
+	// main file, and a checkpoint landing in that window would fold 2026-04-02
+	// into the bytes just copied. Re-reading the WAL afterwards is what rules
+	// that out: nothing writes to this database between the two checks, so a WAL
+	// that still carries bytes was never folded away. Without it the absence
+	// below could fail on a race while telling the reader to go and relax a
+	// sentence in the runbook.
+	assertWALCarriesBytes(t, livePath)
+
 	restoredDays := restoredDayList(t, copyPath, user.ID)
 	if !slices.Contains(restoredDays, "2026-04-01") {
 		t.Fatalf("the hot single-file copy restored %v — a copy that lost everything says nothing about the WAL-resident commit this test is about", restoredDays)
 	}
 	if slices.Contains(restoredDays, "2026-04-02") {
-		t.Fatalf("the hot single-file copy restored %v, the WAL-resident day included: copying ovumcy.db alone on a running instance no longer loses the commits still in ovumcy.db-wal, so the last bullet of the Backup and Restore Contract in docs/self-hosted.md can be relaxed", restoredDays)
+		t.Fatalf("the hot single-file copy restored %v, the WAL-resident day included, with the write-ahead log still carrying bytes on both sides of the copy: copying ovumcy.db alone on a running instance no longer loses the commits still in ovumcy.db-wal, so the last bullet of the Backup and Restore Contract in docs/self-hosted.md can be relaxed", restoredDays)
 	}
 }
 

--- a/internal/db/sqlite_backup_restore_test.go
+++ b/internal/db/sqlite_backup_restore_test.go
@@ -263,6 +263,77 @@ func TestLiveWholeVolumeCaptureLosesACommitToACheckpointMidCapture(t *testing.T)
 	}
 }
 
+// TestAHotCopyOfTheMainDatabaseFileAloneRestoresWithoutTheWALResidentDay pins
+// the other hazard docs/self-hosted.md warns about, the one an operator reaches
+// for when the whole-volume archive feels like too much: copying `ovumcy.db` on
+// its own while the app is running.
+//
+// It is NOT the checkpoint race the test above takes apart, and it needs no
+// race at all. Under WAL every commit lands in `ovumcy.db-wal` and reaches
+// `ovumcy.db` only at a checkpoint, so the main file on its own is always a
+// consistent database as of the LAST checkpoint — never the database as of the
+// copy. Whatever was committed since is simply not in the bytes that were
+// copied. Nothing reports it: the copy is not corrupt, it opens cleanly, it
+// answers every query, and it is missing health records the owner entered.
+// That is the loss docs/self-hosted.md closes with — "the same applies, for the
+// same reason, if you copy individual files instead; stopping the app also
+// checkpoints the WAL into the main database file" — and this is the arm that
+// makes the sentence measurable.
+//
+// Like its neighbour, this characterizes SQLite and filesystem semantics rather
+// than a defect this repository can fix, so it is written to be read as a known
+// property. If the ABSENCE below ever fails, a single-file copy no longer loses
+// the WAL and that sentence in the runbook can be relaxed.
+func TestAHotCopyOfTheMainDatabaseFileAloneRestoresWithoutTheWALResidentDay(t *testing.T) {
+	sourceDir := t.TempDir()
+	livePath := filepath.Join(sourceDir, sqliteVolumeDatabaseFile)
+
+	liveDB, err := OpenDatabase(Config{Driver: DriverSQLite, SQLitePath: livePath})
+	if err != nil {
+		t.Fatalf("open live database: %v", err)
+	}
+	defer closeBackupTestDatabase(t, liveDB)
+
+	repos := NewRepositories(liveDB)
+	user := createBackupRaceOwner(t, repos)
+
+	// One day on each side of the last checkpoint: the first is inside
+	// `ovumcy.db` itself, the second is only in the WAL beside it.
+	createBackupRaceDay(t, repos, user.ID, "2026-04-01")
+	checkpointWALTruncate(t, liveDB)
+	createBackupRaceDay(t, repos, user.ID, "2026-04-02")
+	assertWALCarriesBytes(t, livePath)
+
+	// The copy an operator takes when they treat the database as one file: the
+	// main file only, no sidecars, app still running.
+	copyPath := filepath.Join(t.TempDir(), sqliteVolumeDatabaseFile)
+	copyFileForBackupTest(t, livePath, copyPath)
+	assertNoWALSidecarsBesideTheCopy(t, copyPath)
+
+	restoredDays := restoredDayList(t, copyPath, user.ID)
+	if !slices.Contains(restoredDays, "2026-04-01") {
+		t.Fatalf("the hot single-file copy restored %v — a copy that lost everything says nothing about the WAL-resident commit this test is about", restoredDays)
+	}
+	if slices.Contains(restoredDays, "2026-04-02") {
+		t.Fatalf("the hot single-file copy restored %v, the WAL-resident day included: copying ovumcy.db alone on a running instance no longer loses the commits still in ovumcy.db-wal, so the last bullet of the Backup and Restore Contract in docs/self-hosted.md can be relaxed", restoredDays)
+	}
+}
+
+// assertNoWALSidecarsBesideTheCopy is what keeps the test above about the copy
+// it names. The hazard is copying the main file ALONE; a sidecar carried along
+// beside it — by an edit here, or by a future helper — would restore the very
+// commit the absence assertion expects to be gone, and the test would then be
+// green about a procedure nobody performs.
+func assertNoWALSidecarsBesideTheCopy(t *testing.T, copyPath string) {
+	t.Helper()
+
+	for _, sidecar := range []string{copyPath + "-wal", copyPath + "-shm"} {
+		if _, err := os.Stat(sidecar); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("%s is beside the copy (stat error: %v): this test is about copying the main database file alone", filepath.Base(sidecar), err)
+		}
+	}
+}
+
 // captureWALSet copies the WAL set the way a sequential archiver reads it: the
 // main database file first, then the sidecars, with the database live and free
 // to move in between. betweenReads, when set, runs in exactly that window.


### PR DESCRIPTION
## What was wrong

Two persistence properties in `internal/db` held with nothing pinning them, and a third turned out to be pinned already.

**A migration that fails part-way had no test.** `applyMigration` (`internal/db/migrations.go:176`) runs a migration's statements and writes its `schema_migrations` row inside one transaction, so a statement the engine rejects must leave neither the schema change nor the ledger row. Every neighbouring failure case stops somewhere else: the inspection cases (`internal/db/migrations_inspection_failure_test.go:196`, `:219`, `:246`) fail an injected *catalog read*; the destructive-replay cases (`internal/db/migrations_destructive_replay_test.go:233`) are refused by the runner's own post-condition *after every statement ran*; `TestOpenSQLiteReleasesTheConnectionWhenMigrationsFail` (`internal/db/migrations_bootstrap_test.go:1124`) aborts on the ledger SELECT *before* `applyMigration` is reached. None is a statement rejected in the middle of the list, and **no case anywhere read `schema_migrations` back after a failure** — the half that decides what the next boot does: a row recorded for a migration that did not finish makes every later boot skip it for good, on a schema missing what the migration was for.

**The backup suite covered only the safe copy and the whole-WAL-set race.** `TestSQLiteBackupRestorePreservesHealthData` (`internal/db/sqlite_backup_restore_test.go:23`) closes the connection first; `TestLiveWholeVolumeCaptureLosesACommitToACheckpointMidCapture` (`:220`) copies `ovumcy.db` **and then its sidecars** (`captureWALSet`, `:349`) with a checkpoint injected between the reads. The hazard `docs/self-hosted.md:331` closes with — "the same applies, for the same reason, if you copy individual files instead" — is a different and unconditional one: under WAL the main file is the database as of the *last checkpoint*, so a copy of `ovumcy.db` alone opens cleanly, answers every query, and is missing every day still resident in `ovumcy.db-wal`. No race required, no error at any step.

## What changed

Tests only. No production file is touched by this branch.

- `internal/db/migrations_partial_failure_test.go` (new) — `TestAMigrationThatFailsPartWayRecordsNeitherItsSchemaChangeNorItsLedgerRow` (`:112`). A **four**-statement fixture (`:98`): create a table, overwrite `daily_logs.mood` on the seeded sentinel day, then the statement under test, then create a second table. The failing case runs `INSERT INTO partial_failure_no_such_table …` as the third of four and requires all of: the error names the migration, the missing table and the engine's cause; neither fixture table survives; the rewritten health row is back (`assertSentinelDayIntact`, `:148`); `schema_migrations` holds **0** rows for the fixture's version **and** exactly the embedded set otherwise (`:143`). The anchor runs the same fixture with a working middle statement and requires both tables, the ledger row, the embedded set **plus one**, and `mood` carrying the fixture's write — so every absence above is the rollback and not the fixture doing nothing.
- `internal/db/sqlite_backup_restore_test.go:287` — `TestAHotCopyOfTheMainDatabaseFileAloneRestoresWithoutTheWALResidentDay`. One day before a `wal_checkpoint(TRUNCATE)`, one after; WAL residency is asserted **on both sides of the copy** (`:305`, `:320`); the copy takes **only** `ovumcy.db` with the app still open, and `assertNoWALSidecarsBesideTheCopy` (`:336`) keeps it that way.
- `changelog.d/test-db-partial-migration-and-hot-copy-guards.md` — `none`, test-only.

## Design notes the next reader will want

- **The fixture's version is written once, in its file name.** `partialFailureFixtureMigration` (`:187`) reads version and order back out of it with the runner's own `migrationFilePattern`, and the case queries the ledger off that same value. A second spelling would let a rename leave the failing case counting rows for a version nobody wrote — a zero earned by asking the wrong question.
- **The ledger is checked twice.** Per-version, and as a total derived at runtime from `loadEmbeddedMigrations(DriverSQLite)` (`:239`). The per-version count alone is satisfied by a rollback that dropped the rows of the migrations that *are* applied — a state worse than the one under test, since the next boot re-applies the whole set against a schema that already has it.
- **Postgres is declined, with reasoning, in the file prologue.** The transaction is the runner's own dialect-neutral `database.Transaction`, and both supported engines have transactional DDL, so the SQLite arm measures the runner. Postgres additionally refuses every command issued after a failed one inside a transaction block (SQLSTATE `25P02`), so a green there could not distinguish the runner's rollback from the engine's own refusal — the weaker arm on exactly the axis under test, at a container per case on every run of this package. The prologue names what would change the call: a runner that stops wrapping a migration in one transaction, or an engine without transactional DDL.
- **The error assertion matches the missing table's name, not the runner's whole statement echo**, so truncating or re-quoting a long statement cannot redden it with no behaviour regressed.

## Red → green: every assertion was watched failing

All three subjects are latent properties — they hold today — so there is no natural red. **Every red below was INDUCED deliberately**, by the break named beside it, and reverted; `internal/db/migrations.go` was restored from a byte-identical snapshot (`md5 7a63d8d5a47ac87fdf9c37dc2da55763`) after each one and `git status` is clean of it.

**Induced red 1 — gutted `applyMigration`'s transaction** (`return database.Transaction(func(tx …))` → `return func(tx …)(database)`), the fix's body, not its call site:

```
--- FAIL: …/the_third_statement_of_four_is_rejected_by_the_engine (0.55s)
    migrations_partial_failure_test.go:137: table partial_failure_first present=true, want false:
      statement 1 ran before the failure and its table is still there: the migration was not rolled back
    migrations_partial_failure_test.go:148: daily_logs.mood = "0", want "4"
```

The second line is `assertSentinelDayIntact`: without the transaction, the health field the failed migration overwrote stays overwritten.

**Induced red 2 — swallowed the statement error** (`return fmt.Errorf("execute migration …")` → `_ = fmt.Errorf(…)`), run with the fixture file **renamed to `901_partial_failure.sql`** so the version derivation is exercised at the same time:

```
--- FAIL: …/the_third_statement_of_four_is_rejected_by_the_engine (0.34s)
    migrations_partial_failure_test.go:125: a migration whose statement the engine rejects must fail, got no error
    migrations_partial_failure_test.go:137: table partial_failure_first present=true, want false: … not rolled back
    migrations_partial_failure_test.go:139: table partial_failure_last present=true, want false:
      the last statement is after the failing one and its table is there: the runner ran past a statement …
    migrations_partial_failure_test.go:141: schema_migrations holds 1 row(s) for version 901, want 0:
      the migration is recorded as applied although it failed part-way …
    migrations_partial_failure_test.go:143: schema_migrations holds 38 row(s) in total, want 37: …
    migrations_partial_failure_test.go:148: daily_logs.mood = "0", want "4"
```

The ledger question followed the rename to **901** with no other edit: the version cannot drift from the fixture's name.

**Induced red 3 — the ledger total, fed the state it names**: the gutted transaction of red 1, with the fixture's first statement temporarily made `DELETE FROM schema_migrations WHERE version = '001'` — a failing migration that had already damaged the rest of the ledger. The per-version count stays silent at 0; only the total speaks:

```
    migrations_partial_failure_test.go:144: schema_migrations holds 36 row(s) in total, want 37:
      the rolled-back migration cost the ledger rows of migrations that ARE applied:
      the next boot re-applies the whole set against a schema that already has it
```

**The mutation this guard was originally specified against does NOT redden it, and that was measured.** Moving the `INSERT INTO schema_migrations` above the statement loop leaves the test **green** (`ok … 6.165s`): the ledger write shares the migration's transaction, so writing it first still rolls back. That is why the mutations above replace it.

**Induced red 4 — copied the sidecars beside the main file** (`copyFileForBackupTest` for `-wal` and `-shm`), with the fixture guard armed:

```
--- FAIL: TestAHotCopyOfTheMainDatabaseFileAloneRestoresWithoutTheWALResidentDay (1.12s)
    sqlite_backup_restore_test.go:314: ovumcy.db-wal is beside the copy (stat error: <nil>):
      this test is about copying the main database file alone
```

**Induced red 5 — the same input with that guard lifted**, so the absence assertion itself is fed the WAL-carrying copy it names:

```
    the hot single-file copy restored [2026-04-01 2026-04-02], the WAL-resident day included …
```

**Induced red 6 — dropped the `wal_checkpoint(TRUNCATE)`**, so nothing was ever in the main file, proving the anchor is not decorative:

```
    the hot single-file copy restored [] —
      a copy that lost everything says nothing about the WAL-resident commit this test is about
```

## One record refuted, and not implemented

A third record claimed nothing pins `_txlock=immediate` in the SQLite DSN, on the evidence that `grep -rn '_txlock' --include=*_test.go` matches only a comment, and asked for `sqliteDSN(path)` to be extracted so the string could be asserted. **The property is already pinned, behaviourally.** Removing `&_txlock=immediate` from `internal/db/sqlite.go:33` reddens the existing regression:

```
--- FAIL: TestSQLiteConcurrentDayWritesNoBusyError (2.95s)
    sqlite_concurrency_test.go:165: got 779 SQLITE_BUSY errors under concurrent day writes;
      busy_timeout/BEGIN IMMEDIATE not engaging
```

The grep measured the **spelling**; the test measures the **thing**, through the real `OpenDatabase`, and names the culprit in its failure. A string assertion on an extracted builder would be strictly weaker — it survives an unwired call site, which the concurrency test does not. So the seam is declined and no guard is added. `internal/db/sqlite.go` is byte-identical to `main`.

## Rollback

Revert the two commits, or the branch. Tests only — no persisted data, no schema, no public contract.

## Validation

`go build ./...`; `go test ./internal/db/ -count=1 -timeout 20m` (**ok, 312 s** after the review fixes, 351 s before them — Postgres-backed cases included, no contention either time); `go test ./internal/i18n/...` (ok); `golangci-lint run` repo-wide (**0 issues**); `go run ./scripts/changelogd check` (OK, after each commit). `./internal/api/...` was not run: this branch adds no production code and does not cross the persistence layer.
