### PR TITLE
chore: gofmt the seven files the release gate flags

### DIFF
--- a/changelog.d/chore-gofmt-the-seven-drifted-files.md
+++ b/changelog.d/chore-gofmt-the-seven-drifted-files.md
@@ -1,0 +1,8 @@
+### Internal
+
+- **Seven files are `gofmt`-clean again.** The release checklist declares a formatting gate before
+  a tag, and the tree failed it: `gofmt -l` over the scoped package list named two `internal/api`
+  regression tests, four `internal/services` files and `scripts/changelogd/main_test.go`. Six were
+  struct- and comment-alignment drift; `webhook_reminder.go` also gains the blank comment lines
+  gofmt inserts between the items of a list in a doc comment. No behaviour changes — `git diff -w`
+  is empty except for those comment lines.

--- a/internal/api/calendar_ovulation_tag_regression_test.go
+++ b/internal/api/calendar_ovulation_tag_regression_test.go
@@ -24,7 +24,7 @@ import (
 func TestCalendarRendersOvulationTagWithoutFertileOverride(t *testing.T) {
 	app, database := newOnboardingTestApp(t)
 	user := createOnboardingTestUser(t, database, "calendar-ovulation-tag@example.com", "StrongPass1", true)
-	periodStart := time.Now().UTC().Truncate(24 * time.Hour).AddDate(0, 0, -4)
+	periodStart := time.Now().UTC().Truncate(24*time.Hour).AddDate(0, 0, -4)
 
 	if err := database.Model(&models.User{}).Where("id = ?", user.ID).Updates(map[string]any{
 		"cycle_length":      28,

--- a/internal/api/owner_only_coverage_regression_test.go
+++ b/internal/api/owner_only_coverage_regression_test.go
@@ -75,7 +75,7 @@ func TestUnsupportedRoleRejectedAcrossEveryAuthedV1Route(t *testing.T) {
 		// cookie changes nothing and gets the ordinary answer; that is pinned by
 		// TestUnsupportedRoleLanguageSwitchStoresNothing
 		// (account_language_regressions_test.go), not by this cookie-role matrix.
-		"POST /lang": {},
+		"POST /lang":                          {},
 		"GET /login":                          {},
 		"GET /auth/oidc/start":                {},
 		"GET " + oidcLogoutBridgePath:         {},

--- a/internal/services/day_service.go
+++ b/internal/services/day_service.go
@@ -22,16 +22,16 @@ var (
 )
 
 type DayEntryInput struct {
-	IsPeriod              bool
-	Flow                  string
-	Mood                  int
-	SexActivity           string
-	BBT                   *float64
-	CervicalMucus         string
-	PregnancyTest         string
-	CycleFactorKeys       []string
-	Notes                 string
-	SymptomIDs            []uint
+	IsPeriod        bool
+	Flow            string
+	Mood            int
+	SexActivity     string
+	BBT             *float64
+	CervicalMucus   string
+	PregnancyTest   string
+	CycleFactorKeys []string
+	Notes           string
+	SymptomIDs      []uint
 	// ConfirmCycleStart carries the owner's answer to the inline question the
 	// day form asks next to the period toggle ("does a new cycle begin here?").
 	// It is set only for an explicit yes: an untouched control writes nothing.

--- a/internal/services/settings_view_service.go
+++ b/internal/services/settings_view_service.go
@@ -77,27 +77,27 @@ type SettingsSymptomsViewData struct {
 }
 
 type SettingsPageViewData struct {
-	CurrentUser             models.User
-	ErrorKey                string
-	ChangePasswordErrorKey  string
-	SuccessKey              string
-	CycleLength             int
-	PeriodLength            int
-	AutoPeriodFill          bool
-	IrregularCycle          bool
-	UnpredictableCycle      bool
-	AgeGroup                string
-	UsageGoal               string
-	ShownPeriodTip          bool
-	TrackBBT                bool
-	TemperatureUnit         string
-	TrackCervicalMucus      bool
+	CurrentUser            models.User
+	ErrorKey               string
+	ChangePasswordErrorKey string
+	SuccessKey             string
+	CycleLength            int
+	PeriodLength           int
+	AutoPeriodFill         bool
+	IrregularCycle         bool
+	UnpredictableCycle     bool
+	AgeGroup               string
+	UsageGoal              string
+	ShownPeriodTip         bool
+	TrackBBT               bool
+	TemperatureUnit        string
+	TrackCervicalMucus     bool
 	// The three section toggles are rendered positively; the stored columns are
 	// inverted and are converted exactly once, in tracking_visibility.go.
-	ShowSexChip          bool
-	ShowCycleFactors     bool
-	ShowNotesField       bool
-	ShowHistoricalPhases bool
+	ShowSexChip             bool
+	ShowCycleFactors        bool
+	ShowNotesField          bool
+	ShowHistoricalPhases    bool
 	WeekStartsOn            string
 	ReminderLeadDays        int
 	LastPeriodStart         string

--- a/internal/services/webhook_reminder.go
+++ b/internal/services/webhook_reminder.go
@@ -116,8 +116,10 @@ func WebhookReminderSettingsFromNotifyRecord(record models.WebhookNotifyRecord) 
 // The decision, in order:
 //
 //   - Webhook delivery disabled ⇒ nothing.
+//
 //   - Build cycle stats from the owner's logs via the SAME path the dashboard
 //     uses (BuildCycleStatsFromLogs, which needs no repositories).
+//
 //   - In-app predictions suppressed (DashboardPredictionDisabled — the owner's
 //     unpredictable-cycle mode — stats.PregnancyPaused, or DashboardCycleOverdue
 //     — the running cycle is past the account's reference length by more than a
@@ -137,17 +139,20 @@ func WebhookReminderSettingsFromNotifyRecord(record models.WebhookNotifyRecord) 
 //     projected next-period date — different from the stale watermark — so the
 //     next legitimate reminder fires exactly once and its own watermark then
 //     covers it.
+//
 //   - Resolve "today" as the owner-local calendar day (DateAtLocation) and the
 //     median-first projection cycle length the dashboard feeds to its predictions
 //     (DashboardProjectionCycleLength — the same statistic as stats.NextPeriodStart,
 //     NOT the average-first staleness reference), then take the dashboard's own
 //     upcoming prediction (DashboardUpcomingPredictions) for the authoritative
 //     next-period and ovulation dates + flags.
+//
 //   - period-soon: emitted when NotifyPeriod is on, the next period start is
 //     known, and it falls within [today, today+leadDays] (inclusive) — i.e. not
 //     in the past and not beyond the window. Its cycle anchor is the next period
 //     start itself (definitionally the start of the next cycle). Skipped when the
 //     incoming period watermark already equals that anchor.
+//
 //   - ovulation-soon: emitted when NotifyOvulation is on and ovulation is
 //     calculable (not impossible, non-zero) and within the same window. Its cycle
 //     anchor is the start of the cycle the ovulation belongs to (derived with the

--- a/internal/services/webhook_settings_cli.go
+++ b/internal/services/webhook_settings_cli.go
@@ -36,7 +36,7 @@ type WebhookSettingsView struct {
 	// Host is the destination hostname only (e.g. "ntfy.example.io"), or "" when
 	// no endpoint is configured. It is the single form of a webhook URL that may
 	// appear in operator output — never the scheme/path/query/token.
-	Host             string
+	Host            string
 	NotifyPeriod    bool
 	NotifyOvulation bool
 	// ReminderLeadDays is the lead window IN FORCE — always clamped through

--- a/scripts/changelogd/main_test.go
+++ b/scripts/changelogd/main_test.go
@@ -202,7 +202,7 @@ func TestAddsReleaseHeadingReadsAddedLinesOnly(t *testing.T) {
 		"+++ b/CHANGELOG.md\n+## [1.2.3] - 2026-02-02\n":  true,
 		"+++ b/CHANGELOG.md\n+- **An ordinary entry.**\n": false,
 		"+++ b/CHANGELOG.md\n-## [1.2.3] - 2026-02-02\n":  false,
-		"":                                               false,
+		"": false,
 	}
 	for diff, want := range cases {
 		if got := addsReleaseHeading(diff); got != want {


### PR DESCRIPTION
Audit adjudication A19(a): the release checklist declares a `gofmt` gate before a tag, and the snapshot tree fails it. This is tree drift against a release-time gate, not a false sentence — the checklist needs no edit, the files do.

`gofmt -l ./cmd/... ./internal/... ./migrations/... ./scripts/... ./web/...` named seven:

- `internal/api/calendar_ovulation_tag_regression_test.go`
- `internal/api/owner_only_coverage_regression_test.go`
- `internal/services/day_service.go`
- `internal/services/settings_view_service.go`
- `internal/services/webhook_reminder.go`
- `internal/services/webhook_settings_cli.go`
- `scripts/changelogd/main_test.go`

Six are struct-field and comment alignment. The seventh, `webhook_reminder.go`, additionally gains the blank comment lines gofmt inserts between the items of a list inside a doc comment — the only hunk `git diff -w` shows, and it is comment text.

Verification: `gofmt -l` over the same scoped list is now empty, `go build ./...` and `go test ./scripts/changelogd/...` pass, and `git diff -w` is empty apart from those comment lines.

Rollback: `git revert` — formatting only.
