### PR TITLE
docs: frame the two superseded mutation survivor sections as history

### DIFF
--- a/.mutation/internal-api.md
+++ b/.mutation/internal-api.md
@@ -97,7 +97,7 @@ asks for has happened, and neither the 128 count nor the 79.22% describes the tr
 
 Unlike `internal-services.md`/`internal-security.md`, the 128 survivors here were
 **not** individually triaged into "real gap" vs. "documented equivalent mutant"
-yet — that requires a source-level equivalence review per mutant (apply the
+at the time — that requires a source-level equivalence review per mutant (apply the
 mutation, confirm no test fails, judge whether it's reachable), which is a
 separate follow-up, not implied by getting real numbers out of CI for the first
 time. Do not read the raw 79.22% efficacy as "21% of behavior is untested" —

--- a/.mutation/internal-api.md
+++ b/.mutation/internal-api.md
@@ -87,9 +87,15 @@ combined row above):
 | internal_api_4 | 115 | 52 | 46 | 68.86% | 78.40% |
 | internal_api_5 | 92 | 18 | 18 | 83.64% | 85.94% |
 
-## Survivors — not yet triaged
+## Survivors of the `a6d7e41` run — history, backlog closed
 
-Unlike `internal-services.md`/`internal-security.md`, the 128 survivors here are
+**Superseded, kept for the reasoning.** The section that follows records the state
+at the `a6d7e41` run above. The exhaustive verification of 2026-07-12 triaged every
+survivor of the later v1.8.0 baseline per-mutant, and the post-hardening re-measure
+(**97.3%**, 18 lived) is the current canonical figure — so the follow-up this section
+asks for has happened, and neither the 128 count nor the 79.22% describes the tree.
+
+Unlike `internal-services.md`/`internal-security.md`, the 128 survivors here were
 **not** individually triaged into "real gap" vs. "documented equivalent mutant"
 yet — that requires a source-level equivalence review per mutant (apply the
 mutation, confirm no test fails, judge whether it's reachable), which is a

--- a/.mutation/internal-security.md
+++ b/.mutation/internal-security.md
@@ -68,13 +68,17 @@ verification, TLS bootstrap) is exercised by the end-to-end OIDC lanes
 `go test`, so those lines survive or show "not covered" here while being covered
 at the e2e layer.
 
-## Documented survivors
+## Documented survivors of run `28837779621` — history
+
+**Superseded, kept for the reasoning.** The canonical state is the post-hardening
+re-measure above — **97.8%**, 3 lived — so the eight below are that run's survivor
+set, not a current count, and their line numbers track `oidc.go` as it stood then.
 
 The 8 mutants below survived run `28837779621`. Relative to the prior
 `28758365493` set, `oidc.go:613` was **killed** this round (re-triaged from
 equivalent to a real gap — see the score note above); the rest carry the same
 argument as before (equivalent, or reachable only through the e2e OIDC lanes,
-not `go test`). Line numbers track the current `oidc.go`.
+not `go test`).
 
 ### Equivalent mutants
 

--- a/changelog.d/docs-mutation-history-frames.md
+++ b/changelog.d/docs-mutation-history-frames.md
@@ -1,0 +1,10 @@
+### Internal
+
+- **Two `.mutation/` sections that read as current backlogs are framed as history.**
+  `internal-api.md`'s "Survivors — not yet triaged" describes 128 untriaged survivors and a
+  79.22% efficacy in the present tense; the same file's 2026-07-12 pass triaged every survivor
+  of the later v1.8.0 baseline and the post-hardening re-measure (97.3%, 18 lived) is the
+  canonical figure. `internal-security.md`'s "Documented survivors" presents 8 mutants with
+  "line numbers track the current `oidc.go`" while the canonical state is 3 lived. Both keep
+  their reasoning; only the headings and their prefaces change, so neither reads as a count
+  of the tree today.


### PR DESCRIPTION
Documentation audit 2026-08-28, package C3 (owner ruling 11: keep the historical sections, fix their frames).

Two `.mutation/` sections state a survivor backlog in the present tense that the same files elsewhere report as closed. A reader — or an agent — sizing work from them picks up counts that describe no run of the current tree.

- `.mutation/internal-api.md` — "Survivors — not yet triaged": 128 survivors, 79.22% efficacy, "a separate follow-up". The follow-up happened: the 2026-07-12 exhaustive pass in the same file triaged every survivor of the later v1.8.0 baseline, and the post-hardening re-measure (`internal_api` **97.3%**, 18 lived, run 29192052605) is the canonical figure mirrored in `TESTING.md`. The heading now names the run it belongs to and a preface says it is superseded. F021.
- `.mutation/internal-security.md` — "Documented survivors": 8 mutants from run `28837779621` plus "Line numbers track the current `oidc.go`", against a canonical 3 lived (134 killed). Heading names the run; preface states the canonical figure; the line-number sentence is dropped rather than rewritten as a promise nobody re-checks. F022.

Bodies and reasoning are untouched — only headings and prefaces. Nothing here is a measurement change: the next re-measure is the ordinary weekly job.

Rollback: `git revert` — two Markdown files, no code.
