### PR TITLE
docs(changelog): fix dependabot-exemption fragment's assembly claim

### DIFF
--- a/changelog.d/ci-changelog-fragment-dependabot-exemption.md
+++ b/changelog.d/ci-changelog-fragment-dependabot-exemption.md
@@ -4,5 +4,8 @@
   The check stays required for every pull request and keeps its `merge_group`
   trigger; it returns success immediately when the pull request's author is
   `dependabot[bot]`, which cannot write a fragment. Dependency updates therefore
-  no longer reach `changelog.d/`, and a release's `### Dependencies` section is
-  assembled from the bumps that merged rather than from fragments.
+  no longer reach `changelog.d/`. At release time the operator compiles a
+  release's `### Dependencies` section by hand from `git log <last-tag>..HEAD`
+  over the dependabot merges and enters it as one fragment before running
+  `changelogd assemble`, which itself reads only fragments and the frozen
+  `[Unreleased]` body.

--- a/changelog.d/docs-changelog-dependabot-exemption-wording.md
+++ b/changelog.d/docs-changelog-dependabot-exemption-wording.md
@@ -1,0 +1,10 @@
+none
+
+Docs-only: corrected `changelog.d/ci-changelog-fragment-dependabot-exemption.md`
+in place, which claimed the `### Dependencies` section "is assembled from the
+bumps that merged" — no such automatic mechanism exists. Both unreleased
+fragments would have landed in the same release contradicting each other
+(this one against `docs-root-truth-and-local-checks.md`, which already states
+the real mechanism: the operator compiles the section by hand from
+`git log <last-tag>..HEAD` and enters it as a fragment before `changelogd
+assemble` runs). No code change; assembler not run.


### PR DESCRIPTION
## Summary
- `changelog.d/ci-changelog-fragment-dependabot-exemption.md:7-8` claimed the `### Dependencies` section "is assembled from the bumps that merged" — no such automatic mechanism exists.
- `changelog.d/docs-root-truth-and-local-checks.md:23-27` already says the opposite ("no such mechanism exists; assemble reads fragments and nothing else") and both fragments assemble into the same unreleased section — a reader of that release would hit a direct contradiction.
- Target truth (owner ruling 7, already correctly stated in `ci-cache-changelog.md:21`): the operator compiles `### Dependencies` by hand from `git log <last-tag>..HEAD` over dependabot merges and enters it as one fragment before `changelogd assemble` runs; the assembler itself reads only fragments and the frozen `[Unreleased]` body.
- Reworded the exemption fragment to match. `docs-root-truth-and-local-checks.md` was already correct — untouched.
- Assembler not run (ruling 13 still in force).

## Test plan
- Docs-only; no code changed. Read both fragments side by side after the edit — they no longer contradict.