### PR TITLE
docs: repair the changelog link block, the 1.3.0 date and the brand palette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   leave the container health check where it is. See *Health Checks by Deployment
   Mode* in [docs/self-hosted.md](docs/self-hosted.md).
 
+- **An account signed in through an identity provider can now erase its own
+  data.** `Clear data` and `Delete account` require a fresh re-authentication,
+  and that had exactly one accepted form: the current local password. An owner
+  provisioned through OIDC has none, so both flows answered `403 local password
+  required` — while `SECURITY.md` and the GDPR cross-reference described the
+  right to erasure without qualification. The workaround (enrol a local password
+  through the step-up flow, then erase) worked but was documented nowhere near
+  the claim it qualified.
+
+  Such an account now confirms an erasure where it already authenticates. The
+  danger zone offers the action directly; confirming it starts the same
+  purpose-bound step-up that gates local-password enrollment, and the erasure
+  runs when the provider sends the browser back — never before. Which erasure
+  was confirmed travels inside the sealed step-up state, not in the callback
+  request, so nothing observable between the two can turn a data wipe into an
+  account deletion.
+
+  The re-authentication requirement itself is unchanged, and it does not
+  downgrade: an account that **has** a local password is refused this route and
+  keeps confirming with its password.
+
 ### Changed
 
 - **The calendar feed verifies its subscribe token with a keyed MAC instead of
