### PR TITLE
docs: correct the root docs' CI model, local checks and mutation cadence

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,8 @@ npm ci
 go test ./cmd/... ./internal/... ./migrations/... ./scripts/... ./web/... -timeout 20m
 go run ./scripts/archcheck
 npm run lint:js
+npm run lint:types
+npm run test:unit
 npm run build
 ```
 
@@ -82,7 +84,7 @@ Security issues should not be reported publicly. Use [SECURITY.md](SECURITY.md).
 
 - Keep changes scoped and atomic.
 - Add/adjust tests for behavioral changes.
-- `internal/i18n/locales/en.json` is the canonical source for UI strings. When you add or rename strings, mirror the change in `ru.json`, `es.json`, `fr.json`, `de.json`, and `it.json` (the six locales advertised as supported in the README). If you cannot provide a native translation for a non-`en` locale, copy the English string verbatim and leave a `TODO(<locale>)` next to it so the gap is visible in review and search.
+- `internal/i18n/locales/en.json` is the canonical source for UI strings. When you add or rename strings, mirror the change in `ru.json`, `es.json`, `fr.json`, `de.json`, and `it.json` (the six locales advertised as supported in the README). If you cannot provide a native translation for a non-`en` locale, copy the English string verbatim and list the copied keys and their locales in the pull request description. The gap cannot be marked in the file itself: the locale files are strict JSON parsed at boot, so a comment breaks startup, an extra key fails `TestLocaleKeysParity`, and a marker inside the value is no longer the verbatim English string.
 - Do not introduce legacy compatibility paths unless explicitly required.
 - When cutting a release, bump every release-tag mention in README.md (intro blurb, Docker quick
   start image tag, cosign/attestation/SBOM verification examples, Releases section) to the new tag.
@@ -149,9 +151,10 @@ header plus the entry:
   fragment nor a new `## [` heading in `CHANGELOG.md`, and it names the file and the problem when a
   fragment has an unknown section header or no entry text.
 - Dependency updates opened by Dependabot are exempt: the check stays required for them but returns
-  success without a fragment, since the bot cannot write one. Their entries reach the changelog at
-  release time instead — the `### Dependencies` section is assembled from the dependency bumps that
-  merged, not from fragments.
+  success without a fragment, since the bot cannot write one. Nothing collects their entries
+  automatically either: at release time the `### Dependencies` section is compiled from
+  `git log <last-tag>..HEAD` over the Dependabot merges and entered as one fragment before
+  `assemble` runs — a step of the release checklist, not of the gate.
 
 ## Commit Style
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ No — you run it yourself, on your own server, with no vendor account in the mi
 
 ### Where is the data stored?
 
-On the server you deploy Ovumcy to. SQLite is the default and works out of the box; PostgreSQL is there when you want it for a more involved setup. Nothing leaves that server unless you switch it on yourself: the optional webhook reminders POST the predicted dates to a URL you choose, and a calendar app you point at the `.ics` feed fetches those dates onto whatever servers it runs on.
+On the server you deploy Ovumcy to. SQLite is the default and works out of the box; PostgreSQL is there when you want it for a more involved setup. Nothing leaves that server unless you switch it on yourself: the optional webhook reminders POST the predicted dates to a URL you choose, and a calendar app you subscribe to the `.ics` feed fetches those dates wherever it runs — onto Google's or Apple's servers if that is where your calendar lives.
 
 ### Does Ovumcy use analytics or ad trackers?
 
@@ -485,7 +485,7 @@ Project structure:
 - `web/` - templates, JavaScript, and CSS assets
 
 CI runs staticcheck, `go vet`, tests, and the frontend build on pull requests and on the merge queue's validation of the commit that lands.
