### PR TITLE
docs: correct the export contract, the prediction floor and the demo pack

### DIFF
--- a/changelog.d/docs-export-prediction-and-demo-truth.md
+++ b/changelog.d/docs-export-prediction-and-demo-truth.md
@@ -1,0 +1,18 @@
+### Internal
+
+- **The export doc described the CSV `Cycle factors` cell as machine keys.** It emits the same
+  human-readable labels the app shows — `Stress`, `Sleep disruption` — joined with `"; "`, not
+  the lowercase enum strings the JSON export carries; a consumer coding against the doc
+  mis-parsed every non-empty cell. The separator nit is fixed on the `Other` column too, and
+  the JSON `cycle_factors` field no longer calls its five-key catalog "free-form".
+- **The documented `Content-Disposition` header now matches the one the server sends** — the
+  filename is unquoted on both the JSON and the CSV response.
+- **`docs/cycle-prediction.md` documents the first-cycle floor.** The document claimed to
+  describe the estimates "in full" while the fertility half — ovulation date, fertile window,
+  peak band, feed events, webhook reminder, dashboard banner — has been withheld until one
+  cycle completes since the floor landed. The math and every worked example were and remain
+  correct; what was missing is the gate that decides whether those numbers reach a surface.
+- **`docs/hero-demo.md` names the whole pack and the scripts that generate it.** `docs/demo.gif`
+  (with `demo.mp4` behind it) is the README's hero and the doc never mentioned it, nor
+  `scripts/take-screenshots.mjs` / `scripts/record-demo.mjs`, so a reader regenerating the pack
+  from the Capture Checklist would leave the one moving asset stale and unreviewed for PII.

--- a/docs/cycle-prediction.md
+++ b/docs/cycle-prediction.md
@@ -5,7 +5,8 @@ window, and the next period. It exists so that anyone — users, contributors,
 auditors — can read exactly what the app computes and verify it against the
 code. It covers what is computed; whether a given estimate is *shown* is a
 separate gate, and the one that withholds the whole fertility half until the
-account completes its first cycle is described under "First cycle" below. The worked examples below are mirrored 1:1 by automated reference tests
+account completes its first cycle is described under "First cycle" below.
+The worked examples below are mirrored 1:1 by automated reference tests
 (`internal/services/cycles_reference_test.go`), so the documentation and the
 implementation cannot silently drift apart.
 
@@ -173,11 +174,17 @@ completed cycles"), the whole fertility half of the projection is withheld:
 - the ovulation reminder in the webhook pass;
 - the ovulation banner on the dashboard.
 
-The next-period estimate survives, with its own estimate qualifier — its anchor is
-a date the owner actually recorded. The same suppression applies whenever
-predictions are switched off for the account. Predicate:
-`FertilityProjectionSuppressed` (`internal/services/dashboard_cycle.go`); every one
-of the four surfaces is pinned by
+The next-period estimate survives this floor, with its own estimate qualifier —
+its anchor is a date the owner actually recorded.
+
+Three further signals withhold **every** projected date, the next period included,
+on every one of those surfaces: predictions switched off for the account, a
+pregnancy pause, and a cycle overdue past its own reference length. The floor is
+the fourth signal and the only partial one. Predicates:
+`FertilityProjectionSuppressed` over `PredictionsSuppressed`
+(`internal/services/dashboard_cycle.go`) — one predicate rather than a copy per
+surface, precisely because the floor had once been missed at one of four sites.
+All four surfaces are pinned by
 `TestFirstCycleFloorSuppressesFertilityOnEverySurface`.
 
 Everything below and above describes the numbers themselves — the floor decides

--- a/docs/cycle-prediction.md
+++ b/docs/cycle-prediction.md
@@ -178,8 +178,9 @@ The next-period estimate survives this floor, with its own estimate qualifier â€
 its anchor is a date the owner actually recorded.
 
 Three further signals withhold **every** projected date, the next period included,
-on every one of those surfaces: predictions switched off for the account, a
-pregnancy pause, and a cycle overdue past its own reference length. The floor is
+on every one of those surfaces: unpredictable-cycle mode (the settings toggle
+"My cycle is unpredictable"), a pregnancy pause, and a cycle overdue past its own
+reference length. The floor is
 the fourth signal and the only partial one. Predicates:
 `FertilityProjectionSuppressed` over `PredictionsSuppressed`
 (`internal/services/dashboard_cycle.go`) â€” one predicate rather than a copy per