@@ -87,29 +108,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unchanged for both — the commands in
   [SECURITY.md](SECURITY.md#verifying-release-authenticity) still apply as
   written.
-
-### Added
-
-- **An account signed in through an identity provider can now erase its own
-  data.** `Clear data` and `Delete account` require a fresh re-authentication,
-  and that had exactly one accepted form: the current local password. An owner
-  provisioned through OIDC has none, so both flows answered `403 local password
-  required` — while `SECURITY.md` and the GDPR cross-reference described the
-  right to erasure without qualification. The workaround (enrol a local password
-  through the step-up flow, then erase) worked but was documented nowhere near
-  the claim it qualified.
-
-  Such an account now confirms an erasure where it already authenticates. The
-  danger zone offers the action directly; confirming it starts the same
-  purpose-bound step-up that gates local-password enrollment, and the erasure
-  runs when the provider sends the browser back — never before. Which erasure
-  was confirmed travels inside the sealed step-up state, not in the callback
-  request, so nothing observable between the two can turn a data wipe into an
-  account deletion.
-
-  The re-authentication requirement itself is unchanged, and it does not
-  downgrade: an account that **has** a local password is refused this route and
-  keeps confirming with its password.
 
 ### Fixed
 
@@ -1203,7 +1201,7 @@ self-hosting. No database migrations; no breaking API changes.
 
 - Removed the never-shipped non-owner "viewer" sanitization path; the day-read service now returns owner data directly. The role-integrity guard (`ValidateSupportedWebUser`) is retained.
 
-## [1.3.0] - 2026-06-13
+## [1.3.0] - 2026-06-15
 
 A large security-and-quality release: a multi-phase security audit follow-up
 across auth, sessions, OIDC, privacy, and accessibility; medically-aligned
@@ -1701,7 +1699,9 @@ build-hardening work. No database migrations; no breaking API changes.
   - CSV/JSON export,
   - Russian/English localization.
 
-[Unreleased]: https://github.com/ovumcy/ovumcy-web/compare/v1.9.0...HEAD
+[Unreleased]: https://github.com/ovumcy/ovumcy-web/compare/v1.9.2...HEAD
+[1.9.2]: https://github.com/ovumcy/ovumcy-web/compare/v1.9.1...v1.9.2
+[1.9.1]: https://github.com/ovumcy/ovumcy-web/compare/v1.9.0...v1.9.1
 [1.9.0]: https://github.com/ovumcy/ovumcy-web/compare/v1.8.0...v1.9.0
 [1.8.0]: https://github.com/ovumcy/ovumcy-web/compare/v1.7.0...v1.8.0
 [1.7.0]: https://github.com/ovumcy/ovumcy-web/compare/v1.6.0...v1.7.0

--- a/changelog.d/docs-changelog-links-and-brand-tints.md
+++ b/changelog.d/docs-changelog-links-and-brand-tints.md
@@ -1,0 +1,18 @@
+### Internal
+
+- **The changelog's link-reference block knows about 1.9.1 and 1.9.2.** `[Unreleased]` compared
+  `v1.9.0...HEAD`, so its diff carried two released versions' changes as if unreleased, and the
+  `[1.9.1]`/`[1.9.2]` headings rendered as literal bracketed text with no target. Both patch
+  releases are tagged; the block now defines them and `[Unreleased]` starts at `v1.9.2`.
+  Assembly never maintained this block — it is a per-release manual step that was missed twice.
+- **Release 1.3.0 is dated 2026-06-15**, the date of the tag and of the very commit that wrote
+  the heading (`63ad241f`); it was written two days early at authorship. Every other release
+  heading matches its tag.
+- **`[Unreleased]` carries one `### Added` section, not two.** The OIDC self-erasure entry sat
+  in a second `### Added` after `### Changed`, which the declared Keep a Changelog format does
+  not do. Assembly already merged repeated headers, so this only ever affected the rendered
+  file — the entry text is moved, not edited.
+- **The brand README documents the dark-background tints.** `ovumcy-icon-dark.svg` and
+  `ovumcy-logo-horizontal-dark.svg` use `#CFBBFF` and `#FFA2AF`, which the palette never
+  mentioned — a designer recreating a dark asset from this file reached for the light-background
+  values.

--- a/web/static/brand/README.md
+++ b/web/static/brand/README.md
@@ -6,10 +6,15 @@ Files:
 - `ovumcy-logo-horizontal.svg`: lockup (symbol + wordmark) for light backgrounds
 - `ovumcy-logo-horizontal-dark.svg`: lockup for dark backgrounds
 
-Core palette:
+Core palette (the light-background assets):
 - Lavender: `#A989E7`
 - Coral accent: `#FF7F93`
 - Wordmark (light bg): `#4A3D6A`
+
+On dark backgrounds the two brand colors are lightened and the wordmark inverts —
+the `-dark.svg` assets use these, and nothing else:
+- Lavender: `#CFBBFF`
+- Coral accent: `#FFA2AF`
 - Wordmark (dark bg): `#F6F3FF`
 
 Usage notes:


### PR DESCRIPTION
Documentation audit 2026-08-28, package C3 — the changelog's own hygiene plus the brand palette. All four are corrections to already-released or already-frozen text, which is what `changelogFile` (`scripts/changelogd/main.go:47-48`) sanctions a hand edit for; the branch still carries its own fragment.

- **F000** — the link-reference block's newest definition was `[1.9.0]`, while `v1.9.1` (`44e4cf7b`) and `v1.9.2` (`0d044f21`) are tagged and their release headings exist at `CHANGELOG.md:962` and `:982`. Clicking `Unreleased` handed the reader a `v1.9.0...HEAD` diff carrying two released versions, and both patch headings rendered as literal bracketed text. `[Unreleased]` now starts at `v1.9.2` and the two definitions are added. Assembly does not maintain this block; it is the per-release manual step missed at both patches.
- **F001** — `## [1.3.0] - 2026-06-13` against a tag dated 2026-06-15 and a heading written by the tag's own commit `63ad241f` (author and committer date 2026-06-15). Wrong at authorship, not drift; every other release heading matches.
- **F002** — `[Unreleased]` carried two `### Added` sections split by `### Changed`, which the declared Keep a Changelog 1.1.0 format does not do. The OIDC self-erasure entry moves into the first one, text unedited. Not operative at release — `parseSections` (`main.go:228-231`) concatenates repeated headers — so this was the rendered file only.
- **F024** — `web/static/brand/README.md` gave one palette for four assets. `ovumcy-icon-dark.svg` and `ovumcy-logo-horizontal-dark.svg` use `#CFBBFF` and `#FFA2AF` (grep of the hex values in `web/static/brand/*.svg`), which the README never mentioned, so a designer recreating a dark asset reached for the light-background values.

Note for the changelog-hygiene package: F000 is done here, so that package's link-block line is spent. The `[Unreleased]` text contradictions (adjudication A26 — the "as before" image-tag sentence and the old bare-429 clause) are deliberately **not** in this PR; they are that package's subject.

Rollback: `git revert` — Markdown only, no code, and the assembler is unaffected either way.
