### PR TITLE
ci: pass language: go to ClusterFuzzLite run_fuzzers in both workflows

### DIFF
--- a/.github/workflows/cflite_batch.yml
+++ b/.github/workflows/cflite_batch.yml
@@ -28,6 +28,7 @@ jobs:
         id: run
         uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
         with:
+          language: go
           github-token: ${{ secrets.GITHUB_TOKEN }}
           fuzz-seconds: 600
           mode: batch

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -59,6 +59,7 @@ jobs:
         id: run
         uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
         with:
+          language: go
           github-token: ${{ secrets.GITHUB_TOKEN }}
           fuzz-seconds: 300
           mode: code-change

--- a/changelog.d/ci-clusterfuzzlite-run-fuzzers-language.md
+++ b/changelog.d/ci-clusterfuzzlite-run-fuzzers-language.md
@@ -1,0 +1,6 @@
+none
+
+CI-only fix: `run_fuzzers` in both ClusterFuzzLite workflows (`cflite_pr.yml`,
+`cflite_batch.yml`) was missing `language: go`, present only on `build_fuzzers`.
+`run_fuzzers`' default is C++, which can drive the Go targets down the wrong
+libFuzzer path. No user-visible change.


### PR DESCRIPTION
## Summary
- `run_fuzzers` in `cflite_pr.yml` and `cflite_batch.yml` was missing `language: go` — only `build_fuzzers` had it (pr:56, batch:25 before this change).
- `.claude/rules/ci.md:25` requires the parameter on both steps: `run_fuzzers`' default is C++, which drives the Go targets down the wrong libFuzzer path and SEGVs at startup, misattributed as a target crash.
- Fix: add `language: go` to `run_fuzzers`' `with:` block in both workflows.

## Test plan
- [x] `actionlint` on both changed workflow files: clean
- Reviewed by inspection against `ci.md:25` — no other run_fuzzers/build_fuzzers steps exist in the repo