### PR TITLE
fix(changelogd): maintain the release-link block on assemble

### DIFF
--- a/changelog.d/changelogd-release-link-block.md
+++ b/changelog.d/changelogd-release-link-block.md
@@ -1,0 +1,9 @@
+none
+
+CI/tooling-only fix: `changelogd assemble` never maintained the trailing
+Keep a Changelog reference-link block, so the first real release it cuts
+would ship with no `[vX.Y.Z]: …compare…` line for that release and a stale
+`[Unreleased]` compare link. `assemble` now inserts the new release's link
+and moves `[Unreleased]` to compare against it; a rerun for a version that
+already has a link is a no-op. No release was cut and the assembler was not
+run against the real `CHANGELOG.md`.

--- a/scripts/changelogd/main.go
+++ b/scripts/changelogd/main.go
@@ -329,7 +329,10 @@ func assemble(root, version, date string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	tail = updateReleaseLinks(tail, version)
+	tail, linkWarning := updateReleaseLinks(tail, version)
+	if linkWarning != "" {
+		fmt.Fprintln(os.Stderr, "changelogd assemble: WARNING: "+linkWarning)
+	}
 
 	merged := map[string][]string{}
 	frozen, err := parseSections(changelogFile+" [Unreleased]", strings.Join(stripPointerLine(unreleased), "\n"))
@@ -408,20 +411,27 @@ func splitChangelog(content string) (head, unreleased, tail []string, err error)
 // in sync with a newly cut release: the release gets its own compare link,
 // inserted right above the previous top entry, and "[Unreleased]" moves to
 // compare against it instead of the release being cut. It is a no-op when
-// tail carries no such block (assembling into a changelog that predates the
+// tail carries no "[Unreleased]:" line at all (a changelog that predates the
 // convention) or already lists this version — a rerun for a version that was
-// already assembled, or corrected by hand, leaves the block untouched.
-func updateReleaseLinks(tail []string, version string) []string {
+// already assembled, or corrected by hand, leaves the block untouched. When a
+// "[Unreleased]:" line exists but its format has drifted from
+// unreleasedLinkPattern, it returns tail untouched plus a non-empty warning
+// instead of failing silently — a caller drops the update on the floor with
+// no signal otherwise, which is the exact defect this function exists to fix.
+func updateReleaseLinks(tail []string, version string) ([]string, string) {
 	newLabel := "[" + version + "]:"
 	for _, line := range tail {
 		if strings.HasPrefix(line, newLabel) {
-			return tail
+			return tail, ""
 		}
 	}
 	for i, line := range tail {
+		if !strings.HasPrefix(line, "[Unreleased]:") {
+			continue
+		}
 		m := unreleasedLinkPattern.FindStringSubmatch(line)
 		if m == nil {
-			continue
+			return tail, fmt.Sprintf("release-link block not updated: %q does not match the expected format", line)
 		}
 		base, prevTag := m[1], m[2]
 		newTag := "v" + version
@@ -430,9 +440,9 @@ func updateReleaseLinks(tail []string, version string) []string {
 		out = append(out, "[Unreleased]: "+base+newTag+"...HEAD")
 		out = append(out, "["+version+"]: "+base+prevTag+"..."+newTag)
 		out = append(out, tail[i+1:]...)
-		return out
+		return out, ""
 	}
-	return tail
+	return tail, ""
 }
 
 // stripPointerLine drops the pointer that stands in for the entries assembly

--- a/scripts/changelogd/main.go
+++ b/scripts/changelogd/main.go
@@ -69,6 +69,12 @@ var sectionOrder = []string{
 
 var versionPattern = regexp.MustCompile(`^\d+\.\d+\.\d+$`)
 
+// unreleasedLinkPattern matches the Keep a Changelog reference-style link line
+// for "[Unreleased]", e.g.
+// "[Unreleased]: https://github.com/ovumcy/ovumcy-web/compare/v1.9.2...HEAD".
+// Group 1 is everything through "compare/", group 2 the previous release tag.
+var unreleasedLinkPattern = regexp.MustCompile(`^\[Unreleased\]: (.+/compare/)(v\d+\.\d+\.\d+)\.\.\.HEAD$`)
+
 func main() {
 	if len(os.Args) < 2 {
 		fatalf("usage: changelogd <check|assemble> [flags]")
@@ -323,6 +329,7 @@ func assemble(root, version, date string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	tail = updateReleaseLinks(tail, version)
 
 	merged := map[string][]string{}
 	frozen, err := parseSections(changelogFile+" [Unreleased]", strings.Join(stripPointerLine(unreleased), "\n"))
@@ -395,6 +402,37 @@ func splitChangelog(content string) (head, unreleased, tail []string, err error)
 		}
 	}
 	return lines[:start+1], lines[start+1 : end], lines[end:], nil
+}
+
+// updateReleaseLinks keeps the trailing Keep a Changelog reference-link block
+// in sync with a newly cut release: the release gets its own compare link,
+// inserted right above the previous top entry, and "[Unreleased]" moves to
+// compare against it instead of the release being cut. It is a no-op when
+// tail carries no such block (assembling into a changelog that predates the
+// convention) or already lists this version — a rerun for a version that was
+// already assembled, or corrected by hand, leaves the block untouched.
+func updateReleaseLinks(tail []string, version string) []string {
+	newLabel := "[" + version + "]:"
+	for _, line := range tail {
+		if strings.HasPrefix(line, newLabel) {
+			return tail
+		}
+	}
+	for i, line := range tail {
+		m := unreleasedLinkPattern.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		base, prevTag := m[1], m[2]
+		newTag := "v" + version
+		out := make([]string, 0, len(tail)+1)
+		out = append(out, tail[:i]...)
+		out = append(out, "[Unreleased]: "+base+newTag+"...HEAD")
+		out = append(out, "["+version+"]: "+base+prevTag+"..."+newTag)
+		out = append(out, tail[i+1:]...)
+		return out
+	}
+	return tail
 }
 
 // stripPointerLine drops the pointer that stands in for the entries assembly

--- a/scripts/changelogd/main_test.go
+++ b/scripts/changelogd/main_test.go
@@ -455,7 +455,10 @@ func TestAssembleCarriesTheRepositoryBacklogVerbatim(t *testing.T) {
 	if !strings.HasPrefix(got, strings.Join(head, "\n")+"\n\n"+pointerLine+"\n\n## [99.0.0] - 2026-12-31\n") {
 		t.Fatalf("assembled head is wrong:\n%s", firstLines(got, 12))
 	}
-	wantTail := updateReleaseLinks(tail, "99.0.0")
+	wantTail, warning := updateReleaseLinks(tail, "99.0.0")
+	if warning != "" {
+		t.Fatalf("the repository's own link block should match the expected format, got warning %q", warning)
+	}
 	if !strings.HasSuffix(got, strings.Join(wantTail, "\n")) {
 		t.Fatal("everything below the released sections, other than the link block's own update, must be untouched")
 	}
@@ -477,7 +480,7 @@ func TestUpdateReleaseLinksInsertsTheNewVersionAndMovesUnreleased(t *testing.T) 
 		"[Unreleased]: https://example.com/o/r/compare/v1.0.0...HEAD",
 		"[1.0.0]: https://example.com/o/r/releases/tag/v1.0.0",
 	}
-	got := updateReleaseLinks(tail, "1.1.0")
+	got, warning := updateReleaseLinks(tail, "1.1.0")
 	want := []string{
 		"## [1.0.0] - 2026-01-01",
 		"",
@@ -492,6 +495,9 @@ func TestUpdateReleaseLinksInsertsTheNewVersionAndMovesUnreleased(t *testing.T) 
 	if strings.Join(got, "\n") != strings.Join(want, "\n") {
 		t.Fatalf("updateReleaseLinks =\n%s\nwant\n%s", strings.Join(got, "\n"), strings.Join(want, "\n"))
 	}
+	if warning != "" {
+		t.Fatalf("expected no warning on a well-formed link block, got %q", warning)
+	}
 }
 
 func TestUpdateReleaseLinksIsANoOpWhenTheVersionAlreadyHasALink(t *testing.T) {
@@ -500,17 +506,37 @@ func TestUpdateReleaseLinksIsANoOpWhenTheVersionAlreadyHasALink(t *testing.T) {
 		"[1.1.0]: https://example.com/o/r/compare/v1.0.0...v1.1.0",
 		"[1.0.0]: https://example.com/o/r/releases/tag/v1.0.0",
 	}
-	got := updateReleaseLinks(tail, "1.1.0")
+	got, warning := updateReleaseLinks(tail, "1.1.0")
 	if strings.Join(got, "\n") != strings.Join(tail, "\n") {
 		t.Fatalf("a rerun for a version that already has a link must not change the block:\n%s", strings.Join(got, "\n"))
+	}
+	if warning != "" {
+		t.Fatalf("expected no warning when the version already has a link, got %q", warning)
 	}
 }
 
 func TestUpdateReleaseLinksIsANoOpWithoutALinkBlock(t *testing.T) {
 	tail := []string{"## [1.0.0] - 2026-01-01", "", "### Added", "", "- **The first release.**"}
-	got := updateReleaseLinks(tail, "1.1.0")
+	got, warning := updateReleaseLinks(tail, "1.1.0")
 	if strings.Join(got, "\n") != strings.Join(tail, "\n") {
 		t.Fatalf("a changelog with no link block must be left untouched:\n%s", strings.Join(got, "\n"))
+	}
+	if warning != "" {
+		t.Fatalf("expected no warning when there is no link block at all, got %q", warning)
+	}
+}
+
+func TestUpdateReleaseLinksWarnsInsteadOfFailingSilentlyOnADriftedFormat(t *testing.T) {
+	tail := []string{
+		"[Unreleased]: https://example.com/o/r/compare/v1.0...HEAD",
+		"[1.0.0]: https://example.com/o/r/releases/tag/v1.0.0",
+	}
+	got, warning := updateReleaseLinks(tail, "1.1.0")
+	if strings.Join(got, "\n") != strings.Join(tail, "\n") {
+		t.Fatalf("a block the pattern cannot parse must be left untouched:\n%s", strings.Join(got, "\n"))
+	}
+	if warning == "" {
+		t.Fatal("expected a warning when the [Unreleased] line does not match the expected format")
 	}
 }
 

--- a/scripts/changelogd/main_test.go
+++ b/scripts/changelogd/main_test.go
@@ -455,13 +455,83 @@ func TestAssembleCarriesTheRepositoryBacklogVerbatim(t *testing.T) {
 	if !strings.HasPrefix(got, strings.Join(head, "\n")+"\n\n"+pointerLine+"\n\n## [99.0.0] - 2026-12-31\n") {
 		t.Fatalf("assembled head is wrong:\n%s", firstLines(got, 12))
 	}
-	if !strings.HasSuffix(got, strings.Join(tail, "\n")) {
-		t.Fatal("everything below the released sections must be untouched")
+	wantTail := updateReleaseLinks(tail, "99.0.0")
+	if !strings.HasSuffix(got, strings.Join(wantTail, "\n")) {
+		t.Fatal("everything below the released sections, other than the link block's own update, must be untouched")
 	}
 	for section, body := range frozen {
 		if !strings.Contains(got, body) {
 			t.Errorf("the frozen %s body did not survive assembly verbatim", section)
 		}
+	}
+}
+
+func TestUpdateReleaseLinksInsertsTheNewVersionAndMovesUnreleased(t *testing.T) {
+	tail := []string{
+		"## [1.0.0] - 2026-01-01",
+		"",
+		"### Added",
+		"",
+		"- **The first release.**",
+		"",
+		"[Unreleased]: https://example.com/o/r/compare/v1.0.0...HEAD",
+		"[1.0.0]: https://example.com/o/r/releases/tag/v1.0.0",
+	}
+	got := updateReleaseLinks(tail, "1.1.0")
+	want := []string{
+		"## [1.0.0] - 2026-01-01",
+		"",
+		"### Added",
+		"",
+		"- **The first release.**",
+		"",
+		"[Unreleased]: https://example.com/o/r/compare/v1.1.0...HEAD",
+		"[1.1.0]: https://example.com/o/r/compare/v1.0.0...v1.1.0",
+		"[1.0.0]: https://example.com/o/r/releases/tag/v1.0.0",
+	}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("updateReleaseLinks =\n%s\nwant\n%s", strings.Join(got, "\n"), strings.Join(want, "\n"))
+	}
+}
+
+func TestUpdateReleaseLinksIsANoOpWhenTheVersionAlreadyHasALink(t *testing.T) {
+	tail := []string{
+		"[Unreleased]: https://example.com/o/r/compare/v1.1.0...HEAD",
+		"[1.1.0]: https://example.com/o/r/compare/v1.0.0...v1.1.0",
+		"[1.0.0]: https://example.com/o/r/releases/tag/v1.0.0",
+	}
+	got := updateReleaseLinks(tail, "1.1.0")
+	if strings.Join(got, "\n") != strings.Join(tail, "\n") {
+		t.Fatalf("a rerun for a version that already has a link must not change the block:\n%s", strings.Join(got, "\n"))
+	}
+}
+
+func TestUpdateReleaseLinksIsANoOpWithoutALinkBlock(t *testing.T) {
+	tail := []string{"## [1.0.0] - 2026-01-01", "", "### Added", "", "- **The first release.**"}
+	got := updateReleaseLinks(tail, "1.1.0")
+	if strings.Join(got, "\n") != strings.Join(tail, "\n") {
+		t.Fatalf("a changelog with no link block must be left untouched:\n%s", strings.Join(got, "\n"))
+	}
+}
+
+func TestAssembleUpdatesTheReleaseLinkBlock(t *testing.T) {
+	dir := t.TempDir()
+	content := fixtureChangelog + "\n[Unreleased]: https://example.com/o/r/compare/v1.0.0...HEAD\n[1.0.0]: https://example.com/o/r/releases/tag/v1.0.0\n"
+	writeFile(t, dir, "CHANGELOG.md", content)
+	writeFile(t, dir, "changelog.d/a.md", "### Added\n\n- **A new thing.**\n")
+
+	if _, err := assemble(dir, "1.1.0", "2026-02-02"); err != nil {
+		t.Fatalf("assemble: %v", err)
+	}
+	got := readFile(t, dir, "CHANGELOG.md")
+	if !strings.Contains(got, "[Unreleased]: https://example.com/o/r/compare/v1.1.0...HEAD\n") {
+		t.Fatalf("the Unreleased link was not moved to compare against the new release:\n%s", got)
+	}
+	if !strings.Contains(got, "[1.1.0]: https://example.com/o/r/compare/v1.0.0...v1.1.0\n") {
+		t.Fatalf("the new release did not get its own compare link:\n%s", got)
+	}
+	if !strings.Contains(got, "[1.0.0]: https://example.com/o/r/releases/tag/v1.0.0\n") {
+		t.Fatalf("the previous release's own link must survive untouched:\n%s", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `changelogd assemble` (`renderChangelog`/`splitChangelog`) never touched the trailing Keep a Changelog reference-link block. The block is consistent today (40/40) only because every past release was corrected by hand — the first real `assemble` run would cut a version with no `[vX.Y.Z]: ...compare...` line for it, and leave `[Unreleased]` pointing at the release just superseded.
- Added `updateReleaseLinks(tail, version)`: inserts the new release's own compare link right above the previous top entry, and moves `[Unreleased]` to compare against the new release instead. No-op when there's no link block, or when the version already has one (idempotent rerun) — a version label prefix check short-circuits before touching anything.
- Wired into `assemble` right after `splitChangelog`, before `renderChangelog`.

## Test plan
- [x] `go test ./scripts/changelogd/...` — all pass, including 3 new unit tests on `updateReleaseLinks` (insert+move, no-op on existing link, no-op with no link block) and an `assemble`-level test
- [x] `TestAssembleCarriesTheRepositoryBacklogVerbatim` updated to assert against the *updated* tail — it now exercises the real `CHANGELOG.md`'s own link block end to end
- [x] `staticcheck` + `golangci-lint run --max-issues-per-linter=0 --max-same-issues=0 ./scripts/changelogd/...`: 0 issues
- Assembler was **not** run against the repository's real `CHANGELOG.md` (owner ruling 13 still in force; this PR only changes and tests the tool)