### PR TITLE
docs: anchor the two operator measurements and count the OIDC cookies

### DIFF
--- a/changelog.d/docs-anchor-the-two-operator-measurements.md
+++ b/changelog.d/docs-anchor-the-two-operator-measurements.md
@@ -1,0 +1,13 @@
+### Internal
+
+- **`docs/self-hosted.md` miscounted the OIDC cookies in its `431` arithmetic.** The section said
+  "the two OIDC cookies only apply on the callback path"; the app defines four —
+  `ovumcy_oidc_auth` and `ovumcy_oidc_stepup` on `/auth/oidc/callback`, `ovumcy_oidc_link_pending`
+  on `/auth/oidc/link-confirm`, `ovumcy_oidc_logout_bridge` on `/auth/oidc/logout`. The exclusion
+  argument the section rests on gets stronger, not weaker: each one is `Path`-scoped to the single
+  endpoint that consumes it, so none reaches an ordinary page request.
+- **Both operator-facing measurements now carry their date and the release they were taken on.**
+  The SQLite write-concurrency table was a drill of 2026-07-28 on the then-current release image
+  (v1.9.2); the cookie byte counts were measured from the running app on 2026-07-25 against the
+  same release. Neither said so, so a reader could not tell which build produced them or whether
+  they had gone stale — and nothing in the repository re-derives either.

--- a/docs/self-hosted.md
+++ b/docs/self-hosted.md
@@ -289,7 +289,7 @@ For the public reverse-proxy stacks, do not treat a missing host-level `127.0.0.
 
 The SQLite baseline is sized for a household, and it has a ceiling worth knowing before you meet it. SQLite allows one writer at a time. Reads scale fine — eight clients browsing the dashboard, calendar, stats and exports at once stay in the tens of milliseconds — but **concurrent writers serialize**, and a writer that cannot take the lock waits out the five-second busy timeout before the app retries.
 
-Measured on a release image, mixed traffic with 40% day saves, per-request latency for `PUT /api/v1/days/{date}`:
+Measured 2026-07-28 on the release image current that day (v1.9.2, tagged 2026-07-24) — mixed traffic with 40% day saves, per-request latency for `PUT /api/v1/days/{date}`. The numbers are a dated drill, not a guarantee; re-run them before sizing on a different host or a later release:
 
 | Clients writing at once | Median save | 95th percentile |
 | --- | --- | --- |
@@ -537,15 +537,20 @@ Clearing them fixes it immediately, which is also how you confirm the diagnosis.
 The whole **head** of a request — start line plus every header, cookies included — must fit in a
 4 KB read buffer.
 
-A normal signed-in request carries about **450 B** of Ovumcy cookies (measured from the running app:
-`ovumcy_auth` 350 B, `ovumcy_csrf` 55 B, plus the language and timezone cookies). The largest single
+A normal signed-in request carries about **450 B** of Ovumcy cookies (measured from the running app
+on 2026-07-25, against v1.9.2: `ovumcy_auth` 350 B, `ovumcy_csrf` 55 B, plus the language and
+timezone cookies). Cookie payloads change with the code, so treat every byte count in this section
+as that dated measurement rather than a current fact. The largest single
 cookies are `ovumcy_oidc_stepup` at 514 B, `ovumcy_reset_password` at 460 B and `ovumcy_auth` — the
 three that carry a signed token or a password hash.
 
 Summing **every** cookie the app can define reaches roughly 2.9 KB, which with a browser's own
 0.6–1.2 KB of headers would sit close to the limit. That total is arithmetic rather than a reachable
 state: the transient cookies in it are mutually exclusive by lifecycle — a password-reset cookie and a
-2FA-setup cookie never coexist, and the two OIDC cookies only apply on the callback path. Ovumcy on
+2FA-setup cookie never coexist — and the four OIDC cookies are each `Path`-scoped to the one
+endpoint that consumes them, so none of them rides on an ordinary page request at all:
+`ovumcy_oidc_auth` and `ovumcy_oidc_stepup` on `/auth/oidc/callback`, `ovumcy_oidc_link_pending`
+on `/auth/oidc/link-confirm`, and `ovumcy_oidc_logout_bridge` on `/auth/oidc/logout`. Ovumcy on
 its own therefore stays far below the buffer in every state a real flow produces, but the margin comes
 from those exclusions, not from a large absolute gap.
 


### PR DESCRIPTION
Audit findings F053 and F054, filed as "unverifiable". Half of one of them is not unverifiable — it is checkable and wrong — and the provenance of both measurements exists in this repository's own history.

**The wrong half (F054).** The `431` section argues its 2.9 KB total is arithmetic rather than a reachable state, and one leg of that argument reads "the two OIDC cookies only apply on the callback path". The app defines **four**, on **three** paths:

| cookie | `Path` |
|---|---|
| `ovumcy_oidc_auth` (state) | `/auth/oidc/callback` (`oidc_state_cookie.go:61`) |
| `ovumcy_oidc_stepup` | `/auth/oidc/callback` (`oidc_stepup_cookie.go:162`) |
| `ovumcy_oidc_link_pending` | `/auth/oidc/link-confirm` (`oidc_link_pending_cookie.go:71`) |
| `ovumcy_oidc_logout_bridge` | `/auth/oidc/logout` (`oidc_logout_cookie.go:13`) |

The conclusion survives — it strengthens. Every one is `Path`-scoped to the single endpoint that consumes it, so none of them rides on an ordinary page request at all, which is a sharper statement than "only on the callback path" and true of all four.

**The anchors.** Neither measurement was invented; both were dated drills whose dates the documents dropped.

- The SQLite write-concurrency table came in with `adaa2edf` (#334, 2026-07-28): *"Measured on a release image, the median day save goes 8 ms at one concurrent writer … the median reaches five seconds at eight."* The current tag that day was v1.9.2 (2026-07-24), and none has been cut since.
- The cookie byte counts came in with `4e99f8b1` (#296, 2026-07-25): *"Measured from the running app, not modelled: a normal signed-in request carries ~450 B of cookies…"* — same release.

Both now say so in the document, with the caveat that fits each: the latency table is a dated drill to re-run before sizing on a different host or a later release, and the byte counts move whenever a cookie payload does. Nothing in the repository re-derives either number, which is exactly why the anchor has to be prose.

The numbers themselves are untouched — this PR does not re-measure, and the operator guidance drawn from them was fine either way.

Rollback: `git revert` — one Markdown file.