--- a/docs/cycle-prediction.md
+++ b/docs/cycle-prediction.md
@@ -3,7 +3,9 @@
 This document describes, in full, how ovumcy estimates ovulation, the fertile
 window, and the next period. It exists so that anyone — users, contributors,
 auditors — can read exactly what the app computes and verify it against the
-code. The worked examples below are mirrored 1:1 by automated reference tests
+code. It covers what is computed; whether a given estimate is *shown* is a
+separate gate, and the one that withholds the whole fertility half until the
+account completes its first cycle is described under "First cycle" below. The worked examples below are mirrored 1:1 by automated reference tests
 (`internal/services/cycles_reference_test.go`), so the documentation and the
 implementation cannot silently drift apart.
 
@@ -102,7 +104,7 @@ These are the exact cases asserted by the reference tests.
   being the gap between two detected period starts). The median is used rather
   than the mean, so a single missed-log gap that merges two cycles cannot skew
   the estimate. When there is not enough history, the owner's configured value
-  is used.
+  is used — for the next-period estimate only; see "First cycle" below.
 - **Luteal phase** defaults to the fixed 14-day model value, but is refined for
   the owner when their logs carry enough signal: when basal body temperature or
   cervical-mucus entries let the app infer the ovulation-to-next-period length
@@ -156,6 +158,30 @@ then there is nothing physiologically meaningful to draw. Even a confirmed
 shift remains an estimate (±1–2 days), never a fact: prospective studies find
 BBT alone identifies the ovulation day imperfectly, so treat the marker as
 indicative, not diagnostic.
