### PR TITLE
docs(security): accuracy pass over auth-policy and data-handling

### DIFF
--- a/changelog.d/docs-auth-policy-and-data-handling.md
+++ b/changelog.d/docs-auth-policy-and-data-handling.md
@@ -1,0 +1,17 @@
+### Internal
+
+- **The auth-policy and data-handling concern docs stop misdescribing the code.** Accuracy pass
+  from the 2026-08-28 documentation audit. `auth-policy-and-rate-limits.md`: the recovery-code
+  offline-guessing bound no longer names `SECRET_KEY` — the hash is plain bcrypt and verification
+  compares it directly, so a database leak on its own already permits offline candidate testing
+  (regenerate outstanding codes after any database compromise); the settings re-auth budget's
+  enumeration gains the two password-gated actions it omitted (`PUT …/2fa` enrollment
+  confirmation, `POST …/recovery-code` regeneration); the single-document-era pointers ("see
+  *Cookies* above", *Session Invalidation*, *Field-Level Encryption*) become links to the sibling
+  concern docs they moved to. `data-handling.md`: the canonical egress statement now covers the
+  pull-based `.ics` feed alongside the push integrations; the `users`-table inventory gains the
+  migration-036 reveal consumption marks (`recovery_code_revealed_at`,
+  `calendar_feed_revealed_at`) and the clear-data contract records two facts the code already
+  held — the wipe blanks the stored `timezone`, and the reveal marks deliberately survive it;
+  the *Logging Policy* and *Field-Level Encryption* pointers become file links. No behaviour
+  changes.

--- a/docs/security/auth-policy-and-rate-limits.md
+++ b/docs/security/auth-policy-and-rate-limits.md
@@ -20,7 +20,7 @@ _Part of the [Ovumcy security policy](../../SECURITY.md)._
 **Session tokens:**
 
 - `ovumcy_auth` payload is sealed (AES-256-GCM under an HKDF-derived key, see *Cookies* in [docs/security/cryptography.md](cryptography.md#cookies)) and verified per request against `users.auth_session_version`.
-- Issued by `setAuthCookie`; reissued inline on the originating device whenever `auth_session_version` is bumped (see *Session Invalidation on Credential Rotation* in [docs/security/oidc-and-sessions.md](oidc-and-sessions.md)).
+- Issued by `setAuthCookie`; reissued inline on the originating device whenever `auth_session_version` is bumped (see *Session Invalidation on Credential Rotation* in [docs/security/oidc-and-sessions.md](oidc-and-sessions.md#session-invalidation-on-credential-rotation)).
 
 **TOTP 2FA:**
 
@@ -60,6 +60,6 @@ Plus per-account, identity-keyed budgets enforced by `AuthAttemptPolicy` (`inter
 - Logout attempts: 20 failures / 15 minutes (account-scoped).
 - TOTP login challenge: 5 failures / 15 minutes.
 - TOTP disable: 5 failures / 15 minutes.
-- Settings re-authentication: 5 failures / 15 minutes, covering every password-gated settings action — `POST /api/v1/users/current/data-wipe/validate`, `POST …/data-wipe`, `DELETE /api/v1/users/current`, `PUT …/password`, `PUT …/2fa` (the TOTP-enrollment confirmation), and `POST …/recovery-code` (recovery-code regeneration). Without it these would be faster password oracles than the login form (the `/api` catch-all allows 300 requests per minute against login's 8 per 15 minutes), and `/data-wipe/validate` changes no state, which makes it a pure oracle. Once the budget is spent the endpoints answer `429` even for the correct password. The budget is keyed on `(client, account)` and on the account alone, deliberately **not** on the client address by itself: several independent owners share one address on a household instance, and one owner mistyping must not lock out the others, while the account-wide bucket still caps an attacker rotating addresses.
+- Settings re-authentication: 5 failures / 15 minutes, covering every password-gated settings action except the TOTP disable, whose password check draws its own budget above — `POST /api/v1/users/current/data-wipe/validate`, `POST …/data-wipe`, `DELETE /api/v1/users/current`, `PUT …/password`, `PUT …/2fa` (the TOTP-enrollment confirmation), and `POST …/recovery-code` (recovery-code regeneration). Without it these would be faster password oracles than the login form (the `/api` catch-all allows 300 requests per minute against login's 8 per 15 minutes), and `/data-wipe/validate` changes no state, which makes it a pure oracle. Once the budget is spent the endpoints answer `429` even for the correct password. The budget is keyed on `(client, account)` and on the account alone, deliberately **not** on the client address by itself: several independent owners share one address on a household instance, and one owner mistyping must not lock out the others, while the account-wide bucket still caps an attacker rotating addresses.
 
 Per-account budgets are keyed by `HMAC-SHA256(SECRET_KEY, "ovumcy.auth-attempt.identity.v1:" || identity)`, so the limiter never persists the raw identifier.

--- a/docs/security/auth-policy-and-rate-limits.md
+++ b/docs/security/auth-policy-and-rate-limits.md
@@ -15,17 +15,17 @@ _Part of the [Ovumcy security policy](../../SECURITY.md)._
 
 - Shape: `OVUM-XXXX-XXXX-XXXX`, 12 characters drawn uniformly via `crypto/rand` from a 32-symbol Crockford-style base32 alphabet (`A`–`Z` without `I`/`O`, digits `2`–`9`) — 60 bits of effective entropy (`GenerateRecoveryCode`, `internal/services/auth_reset_policy.go`).
 - Storage: bcrypt-hashed in `users.recovery_code_hash`. The plaintext is shown to the user exactly once at issuance and is never retrievable server-side afterwards.
-- Online guessing is bounded by the per-account rate limiter (`Rate Limits`, below); the bcrypt cost bounds offline guessing if the database and `SECRET_KEY` leak together.
+- Online guessing is bounded by the per-account rate limiter (`Rate Limits`, below); the code's 60 bits of entropy and the bcrypt cost bound offline guessing if the database leaks. Recovery-code hashing involves no `SECRET_KEY` — `GenerateRecoveryCodeHash` is plain bcrypt and verification is a direct compare against `users.recovery_code_hash` — so a database leak **on its own** already permits offline candidate testing; treat any database compromise as a reason to regenerate outstanding recovery codes.
 
 **Session tokens:**
 
-- `ovumcy_auth` payload is sealed (AES-256-GCM under an HKDF-derived key, see *Cookies* above) and verified per request against `users.auth_session_version`.
-- Issued by `setAuthCookie`; reissued inline on the originating device whenever `auth_session_version` is bumped (see *Session Invalidation on Credential Rotation*).
+- `ovumcy_auth` payload is sealed (AES-256-GCM under an HKDF-derived key, see *Cookies* in [docs/security/cryptography.md](cryptography.md#cookies)) and verified per request against `users.auth_session_version`.
+- Issued by `setAuthCookie`; reissued inline on the originating device whenever `auth_session_version` is bumped (see *Session Invalidation on Credential Rotation* in [docs/security/oidc-and-sessions.md](oidc-and-sessions.md)).
 
 **TOTP 2FA:**
 
 - RFC 6238 with a 30-second step.
-- Secrets are AES-256-GCM encrypted at rest with per-row AAD binding (see *Field-Level Encryption*).
+- Secrets are AES-256-GCM encrypted at rest with per-row AAD binding (see *Field-Level Encryption* in [docs/security/cryptography.md](cryptography.md#field-level-encryption)).
 - Replay protection: `users.totp_last_used_step` carries the RFC 6238 step index of the last successfully consumed code. `ClaimTOTPStep` performs an atomic `UPDATE … WHERE totp_last_used_step < ?`, so the same code cannot be consumed twice and concurrent submissions of the same step collapse to a single winner.
 
 ## Rate Limits
@@ -60,6 +60,6 @@ Plus per-account, identity-keyed budgets enforced by `AuthAttemptPolicy` (`inter
 - Logout attempts: 20 failures / 15 minutes (account-scoped).
 - TOTP login challenge: 5 failures / 15 minutes.
 - TOTP disable: 5 failures / 15 minutes.
-- Settings re-authentication: 5 failures / 15 minutes, covering every password-gated settings action — `POST /api/v1/users/current/data-wipe/validate`, `POST …/data-wipe`, `DELETE /api/v1/users/current`, and `PUT …/password`. Without it these would be faster password oracles than the login form (the `/api` catch-all allows 300 requests per minute against login's 8 per 15 minutes), and `/data-wipe/validate` changes no state, which makes it a pure oracle. Once the budget is spent the endpoints answer `429` even for the correct password. The budget is keyed on `(client, account)` and on the account alone, deliberately **not** on the client address by itself: several independent owners share one address on a household instance, and one owner mistyping must not lock out the others, while the account-wide bucket still caps an attacker rotating addresses.
+- Settings re-authentication: 5 failures / 15 minutes, covering every password-gated settings action — `POST /api/v1/users/current/data-wipe/validate`, `POST …/data-wipe`, `DELETE /api/v1/users/current`, `PUT …/password`, `PUT …/2fa` (the TOTP-enrollment confirmation), and `POST …/recovery-code` (recovery-code regeneration). Without it these would be faster password oracles than the login form (the `/api` catch-all allows 300 requests per minute against login's 8 per 15 minutes), and `/data-wipe/validate` changes no state, which makes it a pure oracle. Once the budget is spent the endpoints answer `429` even for the correct password. The budget is keyed on `(client, account)` and on the account alone, deliberately **not** on the client address by itself: several independent owners share one address on a household instance, and one owner mistyping must not lock out the others, while the account-wide bucket still caps an attacker rotating addresses.
 
 Per-account budgets are keyed by `HMAC-SHA256(SECRET_KEY, "ovumcy.auth-attempt.identity.v1:" || identity)`, so the limiter never persists the raw identifier.

--- a/docs/security/data-handling.md
+++ b/docs/security/data-handling.md
@@ -4,7 +4,7 @@ _Part of the [Ovumcy security policy](../../SECURITY.md)._
 
 ## Data Inventory
 
-What Ovumcy persists per account and per record. All storage is in the operator's configured SQLite file or Postgres database; nothing is sent to any external service unless the owner explicitly enables an integration (OIDC sign-in, or webhook reminders — see [docs/notifications.md](../notifications.md)). This sentence is the canonical egress statement; README and the GDPR guide defer to it.
+What Ovumcy persists per account and per record. All storage is in the operator's configured SQLite file or Postgres database; nothing is sent to any external service unless the owner explicitly enables an integration (OIDC sign-in, or webhook reminders — see [docs/notifications.md](../notifications.md)), and the one **pull-based** egress path — the `.ics` calendar feed, which a calendar client of the owner's choosing polls — is likewise armed only when the owner generates its subscribe URL. This paragraph is the canonical egress statement; README and the GDPR guide defer to it.
 
 **`users`** — one row per account:
 
@@ -14,7 +14,8 @@ What Ovumcy persists per account and per record. All storage is in the operator'
 - Cycle preferences: `cycle_length`, `period_length`, `luteal_phase`, `auto_period_fill`, `irregular_cycle`, `unpredictable_cycle`, `age_group`, `usage_goal`, `last_period_start`, `long_period_warning_cycle_start`.
 - Tracking preferences: `track_bbt`, `temperature_unit`, `track_cervical_mucus`, `hide_sex_chip`, `hide_cycle_factors`, `hide_notes_field`, `show_historical_phases`, `shown_period_tip`, `week_starts_on`.
 - Interface: `timezone` — the last known IANA zone name observed on a request, used to resolve "today" for date-only writes. Not a secret. `interface_language` — the UI language the owner chose explicitly, in `Settings` or through the public switcher while signed in (migration 034), re-issued as the `ovumcy_lang` cookie on every sign-in so a fresh browser keeps it. Empty means never chosen, in which case the language is negotiated per request as before. Not a secret.
-- 2FA: `totp_enabled`, `totp_secret` (AES-256-GCM aad-bound under an HKDF-derived key, see *Field-Level Encryption*), `totp_last_used_step` (RFC 6238 replay floor).
+- 2FA: `totp_enabled`, `totp_secret` (AES-256-GCM aad-bound under an HKDF-derived key, see *Field-Level Encryption* in [docs/security/cryptography.md](cryptography.md#field-level-encryption)), `totp_last_used_step` (RFC 6238 replay floor).
+- One-time reveal consumption marks: `recovery_code_revealed_at` and `calendar_feed_revealed_at` (migration 036) — timestamps recording that the outstanding secret was shown its one time, claimed with a compare-and-set before anything renders; every write that mints a fresh secret NULLs the matching mark in the same statement. They are metadata about a secret's disclosure, not secrets themselves, and they deliberately survive `clear-data` (see *Retention and Deletion* below).
 - Webhook reminders (only meaningful once the owner enables them): `webhook_enabled`, `webhook_url` (**AES-256-GCM aad-bound under an HKDF-derived key, the same field-encryption path as `totp_secret`** — it is an owner-chosen egress destination, not a display value), `webhook_notify_period`, `webhook_notify_ovulation`, `reminder_lead_days`, and the per-kind send watermarks `webhook_period_last_sent_cycle_start` / `webhook_ovulation_last_sent_cycle_start` that stop a reminder firing twice for one cycle.
 - Calendar (`.ics`) feed subscription (only populated once the owner generates a feed): `calendar_feed_selector` — the non-secret lookup half of the capability token — plus `calendar_feed_verifier_mac` (keyed HMAC-SHA256 under a `SECRET_KEY`-derived label, the value the endpoint actually compares) and the legacy `calendar_feed_verifier_hash` (bcrypt, still written for rollback and still accepted for rows created before migration 032). This is the one sanctioned bearer-token surface; see *Calendar feed subscription* in `SECURITY.md`.
 
@@ -35,7 +36,7 @@ What Ovumcy persists per account and per record. All storage is in the operator'
 
 **`app_state`** — process-level key/value operational bookkeeping (migration 028), not scoped to any `user_id` and holding no personal or health data. Its keys record things like the built-in reminder scheduler's last-completed-run date (restart safety and current-day catch-up); the table is a general-purpose store, so further operational keys land here as they appear.
 
-**Not stored**: analytics, telemetry, third-party identifiers, advertising attribution, error reports, or per-action audit history. Per-action security-event logging is **off by default** and can be toggled per deployment via `AUDIT_LOG_ENABLED` — see *Logging Policy* below.
+**Not stored**: analytics, telemetry, third-party identifiers, advertising attribution, error reports, or per-action audit history. Per-action security-event logging is **off by default** and can be toggled per deployment via `AUDIT_LOG_ENABLED` — see [Logging Policy](logging.md).
 
 ## Retention and Deletion
 
@@ -43,12 +44,12 @@ What Ovumcy persists per account and per record. All storage is in the operator'
 
 - Deletes every `daily_logs` row for the user.
 - Deletes every user-defined row in `symptom_types` (built-in symptoms remain).
-- Resets cycle and tracking preferences to documented defaults.
+- Resets cycle and tracking preferences to documented defaults, and blanks the stored `timezone` — the last observed IANA zone is part of the health-adjacent residue the wipe clears.
 - **Disarms webhook reminders**: clears `webhook_enabled`, blanks the encrypted `webhook_url`, resets `reminder_lead_days` and the per-kind opt-ins to their defaults, and clears both send watermarks so no reminder fires against the freshly emptied account.
 - **Revokes the calendar feed**: NULLs `calendar_feed_selector` and both verifier columns, so a subscribe URL issued earlier stops resolving and answers `404`. Calendar clients holding it need a fresh URL from Settings.
 - Atomically bumps `auth_session_version`, invalidating every other auth cookie for the account. The originating device is re-issued a fresh cookie inline so the user stays signed in there.
 
-`clear-data` does **not** touch email, password hash, recovery code hash, role, display name, OIDC identity links, TOTP state, onboarding status, or the interface language (`interface_language`) — the language the owner reads the product in is not part of the health record, and resetting it would answer a wipe by switching the interface back to the operator default. Account deletion removes the row, and with it the column.
+`clear-data` does **not** touch email, password hash, recovery code hash, role, display name, OIDC identity links, TOTP state, onboarding status, or the interface language (`interface_language`) — the language the owner reads the product in is not part of the health record, and resetting it would answer a wipe by switching the interface back to the operator default. The two reveal consumption marks also stand: they record that a secret was disclosed, and the wipe revokes the feed and leaves the recovery code alone rather than minting fresh secrets, so there is no new outstanding reveal for them to track. Account deletion removes the row, and with it every column named here.
 
 **`DELETE /api/v1/users/current`** removes the account entirely:
 

--- a/docs/security/data-handling.md
+++ b/docs/security/data-handling.md
@@ -4,7 +4,7 @@ _Part of the [Ovumcy security policy](../../SECURITY.md)._
 
 ## Data Inventory
 
-What Ovumcy persists per account and per record. All storage is in the operator's configured SQLite file or Postgres database; nothing is sent to any external service unless the owner explicitly enables an integration (OIDC sign-in, or webhook reminders — see [docs/notifications.md](../notifications.md)), and the one **pull-based** egress path — the `.ics` calendar feed, which a calendar client of the owner's choosing polls — is likewise armed only when the owner generates its subscribe URL. This paragraph is the canonical egress statement; README and the GDPR guide defer to it.
+What Ovumcy persists per account and per record. All storage is in the operator's configured SQLite file or Postgres database; nothing is sent to any external service unless the owner explicitly enables an integration (OIDC sign-in, or webhook reminders — see [docs/notifications.md](../notifications.md)), and the one **pull-based** egress path — the `.ics` calendar feed, which a calendar client of the owner's choosing polls — is likewise armed only when the owner generates its subscribe URL. Of the three, the webhook and the feed are the two standing paths that carry **health-derived** data to a third party (`SECURITY.md`'s "exactly two"); the OIDC exchange carries identity, never the health record. This paragraph is the canonical egress statement; README defers to it explicitly, and the GDPR guide's data-inventory section points here.
 
 **`users`** — one row per account:
 
@@ -49,7 +49,7 @@ What Ovumcy persists per account and per record. All storage is in the operator'
 - **Revokes the calendar feed**: NULLs `calendar_feed_selector` and both verifier columns, so a subscribe URL issued earlier stops resolving and answers `404`. Calendar clients holding it need a fresh URL from Settings.
 - Atomically bumps `auth_session_version`, invalidating every other auth cookie for the account. The originating device is re-issued a fresh cookie inline so the user stays signed in there.
 
-`clear-data` does **not** touch email, password hash, recovery code hash, role, display name, OIDC identity links, TOTP state, onboarding status, or the interface language (`interface_language`) — the language the owner reads the product in is not part of the health record, and resetting it would answer a wipe by switching the interface back to the operator default. The two reveal consumption marks also stand: they record that a secret was disclosed, and the wipe revokes the feed and leaves the recovery code alone rather than minting fresh secrets, so there is no new outstanding reveal for them to track. Account deletion removes the row, and with it every column named here.
+`clear-data` does **not** touch email, password hash, recovery code hash, role, display name, OIDC identity links, TOTP state, onboarding status, or the interface language (`interface_language`) — the language the owner reads the product in is not part of the health record, and resetting it would answer a wipe by switching the interface back to the operator default. The two reveal consumption marks also stand, and for a sharper reason than bookkeeping: NULL is the **armed** value, so resetting them here would answer a wipe by re-arming a reveal for a sealed cookie the client may still hold — only the write that mints a fresh secret clears a mark. Account deletion removes the row, and with it every column named here.
 
 **`DELETE /api/v1/users/current`** removes the account entirely:
 


### PR DESCRIPTION
Closes audit findings A11 (adjudicated P1), F078, F079, F080, F081 from the 2026-08-28 documentation audit, package C1. Docs only; no behaviour changes.

**auth-policy-and-rate-limits.md.** Line 18 claimed the bcrypt cost bounds offline guessing "if the database and `SECRET_KEY` leak together" — recovery-code hashing involves no `SECRET_KEY` at any point (`GenerateRecoveryCodeHash` is plain `bcrypt.GenerateFromPassword`, verification is a direct compare against `users.recovery_code_hash`), so a DB-only leak already permits offline candidate testing; the doc now says so and advises regenerating outstanding codes after a DB compromise (A11). The settings re-auth budget enumeration omitted two password-gated actions that draw the same budget: `PUT …/2fa` (enrollment confirmation, `handlers_settings_2fa.go:78`) and `POST …/recovery-code` (`handlers_settings_recovery.go:22`) (F080). The "see *Cookies* above" / *Session Invalidation* / *Field-Level Encryption* pointers referred to sections that moved to sibling files at the SECURITY.md split — now file links (F081).

**data-handling.md.** The canonical egress statement's push-only phrasing ("sent to") made the pull-based `.ics` feed invisible while SECURITY.md counts it as one of exactly two standing egress paths — now covered (F079). The users-table inventory omitted the migration-036 reveal consumption marks; the clear-data contract omitted that the wipe blanks `users.timezone` (privacy-positive) and that the reveal marks deliberately survive (F078, verified against `ClearAllDataAndResetSettings`). Pointer fixes as above.

**Deliberately untouched:** the per-account logout row (`20 failures / 15 minutes`, line 60) — the owner-ruled wiring PR in package C3 makes it true as written (audit F069, ruling 3).

Doc guards green locally. **Rollback:** revert the single commit.