-The post-merge run on `main` deliberately skips that work — the queue already proved this exact commit — and executes only the lanes the queue does not: cross-browser e2e, image smoke, and the Postgres smoke test.
+The post-merge run on `main` deliberately skips that work — the queue already proved this exact commit — and executes only the work the queue does not: the cross-browser e2e, image-smoke and Postgres-smoke lanes, and the image publish.
 Dedicated security workflows run CodeQL plus `gosec`, `govulncheck`, Trivy filesystem/container scanning, and publish a CycloneDX image SBOM artifact for each scan run.
 
 Beyond plain unit and integration tests, the suite uses property-based tests,

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
   <a href="https://github.com/ovumcy/ovumcy-web/commits/main"><img src="https://img.shields.io/github/last-commit/ovumcy/ovumcy-web" alt="Last Commit"></a>
   <a href="https://www.gnu.org/licenses/agpl-3.0"><img src="https://img.shields.io/badge/License-AGPL%20v3-blue.svg" alt="License: AGPL v3"></a>
   <a href="https://pkg.go.dev/github.com/ovumcy/ovumcy-web"><img src="https://pkg.go.dev/badge/github.com/ovumcy/ovumcy-web.svg" alt="Go Reference"></a>
-  <a href="https://go.dev/"><img src="https://img.shields.io/badge/Go-1.26+-00ADD8?logo=go" alt="Go Version"></a>
+  <a href="https://go.dev/"><img src="https://img.shields.io/badge/Go-1.26.6+-00ADD8?logo=go" alt="Go Version"></a>
   <a href="https://github.com/ovumcy/ovumcy-web/actions/workflows/docker-image.yml"><img src="https://img.shields.io/badge/Docker-ready-2496ED?logo=docker" alt="Docker"></a>
   <a href="https://github.com/ovumcy/ovumcy-web/blob/main/docs/self-hosted.md"><img src="https://img.shields.io/badge/Self--hosted-yes-2ea44f" alt="Self-hosted"></a>
   <a href="https://github.com/ovumcy/ovumcy-web#privacy-and-security"><img src="https://img.shields.io/badge/Telemetry-none-2ea44f" alt="No telemetry"></a>
@@ -118,7 +118,7 @@ No — you run it yourself, on your own server, with no vendor account in the mi
 
 ### Where is the data stored?
 
-On the server you deploy Ovumcy to, and nowhere else. SQLite is the default and works out of the box; PostgreSQL is there when you want it for a more involved setup.
+On the server you deploy Ovumcy to. SQLite is the default and works out of the box; PostgreSQL is there when you want it for a more involved setup. Nothing leaves that server unless you switch it on yourself: the optional webhook reminders POST the predicted dates to a URL you choose, and a calendar app you point at the `.ics` feed fetches those dates onto whatever servers it runs on.
 
 ### Does Ovumcy use analytics or ad trackers?
 
@@ -324,7 +324,7 @@ For production-style setups:
 
 Requirements:
 
-- Go 1.26+
+- Go 1.26.6+
 - Node.js 22+
 
 ```bash
@@ -484,7 +484,8 @@ Project structure:
 - `internal/db` - persistence and migrations
 - `web/` - templates, JavaScript, and CSS assets
 
-CI runs staticcheck, `go vet`, tests, and frontend build on pushes and pull requests.
+CI runs staticcheck, `go vet`, tests, and the frontend build on pull requests and on the merge queue's validation of the commit that lands.
+The post-merge run on `main` deliberately skips that work — the queue already proved this exact commit — and executes only the lanes the queue does not: cross-browser e2e, image smoke, and the Postgres smoke test.
 Dedicated security workflows run CodeQL plus `gosec`, `govulncheck`, Trivy filesystem/container scanning, and publish a CycloneDX image SBOM artifact for each scan run.
 
 Beyond plain unit and integration tests, the suite uses property-based tests,

--- a/TESTING.md
+++ b/TESTING.md
@@ -143,8 +143,10 @@ command below, before trusting a local "gate OK".
 
 This isn't enforced by a local hook — CI's `patch-coverage` job is the gate,
 run on every PR. To check before pushing, reproduce CI's coverage condition
-end to end. The two steps that matter are `go clean -testcache` and
-`-count=1`; either alone defeats the cache, run both for good measure:
+end to end: delete the old profile and regenerate it over the whole scoped
+package set. `go clean -testcache` and `-count=1` are belt and braces — an
+edited file already invalidates its own cached result — but the recipe keeps
+both so a partial local rerun cannot leave any of the profile stale:
 
 ```bash
 rm -f coverage.out

