### PR TITLE
fix(ci): gate publish-image on the five results, not an implicit success()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1717,16 +1717,18 @@ jobs:
     # THE `if` MUST CARRY A STATUS FUNCTION, AND THE FIVE RESULTS BY NAME.
     #
     # What was MEASURED, which is the outcome and not the mechanism: with an
-    # `if` naming only the event and the ref, this job was `skipped` on every
-    # push to `main` while the run stayed green. Runs 33217555948, 33213567903,
-    # 33188023148, 32905532451, 32882518209 and 32853636750 — `skipped` in all
-    # six, `started_at == completed_at`, and in each of them all five jobs in
-    # `needs:` reported `success`. What those five have in common is that their
-    # OWN dependencies (`test-go-shard`, `test-go-rest`, `test-go-analysis`,
-    # `coverage-merge`, `test-frontend`, both race lanes) are `skipped` on
-    # `push`, because `changes` clears `run_core` there by design. At
-    # `4b3c01d7`, `latest`, `main` and `sha-3891c0f` all pointed at one index
-    # 242 commits behind `main`, and `sha-4b3c01d` did not exist at all.
+    # `if` naming only the event and the ref, this job was `skipped` while the
+    # run stayed green in every push run examined — 33217555948, 33213567903,
+    # 33188023148, 32905532451, 32882518209 and 32853636750, `skipped` in all
+    # six with `started_at == completed_at`, and in each of them all five jobs
+    # in `needs:` reported `success`. What those five have in common is that
+    # their OWN dependencies (`test-go-shard`, `test-go-rest`,
+    # `test-go-analysis`, `coverage-merge`, `test-frontend`, both race lanes)
+    # are `skipped` on `push`, because `changes` clears `run_core` there
+    # unconditionally — which is also why this holds for every push and not
+    # only for those six: nothing about a particular commit takes part in it.
+    # At `4b3c01d7`, `latest`, `main` and `sha-3891c0f` all pointed at one
+    # index 242 commits behind `main`, and `sha-4b3c01d` did not exist at all.
     #
     # Two mechanisms explain that equally well, and nothing here has separated
     # them. Either the implicit `success()` an `if` without a status-check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1738,18 +1738,15 @@ jobs:
     # own `if` does name a status function — which is exactly the shape the
     # five gates above have.
     #
