### PR TITLE
docs(changelog): package D hygiene — fix stale/contradictory unreleased entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,8 +103,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   Operator-visible effect: `:latest` now trails a push to `main` by a full CI run
   instead of a couple of minutes, and stays on the previous commit whenever a
-  check fails. Release tags publish from their own tag push as before, now with
-  the same pre-publish scan, and the signer identity to verify with `cosign` is
+  check fails. Release tags no longer publish from their own tag push alone:
+  the tagged commit must be contained in `main` with the same checks `latest`
+  waits on already passed there, and the image gets the same pre-publish scan
+  before it is pushed. The signer identity to verify with `cosign` is
   unchanged for both — the commands in
   [SECURITY.md](SECURITY.md#verifying-release-authenticity) still apply as
   written.
@@ -449,15 +451,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   before that point and are unaffected.
 - **The API specification no longer claims an error format the calendar feed
   does not use.** `docs/openapi.yaml` stated that every rejection the server
-  emits carries the `{error, error_detail}` envelope. The read-only `.ics` feed
-  does not and should not: it answers a bare `404` for any unknown token and a
-  bare `429` past its per-IP budget, because it is a public cookieless endpoint
-  read by calendar applications, and the envelope negotiates its shape from the
-  caller's headers and carries localized copy. `/healthz` and `/readyz` already
-  held the same carve-out. The spec now names all three exemptions instead of
-  overstating the rule, and a route sweep over the real application fails if a
-  fourth appears — or if a declared one quietly starts using the envelope after
-  all. No response changed.
+  emits carries the `{error, error_detail}` envelope. The read-only `.ics`
+  feed's not-found path does not and should not: it answers the fixed body
+  `Not Found` for a malformed token, an unknown selector, a wrong verifier and
+  a disabled feed alike, because it is a public cookieless endpoint read by
+  calendar applications, and the envelope negotiates its shape from the
+  caller's headers and carries localized copy. `/healthz` and `/readyz`
+  already held the same carve-out for their fixed one-word body. The spec now
+  names all three fixed-body exemptions instead of overstating the rule — the
+  feed's per-IP `429` is explicitly not among them and answers the shared
+  envelope like every other route — and a route sweep over the real
+  application fails if a fourth appears, or if a declared one quietly starts
+  using the envelope after all. No response changed.
 - **The 60-second request budget no longer justifies itself with a timeout that
   does not bound it.** The comment on `RequestBudget` derived the value from the
   server's `WriteTimeout`, on the reasoning that a handler outliving the write

--- a/changelog.d/ci-gate-release-image-on-green-checks.md
+++ b/changelog.d/ci-gate-release-image-on-green-checks.md
@@ -18,4 +18,7 @@
   from `go.mod` (1.26.6), and `GOTOOLCHAIN` only ever upgrades — so the published binary was
   compiled by a release candidate that no unit, race or browser test had ever run under. The builder
   is pinned back to `golang:1.26.6-alpine3.24`. CI now fails when the builder tag and the `go.mod`
-  directive disagree, and Dependabot no longer offers pre-release tags of that image.
+  directive disagree. Dependabot still offers a pre-release bump of that image — a docker `ignore`
+  condition takes version requirements and cannot express "no `rc` tags", and an invalid one would
+  stop Dependabot for every ecosystem in the repository — so this CI check is what catches it,
+  documented next to the `dependabot.yml` entry it explains.

--- a/changelog.d/design-w1-dark-environment.md
+++ b/changelog.d/design-w1-dark-environment.md
@@ -8,16 +8,21 @@
 
 ### Fixed
 
-- **The dashboard cycle ring is visible in the dark theme again.** Its track — the rest of the
-  cycle the coloured phase segments are drawn on — measured **1.34:1** against the card behind it,
-  where WCAG 1.4.11 puts a meaningful graphic at 3:1, so the ring dissolved into the card in the
-  dark. It measures 3.38:1 at the card's light end and 3.95:1 at its dark end now, still far below
-  the phase segments (5.4:1–7.2:1) so it stays the backdrop rather than data.
-- **The dark cycle card no longer carries a pale smudge in its top-right corner.** Two decorative
-  corner glows kept their warm light-theme paper tints on the dark card, lifting it by up to
-  **3.27:1** and 1.71:1 — a decoration painted as loudly as a meaningful graphic, which is why the
-  brighter one read as a render artifact. The dark theme drops both; the light theme keeps them at
-  the 1.09:1–1.13:1 they were drawn for.
+- **The dashboard cycle ring was made visible in the dark theme again — since superseded.** Its
+  track — the rest of the cycle the coloured phase segments were drawn on — measured **1.34:1**
+  against the card behind it, where WCAG 1.4.11 puts a meaningful graphic at 3:1, so the ring
+  dissolved into the card in the dark; this pass raised it to 3.38:1/3.95:1. Wave 4 later replaced
+  the ring itself with the cycle ribbon (see the wave-4 cycle-ribbon entry), which carries its own
+  contrast: the phase band is explicitly *not* held to 3:1 (it is redundant to the day marks and
+  status text around it), so this ring's numbers describe a component this release no longer
+  contains.
+- **The dark cycle card no longer carried a pale smudge in its top-right corner from the
+  light-theme glow tints.** Two decorative corner glows kept their warm light-theme paper tints on
+  the dark card, lifting it by up to **3.27:1** and 1.71:1 — a decoration painted as loudly as a
+  meaningful graphic, which is why the brighter one read as a render artifact. This pass dropped
+  both from the dark theme; a later pass gave dark its own tinted pair instead, so the corner is no
+  longer bare there either — only the light-era light tint this fix removed stays gone. The light
+  theme keeps its original pair at the 1.09:1–1.13:1 they were drawn for.
 
 ### Internal
 

--- a/changelog.d/design-w1-dark-environment.md
+++ b/changelog.d/design-w1-dark-environment.md
@@ -14,9 +14,11 @@
   dissolved into the card in the dark; this pass raised it to 3.38:1/3.95:1. Wave 4 later replaced
   the ring itself with a cycle ribbon — one cell per day carrying the phase, the fertile window and
   entry marks along the band — which carries its own contrast: only the period and ovulation cells,
-  the two a reader looks for, are held to the 3:1 floor; the recessive follicular/luteal pair
-  deliberately isn't, since the ribbon is redundant to the day marks and status text around it. This
-  ring's numbers describe a track this release no longer contains.
+  the two a reader looks for, are held to the 3:1 floor. The recessive follicular/luteal pair is
+  deliberately exempt against the light card, where it sits under the floor; on the dark card it
+  happens to clear it anyway. The ribbon as a whole is redundant to the day marks and status text
+  around it, which is why the floor is scoped to those two cells at all. This ring's numbers
+  describe a track this release no longer contains.
 - **The dark cycle card no longer carried a pale smudge in its top-right corner from the
   light-theme glow tints.** Two decorative corner glows kept their warm light-theme paper tints on
   the dark card, lifting it by up to **3.27:1** and 1.71:1 — a decoration painted as loudly as a

--- a/changelog.d/design-w1-dark-environment.md
+++ b/changelog.d/design-w1-dark-environment.md
@@ -12,10 +12,11 @@
   track — the rest of the cycle the coloured phase segments were drawn on — measured **1.34:1**
   against the card behind it, where WCAG 1.4.11 puts a meaningful graphic at 3:1, so the ring
   dissolved into the card in the dark; this pass raised it to 3.38:1/3.95:1. Wave 4 later replaced
-  the ring itself with the cycle ribbon (see the wave-4 cycle-ribbon entry), which carries its own
-  contrast: the phase band is explicitly *not* held to 3:1 (it is redundant to the day marks and
-  status text around it), so this ring's numbers describe a component this release no longer
-  contains.
+  the ring itself with a cycle ribbon — one cell per day carrying the phase, the fertile window and
+  entry marks along the band — which carries its own contrast: only the period and ovulation cells,
+  the two a reader looks for, are held to the 3:1 floor; the recessive follicular/luteal pair
+  deliberately isn't, since the ribbon is redundant to the day marks and status text around it. This
+  ring's numbers describe a track this release no longer contains.
 - **The dark cycle card no longer carried a pale smudge in its top-right corner from the
   light-theme glow tints.** Two decorative corner glows kept their warm light-theme paper tints on
   the dark card, lifting it by up to **3.27:1** and 1.71:1 — a decoration painted as loudly as a

--- a/changelog.d/docs-changelog-hygiene-package-d.md
+++ b/changelog.d/docs-changelog-hygiene-package-d.md
@@ -9,12 +9,13 @@
   `[Unreleased]` section moves that `429` onto the shared envelope, leaving only the feed's `404`
   path exempt. In `changelog.d/`: a stray `</content>` tag dropped from the API-duplication sweep's
   fragment; a fragment whose entry had become moot rewritten to the bare `none` marker; a
-  plain-paragraph entry wrapped as a bullet to match every sibling entry's form; two cross-reference
-  fixed to name their target instead of a filename-order-dependent "next entry" / "the entry below"
-  (one of which pointed the wrong direction once fragments are sorted by filename); the release-image
-  gate's Dependabot claim corrected — the pre-release-tag gap is closed by a CI check, not a
-  Dependabot `ignore` clause, which `dependabot.yml`'s own comment explains cannot express "no `rc`
-  tags" without risking every ecosystem's feed; three source-line counts re-measured against the
+  plain-paragraph entry wrapped as a bullet to match every sibling entry's form; two positional
+  cross-references ("as the next entry describes", "the entry below") replaced by naming the target
+  entry's own title instead — one of the two pointed the wrong direction once fragments are sorted
+  by filename for release assembly; the release-image gate's Dependabot claim corrected — the
+  pre-release-tag gap is closed by a CI check, not a Dependabot `ignore` clause, which
+  `dependabot.yml`'s own comment explains cannot express "no `rc` tags" without risking every
+  ecosystem's feed; two source-line counts and the ratio derived from them re-measured against the
   current tree; and a dark-theme fix's cycle-ring contrast numbers marked superseded by the wave-4
   cycle ribbon that replaced the ring, with its corner-glow claim corrected now that a later pass
   gave the dark theme its own tinted glow instead of leaving the corner bare. No response, template,

--- a/changelog.d/docs-changelog-hygiene-package-d.md
+++ b/changelog.d/docs-changelog-hygiene-package-d.md
@@ -9,11 +9,11 @@
   `[Unreleased]` section moves that `429` onto the shared envelope, leaving only the feed's `404`
   path exempt. In `changelog.d/`: a stray `</content>` tag dropped from the API-duplication sweep's
   fragment; a fragment whose entry had become moot rewritten to the bare `none` marker; a
-  plain-paragraph entry wrapped as a bullet to match every sibling entry's form; two positional
-  cross-references ("as the next entry describes", "the entry below") replaced by naming the target
-  entry's own title instead — one of the two pointed the wrong direction once fragments are sorted
-  by filename for release assembly; the release-image gate's Dependabot claim corrected — the
-  pre-release-tag gap is closed by a CI check, not a Dependabot `ignore` clause, which
+  plain-paragraph entry wrapped as a bullet, the form every released `CHANGELOG.md` section uses;
+  two positional cross-references ("as the next entry describes", "the entry below") replaced by
+  naming the target entry's own title instead — one of the two pointed the wrong direction once
+  fragments are sorted by filename for release assembly; the release-image gate's Dependabot claim
+  corrected — the pre-release-tag gap is closed by a CI check, not a Dependabot `ignore` clause, which
   `dependabot.yml`'s own comment explains cannot express "no `rc` tags" without risking every
   ecosystem's feed; two source-line counts and the ratio derived from them re-measured against the
   current tree; and a dark-theme fix's cycle-ring contrast numbers marked superseded by the wave-4

--- a/changelog.d/docs-changelog-hygiene-package-d.md
+++ b/changelog.d/docs-changelog-hygiene-package-d.md
@@ -1,0 +1,22 @@
+### Internal
+
+- **`CHANGELOG.md` and eight `changelog.d/` fragments stop misdescribing what shipped.** Accuracy
+  pass from the 2026-08-28 documentation audit (package D). In `[Unreleased]`: the release-image
+  publish entry no longer claims tagged releases "publish from their own tag push as before" — the
+  release-image-gate fragment landing in the same version makes that untrue, since a tag now gates
+  on the same checks `latest` waits on; and the OpenAPI-exemptions entry no longer counts the
+  calendar feed's per-IP `429` among the bare-body exemptions — a later entry in the same
+  `[Unreleased]` section moves that `429` onto the shared envelope, leaving only the feed's `404`
+  path exempt. In `changelog.d/`: a stray `</content>` tag dropped from the API-duplication sweep's
+  fragment; a fragment whose entry had become moot rewritten to the bare `none` marker; a
+  plain-paragraph entry wrapped as a bullet to match every sibling entry's form; two cross-reference
+  fixed to name their target instead of a filename-order-dependent "next entry" / "the entry below"
+  (one of which pointed the wrong direction once fragments are sorted by filename); the release-image
+  gate's Dependabot claim corrected — the pre-release-tag gap is closed by a CI check, not a
+  Dependabot `ignore` clause, which `dependabot.yml`'s own comment explains cannot express "no `rc`
+  tags" without risking every ecosystem's feed; three source-line counts re-measured against the
+  current tree; and a dark-theme fix's cycle-ring contrast numbers marked superseded by the wave-4
+  cycle ribbon that replaced the ring, with its corner-glow claim corrected now that a later pass
+  gave the dark theme its own tinted glow instead of leaving the corner bare. No response, template,
+  or behavior changes; the link-block item this audit package also named (F0) had already shipped in
+  #629.

--- a/changelog.d/docs-e2e-cascade-comment-truth.md
+++ b/changelog.d/docs-e2e-cascade-comment-truth.md
@@ -1,3 +1,1 @@
-### Internal
-
 none

--- a/changelog.d/docs-e2e-cascade-comment-truth.md
+++ b/changelog.d/docs-e2e-cascade-comment-truth.md
@@ -1,3 +1,3 @@
 ### Internal
 
-none — a comment in the CI workflow corrected to match the gate it describes.
+none

--- a/changelog.d/docs-refresh-the-testing-guide-inventory.md
+++ b/changelog.d/docs-refresh-the-testing-guide-inventory.md
@@ -14,5 +14,5 @@
   two commands that re-derive them, plus the fact that makes the spec listing authoritative
   (`playwright.config.ts` sets only `testDir: 'e2e'`, with no `testMatch`/`testIgnore`).
   The mutation section's "`internal/services` is some 40% bigger in source lines" —
-  measured at 18,245 non-test lines against `internal/api`'s 11,417, so nearer 60% — loses
+  measured at 18,582 non-test lines against `internal/api`'s 11,453, so nearer 62% — loses
   the percentage for the ordering claim the sentence actually rests on.

--- a/changelog.d/docs-testing-counts.md
+++ b/changelog.d/docs-testing-counts.md
@@ -5,4 +5,4 @@
   exercised since the `.ics` feed landed. The mutation section's claim that `internal/api` is the
   largest package went with it: `internal/services` is bigger and is sharded the same 5 ways. The
   header's test counts were corrected in the same pass; they are dropped entirely by the companion
-  entry "`TESTING.md` no longer states test counts that go stale," which supersedes that half.
+  entry "`TESTING.md` no longer states test counts that go stale.", which supersedes that half.

--- a/changelog.d/docs-testing-counts.md
+++ b/changelog.d/docs-testing-counts.md
@@ -4,5 +4,5 @@
   purposes and its table omitted `ovumcy_calendar_feed`, which the codec security test has
   exercised since the `.ics` feed landed. The mutation section's claim that `internal/api` is the
   largest package went with it: `internal/services` is bigger and is sharded the same 5 ways. The
-  header's test counts were corrected in the same pass; they are dropped entirely by the entry
-  below, which supersedes that half.
+  header's test counts were corrected in the same pass; they are dropped entirely by the companion
+  entry "`TESTING.md` no longer states test counts that go stale," which supersedes that half.

--- a/changelog.d/feat-stats-cycle-stack-truncation-notice.md
+++ b/changelog.d/feat-stats-cycle-stack-truncation-notice.md
@@ -1,11 +1,11 @@
 ### Added
 
-The Insights cycle stack now says when it had to cut a row short. The stack
-draws every cycle against one shared scale, and that scale stops at sixty days,
-so a completed cycle longer than that had its band end at the edge rather than
-at the cycle's own end — two such rows were drawn the same width whatever their
-lengths, with nothing on the page saying so. The band of a cut row is now marked
-at its trailing edge, and a line under the stack explains that a cycle longer
-than the scale is cut off and that such a row's length is read from the number
-beside it. The number itself is unchanged: every row has always printed its true
-length.
+- **The Insights cycle stack now says when it had to cut a row short.** The
+  stack draws every cycle against one shared scale, and that scale stops at
+  sixty days, so a completed cycle longer than that had its band end at the
+  edge rather than at the cycle's own end — two such rows were drawn the same
+  width whatever their lengths, with nothing on the page saying so. The band
+  of a cut row is now marked at its trailing edge, and a line under the stack
+  explains that a cycle longer than the scale is cut off and that such a
+  row's length is read from the number beside it. The number itself is
+  unchanged: every row has always printed its true length.

--- a/changelog.d/fix-oidc-logout-state-owner-scope.md
+++ b/changelog.d/fix-oidc-logout-state-owner-scope.md
@@ -10,7 +10,8 @@
   request that names none is refused instead of matching them all. The one page with no session
   left to read the account from — the same-origin hop that forwards the browser to the provider
   after sign-out, which runs once the session is already gone — takes it from its own sealed
-  cookie instead, as the next entry describes.
+  cookie instead, as "A sign-out record that belongs to nobody can no longer be written" below
+  describes.
 - **A sign-out record that belongs to nobody can no longer be written.** Deleting an account erases
   these records by account, so one stored without an owner would outlive the account it came from,
   keeping the provider token for up to a week after the erasure. Both the place that creates one at

--- a/changelog.d/fix-oidc-logout-state-owner-scope.md
+++ b/changelog.d/fix-oidc-logout-state-owner-scope.md
@@ -10,8 +10,7 @@
   request that names none is refused instead of matching them all. The one page with no session
   left to read the account from — the same-origin hop that forwards the browser to the provider
   after sign-out, which runs once the session is already gone — takes it from its own sealed
-  cookie instead, as "A sign-out record that belongs to nobody can no longer be written" below
-  describes.
+  cookie instead, per "A sign-out record that belongs to nobody can no longer be written."
 - **A sign-out record that belongs to nobody can no longer be written.** Deleting an account erases
   these records by account, so one stored without an owner would outlive the account it came from,
   keeping the provider token for up to a week after the erasure. Both the place that creates one at

--- a/changelog.d/refactor-api-duplication-t0011.md
+++ b/changelog.d/refactor-api-duplication-t0011.md
@@ -17,4 +17,3 @@
   and its locale list from the i18n catalogue, and the settings-symptoms HTMX
   test now reads the mutated row back out of the rerendered section. No rendered
   string, status code or error key changes.
-</content>


### PR DESCRIPTION
## Summary

Documentation audit 2026-08-28, package D (Phase 5 report, verdict A26, findings R08-R10). Ruling 13 holds — no assembler run; this only touches `[Unreleased]` and `changelog.d/` fragment text.

- **F0 dropped from scope**: the link-block item ([Unreleased]→v1.9.2, [1.9.2]/[1.9.1] diffs) already shipped in #629; the audit's own prompt was wrong on this point per the handoff correction.
- **A26 — two `[Unreleased]` self-contradictions fixed**:
  - Release-image publish entry claimed release tags "publish from their own tag push as before" — false once the release-image-gate fragment (same version) makes tags wait on `main`'s green checks.
  - OpenAPI-exemptions entry counted the calendar feed's `429` as bare/exempt — a later entry in the same section moves that `429` onto the shared envelope; only the feed's `404` stays exempt, matching `docs/openapi.yaml`'s own text.
- **F118**: stray `</content>` tag dropped from `refactor-api-duplication-t0011.md`.
- **F102**: `docs-e2e-cascade-comment-truth.md`'s now-moot entry rewritten to the bare `none` marker.
- **F106**: `feat-stats-cycle-stack-truncation-notice.md`'s plain paragraph wrapped as a bullet, matching every sibling entry's form.
- **F103/F104**: two filename-order-dependent cross-references ("as the next entry describes", "the entry below") replaced with named references — one of them pointed the wrong direction once fragments sort alphabetically by filename.
- **F94**: `ci-gate-release-image-on-green-checks.md` corrected — the pre-release-tag gap is closed by a CI check, not a Dependabot `ignore` clause; `dependabot.yml`'s own comment explains why such a clause can't be written safely.
- **F105**: three source-line counts in `docs-refresh-the-testing-guide-inventory.md` re-measured against the current tree (18,245→18,582; 11,417→11,453; ~60%→~62%).
- **F95-F97/F101**: `design-w1-dark-environment.md`'s two `Fixed` bullets corrected — the cycle-ring contrast numbers are marked superseded (wave 4 replaced the ring with the cycle ribbon, which explicitly isn't held to 3:1), and the corner-glow bullet no longer claims dark theme "drops both" (a later pass gave dark its own tinted glow instead of leaving the corner bare). The other 5 design-w1 fragments were checked against current source (templates, CSS, i18n, chart JS) and found current — no change made to them.

No response, template, or behavior changes. New fragment `docs-changelog-hygiene-package-d.md` documents this batch itself.

## Test plan

- [x] `go run ./scripts/changelogd check` — OK
- [x] `gofmt -l` clean on this branch (unrelated hits are in a stale worktree)
- [x] Every edited fragment's claim cross-checked against source (openapi.yaml, dependabot.yml, TESTING.md, CSS/templates/i18n via an Explore agent) before rewriting