--- a/TESTING.md
+++ b/TESTING.md
@@ -41,7 +41,7 @@ fails ("kills" the mutant). Surviving mutants reveal weak assertions.
 - Run it locally: `scripts/mutation.sh baseline` (full) or `scripts/mutation.sh diff <ref>` (changed code only).
 - A weekly CI job tracks the trend; it is advisory and never blocks a merge.
 - Baseline scope now covers business-logic, security, and transport: `internal/services`, `internal/security`, and `internal/api`.
-- **Mutation efficacy** (gremlins, killed / (killed + survived); tracked weekly): `internal/services` **93.3%** (1529/1638), `internal/security` **97.8%** (134/137), and `internal/api` **97.3%** (649/667), measured on a clean-Linux CI run. Efficacy dipped from an earlier ~99% as v1.8.0 landed large new subsystems (webhooks, `.ics` feed, reminders) whose mutants were then triaged. An exhaustive per-mutant pass re-verified **every** survivor against a broad covering suite — the coverage-guided run over-reports survivors (Go leaves `const`/`case` lines uninstrumented, and its test selection can skip the killing test, so a mutant an existing test already kills can still show as survived) — closing the genuine gaps and documenting the residual as equivalents or coverage-attribution artifacts. `internal/api` is the slowest package to mutate — not the largest (`internal/services` has more non-test source lines) but the one whose tests are heavy DB integration — and it exceeds CI's 3h job timeout unsharded, so it runs as 5 file-subset shards (`internal_api_1`..`5`, a deterministic partition of the package's own files — see `scripts/mutation.sh`) merged into one `internal_api.json`. `internal/services` is sharded 5 ways on the same mechanism. Canonical efficacy comes only from the weekly clean-Linux job, never a local Windows run; per-package breakdowns live in [`.mutation/`](.mutation/).
+- **Mutation efficacy** (gremlins, killed / (killed + survived); tracked weekly): `internal/services` **93.3%** (1529/1638), `internal/security` **97.8%** (134/137), and `internal/api` **97.3%** (649/667), measured on a clean-Linux CI run. `internal/services` dipped from an earlier ~99% as v1.8.0 landed large new subsystems (webhooks, `.ics` feed, reminders) whose mutants were then triaged; `internal/security` and `internal/api` rose to the figures above through the same hardening pass, from 93.4% and 79.2%. An exhaustive per-mutant pass re-verified **every** survivor against a broad covering suite — the coverage-guided run over-reports survivors (Go leaves `const`/`case` lines uninstrumented, and its test selection can skip the killing test, so a mutant an existing test already kills can still show as survived) — closing the genuine gaps and documenting the residual as equivalents or coverage-attribution artifacts. `internal/api` is the slowest package to mutate — not the largest (`internal/services` has more non-test source lines) but the one whose tests are heavy DB integration — and it exceeds CI's 3h job timeout unsharded, so it runs as 5 file-subset shards (`internal_api_1`..`5`, a deterministic partition of the package's own files — see `scripts/mutation.sh`) merged into one `internal_api.json`. `internal/services` is sharded 5 ways on the same mechanism. Canonical efficacy comes only from the weekly clean-Linux job, never a local Windows run; per-package breakdowns live in [`.mutation/`](.mutation/).
 - Statement coverage is lower than efficacy by design: mutation testing checks whether a test *fails when the code breaks*, not merely whether a line ran. The "not covered" mutants are dominated by package-level `const`/`var` declarations (which Go coverage never instruments) and the network-facing OIDC client (covered end-to-end).
 
 Surviving mutants are triaged honestly: a *real* gap gets a new behavior test; an
