### PR TITLE
fix(e2e): anchor the auto-fill spec mid-month so its window never crosses a month boundary

### DIFF
--- a/changelog.d/fix-e2e-autofill-month-boundary.md
+++ b/changelog.d/fix-e2e-autofill-month-boundary.md
@@ -10,6 +10,7 @@
   `lastPeriodStart = today−3` and well clear of the predicted next period. The same class lived in
   the baseline-period test in `bugs.spec.ts`, whose `preFertileDay = today+1` crosses into the
   next month at month end and is unrendered whenever the old month's last day closes the grid's
-  final week (next trigger: 2026-02-28, a Saturday) — that assertion now runs in `preFertileDay`'s
-  own month view, where the cell always exists and the per-day state is unchanged. Test-only
+  final week (2026-02-28 was such a Saturday; the next is 2026-10-31) — that assertion now runs in
+  `preFertileDay`'s own month view, where the cell always exists and the per-day state is
+  unchanged. Test-only
   change.

--- a/changelog.d/fix-e2e-autofill-month-boundary.md
+++ b/changelog.d/fix-e2e-autofill-month-boundary.md
@@ -1,10 +1,15 @@
 ### Internal
 
-- **The calendar auto-fill e2e spec no longer fails at the end of every month.** Both tests
+- **Two e2e specs no longer fail in the month-end window.** Both calendar auto-fill tests
   anchored on `today−30` and asserted the four following days in the anchor month's calendar view;
-  from the 28th of a month onward those neighbors spill into the next month, whose day cells the
-  anchor month's grid does not always render (2026-08-28: anchor Jul 29, neighbor Aug 2 — July's
-  Sunday-start grid ends Aug 1, so the neighbor's button does not exist and all retries fail
-  identically). The anchor is now the 5th of the month holding `today−30`, which keeps the whole
-  auto-fill window mid-month — still at least ~3 weeks from `lastPeriodStart = today−3` and from
-  the predicted next period — so the spec is date-independent. Test-only change.
+  near month end (the 28th onward in a 31-day month, as early as the 25th in February) those
+  neighbors spill into the next month, whose day cells the anchor month's grid does not always
+  render (2026-08-28: anchor Jul 29, neighbor Aug 2 — July's Sunday-start grid ends Aug 1, so all
+  retries failed identically). The anchor is now the 5th of the month holding `today−30`, which
+  keeps the whole auto-fill window mid-month; the window's last day stays at least ~19 days from
+  `lastPeriodStart = today−3` and well clear of the predicted next period. The same class lived in
+  the baseline-period test in `bugs.spec.ts`, whose `preFertileDay = today+1` crosses into the
+  next month at month end and is unrendered whenever the old month's last day closes the grid's
+  final week (next trigger: 2026-02-28, a Saturday) — that assertion now runs in `preFertileDay`'s
+  own month view, where the cell always exists and the per-day state is unchanged. Test-only
+  change.

--- a/changelog.d/fix-e2e-autofill-month-boundary.md
+++ b/changelog.d/fix-e2e-autofill-month-boundary.md
@@ -1,0 +1,10 @@
+### Internal
+
+- **The calendar auto-fill e2e spec no longer fails at the end of every month.** Both tests
+  anchored on `today−30` and asserted the four following days in the anchor month's calendar view;
+  from the 28th of a month onward those neighbors spill into the next month, whose day cells the
+  anchor month's grid does not always render (2026-08-28: anchor Jul 29, neighbor Aug 2 — July's
+  Sunday-start grid ends Aug 1, so the neighbor's button does not exist and all retries fail
+  identically). The anchor is now the 5th of the month holding `today−30`, which keeps the whole
+  auto-fill window mid-month — still at least ~3 weeks from `lastPeriodStart = today−3` and from
+  the predicted next period — so the spec is date-independent. Test-only change.

--- a/e2e/bugs.spec.ts
+++ b/e2e/bugs.spec.ts
@@ -345,7 +345,8 @@ test.describe('Bug regressions', () => {
       // end — and a month whose last day closes the grid's final week renders
       // no trailing cells at all (2026-02-28 is such a Saturday) — so the
       // assertion runs in preFertileDay's OWN month view, which always
-      // renders it; the day's state is per-day, not per-view.
+      // renders it; with no logged days, the cell's state is the same in
+      // either view.
       await page.goto(`/calendar?month=${preFertileDay.slice(0, 7)}`);
       await expect(page.locator(`button[data-day="${preFertileDay}"]`)).toHaveAttribute('data-calendar-state', 'default');
     });

--- a/e2e/bugs.spec.ts
+++ b/e2e/bugs.spec.ts
@@ -340,6 +340,13 @@ test.describe('Bug regressions', () => {
       // configuration default behind it is suppressed rather than qualified. The
       // predicted period days asserted above stay — their anchor is the last
       // period start the owner entered, and only the length falls back.
+      //
+      // preFertileDay is today+1, which crosses into the next month at month
+      // end — and a month whose last day closes the grid's final week renders
+      // no trailing cells at all (2026-02-28 is such a Saturday) — so the
+      // assertion runs in preFertileDay's OWN month view, which always
+      // renders it; the day's state is per-day, not per-view.
+      await page.goto(`/calendar?month=${preFertileDay.slice(0, 7)}`);
       await expect(page.locator(`button[data-day="${preFertileDay}"]`)).toHaveAttribute('data-calendar-state', 'default');
     });
 