+
+## First cycle — what is computed but not shown
+
+The math above runs from the first day logged, but a projection whose only source
+is the onboarding cycle-length slider is a configuration default wearing the
+clothes of a measurement. Until the account completes **one** cycle
+(`CompletedCycleCount >= 1` — the same count the stats page reports as "based on N
+completed cycles"), the whole fertility half of the projection is withheld:
+
+- the ovulation date, the fertile window and the peak-fertility band on the
+  calendar grid;
+- the ovulation events in the `.ics` feed;
+- the ovulation reminder in the webhook pass;
+- the ovulation banner on the dashboard.
+
+The next-period estimate survives, with its own estimate qualifier — its anchor is
+a date the owner actually recorded. The same suppression applies whenever
+predictions are switched off for the account. Predicate:
+`FertilityProjectionSuppressed` (`internal/services/dashboard_cycle.go`); every one
+of the four surfaces is pinned by
+`TestFirstCycleFloorSuppressesFertilityOnEverySurface`.
+
+Everything below and above describes the numbers themselves — the floor decides
+whether they reach a surface, never what they are.
 
 ## Assumptions and limitations
 

--- a/docs/export.md
+++ b/docs/export.md
@@ -17,7 +17,7 @@ GET /api/v1/exports/json?from=2026-01-01&to=2026-05-31
 Cookie: ovumcy_auth=...
 ```
 
-Response headers: `Content-Disposition: attachment; filename="ovumcy-export-<timestamp>.json"`, `Content-Type: application/json`.
+Response headers: `Content-Disposition: attachment; filename=ovumcy-export-<timestamp>.json`, `Content-Type: application/json`. The filename is unquoted, as the server emits it.
 
 Response body:
 
@@ -76,7 +76,7 @@ Field semantics:
 | `bbt` | float | Basal body temperature in Celsius, always — storage is canonical Celsius regardless of the account's display unit, and export emits the stored value unconverted. Emitted only when measured; the key is absent on unmeasured days. On import, an absent key, an explicit `null`, or a legacy `0` are all read as "not measured". |
 | `cervical_mucus` | string | One of `none`, `dry`, `moist`, `creamy`, `eggwhite`. |
 | `pregnancy_test` | string | One of `none`, `negative`, `positive`. |
-| `cycle_factors` | array of strings | Free-form factor keys recorded that day (e.g. `stress`, `travel`, `illness`). |
+| `cycle_factors` | array of strings | Factor keys recorded that day, from the closed catalog `stress`, `illness`, `travel`, `sleep_disruption`, `medication_change`. Any other key is dropped on import. |
 | `symptoms` | object of booleans | Flags for the 16 built-in symptoms. Always present, even when all false. |
 | `other_symptoms` | array of strings | Names of owner-managed custom symptoms recorded that day. |
 | `notes` | string | Free-text note. |
@@ -92,7 +92,7 @@ GET /api/v1/exports/csv?from=2026-01-01&to=2026-05-31
 Cookie: ovumcy_auth=...
 ```
 
-Response headers: `Content-Disposition: attachment; filename="ovumcy-export-<timestamp>.csv"`, `Content-Type: text/csv`.
+Response headers: `Content-Disposition: attachment; filename=ovumcy-export-<timestamp>.csv`, `Content-Type: text/csv`. The filename is unquoted, as the server emits it.
 
 Columns (in order, single header row):
 
@@ -111,8 +111,8 @@ Cell semantics:
 - `Swelling` was appended after `Constipation` (the last symptom column at the time) rather than at the very end of the file; every column at or after `Cycle factors` therefore shifted one position to the right for files generated after this change. Downstream consumers reading columns by position (not by header name) must account for the shift.
 - `Flow`, `Sex activity`, `Cervical mucus`, `Pregnancy test` are human-readable, capitalized labels (e.g. `Spotting`, `Protected`, `Egg white`, `Negative`), not the same lowercase enum strings used by the JSON export.
 - `BBT (C)` is always the stored value in Celsius; storage is canonical Celsius regardless of the account's display unit, and export emits it unconverted. The cell is empty on days with no measurement. The header keeps the literal text `BBT (C)` for stability even though it always holds Celsius.
-- `Cycle factors` is a `;`-separated list of factor keys; empty when none were recorded.
-- `Other` is a `;`-separated list of owner-managed custom symptom names; empty when none.
+- `Cycle factors` is a `; `-separated list of the same human-readable labels the app shows (`Stress`, `Illness`, `Travel`, `Sleep disruption`, `Medication change`) — not the lowercase keys the JSON export emits; empty when none were recorded.
+- `Other` is a `; `-separated list of owner-managed custom symptom names; empty when none.
 - `Notes` is the free-text note; the CSV writer quotes the cell as needed.
 - CSV-injection mitigation: `Cycle factors`, `Other`, and `Notes` are the only cells built from user-entered text. If such a cell (after stripping leading spaces) starts with `=`, `+`, `-`, `@`, or a tab/CR/LF, a leading `'` is prepended so spreadsheet apps do not interpret it as a formula.
 - `Pregnancy test` was introduced after the 1.1.1 layout and appended after the original columns so existing column positions stay stable, per the stability rule below.

--- a/docs/hero-demo.md
+++ b/docs/hero-demo.md
@@ -4,7 +4,7 @@ This document defines the privacy-safe hero demo pack for Ovumcy.
 
 The goal is to keep one reusable asset set for README screenshots, release notes, and short walkthrough clips without ever relying on a live public instance.
 
-The pack is the six stills under `docs/screenshots/` plus the recorded first-run clip `docs/demo.gif` (with `docs/demo.mp4` as its source copy), which the README embeds as its hero. Both halves are generated: `scripts/take-screenshots.mjs` writes the six stills, `scripts/record-demo.mjs` writes the GIF and the MP4. Regenerate through those scripts — the Capture Checklist below is the manual description of what they do and the privacy review they cannot do for you.
+The pack is the six stills listed under Asset Guidance below — `docs/screenshots/` also holds logo and social-preview art that is not part of it — plus the recorded first-run clip `docs/demo.gif` (with `docs/demo.mp4` as its source copy), which the README embeds as its hero. Both halves are generated: one run of `scripts/take-screenshots.mjs` writes all six stills, `scripts/record-demo.mjs` writes the GIF and the MP4. Regenerate through those scripts — the Capture Checklist below is the manual description of what they do and the privacy review they cannot do for you.
 
 ## Core Flow
 
@@ -46,8 +46,8 @@ For short release clips or social cuts, prefer stitching these assets together o
 When regenerating the pack:
 
 1. Start a local instance with a private demo account and seeded sample data.
-2. Capture the four authenticated surfaces from that local instance (`node scripts/take-screenshots.mjs`, which needs an already-onboarded account and its cookie).
-3. Capture the mobile install prompt on `/login` with a mobile viewport and a synthetic `beforeinstallprompt` event.
-4. Capture the dark theme surface with the dark theme option enabled.
+2. Run `node scripts/take-screenshots.mjs` against it (it needs an already-onboarded account and its cookie). One run produces all six stills — steps 3 and 4 describe what it does for two of them, and are the recipe only if you are capturing by hand.
+3. The mobile install prompt on `/login`: a mobile viewport and a synthetic `beforeinstallprompt` event.
+4. The dark theme surface, with the dark theme option enabled.
 5. Re-record the clip if the first-run flow changed (`node scripts/record-demo.mjs`, which needs ffmpeg and a built app).
 6. Review every frame for accidental PII before publishing — the GIF frame by frame, not only the stills.

--- a/docs/hero-demo.md
+++ b/docs/hero-demo.md
@@ -4,6 +4,8 @@ This document defines the privacy-safe hero demo pack for Ovumcy.
 
 The goal is to keep one reusable asset set for README screenshots, release notes, and short walkthrough clips without ever relying on a live public instance.
 
+The pack is the six stills under `docs/screenshots/` plus the recorded first-run clip `docs/demo.gif` (with `docs/demo.mp4` as its source copy), which the README embeds as its hero. Both halves are generated: `scripts/take-screenshots.mjs` writes the six stills, `scripts/record-demo.mjs` writes the GIF and the MP4. Regenerate through those scripts — the Capture Checklist below is the manual description of what they do and the privacy review they cannot do for you.
+
 ## Core Flow
 
 Use these assets in this order when building a short walkthrough or landing-page demo:
@@ -27,7 +29,7 @@ This sequence matches the current product story: create an account, log today qu
 
 ## Asset Guidance
 
-The current asset pack is intentionally static-first:
+The still half of the pack is intentionally static-first:
 
 - `register.jpg` covers the first-run entry point.
 - `dashboard.jpg` covers the primary daily logging surface.
@@ -35,6 +37,7 @@ The current asset pack is intentionally static-first:
 - `settings-export.jpg` covers data ownership and export.
 - `install-prompt.png` covers phone install CTA behavior.
 - `dark-theme.jpg` covers the dark theme option.
+- `demo.gif` covers the first-run flow in motion; it is the one recorded asset, and every privacy rule in this document applies to it exactly as to a still.
 
 For short release clips or social cuts, prefer stitching these assets together over recording a live server session unless a release specifically needs motion.
 
@@ -43,7 +46,8 @@ For short release clips or social cuts, prefer stitching these assets together o
 When regenerating the pack:
 
 1. Start a local instance with a private demo account and seeded sample data.
-2. Capture the four authenticated surfaces from that local instance.
+2. Capture the four authenticated surfaces from that local instance (`node scripts/take-screenshots.mjs`, which needs an already-onboarded account and its cookie).
 3. Capture the mobile install prompt on `/login` with a mobile viewport and a synthetic `beforeinstallprompt` event.
 4. Capture the dark theme surface with the dark theme option enabled.
-5. Review every frame for accidental PII before publishing.
+5. Re-record the clip if the first-run flow changed (`node scripts/record-demo.mjs`, which needs ffmpeg and a built app).
+6. Review every frame for accidental PII before publishing — the GIF frame by frame, not only the stills.


### PR DESCRIPTION
Documentation audit 2026-08-28, package C3 — three product docs whose text a consumer or an owner acts on.

**docs/export.md** (F056, F063, F064)
- `:114` called the CSV `Cycle factors` cell "a `;`-separated list of factor keys". `csvCycleFactorLabels` maps each key through `csvCycleFactorLabel` (`export_service.go:556-580`) and `Columns()` joins with `"; "` (`:357`) — the cell holds `Stress; Sleep disruption`, asserted verbatim at `export_regressions_test.go:153` and `export_service_test.go:611`. The doc's own line 112 already distinguishes labels from "lowercase enum strings", so "keys" could only mean the machine ones. A consumer parsing keys mis-read every non-empty cell. Same separator nit fixed on `Other`.
- `:20`/`:95` showed a quoted filename; `handlers_export_request_helpers.go:62` emits `attachment; filename=%s`, and the regression tests assert the unquoted substring.
- `:79` called JSON `cycle_factors` "free-form"; the vocabulary is the closed five-key catalog `NormalizeDayCycleFactorKeys` enforces, and import drops anything else.

**docs/cycle-prediction.md** (F057)
The document opened "describes, in full" and told a first-cycle owner their configured value is used — implying an ovulation date and fertile window appear. Since the first-cycle floor landed, `FertilityProjectionSuppressed` (`dashboard_cycle.go:162`) withholds the fertility half on all four surfaces until `CompletedCycleCount >= 1`; only the next-period estimate survives. Adds a "First cycle — what is computed but not shown" section naming the four surfaces and the pinning test (`TestFirstCycleFloorSuppressesFertilityOnEverySurface`), and qualifies the two sentences that implied otherwise. The window math and every worked example were correct and are untouched.

**docs/hero-demo.md** (F058)
The pack's one moving asset — `docs/demo.gif`, embedded as the README hero at `README.md:82`, with `demo.mp4` behind it — went unnamed, as did both generating scripts, while the Capture Checklist described by hand what they automate. A reader regenerating the pack from this document would leave the GIF stale and outside the PII review the same document mandates. Names both halves, both scripts, and adds the re-record and frame-by-frame review steps.

Rollback: `git revert` — three Markdown files, no code.