@@ -121,7 +121,7 @@ go test ./internal/services/ -run '^$' -fuzz FuzzParseDayDate -fuzztime 30s
 # End-to-end (Playwright)
 npm run e2e
 
-# Mutation testing (slow; local or nightly)
+# Mutation testing (slow; local, or the weekly CI job)
 bash scripts/mutation.sh baseline
 ```
 
@@ -133,13 +133,13 @@ coverable Go line in your diff against `origin/main` must be exercised by a test
 the comment at the top of `scripts/patchcov/main.go`).
 
 **Warning: running `patchcov` against a stale `coverage.out` gives a false pass.**
-`go test -coverprofile` is subject to Go's test result cache — if you edit a file
-and re-run the coverage command without also touching its test, `go test` can
-silently reuse a cached run from *before* your latest edit. `coverage.out` then
-reflects the old code, `patchcov` reports your newest lines as covered, and CI
-(which always starts from a clean checkout with an empty test cache) fails on the
-same diff. This has bitten contributors more than once — always regenerate the
-profile fresh before trusting a local "gate OK".
+The gate reads whatever profile is on disk and never checks how it was produced.
+A `coverage.out` left over from before your latest edit — or written by a run over
+a narrower package set than the diff touches — still names your newest lines as
+covered, and CI, which always starts from a clean checkout and regenerates the
+profile over the whole scoped tree, fails on the same diff. This has bitten
+contributors more than once — always regenerate the profile fresh, over the full
+command below, before trusting a local "gate OK".
 
 This isn't enforced by a local hook — CI's `patch-coverage` job is the gate,
 run on every PR. To check before pushing, reproduce CI's coverage condition

--- a/changelog.d/docs-root-truth-and-local-checks.md
+++ b/changelog.d/docs-root-truth-and-local-checks.md
@@ -1,0 +1,39 @@
+### Internal
+
+- **The README no longer promises data never leaves your server.** The storage FAQ answered
+  "and nowhere else", which the product's own optional features falsify: a webhook reminder
+  POSTs the predicted period/ovulation dates to whatever URL the owner configures, and a
+  calendar app subscribed to the `.ics` feed pulls those dates onto its own servers. The
+  answer now names both paths as owner-enabled egress instead of denying them.
+- **The README's CI sentence describes the events CI actually runs on.** It said staticcheck,
+  vet, tests and the frontend build run "on pushes and pull requests"; the push lane on `main`
+  clears `run_core` precisely because the merge queue already ran that suite on the same
+  commit, and executes only the cross-browser e2e, image-smoke and Postgres-smoke lanes the
+  queue skips.
+- **`Go 1.26+` is now `Go 1.26.6+` in both places** (badge and Requirements) — `go.mod` requires
+  `go 1.26.6`, which bites a `GOTOOLCHAIN=local` toolchain below that patch.
+- **`CONTRIBUTING.md`'s local check list runs what CI's frontend lane runs.** It listed
+  `npm run lint:js` and `npm run build` only, so a type error or a JS unit failure —
+  `lint:types` and `test:unit`, both required in CI — went green locally and red in CI.
+- **The untranslated-string instruction names a mechanism that can exist.** It asked for a
+  `TODO(<locale>)` inside the locale file; those files are strict JSON parsed at boot, so a
+  comment breaks startup, an added key fails `TestLocaleKeysParity`, and a marker inside the
+  value stops being the verbatim English string the same sentence demands. Copied keys are
+  listed in the pull request description instead.
+- **The Dependabot changelog exemption names a real assembly step.** It said the
+  `### Dependencies` section "is assembled from the dependency bumps that merged" — no such
+  mechanism exists; `changelogd assemble` reads fragments and the frozen `[Unreleased]` body
+  and nothing else. The section is compiled at release time from `git log <last-tag>..HEAD`
+  over the Dependabot merges and entered as one fragment before assembly.
+- **`TESTING.md`'s stale-profile warning attributes the false pass to its real cause.** It
+  blamed Go's test result cache, which cannot produce the effect: the cache is keyed on the
+  content-hashed test binary, every production file is an input under the documented
+  `-coverpkg`, and the documented command passes `-count=1` anyway. `patchcov` reads whatever
+  `coverage.out` is on disk without checking how it was produced — a profile from before the
+  edit, or over a narrower package set, is what passes lines no test ran.
+- **Mutation testing is weekly in the two places that still said nightly** (`TESTING.md`'s
+  command comment and `scripts/mutation.sh`'s mode help); the workflow runs Mondays at
+  04:23 UTC and the same file says weekly twice already.
+- **The efficacy history no longer reads as if all three packages fell from ~99%.** Only
+  `internal/services` was ever there; `internal/security` (93.4%) and `internal/api` (79.2%)
+  rose to their current figures through the hardening pass.

--- a/scripts/mutation.sh
+++ b/scripts/mutation.sh
@@ -9,8 +9,8 @@
 #
 # Modes:
 #   baseline        Full run over the high-value packages. Slow (hours). Run
-#                   locally or nightly; writes per-package JSON under .tmp/mutation/
-#                   and a committed score summary under .mutation/.
+#                   locally or by the weekly CI job; writes per-package JSON under
+#                   .tmp/mutation/ and a committed score summary under .mutation/.
 #   diff [ref]      Mutate only code changed vs <ref> (default origin/main).
 #                   Fast enough for CI. Advisory: never fails the build.
 #   verify-shards   Proves every registered shard partition is exact — for each


### PR DESCRIPTION
Documentation audit 2026-08-28, package C3 — the root docs. Seven claims that a reader acts on and the tree refutes.

**README**
- `:121` answered "and nowhere else" to *where is the data stored*. Falsified by the product's own optional features: `internal/services/webhook_delivery.go:95-111` POSTs Title/Message/Type/EventDate to an operator-chosen URL, and the `.ics` feed is pulled by whatever calendar app subscribes. Now states both as owner-enabled egress.
- `:487` claimed the core suite runs "on pushes and pull requests". `ci.yml:1123` clears `run_core` on `push` because the merge queue already ran it on the same commit; push executes only cross-browser e2e, image-smoke and Postgres-smoke.
- `:27`/`:327` said `Go 1.26+`; `go.mod:3` requires `go 1.26.6`.

**CONTRIBUTING**
- Local checks listed `lint:js` + `build`; CI's frontend lane also runs `lint:types` and `test:unit` (`ci.yml:586,589`). Both added.
- The `TODO(<locale>)` instruction cannot be followed: locale files are strict JSON parsed at boot (`internal/i18n/i18n.go:57`), an added key fails `TestLocaleKeysParity`, and an in-value marker contradicts "verbatim". Replaced by listing the copied keys in the PR description.
- The Dependabot exemption promised a `### Dependencies` section "assembled from the bumps that merged"; `changelogd assemble` reads fragments and the frozen `[Unreleased]` body only. Replaced by the mechanism owner ruling 7 fixed: compile from `git log <last-tag>..HEAD` over the Dependabot merges, enter as one fragment before assembly.

**TESTING / scripts/mutation.sh**
- The stale-`coverage.out` warning blamed Go's test result cache. It cannot produce the effect — the cache keys on the content-hashed test binary, the documented `-coverpkg` makes every production file an input, and the documented command passes `-count=1`. Real cause: `patchcov` trusts whatever profile is on disk. Rewritten; the regenerate-fresh advice stays.
- "local or nightly" in two places against a weekly workflow (Mondays 04:23 UTC), which the same file already calls weekly twice.
- "Efficacy dipped from an earlier ~99%" read as all three packages; only `internal/services` was ever ~99% — `internal/security` (93.4%) and `internal/api` (79.2%) rose.

Evidence: audit findings F019–F023, adjudication A05, A06, A07, A28; owner ruling 7.

Rollback: `git revert` — documentation and one shell comment, no behavior.