--- a/e2e/calendar-autofill-clear.spec.ts
+++ b/e2e/calendar-autofill-clear.spec.ts
@@ -44,14 +44,26 @@ async function todayISOFromCalendar(page: Page): Promise<string> {
   return todayISO!;
 }
 
+// Anchor on the 5th of the month that holds today-30: far from both
+// lastPeriodStart=today-3 (set by completeOnboardingIfPresent) and the
+// predicted next period, so the new period block has no interference — and,
+// because the whole auto-fill window (anchor..anchor+4) then sits mid-month,
+// never split across a month boundary. The previous bare today-30 anchor was
+// a date bomb: from the 28th of a month onward its +1..+4 neighbors spill
+// into the next month, whose day cells the anchor month's grid does not
+// always render (2026-08-28: anchor Jul 29, neighbor Aug 2 — July's
+// Sunday-start grid ends Aug 1, so the neighbor's button does not exist and
+// every retry fails the same way).
+function autofillAnchorISO(todayISO: string): string {
+  return `${shiftISODate(todayISO, -30).slice(0, 7)}-05`;
+}
+
 test.describe('calendar auto-fill clear-on-toggle-off', () => {
   test('clears bare auto-filled neighbors when the anchor period day is toggled off', async ({ page }) => {
     await registerOwnerOnCalendar(page, 'calendar-autofill-clear');
 
     const todayISO = await todayISOFromCalendar(page);
-    // Pick a date far from both lastPeriodStart=today-3 (set by completeOnboardingIfPresent)
-    // and the predicted next period so the new period block has no interference.
-    const anchorISO = shiftISODate(todayISO, -30);
+    const anchorISO = autofillAnchorISO(todayISO);
     const neighborISOs = [1, 2, 3, 4].map((offset) => shiftISODate(anchorISO, offset));
 
     const onForm = await openCalendarDayEditor(page, anchorISO);
@@ -83,7 +95,7 @@ test.describe('calendar auto-fill clear-on-toggle-off', () => {
     await registerOwnerOnCalendar(page, 'calendar-autofill-preserve');
 
     const todayISO = await todayISOFromCalendar(page);
-    const anchorISO = shiftISODate(todayISO, -30);
+    const anchorISO = autofillAnchorISO(todayISO);
     const manualISO = shiftISODate(anchorISO, 2);
     const earlyNeighborISO = shiftISODate(anchorISO, 1);
     const lateNeighborISOs = [3, 4].map((offset) => shiftISODate(anchorISO, offset));

--- a/e2e/calendar-autofill-clear.spec.ts
+++ b/e2e/calendar-autofill-clear.spec.ts
@@ -49,11 +49,12 @@ async function todayISOFromCalendar(page: Page): Promise<string> {
 // predicted next period, so the new period block has no interference — and,
 // because the whole auto-fill window (anchor..anchor+4) then sits mid-month,
 // never split across a month boundary. The previous bare today-30 anchor was
-// a date bomb: from the 28th of a month onward its +1..+4 neighbors spill
-// into the next month, whose day cells the anchor month's grid does not
-// always render (2026-08-28: anchor Jul 29, neighbor Aug 2 — July's
-// Sunday-start grid ends Aug 1, so the neighbor's button does not exist and
-// every retry fails the same way).
+// a date bomb: near month end (the 28th onward in a 31-day month, as early
+// as the 25th in February) its +1..+4 neighbors spill into the next month,
+// whose day cells the anchor month's grid does not always render
+// (2026-08-28: anchor Jul 29, neighbor Aug 2 — July's Sunday-start grid
+// ends Aug 1, so the neighbor's button does not exist and every retry fails
+// the same way).
 function autofillAnchorISO(todayISO: string): string {
   return `${shiftISODate(todayISO, -30).slice(0, 7)}-05`;
 }


### PR DESCRIPTION
Every PR run from the 28th of a month failed shard 1 on `calendar-autofill-clear.spec.ts`: the spec anchored on `today−30` and asserted `button[data-day]` cells for anchor+1..+4 in the anchor month's calendar view. From the 28th those neighbors cross into the next month; the month grid (Sunday week start) does not always render them (2026-08-28: anchor Jul 29, neighbor Aug 2, July grid ends Aug 1 → `element(s) not found`, all retries). Main is green only because it last ran on the 25th.

Fix: anchor on the **5th of the month holding today−30** (`autofillAnchorISO`), keeping the whole auto-fill window mid-month and still ≥ ~3 weeks away from `lastPeriodStart = today−3` and the predicted next period, per the original comment's interference constraints.

Evidence: run 33173265095 shard 1, locator `button[data-day="2026-08-02"]` not found ×3 retries ×2 tests; after the fix both tests pass locally today (the trigger date): `2 passed (19.6s)`.

Test-only change; unblocks CI for every open PR through the month-end window. Rollback: revert the commit.