-    # The condition below is correct under both, which is why it did not wait
-    # for that probe: `!cancelled()` suppresses the implicit predicate whatever
-    # it ranges over, and the five results are then judged here rather than
-    # inferred from anything.
-    #
-    # `!cancelled()` is what suppresses the implicit `success()`; on its own it
-    # would publish off a FAILED gate, so the five results are then required by
-    # name. `success` and nothing else — `skipped` must not publish either,
-    # which is what keeps a docs-only push to `main` (there `run_e2e` is false,
-    # so `image-smoke` never boots the image) from publishing an image no smoke
-    # test looked at. Such a push leaves `latest` on the previous commit, which
-    # carries the identical image.
+    # The condition below is correct under either reading, which is why it did
+    # not wait for that probe. `!cancelled()` suppresses the implicit predicate
+    # whatever that predicate ranges over; on its own it would then publish off
+    # a FAILED gate, so the five results are required by name and judged here
+    # rather than inferred from anything. `success` and nothing else — `skipped`
+    # must not publish either, which is what keeps a docs-only push to `main`
+    # (there `run_e2e` is false, so `image-smoke` never boots the image) from
+    # publishing an image no smoke test looked at. Such a push leaves `latest`
+    # on the previous commit, which carries the identical image.
     if: >-
       ${{ !cancelled()
       && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1733,10 +1733,12 @@ jobs:
     # function receives is evaluated over the whole ancestor graph rather than
     # over the direct `needs:`; or a skip propagates transitively, so a gate
     # that rescues ITSELF with `!cancelled()` does not rescue what depends on
-    # it. DO NOT BUILD A SECOND GATE ON EITHER READING WITHOUT PROBING IT: the
-    # two answer differently for a job whose ancestors are skipped while its
-    # own `if` does name a status function — which is exactly the shape the
-    # five gates above have.
+    # it. Every job shape in this workflow today is explained by both, the five
+    # gates above included — they run, and each reading says so for its own
+    # reason — so nothing here is evidence either way. DO NOT BUILD A SECOND
+    # GATE ON WHICHEVER READING SOUNDS RIGHT: work out first whether the two
+    # differ for the shape you are about to write, and probe it on a throwaway
+    # branch if they do.
     #
     # The condition below is correct under either reading, which is why it did
     # not wait for that probe. `!cancelled()` suppresses the implicit predicate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1715,19 +1715,33 @@ jobs:
     # the same way, since the Docker Image workflow no longer accepts one.
     #
     # THE `if` MUST CARRY A STATUS FUNCTION, AND THE FIVE RESULTS BY NAME.
-    # An `if` holding no status-check function is given an implicit `success()`,
-    # and a skip propagates transitively: a gate that rescues ITSELF with
-    # `!cancelled()` does not rescue what depends on it. Every one of the five
-    # jobs above is such a gate, and all five report `success` on `push` — but
-    # their own dependencies (`test-go-shard`, `test-go-rest`,
-    # `test-go-analysis`, `coverage-merge`, `test-frontend`, both race lanes)
-    # are `skipped` there, because `changes` clears `run_core` on `push` by
-    # design. So the implicit `success()` was false on every push to `main` and
-    # this job was skipped while the run stayed green — measured across runs
-    # 33217555948, 33213567903, 33188023148, 32905532451, 32882518209 and
-    # 32853636750: `skipped` in all six, `started_at == completed_at`. At
+    #
+    # What was MEASURED, which is the outcome and not the mechanism: with an
+    # `if` naming only the event and the ref, this job was `skipped` on every
+    # push to `main` while the run stayed green. Runs 33217555948, 33213567903,
+    # 33188023148, 32905532451, 32882518209 and 32853636750 — `skipped` in all
+    # six, `started_at == completed_at`, and in each of them all five jobs in
+    # `needs:` reported `success`. What those five have in common is that their
+    # OWN dependencies (`test-go-shard`, `test-go-rest`, `test-go-analysis`,
+    # `coverage-merge`, `test-frontend`, both race lanes) are `skipped` on
+    # `push`, because `changes` clears `run_core` there by design. At
     # `4b3c01d7`, `latest`, `main` and `sha-3891c0f` all pointed at one index
     # 242 commits behind `main`, and `sha-4b3c01d` did not exist at all.
+    #
+    # Two mechanisms explain that equally well, and nothing here has separated
+    # them. Either the implicit `success()` an `if` without a status-check
+    # function receives is evaluated over the whole ancestor graph rather than
+    # over the direct `needs:`; or a skip propagates transitively, so a gate
+    # that rescues ITSELF with `!cancelled()` does not rescue what depends on
+    # it. DO NOT BUILD A SECOND GATE ON EITHER READING WITHOUT PROBING IT: the
+    # two answer differently for a job whose ancestors are skipped while its
+    # own `if` does name a status function — which is exactly the shape the
+    # five gates above have.
+    #
+    # The condition below is correct under both, which is why it did not wait
+    # for that probe: `!cancelled()` suppresses the implicit predicate whatever
+    # it ranges over, and the five results are then judged here rather than
+    # inferred from anything.
     #
     # `!cancelled()` is what suppresses the implicit `success()`; on its own it
     # would publish off a FAILED gate, so the five results are then required by

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1713,7 +1713,38 @@ jobs:
     # release tags publish from their own tag push, through the same workflow.
     # `workflow_dispatch` on `main` is kept as the manual re-publish path, gated
     # the same way, since the Docker Image workflow no longer accepts one.
-    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
+    #
+    # THE `if` MUST CARRY A STATUS FUNCTION, AND THE FIVE RESULTS BY NAME.
+    # An `if` holding no status-check function is given an implicit `success()`,
+    # and a skip propagates transitively: a gate that rescues ITSELF with
+    # `!cancelled()` does not rescue what depends on it. Every one of the five
+    # jobs above is such a gate, and all five report `success` on `push` — but
+    # their own dependencies (`test-go-shard`, `test-go-rest`,
+    # `test-go-analysis`, `coverage-merge`, `test-frontend`, both race lanes)
+    # are `skipped` there, because `changes` clears `run_core` on `push` by
+    # design. So the implicit `success()` was false on every push to `main` and
+    # this job was skipped while the run stayed green — measured across runs
+    # 33217555948, 33213567903, 33188023148, 32905532451, 32882518209 and
+    # 32853636750: `skipped` in all six, `started_at == completed_at`. At
+    # `4b3c01d7`, `latest`, `main` and `sha-3891c0f` all pointed at one index
+    # 242 commits behind `main`, and `sha-4b3c01d` did not exist at all.
+    #
+    # `!cancelled()` is what suppresses the implicit `success()`; on its own it
+    # would publish off a FAILED gate, so the five results are then required by
+    # name. `success` and nothing else — `skipped` must not publish either,
+    # which is what keeps a docs-only push to `main` (there `run_e2e` is false,
+    # so `image-smoke` never boots the image) from publishing an image no smoke
+    # test looked at. Such a push leaves `latest` on the previous commit, which
+    # carries the identical image.
+    if: >-
+      ${{ !cancelled()
+      && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+      && github.ref == 'refs/heads/main'
+      && needs.test.result == 'success'
+      && needs.race.result == 'success'
+      && needs.e2e.result == 'success'
+      && needs.e2e-postgres-smoke.result == 'success'
+      && needs.image-smoke.result == 'success' }}
     # A caller cannot grant a called workflow more than it holds, so this must
     # match the permissions the publish job declares — plus `checks: read`, for
     # the tag gate that workflow now runs ahead of the publish. That gate is

--- a/changelog.d/ci-publish-image-gate.md
+++ b/changelog.d/ci-publish-image-gate.md
@@ -1,0 +1,15 @@
+### Fixed
+
+- **`ghcr.io/ovumcy/ovumcy-web:latest` follows `main` again.** The CI job that publishes it was
+  skipped on every push to `main` while the run itself reported green, so `latest`, `main` and the
+  newest `sha-…` tag all still pointed at one image 242 commits old, and no `sha-<commit>` tag had
+  been created for any commit since. The job's condition named only the event and the branch, and
+  a condition holding no status-check function is given an implicit `success()` — which is false
+  once an ancestor job was skipped. On a push to `main` every lane below the five gates the
+  publish depends on is deliberately skipped, because the merge queue has already run them on that
+  exact commit, so the publish was skipped with them. The condition now overrides that implicit
+  predicate and instead requires each of the five gates — `test`, `race`, `e2e`,
+  `e2e-postgres-smoke` and `image-smoke` — to have reported `success` by name, so a gate that
+  fails still blocks the publish. A documentation-only push, where the image smoke test does not
+  boot the image, publishes nothing on purpose and leaves `latest` on the previous commit, which
+  carries the identical image.

--- a/changelog.d/ci-publish-image-gate.md
+++ b/changelog.d/ci-publish-image-gate.md
@@ -7,9 +7,9 @@
   it rested on the predicate GitHub supplies when a condition names no job status of its own. On a
   push to `main` every lane below the five gates the publish depends on is deliberately skipped,
   because the merge queue has already run them on that exact commit, and the publish was skipped
-  with them. The condition now names what it needs instead of resting on that implicit
-  predicate: each of the five gates — `test`, `race`, `e2e`,
-  `e2e-postgres-smoke` and `image-smoke` — to have reported `success` by name, so a gate that
-  fails still blocks the publish. A documentation-only push, where the image smoke test does not
-  boot the image, publishes nothing on purpose and leaves `latest` on the previous commit, which
-  carries the identical image.
+  with them. The condition now names what it needs instead of resting on that implicit predicate:
+  it requires each of the five gates — `test`, `race`, `e2e`, `e2e-postgres-smoke` and
+  `image-smoke` — to have reported `success` by name, so a gate that fails still blocks the
+  publish. A documentation-only push, where the image smoke test does not boot the image,
+  publishes nothing on purpose and leaves `latest` on the previous commit, which carries the
+  identical image.

--- a/changelog.d/ci-publish-image-gate.md
+++ b/changelog.d/ci-publish-image-gate.md
@@ -1,9 +1,9 @@
 ### Fixed
 
 - **`ghcr.io/ovumcy/ovumcy-web:latest` follows `main` again.** The CI job that publishes it was
-  skipped on every push to `main` while the run itself reported green, so `latest`, `main` and the
-  `sha-…` tag they share all still pointed at one image 242 commits behind the head of `main`, and
-  the head carried no tag of its own. The job's condition named only the event and the branch, so
+  skipped on every push to `main` while the run itself reported green, so `latest`, `main` and a
+  `sha-…` tag all still resolved to one image, 242 commits behind the head of `main`, and the head
+  carried no tag of its own. The job's condition named only the event and the branch, so
   it rested on the predicate GitHub supplies when a condition names no job status of its own. On a
   push to `main` every lane below the five gates the publish depends on is deliberately skipped,
   because the merge queue has already run them on that exact commit, and the publish was skipped

--- a/changelog.d/ci-publish-image-gate.md
+++ b/changelog.d/ci-publish-image-gate.md
@@ -3,12 +3,12 @@
 - **`ghcr.io/ovumcy/ovumcy-web:latest` follows `main` again.** The CI job that publishes it was
   skipped on every push to `main` while the run itself reported green, so `latest`, `main` and the
   `sha-…` tag they share all still pointed at one image 242 commits behind the head of `main`, and
-  the head carried no tag of its own. The job's condition named only the event and the branch, and
-  a condition holding no status-check function is given an implicit `success()` — which is false
-  once an ancestor job was skipped. On a push to `main` every lane below the five gates the
-  publish depends on is deliberately skipped, because the merge queue has already run them on that
-  exact commit, so the publish was skipped with them. The condition now overrides that implicit
-  predicate and instead requires each of the five gates — `test`, `race`, `e2e`,
+  the head carried no tag of its own. The job's condition named only the event and the branch, so
+  it rested on the predicate GitHub supplies when a condition names no job status of its own. On a
+  push to `main` every lane below the five gates the publish depends on is deliberately skipped,
+  because the merge queue has already run them on that exact commit, and the publish was skipped
+  with them. The condition now names what it needs instead of resting on that implicit
+  predicate: each of the five gates — `test`, `race`, `e2e`,
   `e2e-postgres-smoke` and `image-smoke` — to have reported `success` by name, so a gate that
   fails still blocks the publish. A documentation-only push, where the image smoke test does not
   boot the image, publishes nothing on purpose and leaves `latest` on the previous commit, which

--- a/changelog.d/ci-publish-image-gate.md
+++ b/changelog.d/ci-publish-image-gate.md
@@ -2,8 +2,8 @@
 
 - **`ghcr.io/ovumcy/ovumcy-web:latest` follows `main` again.** The CI job that publishes it was
   skipped on every push to `main` while the run itself reported green, so `latest`, `main` and the
-  newest `sha-…` tag all still pointed at one image 242 commits old, and no `sha-<commit>` tag had
-  been created for any commit since. The job's condition named only the event and the branch, and
+  `sha-…` tag they share all still pointed at one image 242 commits behind the head of `main`, and
+  the head carried no tag of its own. The job's condition named only the event and the branch, and
   a condition holding no status-check function is given an implicit `success()` — which is false
   once an ancestor job was skipped. On a push to `main` every lane below the five gates the
   publish depends on is deliberately skipped, because the merge queue has already run them on that

--- a/scripts/publishgate/main_test.go
+++ b/scripts/publishgate/main_test.go
@@ -50,39 +50,70 @@ const publishJob = "publish-image"
 // just as much, and would leave a check that reads the actual list green.
 var wantNeeds = []string{"e2e", "e2e-postgres-smoke", "image-smoke", "race", "test"}
 
+// eventDisjunction is the ONE `||` the gate is allowed to hold: the two events
+// that may publish. Everything else has to be a conjunction, and gateProblems
+// enforces exactly that — a clause wrapped in an `||` still carries the
+// substring the per-dependency check matches on while no longer gating
+// anything, which is the one way those checks read green over a reopened gate.
+// Spelled with the same spacing the workflow uses: rewritten differently it is
+// not recognised, its own `||` survives into the check, and the condition is
+// referred back to a reader rather than guessed at.
+const eventDisjunction = "(github.event_name == 'push' || github.event_name == 'workflow_dispatch')"
+
 var (
 	jobHeader   = regexp.MustCompile(`(?m)^  [A-Za-z0-9_.-]+:[ \t]*$`)
-	needsEntry  = regexp.MustCompile(`(?m)^[ \t]*-[ \t]+([A-Za-z0-9_.-]+)[ \t]*$`)
+	needsEntry  = regexp.MustCompile(`^-[ \t]+([A-Za-z0-9_.-]+)$`)
+	plainName   = regexp.MustCompile(`^[A-Za-z0-9_.-]+$`)
 	foldMarker  = regexp.MustCompile(`^[>|][-+]?[ \t]*`)
 	whitespaces = regexp.MustCompile(`[ \t\n\r]+`)
 )
 
-// TestPublishImageGateOverridesTheImplicitSuccessAndJudgesEveryDependency is
-// the whole package: both halves of the gate, over every job the publish
-// actually depends on.
+// TestPublishImageGateOverridesTheImplicitSuccessAndJudgesEveryDependency reads
+// the real workflow and judges the gate it declares.
 func TestPublishImageGateOverridesTheImplicitSuccessAndJudgesEveryDependency(t *testing.T) {
 	block := jobBlock(t)
-	condition := jobField(t, block, "if")
 	needs := jobNeeds(t, block)
 
+	for _, problem := range gateProblems(jobField(t, block, "if"), needs) {
+		t.Errorf("%s, job %q: %s", workflowPath, publishJob, problem)
+	}
+
+	sort.Strings(needs)
+	if strings.Join(needs, ",") != strings.Join(wantNeeds, ",") {
+		t.Errorf("%s: %q now depends on %v, not on %v — a dependency dropped from `needs:` also disappears from the checks above, which read that same list, so the change has to be judged here by hand",
+			workflowPath, publishJob, needs, wantNeeds)
+	}
+}
+
+// gateProblems is the judgement itself, over a condition and the dependency
+// list it is supposed to gate on. It is separated from the workflow it reads so
+// that the rules can be proven against conditions this repository does not
+// contain — a guard whose only input is the tree it passes on has never been
+// shown to fail for the right reason.
+func gateProblems(condition string, needs []string) []string {
+	var problems []string
+
 	if !strings.Contains(condition, "!cancelled()") {
-		t.Errorf("%s: the `if` of %q holds no status-check function (%q), so GitHub supplies the implicit `success()` — which reads the whole ancestor graph and is false on every push to `main`, skipping the publish inside a green run",
-			workflowPath, publishJob, condition)
+		problems = append(problems, "the `if` holds no status-check function ("+condition+"), so GitHub supplies the implicit `success()` — which reads the whole ancestor graph and is false on every push to `main`, skipping the publish inside a green run")
 	}
 
 	for _, job := range needs {
 		clause := "needs." + job + ".result == 'success'"
 		if !strings.Contains(condition, clause) {
-			t.Errorf("%s: the `if` of %q does not carry %q, so a %q that FAILED still publishes: `!cancelled()` suppresses the implicit `success()` for every dependency at once, and nothing else judges them",
-				workflowPath, publishJob, clause, job)
+			problems = append(problems, "the `if` does not carry "+clause+", so a "+job+" that FAILED still publishes: `!cancelled()` suppresses the implicit `success()` for every dependency at once, and nothing else judges them")
 		}
 	}
 
-	sort.Strings(needs)
-	if strings.Join(needs, ",") != strings.Join(wantNeeds, ",") {
-		t.Errorf("%s: %q now depends on %v, not on %v — a dependency dropped from `needs:` also disappears from the loop above, which reads that same list, so the change has to be judged here by hand",
-			workflowPath, publishJob, needs, wantNeeds)
+	// The clauses above are substrings, and a substring survives being wrapped
+	// in an `||` — `(needs.image-smoke.result == 'success' || <anything>)` reads
+	// green above while gating on nothing. Requiring the condition to be a pure
+	// conjunction apart from the two publishing events is what closes that: any
+	// other `||` is refused here and judged by a reader.
+	if strings.Contains(strings.Replace(condition, eventDisjunction, "<events>", 1), "||") {
+		problems = append(problems, "the `if` holds an `||` beyond the two publishing events ("+condition+"), and a clause inside an `||` gates on nothing while still reading as present — write the gate as a conjunction, or judge this condition by hand")
 	}
+
+	return problems
 }
 
 // jobBlock returns the text of the publish job, from its header to the next job
@@ -115,14 +146,38 @@ func jobBlock(t *testing.T) string {
 func jobNeeds(t *testing.T, block string) []string {
 	t.Helper()
 
+	needs := parseNeeds(jobFieldLines(t, block, "needs"))
+	if len(needs) == 0 {
+		t.Fatalf("%s: %q lists no dependencies, so it is gated on nothing at all", workflowPath, publishJob)
+	}
+	return needs
+}
+
+// parseNeeds reads a dependency list in any of the three spellings YAML allows
+// for it. All three are the same list to GitHub, so all three have to be the
+// same list here: a reader that knew only the block sequence would report "no
+// dependencies at all" over a workflow that in fact declares five, and the
+// per-dependency checks would never run.
+func parseNeeds(lines []string) []string {
 	var needs []string
-	for _, line := range jobFieldLines(t, block, "needs") {
+
+	if inline := strings.TrimSpace(strings.Join(lines, " ")); strings.HasPrefix(inline, "[") {
+		for _, item := range strings.Split(strings.Trim(inline, "[]"), ",") {
+			if name := strings.TrimSpace(item); plainName.MatchString(name) {
+				needs = append(needs, name)
+			}
+		}
+		return needs
+	}
+
+	for _, line := range lines {
 		if match := needsEntry.FindStringSubmatch(line); match != nil {
 			needs = append(needs, match[1])
 		}
 	}
-	if len(needs) == 0 {
-		t.Fatalf("%s: %q lists no dependencies, so it is gated on nothing at all", workflowPath, publishJob)
+	if len(needs) == 0 && len(lines) == 1 && plainName.MatchString(lines[0]) {
+		// `needs: one-job`, the single-dependency spelling.
+		return []string{lines[0]}
 	}
 	return needs
 }
@@ -170,6 +225,92 @@ func jobFieldLines(t *testing.T, block, key string) []string {
 		t.Fatalf("%s: %q has no `%s:` key", workflowPath, publishJob, key)
 	}
 	return value
+}
+
+// goodCondition rebuilds the shape the workflow declares out of wantNeeds, so
+// the fixtures below cannot drift away from the dependency set the guard is
+// written around.
+func goodCondition() string {
+	clauses := []string{"!cancelled()", eventDisjunction, "github.ref == 'refs/heads/main'"}
+	for _, job := range wantNeeds {
+		clauses = append(clauses, "needs."+job+".result == 'success'")
+	}
+	return "${{ " + strings.Join(clauses, " && ") + " }}"
+}
+
+// TestGateProblemsRefusesEveryShapeThatReadsGreenWhileGatingOnNothing proves the
+// rules against conditions this repository does not contain. The workflow test
+// above can only ever show that today's condition passes; these fixtures are
+// what show the guard refuses the ones it exists to refuse — including the
+// `||` wrap, which every substring check in it would otherwise walk straight
+// past.
+func TestGateProblemsRefusesEveryShapeThatReadsGreenWhileGatingOnNothing(t *testing.T) {
+	good := goodCondition()
+
+	for _, testCase := range []struct {
+		name      string
+		condition string
+		want      int
+	}{
+		{"the shape the workflow declares", good, 0},
+		{
+			"no status function, so GitHub adds the implicit success()",
+			strings.Replace(good, "!cancelled() && ", "", 1),
+			1,
+		},
+		{
+			"one dependency unjudged",
+			strings.Replace(good, " && needs.image-smoke.result == 'success'", "", 1),
+			1,
+		},
+		{
+			"a clause wrapped in an `||`, which leaves the substring in place",
+			strings.Replace(good, "needs.image-smoke.result == 'success'",
+				"(needs.image-smoke.result == 'success' || github.event_name == 'workflow_dispatch')", 1),
+			1,
+		},
+		{
+			"the whole conjunction bypassed by an actor check",
+			strings.Replace(good, "${{ ", "${{ github.actor == 'someone' || ", 1),
+			1,
+		},
+		{
+			"the event disjunction respelled, which this guard refuses to read",
+			strings.Replace(good, eventDisjunction, "(github.event_name=='push'||github.event_name=='workflow_dispatch')", 1),
+			1,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := gateProblems(testCase.condition, wantNeeds)
+			if len(got) != testCase.want {
+				t.Fatalf("got %d problems %q, want %d", len(got), got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestParseNeedsReadsEveryYAMLSpellingOfADependencyList holds the reader to all
+// three spellings. A reader that knew only one of them would report the gate as
+// depending on nothing over a reformatted but identical workflow, and skip
+// every per-dependency check on the way.
+func TestParseNeedsReadsEveryYAMLSpellingOfADependencyList(t *testing.T) {
+	for _, testCase := range []struct {
+		name  string
+		lines []string
+		want  string
+	}{
+		{"block sequence", []string{"", "- test", "- image-smoke"}, "test,image-smoke"},
+		{"flow sequence", []string{"[test, image-smoke]"}, "test,image-smoke"},
+		{"flow sequence folded over two lines", []string{"[test,", "image-smoke]"}, "test,image-smoke"},
+		{"a single dependency as a scalar", []string{"test"}, "test"},
+		{"an empty list", []string{""}, ""},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := strings.Join(parseNeeds(testCase.lines), ","); got != testCase.want {
+				t.Fatalf("got %q, want %q", got, testCase.want)
+			}
+		})
+	}
 }
 
 // repoRoot walks up from the test's working directory to the module root.

--- a/scripts/publishgate/main_test.go
+++ b/scripts/publishgate/main_test.go
@@ -20,14 +20,15 @@
 // that question and true under both answers: the condition must stop resting
 // on an implicit predicate at all.
 //
-// Nothing in a green CI run says so. A skipped job is a satisfied check, and a
-// tag that never appeared in a registry is not a signal any workflow reads, so
-// the failure is silent by construction and stayed silent for 242 commits.
-// This guard is the signal, and it holds the condition to four things at once —
-// each one alone reads green over a gate the other three would catch:
+// Nothing reported that skip while it was happening. A skipped job is a
+// satisfied check, and a tag that never appeared in a registry is not a signal
+// any workflow reads, so the failure was silent by construction and stayed
+// silent for 242 commits. This guard is the signal, and it holds the condition
+// to four things at once — each one alone reads green over a gate the other
+// three would catch:
 //
-//   - the status override, `!cancelled()`, which is what suppresses the
-//     implicit `success()` this whole finding came from;
+//   - the status override, `!cancelled()`, which is what stops the condition
+//     resting on the implicit predicate at all;
 //   - an explicit `success` requirement per dependency, because `!cancelled()`
 //     on its own publishes off a FAILED gate — read off the job's own `needs:`
 //     list, so a sixth dependency added without a sixth clause fails here;

--- a/scripts/publishgate/main_test.go
+++ b/scripts/publishgate/main_test.go
@@ -3,17 +3,22 @@
 //
 // `publish-image` in .github/workflows/ci.yml is the only path by which
 // `ghcr.io/<repo>:latest` follows `main`. It lists five jobs in `needs:` and
-// carried an `if` naming only the event and the ref. With no status-check
-// function in it, GitHub supplies the implicit `success()` — and a skip
-// propagates transitively, while a gate that rescues ITSELF with `!cancelled()`
-// does not rescue what depends on it. All five gates report `success` on
-// `push`, but every lane beneath them is skipped there (`changes` clears
-// `run_core` on `push` by design), so the implicit predicate was false and the
-// publish job was skipped inside a run that reported green. Six consecutive
-// runs — 33217555948, 33213567903, 33188023148, 32905532451, 32882518209,
-// 32853636750 — show it `skipped` with `started_at == completed_at`, and at
-// `4b3c01d7` the registry's `latest`, `main` and `sha-3891c0f` all pointed at
-// one index 242 commits behind `main`.
+// carried an `if` naming only the event and the ref, with no status-check
+// function in it. Six consecutive runs — 33217555948, 33213567903,
+// 33188023148, 32905532451, 32882518209, 32853636750 — show it `skipped` with
+// `started_at == completed_at` while all five of those jobs reported
+// `success`, every lane beneath them skipped because `changes` clears
+// `run_core` on `push` by design; and at `4b3c01d7` the registry's `latest`,
+// `main` and `sha-3891c0f` all pointed at one index 242 commits behind `main`.
+//
+// That is the outcome and not the mechanism, and the mechanism is not settled
+// here: an implicit `success()` ranging over the whole ancestor graph, and a
+// skip propagating transitively past a gate that rescued only itself with
+// `!cancelled()`, predict those six runs identically. ci.yml says the same
+// where the gate lives, and says what a reader must probe before building a
+// second gate on either reading. What the rules below need is narrower than
+// that question and true under both answers: the condition must stop resting
+// on an implicit predicate at all.
 //
 // Nothing in a green CI run says so. A skipped job is a satisfied check, and a
 // tag that never appeared in a registry is not a signal any workflow reads, so

--- a/scripts/publishgate/main_test.go
+++ b/scripts/publishgate/main_test.go
@@ -1,0 +1,193 @@
+// Package publishgate holds the CI workflow's publish gate to a shape that an
+// `if` carrying no status-check function cannot have.
+//
+// `publish-image` in .github/workflows/ci.yml is the only path by which
+// `ghcr.io/<repo>:latest` follows `main`. It lists five jobs in `needs:` and
+// carried an `if` naming only the event and the ref. With no status-check
+// function in it, GitHub supplies the implicit `success()` — and a skip
+// propagates transitively, while a gate that rescues ITSELF with `!cancelled()`
+// does not rescue what depends on it. All five gates report `success` on
+// `push`, but every lane beneath them is skipped there (`changes` clears
+// `run_core` on `push` by design), so the implicit predicate was false and the
+// publish job was skipped inside a run that reported green. Six consecutive
+// runs — 33217555948, 33213567903, 33188023148, 32905532451, 32882518209,
+// 32853636750 — show it `skipped` with `started_at == completed_at`, and at
+// `4b3c01d7` the registry's `latest`, `main` and `sha-3891c0f` all pointed at
+// one index 242 commits behind `main`.
+//
+// Nothing in a green CI run says so. A skipped job is a satisfied check, and a
+// tag that never appeared in a registry is not a signal any workflow reads, so
+// the failure is silent by construction and stayed silent for 242 commits.
+// This guard is the signal. It asserts the two halves that only work together —
+// the status override that suppresses the implicit `success()`, and an explicit
+// `success` requirement per dependency, since `!cancelled()` alone would publish
+// off a FAILED gate — and it reads the requirements off the job's own `needs:`
+// list, so a sixth dependency added without a sixth clause is a failure here
+// rather than a hole in the gate.
+package publishgate
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// workflowPath is the workflow that owns both the publish job and the five
+// jobs it gates on: `needs:` cannot cross a workflow boundary, which is why the
+// gate lives there rather than beside the publish itself.
+var workflowPath = filepath.Join(".github", "workflows", "ci.yml")
+
+// publishJob is the job whose `if` this package guards.
+const publishJob = "publish-image"
+
+// wantNeeds is the dependency set the gate was designed around. The
+// per-dependency assertions below are driven by the ACTUAL `needs:` list, not
+// by this one — that is what makes an added dependency fail. This list is the
+// other direction: a dependency silently dropped from `needs:` weakens the gate
+// just as much, and would leave a check that reads the actual list green.
+var wantNeeds = []string{"e2e", "e2e-postgres-smoke", "image-smoke", "race", "test"}
+
+var (
+	jobHeader   = regexp.MustCompile(`(?m)^  [A-Za-z0-9_.-]+:[ \t]*$`)
+	needsEntry  = regexp.MustCompile(`(?m)^[ \t]*-[ \t]+([A-Za-z0-9_.-]+)[ \t]*$`)
+	foldMarker  = regexp.MustCompile(`^[>|][-+]?[ \t]*`)
+	whitespaces = regexp.MustCompile(`[ \t\n\r]+`)
+)
+
+// TestPublishImageGateOverridesTheImplicitSuccessAndJudgesEveryDependency is
+// the whole package: both halves of the gate, over every job the publish
+// actually depends on.
+func TestPublishImageGateOverridesTheImplicitSuccessAndJudgesEveryDependency(t *testing.T) {
+	block := jobBlock(t)
+	condition := jobField(t, block, "if")
+	needs := jobNeeds(t, block)
+
+	if !strings.Contains(condition, "!cancelled()") {
+		t.Errorf("%s: the `if` of %q holds no status-check function (%q), so GitHub supplies the implicit `success()` — which reads the whole ancestor graph and is false on every push to `main`, skipping the publish inside a green run",
+			workflowPath, publishJob, condition)
+	}
+
+	for _, job := range needs {
+		clause := "needs." + job + ".result == 'success'"
+		if !strings.Contains(condition, clause) {
+			t.Errorf("%s: the `if` of %q does not carry %q, so a %q that FAILED still publishes: `!cancelled()` suppresses the implicit `success()` for every dependency at once, and nothing else judges them",
+				workflowPath, publishJob, clause, job)
+		}
+	}
+
+	sort.Strings(needs)
+	if strings.Join(needs, ",") != strings.Join(wantNeeds, ",") {
+		t.Errorf("%s: %q now depends on %v, not on %v — a dependency dropped from `needs:` also disappears from the loop above, which reads that same list, so the change has to be judged here by hand",
+			workflowPath, publishJob, needs, wantNeeds)
+	}
+}
+
+// jobBlock returns the text of the publish job, from its header to the next job
+// header at the same indentation. It fails closed: a renamed or moved job is a
+// failure here, never a silently empty search.
+func jobBlock(t *testing.T) string {
+	t.Helper()
+
+	raw, err := os.ReadFile(filepath.Join(repoRoot(t), workflowPath))
+	if err != nil {
+		t.Fatalf("read %s: %v", workflowPath, err)
+	}
+	content := strings.ReplaceAll(string(raw), "\r\n", "\n")
+
+	header := "\n  " + publishJob + ":\n"
+	start := strings.Index(content, header)
+	if start < 0 {
+		t.Fatalf("%s: no job named %q — the publish path was renamed or removed, and this guard would judge nothing", workflowPath, publishJob)
+	}
+	rest := content[start+len(header):]
+
+	if next := jobHeader.FindStringIndex(rest); next != nil {
+		return rest[:next[0]]
+	}
+	return rest
+}
+
+// jobNeeds reads the job's dependency list off the workflow rather than
+// restating it, so the per-dependency assertions grow with the job.
+func jobNeeds(t *testing.T, block string) []string {
+	t.Helper()
+
+	var needs []string
+	for _, line := range jobFieldLines(t, block, "needs") {
+		if match := needsEntry.FindStringSubmatch(line); match != nil {
+			needs = append(needs, match[1])
+		}
+	}
+	if len(needs) == 0 {
+		t.Fatalf("%s: %q lists no dependencies, so it is gated on nothing at all", workflowPath, publishJob)
+	}
+	return needs
+}
+
+// jobField returns the value of one key of the job mapping as a single line,
+// with the block-scalar indicator stripped and whitespace collapsed, so that
+// folding an expression across lines does not change what this file matches on.
+func jobField(t *testing.T, block, key string) string {
+	t.Helper()
+
+	joined := strings.TrimSpace(strings.Join(jobFieldLines(t, block, key), " "))
+	return whitespaces.ReplaceAllString(foldMarker.ReplaceAllString(joined, ""), " ")
+}
+
+// jobFieldLines returns one key of the job mapping line by line — the text
+// after the colon, then every more-indented line under it, comments and blank
+// lines dropped. A sequence value has to stay line-shaped: collapsing it would
+// run its entries together into one string with no item boundary left.
+func jobFieldLines(t *testing.T, block, key string) []string {
+	t.Helper()
+
+	var (
+		value   []string
+		reading bool
+	)
+	for _, line := range strings.Split(block, "\n") {
+		switch {
+		case strings.HasPrefix(line, "    "+key+":"):
+			reading = true
+			value = append(value, strings.TrimSpace(strings.TrimPrefix(line, "    "+key+":")))
+			continue
+		case !reading:
+			continue
+		case strings.TrimSpace(line) == "":
+			continue
+		case strings.HasPrefix(strings.TrimSpace(line), "#"):
+			continue
+		case strings.HasPrefix(line, "     "):
+			value = append(value, strings.TrimSpace(line))
+			continue
+		}
+		reading = false
+	}
+	if len(value) == 0 {
+		t.Fatalf("%s: %q has no `%s:` key", workflowPath, publishJob, key)
+	}
+	return value
+}
+
+// repoRoot walks up from the test's working directory to the module root.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("go.mod not found above %s", dir)
+		}
+		dir = parent
+	}
+}

--- a/scripts/publishgate/main_test.go
+++ b/scripts/publishgate/main_test.go
@@ -14,11 +14,12 @@
 // That is the outcome and not the mechanism, and the mechanism is not settled
 // here: an implicit `success()` ranging over the whole ancestor graph, and a
 // skip propagating transitively past a gate that rescued only itself with
-// `!cancelled()`, predict those six runs identically. ci.yml says the same
-// where the gate lives, and says what a reader must probe before building a
-// second gate on either reading. What the rules below need is narrower than
-// that question and true under both answers: the condition must stop resting
-// on an implicit predicate at all.
+// `!cancelled()`, predict those six runs identically — as they do every other
+// job shape this workflow currently has. ci.yml says the same where the gate
+// lives, and says what to settle before a second gate is built on either
+// reading. What the rules below need is narrower than that question and true
+// under both answers: the condition must stop resting on an implicit predicate
+// at all.
 //
 // Nothing reported that skip while it was happening. A skipped job is a
 // satisfied check, and a tag that never appeared in a registry is not a signal

--- a/scripts/publishgate/main_test.go
+++ b/scripts/publishgate/main_test.go
@@ -18,12 +18,26 @@
 // Nothing in a green CI run says so. A skipped job is a satisfied check, and a
 // tag that never appeared in a registry is not a signal any workflow reads, so
 // the failure is silent by construction and stayed silent for 242 commits.
-// This guard is the signal. It asserts the two halves that only work together —
-// the status override that suppresses the implicit `success()`, and an explicit
-// `success` requirement per dependency, since `!cancelled()` alone would publish
-// off a FAILED gate — and it reads the requirements off the job's own `needs:`
-// list, so a sixth dependency added without a sixth clause is a failure here
-// rather than a hole in the gate.
+// This guard is the signal, and it holds the condition to four things at once —
+// each one alone reads green over a gate the other three would catch:
+//
+//   - the status override, `!cancelled()`, which is what suppresses the
+//     implicit `success()` this whole finding came from;
+//   - an explicit `success` requirement per dependency, because `!cancelled()`
+//     on its own publishes off a FAILED gate — read off the job's own `needs:`
+//     list, so a sixth dependency added without a sixth clause fails here;
+//   - no `||` beyond the two publishing events, because those requirements are
+//     substrings and a substring survives being wrapped in one, which would
+//     leave the check above green over a clause that gates on nothing;
+//   - that `needs:` list itself against the five the gate was designed around,
+//     since a dependency dropped from it also drops out of the check that reads
+//     it.
+//
+// Each rule refuses a shape rather than approving one, so a condition this
+// package cannot read is a failure and not a pass — including a respelled event
+// disjunction, which is referred back to a reader instead of being guessed at.
+// gateProblems is where all four live, away from the workflow they read, so
+// they can be proven against conditions this repository does not contain.
 package publishgate
 
 import (
@@ -109,8 +123,17 @@ func gateProblems(condition string, needs []string) []string {
 	// green above while gating on nothing. Requiring the condition to be a pure
 	// conjunction apart from the two publishing events is what closes that: any
 	// other `||` is refused here and judged by a reader.
+	//
+	// The refusal is deliberate even when the new `||` is CORRECT. The one
+	// change that is known to want a second one is making a dependency
+	// skip-tolerant — `(needs.image-smoke.result == 'success' || … ==
+	// 'skipped')`, so that a docs-only push, where the image is never booted,
+	// publishes anyway. That is a real decision about what may reach the
+	// registry unsmoked, and it must not ride in as a `||` this file waves
+	// through, so the message names both knobs rather than leaving the reader
+	// to find them.
 	if strings.Contains(strings.Replace(condition, eventDisjunction, "<events>", 1), "||") {
-		problems = append(problems, "the `if` holds an `||` beyond the two publishing events ("+condition+"), and a clause inside an `||` gates on nothing while still reading as present — write the gate as a conjunction, or judge this condition by hand")
+		problems = append(problems, "the `if` holds an `||` beyond the two publishing events ("+condition+"), and a clause inside an `||` gates on nothing while still reading as present. Two knobs, and the right one depends on which change this is: a respelled event disjunction is fixed by matching `eventDisjunction` in this file to the workflow's exact spelling; a deliberately skip-tolerant dependency is a decision to publish an image no smoke test booted, and belongs in this function as its own rule, next to the per-dependency check it weakens")
 	}
 
 	return problems
@@ -267,6 +290,15 @@ func TestGateProblemsRefusesEveryShapeThatReadsGreenWhileGatingOnNothing(t *test
 			"a clause wrapped in an `||`, which leaves the substring in place",
 			strings.Replace(good, "needs.image-smoke.result == 'success'",
 				"(needs.image-smoke.result == 'success' || github.event_name == 'workflow_dispatch')", 1),
+			1,
+		},
+		{
+			// The change the guard is most likely to meet, and it is refused on
+			// purpose: publishing an image the smoke test never booted is a
+			// decision, not a spelling.
+			"a dependency made skip-tolerant",
+			strings.Replace(good, "needs.image-smoke.result == 'success'",
+				"(needs.image-smoke.result == 'success' || needs.image-smoke.result == 'skipped')", 1),
 			1,
 		},
 		{


### PR DESCRIPTION
`publish-image` is the only path by which `ghcr.io/ovumcy/ovumcy-web:latest` follows `main`. It was **deterministically skipped on every push to `main`**, inside a run that reported green.

## The mechanism

The job's `if` named only the event and the ref:

```yaml
if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
```

No status-check function in it, so GitHub supplies the implicit `success()` — and a skip propagates transitively, while a gate that rescues *itself* with `!cancelled()` does not rescue what depends on it. All five gates in `needs:` report `success` on `push` (`test` 4 s, `race` 2 s, `e2e` 4 s, `e2e-postgres-smoke` 259 s, `image-smoke` 19 s), but every lane beneath them is `skipped` there — `changes` clears `run_core` on `push` by design, because the merge queue already ran the core suite on that exact commit. So the implicit predicate was false and the publish never ran.

Measured on six consecutive runs — 33217555948, 33213567903, 33188023148, 32905532451, 32882518209, 32853636750 — `skipped` in all six, `started_at == completed_at`.

Nothing reported it: a skipped job is a satisfied check, and a tag that never appeared in a registry is not a signal any workflow reads. At `4b3c01d7` the registry's `latest`, `main` and `sha-3891c0f` all pointed at one index, **242 commits behind `main`**, and `sha-4b3c01d` did not exist (`MANIFEST_UNKNOWN`).

## The fix

`!cancelled()` suppresses the implicit `success()`. On its own it would publish off a **failed** gate, so the five results are then required by name:

```yaml
if: >-
  ${{ !cancelled()
  && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
  && github.ref == 'refs/heads/main'
  && needs.test.result == 'success'
  && needs.race.result == 'success'
  && needs.e2e.result == 'success'
  && needs.e2e-postgres-smoke.result == 'success'
  && needs.image-smoke.result == 'success' }}
```

Nothing else in `ci.yml` changes.

The five names are not taken on trust: `actionlint` type-checks `needs.<job>.result`, and misspelling one to `image-smoek` in a copy produces `property "image-smoek" is not defined in object type {e2e: …; e2e-postgres-smoke: …; image-smoke: …; race: …; test: …}`. The hyphenated properties resolve, and all five exist.

**`success` and nothing else, deliberately.** `image-smoke` is the one gate that can be `skipped` on a push: a documentation-only merge leaves `run_e2e=false`, so the image is never booted. Such a push therefore publishes nothing and leaves `latest` on the previous commit — which carries the identical image. Publishing an image no smoke test looked at is the outcome this gate exists to prevent.

## The guard — `scripts/publishgate`

It reads the requirements **off the job's own `needs:` list**, so a sixth dependency added without a sixth clause fails here rather than reopening the hole, and it compares that list against the known five so a dependency silently dropped is caught in the other direction.

Two holes in the guard itself were found in review and closed in the second commit, both of them the guard reading green over a gate that no longer gates:

- **A clause survives being wrapped in an `||`.** `(needs.image-smoke.result == 'success' || <anything>)` carries every substring the per-dependency check matches on while gating on nothing. The condition must now be a pure conjunction apart from the two publishing events — the one `||` the gate is allowed to hold. An event disjunction respelled is not recognised and is referred back to a reader rather than guessed at.
- **`needs:` was read in one of the three spellings YAML allows.** A flow sequence (`needs: [a, b]`) — the same list to GitHub — matched nothing and reported "gated on nothing at all" over a workflow that declares five, skipping every per-dependency check on the way. All three spellings now read the same.

The judgement lives in `gateProblems`, away from the workflow it reads, so the rules are proven against conditions this repository does not contain: a guard whose only input is the tree it passes on has never been shown to fail for the right reason. Six fixtures for the condition (including the `||` wrap and an actor-check bypass), five for the list.

Against the pre-fix tree the workflow test fails with six errors — the missing status function plus all five missing clauses; green on this branch.

## Sibling search

Every job in every workflow with a `needs:` and no status function in its `if`: `coverage-merge`, `coverage-upload`, `patch-coverage`, `e2e-shard`, `e2e-postgres-smoke`. All five are intentional and already documented in place — the `test` gate judges `coverage-merge` precisely so a failed merge cannot skip `patch-coverage` into a satisfied state, and the two e2e lanes gate per step. `publish-image` was the only one whose skip no required check covers.

## Verification after merge

This cannot be verified before the merge: no push run executes the new `if` until it is on `main`. Afterwards:

- `gh run list --branch main --workflow CI -L 1` carries a `publish-image / publish` job;
- `docker manifest inspect ghcr.io/ovumcy/ovumcy-web:sha-<short-HEAD>` answers instead of `MANIFEST_UNKNOWN`;
- `latest` and `main` carry `org.opencontainers.image.revision` = HEAD.

## Checks run locally

`actionlint`, `go vet`, `staticcheck`, `golangci-lint --max-issues-per-linter=0 --max-same-issues=0`, `deadcode -test` and `archcheck` over the scoped package list — all clean; `gofmt -l` clean; `go test ./scripts/publishgate` and `TestChangeDetectionRunsTheGoLanesForARunbookOnlyDiff` (the other reader of `ci.yml`) both pass; `changelogd check` OK.
