### PR TITLE
fix(services): make the inferred luteal phase round-trip through prediction

### DIFF
--- a/changelog.d/fix-luteal-inference-round-trip.md
+++ b/changelog.d/fix-luteal-inference-round-trip.md
@@ -5,8 +5,12 @@
   phase instead of assuming the 14-day model default, that length was measured one day too long: it
   counted the ovulation day itself, which belongs to the phase before it. The prediction built from
   it then sat one day early — the ovulation date and both edges of the fertile window alike — on the
-  dashboard, the calendar, the API, the webhook reminders and the `.ics` feed. An ovulation observed
+  dashboard, the calendar, the stats cycle ribbon, the API, the webhook reminders and the `.ics`
+  feed. An ovulation observed
   on cycle day 15 came back as a prediction for cycle day 14. Learning and predicting are now two
   directions of one arithmetic, so an ovulation observed on a cycle day is predicted on that same
   cycle day when the next cycle runs the same length. Accounts still on the 14-day default, and
-  every recorded observation, are unchanged.
+  every recorded observation, are unchanged. One side effect is worth naming: the 10-to-20-day
+  plausibility window a cycle must fall inside to count is now measured the corrected way too, so a
+  cycle that sat exactly on its lower edge no longer counts. An account whose signal only just
+  qualified can fall back to the 14-day default rather than shift by a day.

--- a/changelog.d/fix-luteal-inference-round-trip.md
+++ b/changelog.d/fix-luteal-inference-round-trip.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- **A personalized ovulation estimate no longer lands a day before the day your own logs pointed
+  at.** Once enough basal-temperature or cervical-mucus entries let the app learn your own luteal
+  phase instead of assuming the 14-day model default, that length was measured one day too long: it
+  counted the ovulation day itself, which belongs to the phase before it. The prediction built from
+  it then sat one day early — the ovulation date and both edges of the fertile window alike — on the
+  dashboard, the calendar, the API, the webhook reminders and the `.ics` feed. An ovulation observed
+  on cycle day 15 came back as a prediction for cycle day 14. Learning and predicting are now two
+  directions of one arithmetic, so an ovulation observed on a cycle day is predicted on that same
+  cycle day when the next cycle runs the same length. Accounts still on the 14-day default, and
+  every recorded observation, are unchanged.

--- a/docs/cycle-prediction.md
+++ b/docs/cycle-prediction.md
@@ -76,11 +76,19 @@ observedLuteal = cycleLength − observedOvulationDay
 ```
 
 Both directions have to use one indexing, or an observation trains a value that
-predicts a different day than the one observed. The invariant that buys, pinned
-by `TestLutealPhaseRoundTrip_ReferenceVectors`:
+predicts a different day than the one observed. What using one buys:
 
 > An ovulation observed on cycle day **N** predicts cycle day **N** again on a
 > next cycle of the same length.
+
+The table below is asserted row for row by
+`TestLutealPhaseRoundTrip_ReferenceVectors`. The invariant itself is a claim
+about the *observation* path, so it is pinned where that path runs, by
+`TestInferredLutealPhaseRoundTripsThroughPrediction` and
+`TestInferredLutealPhaseReachesTheOwnerSurfacesThroughTheBaseline`: those read an
+ovulation out of logged temperature or mucus entries and follow it all the way to
+a rendered date. A test of the two formulas alone cannot see the drift, because
+each formula stayed correct while they disagreed about the other.
 
 | cycleLength | observed ovulation | → lutealPhase | → predicted ovulation |
 |-------------|--------------------|---------------|-----------------------|
@@ -89,7 +97,7 @@ by `TestLutealPhaseRoundTrip_ReferenceVectors`:
 | 21 | day 8  | 13 | day 8  |
 | 35 | day 21 | 14 | day 21 |
 | 40 | day 26 | 14 | day 26 |
-| 30 | day 20 | 10 (the floor) | day 20 |
+| 30 | day 20 | 10 (equal to the floor, not clamped to it) | day 20 |
 
 The parameter counts the days that *follow* ovulation, so it is one day shorter
 than the calendar span from the ovulation date to the next period start — that

--- a/docs/cycle-prediction.md
+++ b/docs/cycle-prediction.md
@@ -87,8 +87,10 @@ about the *observation* path, so it is pinned where that path runs, by
 `TestInferredLutealPhaseRoundTripsThroughPrediction` and
 `TestInferredLutealPhaseReachesTheOwnerSurfacesThroughTheBaseline`: those read an
 ovulation out of logged temperature or mucus entries and follow it all the way to
-a rendered date. A test of the two formulas alone cannot see the drift, because
-each formula stayed correct while they disagreed about the other.
+a rendered date. A test of the two formulas alone could never have caught the
+drift, and not by oversight: they are exact inverses by construction, so the pair
+always agrees. What drifted was a third thing — the step that read an ovulation
+out of the logs and worked out which argument to hand them.
 
 | cycleLength | observed ovulation | → lutealPhase | → predicted ovulation |
 |-------------|--------------------|---------------|-----------------------|

--- a/docs/cycle-prediction.md
+++ b/docs/cycle-prediction.md
@@ -24,15 +24,16 @@ implementation cannot silently drift apart.
 |-------|---------|--------|
 | `periodStart` | First day of the current menstrual period (cycle day 1) | Detected from logged period days |
 | `cycleLength` | Length of the cycle in days | Median of observed cycles, or the user's configured value |
-| `lutealPhase` | Days from ovulation to the next period | **14-day** default, refined toward the owner's own value from logged BBT / cervical-mucus signals when enough cycles carry them |
+| `lutealPhase` | Days that **follow** ovulation, up to and including the day before the next period | **14-day** default, refined toward the owner's own value from logged BBT / cervical-mucus signals when enough cycles carry them |
 
 ## The model
 
-The model rests on one physiological assumption: **the luteal phase (ovulation →
-next period) is relatively stable per person** — modelled at ~14 days by default,
-and refined toward the owner's own value when logged signals allow — while the
-follicular phase (period → ovulation) absorbs the variation in cycle length. So
-ovulation is counted *backwards* from the next expected period.
+The model rests on one physiological assumption: **the luteal phase (the days
+after ovulation, up to the next period) is relatively stable per person** —
+modelled at ~14 days by default, and refined toward the owner's own value when
+logged signals allow — while the follicular phase (period → ovulation) absorbs
+the variation in cycle length. So ovulation is counted *backwards* from the next
+expected period.
 
 ### Constants
 
@@ -63,6 +64,38 @@ if ovulationDay < 5:                      no prediction
 
 `periodStart` is cycle day 1, so the ovulation **date** is
 `periodStart + (ovulationDay − 1)` days.
+
+### Step 2a — the same arithmetic, run backwards
+
+Personalization travels this arithmetic in the other direction: an ovulation
+*observed* from logged signals is turned back into the `lutealPhase` the step
+above consumes. That is Step 2 solved for the luteal phase, and nothing more:
+
+```
+observedLuteal = cycleLength − observedOvulationDay
+```
+
+Both directions have to use one indexing, or an observation trains a value that
+predicts a different day than the one observed. The invariant that buys, pinned
+by `TestLutealPhaseRoundTrip_ReferenceVectors`:
+
+> An ovulation observed on cycle day **N** predicts cycle day **N** again on a
+> next cycle of the same length.
+
+| cycleLength | observed ovulation | → lutealPhase | → predicted ovulation |
+|-------------|--------------------|---------------|-----------------------|
+| 28 | day 14 | 14 (the model default) | day 14 |
+| 28 | day 15 | 13 | day 15 |
+| 21 | day 8  | 13 | day 8  |
+| 35 | day 21 | 14 | day 21 |
+| 40 | day 26 | 14 | day 26 |
+| 30 | day 20 | 10 (the floor) | day 20 |
+
+The parameter counts the days that *follow* ovulation, so it is one day shorter
+than the calendar span from the ovulation date to the next period start — that
+span counts the ovulation day itself. Measuring that span and feeding it back in
+as the parameter moved every personalized prediction one day early, the
+ovulation date and both fertile-window edges alike.
 
 ### Step 3 — fertile window
 
@@ -108,9 +141,9 @@ These are the exact cases asserted by the reference tests.
   is used — for the next-period estimate only; see "First cycle" below.
 - **Luteal phase** defaults to the fixed 14-day model value, but is refined for
   the owner when their logs carry enough signal: when basal body temperature or
-  cervical-mucus entries let the app infer the ovulation-to-next-period length
-  across several cycles, the average of those observed luteal lengths replaces
-  the default. A cycle whose inferred luteal length falls outside a
+  cervical-mucus entries place the ovulation inside past cycles, each of those
+  observations becomes a luteal length by Step 2a and the average of them
+  replaces the default. A cycle whose inferred luteal length falls outside a
   physiological 10–20 day window is **discarded**, not pulled to the nearest
   edge of it — an implausible inference is treated as a bad reading rather than
   as a 10 or a 20 — and the refinement needs at least two surviving cycles, so

--- a/internal/services/cycle_bounds_and_day_diff_test.go
+++ b/internal/services/cycle_bounds_and_day_diff_test.go
@@ -130,9 +130,11 @@ func periodLogsOn(days ...time.Time) []models.DailyLog {
 
 // eggWhiteLutealLogs builds four 30-day cycles whose only ovulation signal is
 // egg-white mucus, placed so every cycle's inferred luteal phase is exactly
-// lutealLength days. Ovulation is estimated at peak day + 1, so the peak sits
-// lutealLength+1 days before the next cycle start. No BBT values are recorded,
-// which keeps the thermal detector out of the inference.
+// lutealLength days. Working backwards: the luteal phase counts the days that
+// FOLLOW ovulation, so the ovulation lands on cycle day 30-lutealLength, which
+// is lutealLength+1 days before the next cycle start; ovulation is estimated at
+// peak day + 1, so the peak sits one day earlier still. No BBT values are
+// recorded, which keeps the thermal detector out of the inference.
 func eggWhiteLutealLogs(lutealLength int) []models.DailyLog {
 	const cycleLength = 30
 	const cycleCount = 4
@@ -149,7 +151,7 @@ func eggWhiteLutealLogs(lutealLength int) []models.DailyLog {
 			continue
 		}
 		nextStart := start.AddDate(0, 0, cycleLength)
-		peak := nextStart.AddDate(0, 0, -(lutealLength + 1))
+		peak := nextStart.AddDate(0, 0, -(lutealLength + 2))
 		logs = append(logs, models.DailyLog{Date: peak, CervicalMucus: models.CervicalMucusEggWhite})
 	}
 	return logs

--- a/internal/services/cycle_luteal_round_trip_test.go
+++ b/internal/services/cycle_luteal_round_trip_test.go
@@ -75,11 +75,12 @@ func lutealRoundTripLogs(origin time.Time, cycleLength int, ovulationCycleDays [
 	return logs
 }
 
-// assertLutealRoundTrip runs the full loop the owner-facing surfaces run: infer
-// the parameter from the logged signal, then predict with it on a cycle of the
-// same length and check the prediction lands back on the observed cycle day —
-// as a day number, as a date, and as the fertile window's peak edge.
-func assertLutealRoundTrip(t *testing.T, logs []models.DailyLog, location *time.Location, cycleLength, wantOvulationCycleDay int) int {
+// assertLutealRoundTrip runs the loop the owner-facing surfaces run: infer the
+// parameter from the logged signal, then predict with it on the fixture's own
+// in-progress cycle (nextCycleStart, the last start the logs carry) and check
+// the prediction lands back on the observed cycle day — as a day number, as a
+// date, and as the fertile window's peak edge.
+func assertLutealRoundTrip(t *testing.T, logs []models.DailyLog, location *time.Location, cycleLength, wantOvulationCycleDay int, nextCycleStart time.Time) int {
 	t.Helper()
 
 	luteal, refined := InferUserLutealPhase(logs, location)
@@ -101,12 +102,11 @@ func assertLutealRoundTrip(t *testing.T, logs []models.DailyLog, location *time.
 	}
 
 	// The same trip as a date, through the function the surfaces actually call.
-	nextStart := dateOnly(time.Date(2026, time.September, 1, 0, 0, 0, 0, time.UTC))
-	window := PredictCycleWindow(nextStart, cycleLength, luteal)
+	window := PredictCycleWindow(nextCycleStart, cycleLength, luteal)
 	if !window.Calculable {
-		t.Fatalf("PredictCycleWindow(%s, %d, %d) returned no window", nextStart.Format("2006-01-02"), cycleLength, luteal)
+		t.Fatalf("PredictCycleWindow(%s, %d, %d) returned no window", nextCycleStart.Format("2006-01-02"), cycleLength, luteal)
 	}
-	wantDate := dateOnly(nextStart.AddDate(0, 0, wantOvulationCycleDay-1))
+	wantDate := dateOnly(nextCycleStart.AddDate(0, 0, wantOvulationCycleDay-1))
 	if !window.OvulationDate.Equal(wantDate) {
 		t.Errorf("predicted ovulation date = %s, want %s", window.OvulationDate.Format("2006-01-02"), wantDate.Format("2006-01-02"))
 	}
@@ -149,8 +149,11 @@ func TestInferredLutealPhaseRoundTripsThroughPrediction(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
+			// Two signalled cycles plus the in-progress third, which is the one a
+			// prediction is actually made for.
 			logs := lutealRoundTripLogs(origin, testCase.cycleLength, []int{testCase.ovulationCycleDay, testCase.ovulationCycleDay}, testCase.kind)
-			assertLutealRoundTrip(t, logs, time.UTC, testCase.cycleLength, testCase.ovulationCycleDay)
+			nextCycleStart := origin.AddDate(0, 0, 2*testCase.cycleLength)
+			assertLutealRoundTrip(t, logs, time.UTC, testCase.cycleLength, testCase.ovulationCycleDay, nextCycleStart)
 		})
 	}
 }
@@ -169,19 +172,24 @@ func TestInferredLutealPhaseRoundTripsAcrossSeveralSamples(t *testing.T) {
 	origin := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
 	logs := lutealRoundTripLogs(origin, cycleLength, []int{14, 15, 16}, lutealSignalBBT)
 
-	luteal := assertLutealRoundTrip(t, logs, time.UTC, cycleLength, 15)
+	luteal := assertLutealRoundTrip(t, logs, time.UTC, cycleLength, 15, origin.AddDate(0, 0, 3*cycleLength))
 	if luteal != 13 {
 		t.Errorf("inferred luteal phase = %d, want 13 (mean of samples 14, 13, 12)", luteal)
 	}
 }
 
-// TestInferredLutealPhaseRoundTripsAcrossDSTAndTimezones runs the same loop in
-// zones whose clocks move inside the observed cycles. Both quantities the
-// inference measures — the cycle length and the ovulation's offset from the
-// cycle start — are calendar-day counts taken through CalendarDaysBetween, so a
-// transition between the two endpoints must not shorten either: the inferred
-// parameter, and therefore the predicted cycle day, must be identical to the
-// UTC run.
+// TestInferredLutealPhaseRoundTripsAcrossDSTAndTimezones runs the loop in zones
+// whose clocks move inside the observed cycles. Both quantities the INFERENCE
+// measures — the cycle length and the ovulation's offset from the cycle start —
+// are calendar-day counts taken through CalendarDaysBetween, so a transition
+// between the two endpoints must not shorten either: the inferred parameter, and
+// therefore the predicted cycle day, must be identical to the UTC run.
+//
+// The inference is the half that runs in the zone. PredictCycleWindow re-anchors
+// its own operands to UTC midnight (dateOnly), so the date leg is
+// zone-independent by construction rather than by test; the location-aware
+// projection layer above it is pinned separately by
+// TestCycleProjection_GoldenVectors, whose fixture carries its own DST vector.
 func TestInferredLutealPhaseRoundTripsAcrossDSTAndTimezones(t *testing.T) {
 	t.Parallel()
 
@@ -214,7 +222,8 @@ func TestInferredLutealPhaseRoundTripsAcrossDSTAndTimezones(t *testing.T) {
 			}
 
 			logs := lutealRoundTripLogs(testCase.origin, cycleLength, []int{testCase.observed, testCase.observed}, testCase.kind)
-			zoned := assertLutealRoundTrip(t, logs, location, cycleLength, testCase.observed)
+			nextCycleStart := CalendarDay(testCase.origin.AddDate(0, 0, 2*cycleLength), location)
+			zoned := assertLutealRoundTrip(t, logs, location, cycleLength, testCase.observed, nextCycleStart)
 
 			utc, refined := InferUserLutealPhase(logs, time.UTC)
 			if !refined {
@@ -224,5 +233,55 @@ func TestInferredLutealPhaseRoundTripsAcrossDSTAndTimezones(t *testing.T) {
 				t.Errorf("inferred luteal phase = %d in %s but %d in UTC: the location changed a calendar-day count", zoned, testCase.zone, utc)
 			}
 		})
+	}
+}
+
+// TestInferredLutealPhaseReachesTheOwnerSurfacesThroughTheBaseline closes the
+// loop the tests above leave open. ApplyUserCycleBaseline is what every
+// owner-facing surface goes through, and it is the only place that chooses
+// between the live inference and the value persisted in users.luteal_phase.
+//
+// That column is a derived cache — DayService and ImportService write it from
+// InferUserLutealPhase — so a row left behind by an OLDER inference is exactly
+// the shape the precedence has to survive: the stored value here is the
+// one-day-too-long 14 a pre-fix day save would have written for these very logs,
+// and the projection must ignore it in favour of the corrected 13.
+func TestInferredLutealPhaseReachesTheOwnerSurfacesThroughTheBaseline(t *testing.T) {
+	t.Parallel()
+
+	const cycleLength = 28
+	origin := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	logs := lutealRoundTripLogs(origin, cycleLength, []int{15, 15}, lutealSignalBBT)
+
+	// Cycle starts Jan 1, Jan 29 and Feb 26; today sits inside the third.
+	now := time.Date(2026, time.March, 3, 9, 0, 0, 0, time.UTC)
+	user := models.User{
+		ID:          1,
+		Role:        models.RoleOwner,
+		CycleLength: cycleLength,
+		LutealPhase: 14,
+	}
+
+	stats := ApplyUserCycleBaseline(&user, logs, BuildCycleStats(logs, now), now, time.UTC)
+
+	if stats.LutealPhase != 13 {
+		t.Fatalf("stats.LutealPhase = %d, want 13: the live inference must win over the persisted column", stats.LutealPhase)
+	}
+	if !stats.OvulationExact {
+		t.Error("stats.OvulationExact = false; a luteal phase this inference accepted fits a 28-day cycle exactly")
+	}
+
+	// The third cycle starts Feb 26, so its cycle day 15 is March 12. The stale
+	// 14 would have named March 11 — the whole defect, in one assertion.
+	wantOvulation := time.Date(2026, time.March, 12, 0, 0, 0, 0, time.UTC)
+	if !stats.OvulationDate.Equal(wantOvulation) {
+		t.Errorf("stats.OvulationDate = %s, want %s", stats.OvulationDate.Format("2006-01-02"), wantOvulation.Format("2006-01-02"))
+	}
+	if !stats.FertilityWindowEnd.Equal(wantOvulation) {
+		t.Errorf("stats.FertilityWindowEnd = %s, want %s", stats.FertilityWindowEnd.Format("2006-01-02"), wantOvulation.Format("2006-01-02"))
+	}
+	wantFertilityStart := wantOvulation.AddDate(0, 0, -5)
+	if !stats.FertilityWindowStart.Equal(wantFertilityStart) {
+		t.Errorf("stats.FertilityWindowStart = %s, want %s", stats.FertilityWindowStart.Format("2006-01-02"), wantFertilityStart.Format("2006-01-02"))
 	}
 }

--- a/internal/services/cycle_luteal_round_trip_test.go
+++ b/internal/services/cycle_luteal_round_trip_test.go
@@ -1,0 +1,228 @@
+package services
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+)
+
+// The round-trip invariant pinned here: an ovulation OBSERVED on cycle day N
+// must train a luteal-phase parameter that predicts cycle day N again on an
+// identical next cycle. Inference (InferUserLutealPhase) and prediction
+// (CalcOvulationDay) are the two directions of one arithmetic, and nothing but
+// a test crosses them — each is self-consistent alone, so a disagreement about
+// whether the ovulation day itself belongs to the luteal phase is invisible
+// from either side.
+//
+// It was not invisible to owners. Reading the parameter as the calendar span
+// from the ovulation date to the next period start counts the ovulation day
+// twice, making the value one day too large; CalcOvulationDay then subtracts it
+// from the cycle length and lands one day early. An ovulation observed on cycle
+// day 15 predicted cycle day 14 — moving the ovulation date and both edges of
+// the fertile window a day earlier on the dashboard, the calendar, /api/v1, the
+// webhook reminders and the .ics feed, for exactly the owners who had logged
+// enough BBT or cervical-mucus signal to earn a personalized model.
+
+type lutealSignalKind int
+
+const (
+	// lutealSignalBBT drives inference through the shared "3-over-6" thermal
+	// detector; lutealSignalEggWhite drives it through the cervical-mucus
+	// peak-day fallback. Both reach the same luteal-length computation, so both
+	// have to round-trip.
+	lutealSignalBBT lutealSignalKind = iota
+	lutealSignalEggWhite
+)
+
+// lutealRoundTripLogs builds len(ovulationCycleDays)+1 observed cycle starts,
+// cycleLength days apart from origin, and plants an ovulation signal in every
+// cycle but the last (the last start only closes the previous cycle, exactly as
+// an in-progress cycle does in production). Cycle i's signal is placed so the
+// inference must read its ovulation on cycle day ovulationCycleDays[i].
+//
+// The BBT layout is dictated by the detector: six flat readings open the cycle
+// as the coverline window, then three consecutive elevated days start the day
+// AFTER ovulation, because the thermal shift follows ovulation. That needs
+// ovulationCycleDay >= 6 and ovulationCycleDay+3 <= cycleLength. The egg-white
+// layout is the peak-day rule read backwards: ovulation is peak + 1, so the
+// peak sits on the day before.
+func lutealRoundTripLogs(origin time.Time, cycleLength int, ovulationCycleDays []int, kind lutealSignalKind) []models.DailyLog {
+	logs := make([]models.DailyLog, 0, (len(ovulationCycleDays)+1)*11)
+	for cycle := range len(ovulationCycleDays) + 1 {
+		start := origin.AddDate(0, 0, cycle*cycleLength)
+		logs = append(logs,
+			models.DailyLog{Date: start, IsPeriod: true, CycleStart: true, Flow: models.FlowMedium},
+			models.DailyLog{Date: start.AddDate(0, 0, 1), IsPeriod: true, Flow: models.FlowMedium},
+		)
+		if cycle == len(ovulationCycleDays) {
+			continue
+		}
+
+		ovulationCycleDay := ovulationCycleDays[cycle]
+		if kind == lutealSignalEggWhite {
+			peak := start.AddDate(0, 0, ovulationCycleDay-2)
+			logs = append(logs, models.DailyLog{Date: peak, CervicalMucus: models.CervicalMucusEggWhite})
+			continue
+		}
+		for offset := range bbtCoverlineWindow {
+			logs = append(logs, models.DailyLog{Date: start.AddDate(0, 0, offset), BBT: new(36.20)})
+		}
+		for offset := range bbtElevatedStreakDays {
+			logs = append(logs, models.DailyLog{Date: start.AddDate(0, 0, ovulationCycleDay+offset), BBT: new(36.50)})
+		}
+	}
+	return logs
+}
+
+// assertLutealRoundTrip runs the full loop the owner-facing surfaces run: infer
+// the parameter from the logged signal, then predict with it on a cycle of the
+// same length and check the prediction lands back on the observed cycle day —
+// as a day number, as a date, and as the fertile window's peak edge.
+func assertLutealRoundTrip(t *testing.T, logs []models.DailyLog, location *time.Location, cycleLength, wantOvulationCycleDay int) int {
+	t.Helper()
+
+	luteal, refined := InferUserLutealPhase(logs, location)
+	if !refined {
+		t.Fatal("InferUserLutealPhase declined to refine; the fixture must supply at least two usable cycles")
+	}
+	if wantLuteal := cycleLength - wantOvulationCycleDay; luteal != wantLuteal {
+		t.Errorf("inferred luteal phase = %d, want %d (cycle length %d minus the observed ovulation day %d)",
+			luteal, wantLuteal, cycleLength, wantOvulationCycleDay)
+	}
+
+	ovulationDay, exact := CalcOvulationDay(cycleLength, luteal)
+	if !exact {
+		t.Errorf("CalcOvulationDay(%d, %d) reported a clamped estimate; a luteal phase this inference accepted must fit the cycle exactly", cycleLength, luteal)
+	}
+	if ovulationDay != wantOvulationCycleDay {
+		t.Fatalf("round trip broken: an ovulation observed on cycle day %d inferred luteal %d, which predicts cycle day %d",
+			wantOvulationCycleDay, luteal, ovulationDay)
+	}
+
+	// The same trip as a date, through the function the surfaces actually call.
+	nextStart := dateOnly(time.Date(2026, time.September, 1, 0, 0, 0, 0, time.UTC))
+	window := PredictCycleWindow(nextStart, cycleLength, luteal)
+	if !window.Calculable {
+		t.Fatalf("PredictCycleWindow(%s, %d, %d) returned no window", nextStart.Format("2006-01-02"), cycleLength, luteal)
+	}
+	wantDate := dateOnly(nextStart.AddDate(0, 0, wantOvulationCycleDay-1))
+	if !window.OvulationDate.Equal(wantDate) {
+		t.Errorf("predicted ovulation date = %s, want %s", window.OvulationDate.Format("2006-01-02"), wantDate.Format("2006-01-02"))
+	}
+	if !window.FertilityWindowEnd.Equal(wantDate) {
+		t.Errorf("fertile window peak = %s, want %s (the window ends on the ovulation day)",
+			window.FertilityWindowEnd.Format("2006-01-02"), wantDate.Format("2006-01-02"))
+	}
+	return luteal
+}
+
+// TestInferredLutealPhaseRoundTripsThroughPrediction is the regression for the
+// off-by-one described at the top of this file. Every case observes an
+// ovulation, infers the parameter from it, and predicts with that parameter on
+// an identical cycle; the predicted cycle day must equal the observed one.
+func TestInferredLutealPhaseRoundTripsThroughPrediction(t *testing.T) {
+	t.Parallel()
+
+	origin := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name              string
+		kind              lutealSignalKind
+		cycleLength       int
+		ovulationCycleDay int
+	}{
+		// The headline case: a textbook 28-day cycle whose thermal shift starts
+		// on cycle day 16, so ovulation is cycle day 15.
+		{name: "bbt, 28-day cycle, ovulation on day 15", kind: lutealSignalBBT, cycleLength: 28, ovulationCycleDay: 15},
+		{name: "mucus, 28-day cycle, ovulation on day 15", kind: lutealSignalEggWhite, cycleLength: 28, ovulationCycleDay: 15},
+		// Short cycle: the follicular phase absorbs the shortening, so the
+		// luteal phase stays physiological and the prediction stays exact.
+		{name: "bbt, short 21-day cycle, ovulation on day 8", kind: lutealSignalBBT, cycleLength: 21, ovulationCycleDay: 8},
+		{name: "mucus, short 21-day cycle, ovulation on day 9", kind: lutealSignalEggWhite, cycleLength: 21, ovulationCycleDay: 9},
+		// Long cycles: the same, in the other direction.
+		{name: "bbt, long 35-day cycle, ovulation on day 21", kind: lutealSignalBBT, cycleLength: 35, ovulationCycleDay: 21},
+		{name: "mucus, long 40-day cycle, ovulation on day 26", kind: lutealSignalEggWhite, cycleLength: 40, ovulationCycleDay: 26},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			logs := lutealRoundTripLogs(origin, testCase.cycleLength, []int{testCase.ovulationCycleDay, testCase.ovulationCycleDay}, testCase.kind)
+			assertLutealRoundTrip(t, logs, time.UTC, testCase.cycleLength, testCase.ovulationCycleDay)
+		})
+	}
+}
+
+// TestInferredLutealPhaseRoundTripsAcrossSeveralSamples covers the aggregating
+// path rather than the single-sample one: three cycles ovulating on days 14, 15
+// and 16 of a 28-day cycle yield luteal samples 14, 13 and 12, whose mean is 13
+// — the parameter that predicts the middle observation back. The aggregation is
+// a mean of the surviving samples, not a median (the median is what selects the
+// cycle LENGTH), so a shift applied per sample would survive it unchanged; the
+// round trip is what catches it.
+func TestInferredLutealPhaseRoundTripsAcrossSeveralSamples(t *testing.T) {
+	t.Parallel()
+
+	const cycleLength = 28
+	origin := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	logs := lutealRoundTripLogs(origin, cycleLength, []int{14, 15, 16}, lutealSignalBBT)
+
+	luteal := assertLutealRoundTrip(t, logs, time.UTC, cycleLength, 15)
+	if luteal != 13 {
+		t.Errorf("inferred luteal phase = %d, want 13 (mean of samples 14, 13, 12)", luteal)
+	}
+}
+
+// TestInferredLutealPhaseRoundTripsAcrossDSTAndTimezones runs the same loop in
+// zones whose clocks move inside the observed cycles. Both quantities the
+// inference measures — the cycle length and the ovulation's offset from the
+// cycle start — are calendar-day counts taken through CalendarDaysBetween, so a
+// transition between the two endpoints must not shorten either: the inferred
+// parameter, and therefore the predicted cycle day, must be identical to the
+// UTC run.
+func TestInferredLutealPhaseRoundTripsAcrossDSTAndTimezones(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		zone     string
+		origin   time.Time
+		kind     lutealSignalKind
+		observed int
+	}{
+		// Europe/Berlin springs forward on 2026-03-29, which is cycle day 15 of
+		// the first cycle — the observed ovulation day itself.
+		{name: "spring forward on the ovulation day", zone: "Europe/Berlin", origin: time.Date(2026, time.March, 15, 0, 0, 0, 0, time.UTC), kind: lutealSignalBBT, observed: 15},
+		// America/Toronto falls back on 2026-11-01, inside the luteal phase.
+		{name: "fall back inside the luteal phase", zone: "America/Toronto", origin: time.Date(2026, time.October, 20, 0, 0, 0, 0, time.UTC), kind: lutealSignalEggWhite, observed: 15},
+		// A fixed offset far from UTC, where every stored UTC-midnight value
+		// lands on a different wall-clock day.
+		{name: "fixed far-east offset", zone: "Pacific/Kiritimati", origin: time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC), kind: lutealSignalBBT, observed: 15},
+	}
+
+	const cycleLength = 28
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			location, err := time.LoadLocation(testCase.zone)
+			if err != nil {
+				t.Skipf("tz database unavailable for %q: %v", testCase.zone, err)
+			}
+
+			logs := lutealRoundTripLogs(testCase.origin, cycleLength, []int{testCase.observed, testCase.observed}, testCase.kind)
+			zoned := assertLutealRoundTrip(t, logs, location, cycleLength, testCase.observed)
+
+			utc, refined := InferUserLutealPhase(logs, time.UTC)
+			if !refined {
+				t.Fatal("the UTC control must refine from the same logs")
+			}
+			if zoned != utc {
+				t.Errorf("inferred luteal phase = %d in %s but %d in UTC: the location changed a calendar-day count", zoned, testCase.zone, utc)
+			}
+		})
+	}
+}

--- a/internal/services/cycle_luteal_round_trip_test.go
+++ b/internal/services/cycle_luteal_round_trip_test.go
@@ -45,9 +45,29 @@ const (
 // as the coverline window, then three consecutive elevated days start the day
 // AFTER ovulation, because the thermal shift follows ovulation. That needs
 // ovulationCycleDay >= 6 and ovulationCycleDay+3 <= cycleLength. The egg-white
-// layout is the peak-day rule read backwards: ovulation is peak + 1, so the
-// peak sits on the day before.
-func lutealRoundTripLogs(origin time.Time, cycleLength int, ovulationCycleDays []int, kind lutealSignalKind) []models.DailyLog {
+// layout is the peak-day rule read backwards: ovulation is peak + 1, so the peak
+// sits on the day before, which needs ovulationCycleDay >= 2.
+//
+// Those bounds are checked rather than merely documented. A case built outside
+// them yields no detectable shift, and InferUserLutealPhase then declines to
+// refine — a failure that reads as a defect in the production inference instead
+// of as a fixture built outside its own range.
+func lutealRoundTripLogs(t *testing.T, origin time.Time, cycleLength int, ovulationCycleDays []int, kind lutealSignalKind) []models.DailyLog {
+	t.Helper()
+
+	for _, ovulationCycleDay := range ovulationCycleDays {
+		switch {
+		case kind == lutealSignalEggWhite && ovulationCycleDay < 2:
+			t.Fatalf("fixture: egg-white ovulation on cycle day %d leaves no room for the peak day before it", ovulationCycleDay)
+		case kind == lutealSignalBBT && ovulationCycleDay < bbtCoverlineWindow:
+			t.Fatalf("fixture: BBT ovulation on cycle day %d starts the elevated run before the %d-day coverline window is full", ovulationCycleDay, bbtCoverlineWindow)
+		case kind == lutealSignalBBT && ovulationCycleDay+bbtElevatedStreakDays > cycleLength:
+			t.Fatalf("fixture: BBT ovulation on cycle day %d leaves fewer than %d days for the elevated run inside a %d-day cycle", ovulationCycleDay, bbtElevatedStreakDays, cycleLength)
+		case ovulationCycleDay > cycleLength:
+			t.Fatalf("fixture: ovulation on cycle day %d falls outside a %d-day cycle", ovulationCycleDay, cycleLength)
+		}
+	}
+
 	logs := make([]models.DailyLog, 0, (len(ovulationCycleDays)+1)*11)
 	for cycle := range len(ovulationCycleDays) + 1 {
 		start := origin.AddDate(0, 0, cycle*cycleLength)
@@ -151,7 +171,7 @@ func TestInferredLutealPhaseRoundTripsThroughPrediction(t *testing.T) {
 
 			// Two signalled cycles plus the in-progress third, which is the one a
 			// prediction is actually made for.
-			logs := lutealRoundTripLogs(origin, testCase.cycleLength, []int{testCase.ovulationCycleDay, testCase.ovulationCycleDay}, testCase.kind)
+			logs := lutealRoundTripLogs(t, origin, testCase.cycleLength, []int{testCase.ovulationCycleDay, testCase.ovulationCycleDay}, testCase.kind)
 			nextCycleStart := origin.AddDate(0, 0, 2*testCase.cycleLength)
 			assertLutealRoundTrip(t, logs, time.UTC, testCase.cycleLength, testCase.ovulationCycleDay, nextCycleStart)
 		})
@@ -170,7 +190,7 @@ func TestInferredLutealPhaseRoundTripsAcrossSeveralSamples(t *testing.T) {
 
 	const cycleLength = 28
 	origin := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
-	logs := lutealRoundTripLogs(origin, cycleLength, []int{14, 15, 16}, lutealSignalBBT)
+	logs := lutealRoundTripLogs(t, origin, cycleLength, []int{14, 15, 16}, lutealSignalBBT)
 
 	luteal := assertLutealRoundTrip(t, logs, time.UTC, cycleLength, 15, origin.AddDate(0, 0, 3*cycleLength))
 	if luteal != 13 {
@@ -221,7 +241,7 @@ func TestInferredLutealPhaseRoundTripsAcrossDSTAndTimezones(t *testing.T) {
 				t.Skipf("tz database unavailable for %q: %v", testCase.zone, err)
 			}
 
-			logs := lutealRoundTripLogs(testCase.origin, cycleLength, []int{testCase.observed, testCase.observed}, testCase.kind)
+			logs := lutealRoundTripLogs(t, testCase.origin, cycleLength, []int{testCase.observed, testCase.observed}, testCase.kind)
 			nextCycleStart := CalendarDay(testCase.origin.AddDate(0, 0, 2*cycleLength), location)
 			zoned := assertLutealRoundTrip(t, logs, location, cycleLength, testCase.observed, nextCycleStart)
 
@@ -251,7 +271,7 @@ func TestInferredLutealPhaseReachesTheOwnerSurfacesThroughTheBaseline(t *testing
 
 	const cycleLength = 28
 	origin := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
-	logs := lutealRoundTripLogs(origin, cycleLength, []int{15, 15}, lutealSignalBBT)
+	logs := lutealRoundTripLogs(t, origin, cycleLength, []int{15, 15}, lutealSignalBBT)
 
 	// Cycle starts Jan 1, Jan 29 and Feb 26; today sits inside the third.
 	now := time.Date(2026, time.March, 3, 9, 0, 0, 0, time.UTC)
@@ -283,5 +303,16 @@ func TestInferredLutealPhaseReachesTheOwnerSurfacesThroughTheBaseline(t *testing
 	wantFertilityStart := wantOvulation.AddDate(0, 0, -5)
 	if !stats.FertilityWindowStart.Equal(wantFertilityStart) {
 		t.Errorf("stats.FertilityWindowStart = %s, want %s", stats.FertilityWindowStart.Format("2006-01-02"), wantFertilityStart.Format("2006-01-02"))
+	}
+
+	// Only the fertility half of the projection moves. The next-period date is
+	// the cycle start plus the predicted length and never touches the luteal
+	// phase — it is also the one estimate anchored on a day the owner actually
+	// recorded, and the one that survives every suppression gate, so a change
+	// that reached it would be a scope violation rather than a fix.
+	wantNextPeriod := time.Date(2026, time.March, 26, 0, 0, 0, 0, time.UTC)
+	if !stats.NextPeriodStart.Equal(wantNextPeriod) {
+		t.Errorf("stats.NextPeriodStart = %s, want %s: the luteal phase must not reach the next-period estimate",
+			stats.NextPeriodStart.Format("2006-01-02"), wantNextPeriod.Format("2006-01-02"))
 	}
 }

--- a/internal/services/cycle_projection_reference_test.go
+++ b/internal/services/cycle_projection_reference_test.go
@@ -19,6 +19,14 @@ import (
 //   - the displayed next-period derivation (projected start + selected length),
 //   - the ShiftCycleStartToFutureOvulation forward roll for the ovulation date.
 //
+// A vector's `lutealPhase` input carries the model's own reading of that
+// parameter: the count of days that FOLLOW ovulation, so a 28-day cycle with a
+// 14 ovulates on cycle day 14. Step 5 below pins that reading against
+// calcLutealPhase rather than leaving it implied by the expected dates, because
+// the other reading — the calendar span from the ovulation date to the next
+// period start, which is one day longer — is what the personalized luteal
+// inference had silently adopted.
+//
 // The section is a NEW top-level key ("projection"), so ovumcy-app's existing
 // reference test — which decodes only "vectors" — keeps passing against a
 // byte-identical copy until its twin consumer lands. The two implementations
@@ -150,15 +158,28 @@ func TestCycleProjection_GoldenVectors(t *testing.T) {
 			// exact DashboardUpcomingPredictions sequence). The roll is applied to
 			// a SEPARATE anchor so it cannot disturb the displayed next-period
 			// from step 3.
+			ovulationAnchor := cycleStart
 			window := PredictCycleWindow(cycleStart, predictionLength, vector.Input.LutealPhase)
 			if window.Calculable && window.OvulationDate.Before(today) {
-				shifted := ShiftCycleStartToFutureOvulation(cycleStart, window.OvulationDate, predictionLength, today)
-				window = PredictCycleWindow(shifted, predictionLength, vector.Input.LutealPhase)
+				ovulationAnchor = ShiftCycleStartToFutureOvulation(cycleStart, window.OvulationDate, predictionLength, today)
+				window = PredictCycleWindow(ovulationAnchor, predictionLength, vector.Input.LutealPhase)
 			}
 			if !window.Calculable {
 				t.Fatalf("projected ovulation window not calculable for input %+v", vector.Input)
 			}
 			assertProjectionDay(t, "ovulation date", window.OvulationDate, vector.Expected.OvulationDate)
+
+			// 5. Indexing pin: invert the projected ovulation's own cycle day
+			// back through calcLutealPhase and it must return the fixture's
+			// lutealPhase input. That is the direction the personalized path
+			// travels — an observed ovulation trains the parameter — and it is
+			// where the two readings of "luteal phase" diverge by exactly one
+			// day, on the DST vector as much as on the plain ones.
+			ovulationCycleDay := CalendarDaysBetween(ovulationAnchor, window.OvulationDate) + 1
+			if got := calcLutealPhase(predictionLength, ovulationCycleDay); got != vector.Input.LutealPhase {
+				t.Errorf("inverting ovulation cycle day %d over a %d-day cycle gives luteal %d, but the vector's input is %d",
+					ovulationCycleDay, predictionLength, got, vector.Input.LutealPhase)
+			}
 		})
 	}
 }

--- a/internal/services/cycle_projection_reference_test.go
+++ b/internal/services/cycle_projection_reference_test.go
@@ -21,11 +21,12 @@ import (
 //
 // A vector's `lutealPhase` input carries the model's own reading of that
 // parameter: the count of days that FOLLOW ovulation, so a 28-day cycle with a
-// 14 ovulates on cycle day 14. Step 5 below pins that reading against
-// calcLutealPhase rather than leaving it implied by the expected dates, because
-// the other reading — the calendar span from the ovulation date to the next
-// period start, which is one day longer — is what the personalized luteal
-// inference had silently adopted.
+// 14 ovulates on cycle day 14 — not the calendar span from the ovulation date to
+// the next period start, which is one day longer and is the reading the
+// personalized luteal inference had silently adopted. The round trip between the
+// two directions is pinned by TestLutealPhaseRoundTrip_ReferenceVectors; what
+// step 5 below adds is narrower and specific to these vectors: that each one
+// exercises the exact arithmetic rather than the reserve clamp.
 //
 // The section is a NEW top-level key ("projection"), so ovumcy-app's existing
 // reference test — which decodes only "vectors" — keeps passing against a
@@ -158,27 +159,25 @@ func TestCycleProjection_GoldenVectors(t *testing.T) {
 			// exact DashboardUpcomingPredictions sequence). The roll is applied to
 			// a SEPARATE anchor so it cannot disturb the displayed next-period
 			// from step 3.
-			ovulationAnchor := cycleStart
 			window := PredictCycleWindow(cycleStart, predictionLength, vector.Input.LutealPhase)
 			if window.Calculable && window.OvulationDate.Before(today) {
-				ovulationAnchor = ShiftCycleStartToFutureOvulation(cycleStart, window.OvulationDate, predictionLength, today)
-				window = PredictCycleWindow(ovulationAnchor, predictionLength, vector.Input.LutealPhase)
+				shifted := ShiftCycleStartToFutureOvulation(cycleStart, window.OvulationDate, predictionLength, today)
+				window = PredictCycleWindow(shifted, predictionLength, vector.Input.LutealPhase)
 			}
 			if !window.Calculable {
 				t.Fatalf("projected ovulation window not calculable for input %+v", vector.Input)
 			}
 			assertProjectionDay(t, "ovulation date", window.OvulationDate, vector.Expected.OvulationDate)
 
-			// 5. Indexing pin: invert the projected ovulation's own cycle day
-			// back through calcLutealPhase and it must return the fixture's
-			// lutealPhase input. That is the direction the personalized path
-			// travels — an observed ovulation trains the parameter — and it is
-			// where the two readings of "luteal phase" diverge by exactly one
-			// day, on the DST vector as much as on the plain ones.
-			ovulationCycleDay := CalendarDaysBetween(ovulationAnchor, window.OvulationDate) + 1
-			if got := calcLutealPhase(predictionLength, ovulationCycleDay); got != vector.Input.LutealPhase {
-				t.Errorf("inverting ovulation cycle day %d over a %d-day cycle gives luteal %d, but the vector's input is %d",
-					ovulationCycleDay, predictionLength, got, vector.Input.LutealPhase)
+			// 5. Each vector must exercise the exact arithmetic, not the
+			// reserve clamp: a lutealPhase that no longer fits its cycle length
+			// would still produce a date, and the vector would then be pinning
+			// maxSupportedLutealPhase instead of the model. Nothing else here
+			// distinguishes the two, because a clamped window is calculable and
+			// its date is stable.
+			if _, exact := CalcOvulationDay(predictionLength, vector.Input.LutealPhase); !exact {
+				t.Errorf("luteal phase %d does not fit a %d-day cycle exactly, so this vector pins the clamp rather than the projection",
+					vector.Input.LutealPhase, predictionLength)
 			}
 		})
 	}

--- a/internal/services/cycle_signals.go
+++ b/internal/services/cycle_signals.go
@@ -35,6 +35,12 @@ const (
 // from the sample rather than clamped into it. The prediction-time bound is a
 // different quantity — maxSupportedLutealPhase (cycles.go), computed from the
 // cycle length.
+//
+// Both ends bound the parameter in CalcOvulationDay's reading of it: the count
+// of days that FOLLOW ovulation. They are NOT bounds on the calendar span from
+// the ovulation date to the next period start, which is one day longer — a
+// sample at this floor is an ovulation on cycle day cycleLength-10, not one
+// ten calendar days before the next period.
 const maxPlausibleLutealPhaseDays = 20
 
 func InferUserLutealPhase(logs []models.DailyLog, location *time.Location) (int, bool) {

--- a/internal/services/cycle_signals.go
+++ b/internal/services/cycle_signals.go
@@ -56,7 +56,16 @@ func InferUserLutealPhase(logs []models.DailyLog, location *time.Location) (int,
 			continue
 		}
 
-		lutealLength := CalendarDaysBetween(ovulationDate, nextStart)
+		// Derive the parameter through the inverse of the prediction's own
+		// arithmetic rather than measuring the calendar span to nextStart. That
+		// span counts the ovulation day itself, so it runs one day longer than
+		// the luteal phase CalcOvulationDay consumes, and feeding it back in
+		// predicted the day BEFORE the observed ovulation on an identical next
+		// cycle — the personalized path shifted ovulation and both fertile-window
+		// edges one day early on every surface that renders them.
+		cycleLength := CalendarDaysBetween(start, nextStart)
+		ovulationCycleDay := CalendarDaysBetween(start, ovulationDate) + 1
+		lutealLength := calcLutealPhase(cycleLength, ovulationCycleDay)
 		if lutealLength < minLutealPhaseDays || lutealLength > maxPlausibleLutealPhaseDays {
 			continue
 		}

--- a/internal/services/cycle_signals_coverage_test.go
+++ b/internal/services/cycle_signals_coverage_test.go
@@ -82,7 +82,7 @@ func TestCycleSignals_InferUserLutealPhase_FewerThanThreeStartsReturnsDefault(t 
 func TestCycleSignals_InferUserLutealPhase_ExactlyThreeStartsIsAccepted(t *testing.T) {
 	// Exactly 3 observed starts is the minimum the >=3 guard accepts — the
 	// positive complement of ...FewerThanThreeStartsReturnsDefault. The fixture
-	// builds 3 starts with two BBT-confirmed 14-day luteal phases.
+	// builds 3 starts with two BBT-confirmed ovulations on cycle day 15.
 	// Cycles: Jan1→Jan29 (28 days), Jan29→Feb26 (28 days).
 	logs := cyclesignalsCovBuildLutealLogs(t)
 
@@ -90,8 +90,8 @@ func TestCycleSignals_InferUserLutealPhase_ExactlyThreeStartsIsAccepted(t *testi
 	if !ok {
 		t.Fatal("expected ok=true: exactly 3 observed starts must be accepted")
 	}
-	if phase != 14 {
-		t.Fatalf("expected inferred luteal phase 14, got %d", phase)
+	if phase != 13 {
+		t.Fatalf("expected inferred luteal phase 13, got %d", phase)
 	}
 }
 
@@ -128,9 +128,10 @@ func TestCycleSignals_InferUserLutealPhase_LastStartPairIsIncluded(t *testing.T)
 
 func TestCycleSignals_InferUserLutealPhase_OutOfRangeLutealLengthIsSkipped(t *testing.T) {
 	// Three starts: Jan1, Jan29, Feb26 (28-day cycles).
-	// Cycle 1 (Jan1→Jan29): first high Jan16 → ovulation Jan15 → luteal = 14 (valid).
-	// Cycle 2 (Jan29→Feb26): first high Feb23 → ovulation Feb22 → luteal = 4
-	// (< minLutealPhaseDays → skipped).
+	// Cycle 1 (Jan1→Jan29): first high Jan16 → ovulation Jan15 = cycle day 15 →
+	// luteal = 28-15 = 13 (valid).
+	// Cycle 2 (Jan29→Feb26): first high Feb23 → ovulation Feb22 = cycle day 25 →
+	// luteal = 28-25 = 3 (< minLutealPhaseDays → skipped).
 	//
 	// With only 1 valid luteal length (< 2), must return default, false.
 	day := func(s string) time.Time { return cyclesignalsCovDay(t, s) }
@@ -178,8 +179,9 @@ func TestCycleSignals_InferUserLutealPhase_OutOfRangeLutealLengthIsSkipped(t *te
 func TestCycleSignals_InferUserLutealPhase_LutealLengthOverTwentyIsSkipped(t *testing.T) {
 	// Cycle where ovulation is very early → luteal > 20 → skipped.
 	// Three starts: Jan1, Jan29, Feb26.
-	// Cycle 1: first high Jan8 → ovulation Jan7 → luteal = Jan29−Jan7 = 22 (> 20 → skipped).
-	// Cycle 2: first high Feb13 → ovulation Feb12 → luteal = 14 (valid).
+	// Cycle 1: first high Jan8 → ovulation Jan7 = cycle day 7 → luteal = 28-7 = 21
+	// (> maxPlausibleLutealPhaseDays → skipped).
+	// Cycle 2: first high Feb13 → ovulation Feb12 = cycle day 15 → luteal = 13 (valid).
 	// Only 1 valid → default, false.
 	day := func(s string) time.Time { return cyclesignalsCovDay(t, s) }
 
@@ -189,7 +191,7 @@ func TestCycleSignals_InferUserLutealPhase_LutealLengthOverTwentyIsSkipped(t *te
 		{Date: day("2025-02-26"), IsPeriod: true, Flow: models.FlowMedium},
 
 		// Cycle 1 BBT — coverline window Jan1-6 then rise Jan8-10
-		// (ovulation = Jan8−1 = Jan7; luteal = Jan29−Jan7 = 22 > 20).
+		// (ovulation = Jan8−1 = Jan7 = cycle day 7; luteal = 28-7 = 21 > 20).
 		{Date: day("2025-01-01"), BBT: new(36.20)},
 		{Date: day("2025-01-02"), BBT: new(36.20)},
 		{Date: day("2025-01-03"), BBT: new(36.20)},
@@ -681,16 +683,17 @@ func TestCycleSignals_InferEggWhiteOvulationDate_PeakOnLastCycleDayClampsToPeak(
 // ---------------------------------------------------------------------------
 
 func TestCycleSignals_InferUserLutealPhase_CorrectValueFromBBT(t *testing.T) {
-	// Two cycles with BBT-confirmed ovulation, each yielding luteal ~14 days.
+	// Two cycles with BBT-confirmed ovulation on cycle day 15 of 28.
 	logs := cyclesignalsCovBuildLutealLogs(t)
 	phase, ok := InferUserLutealPhase(logs, time.UTC)
 	if !ok {
 		t.Fatalf("expected ok=true")
 	}
 	// Both cycles have their BBT rise on day 16, so ovulation is day 15 of a
-	// 28-day cycle (the day before the shift) → luteal = 14.
-	if phase != 14 {
-		t.Fatalf("expected inferred luteal phase 14, got %d", phase)
+	// 28-day cycle (the day before the shift) → luteal = 28-15 = 13, the value
+	// that feeds CalcOvulationDay(28, 13) back to cycle day 15.
+	if phase != 13 {
+		t.Fatalf("expected inferred luteal phase 13, got %d", phase)
 	}
 }
 
@@ -758,7 +761,7 @@ func cyclesignalsCovBuildLutealLogs(t *testing.T) []models.DailyLog {
 		{Date: day("2025-01-16"), BBT: new(36.50)},
 		{Date: day("2025-01-17"), BBT: new(36.50)},
 		{Date: day("2025-01-18"), BBT: new(36.50)},
-		// ovulation = Jan16−1 = Jan15; Jan29 − Jan15 = 14 days → luteal=14 ✓
+		// ovulation = Jan16−1 = Jan15 = cycle day 15 → luteal = 28-15 = 13 ✓
 
 		// === Cycle 2 BBT: Jan29→Feb26 ===
 		// 6-day coverline window (days 1-6): max = 36.20
@@ -772,7 +775,7 @@ func cyclesignalsCovBuildLutealLogs(t *testing.T) []models.DailyLog {
 		{Date: day("2025-02-13"), BBT: new(36.50)},
 		{Date: day("2025-02-14"), BBT: new(36.50)},
 		{Date: day("2025-02-15"), BBT: new(36.50)},
-		// ovulation = Feb13−1 = Feb12; Feb26 − Feb12 = 14 days → luteal=14 ✓
+		// ovulation = Feb13−1 = Feb12 = cycle day 15 → luteal = 28-15 = 13 ✓
 	}
 	return logs
 }

--- a/internal/services/cycle_signals_mutation_round2_test.go
+++ b/internal/services/cycle_signals_mutation_round2_test.go
@@ -8,15 +8,16 @@ import (
 )
 
 func TestCycleSignals_InferUserLutealPhase_UnchangedByDSTTransitionInCycle(t *testing.T) {
-	// America/Toronto springs forward on 2025-03-09. The first cycle's
-	// ovulation (Mar 6, the day before the BBT rise) and next period start (Mar 20) bracket that
-	// transition. Because CalendarDaysBetween re-anchors both operands to
-	// UTC-midnight, the luteal length is the true calendar-day count (14) and
-	// is immune to the DST transition inside the cycle: a DST-observing local
-	// zone must yield the same value as UTC. Before the fix, the raw
-	// `nextStart.Sub(ovulationDate)/24` truncated the 14*24-1h span down to 13
-	// in Toronto, dragging the inferred phase to 13 in a DST-observing zone
-	// while UTC saw 14 — a location-dependent skew this test now guards against.
+	// America/Toronto springs forward on 2025-03-09. The first cycle's start
+	// (Mar 1) and next period start (Mar 20) bracket that transition. Because
+	// CalendarDaysBetween re-anchors both operands to UTC-midnight, both spans
+	// the inference measures — the cycle length and the ovulation's offset from
+	// the cycle start — are true calendar-day counts and immune to a DST
+	// transition inside the cycle: a DST-observing local zone must yield the
+	// same value as UTC. A raw `nextStart.Sub(start)/24` would truncate the
+	// 19*24-1h cycle span down to 18 in Toronto and drag the inferred phase to
+	// 12 there while UTC saw 13 — a location-dependent skew this test guards
+	// against.
 	loc, err := time.LoadLocation("America/Toronto")
 	if err != nil {
 		t.Skipf("tz database unavailable: %v", err)
@@ -29,9 +30,9 @@ func TestCycleSignals_InferUserLutealPhase_UnchangedByDSTTransitionInCycle(t *te
 		{Date: day("2025-03-20"), IsPeriod: true, Flow: models.FlowMedium},
 		{Date: day("2025-04-08"), IsPeriod: true, Flow: models.FlowMedium},
 
-		// Cycle A (Mar1->Mar20): coverline window Mar1-6, rise Mar7-9 ->
-		// ovulation Mar6 (day before the first high day).
-		// Cycle A spans the Mar 9 DST boundary: luteal = 14 (UTC) / 13 (Toronto).
+		// Cycle A (Mar1->Mar20, 19 days): coverline window Mar1-6, rise Mar7-9 ->
+		// ovulation Mar6 (day before the first high day) = cycle day 6, so
+		// luteal = 19-6 = 13. The cycle spans the Mar 9 DST boundary.
 		{Date: day("2025-03-01"), BBT: new(36.20)},
 		{Date: day("2025-03-02"), BBT: new(36.20)},
 		{Date: day("2025-03-03"), BBT: new(36.20)},
@@ -42,8 +43,9 @@ func TestCycleSignals_InferUserLutealPhase_UnchangedByDSTTransitionInCycle(t *te
 		{Date: day("2025-03-08"), BBT: new(36.50)},
 		{Date: day("2025-03-09"), BBT: new(36.50)},
 
-		// Cycle B (Mar20->Apr8): coverline window Mar20-25, rise Mar27-29 ->
-		// ovulation Mar26. No DST boundary in the luteal span: luteal = 13.
+		// Cycle B (Mar20->Apr8, 19 days): coverline window Mar20-25, rise Mar27-29
+		// -> ovulation Mar26 = cycle day 7, so luteal = 19-7 = 12. No DST boundary
+		// inside this cycle.
 		{Date: day("2025-03-20"), BBT: new(36.20)},
 		{Date: day("2025-03-21"), BBT: new(36.20)},
 		{Date: day("2025-03-22"), BBT: new(36.20)},
@@ -55,14 +57,13 @@ func TestCycleSignals_InferUserLutealPhase_UnchangedByDSTTransitionInCycle(t *te
 		{Date: day("2025-03-29"), BBT: new(36.50)},
 	}
 
-	// Cycle A (Mar6->Mar20) = 14 true calendar days, cycle B (Mar26->Apr8) = 13.
-	// lens = [14, 13] -> round(13.5) = 14, regardless of DST, in every zone.
+	// lens = [13, 12] -> round(12.5) = 13, regardless of DST, in every zone.
 	phaseLocal, ok := InferUserLutealPhase(logs, loc)
 	if !ok {
 		t.Fatalf("expected ok=true with two BBT-confirmed cycles")
 	}
-	if phaseLocal != 14 {
-		t.Fatalf("expected inferred luteal phase 14 in America/Toronto (DST-immune calendar count); got %d. A phase of 13 means a DST transition inside the cycle truncated the luteal span.", phaseLocal)
+	if phaseLocal != 13 {
+		t.Fatalf("expected inferred luteal phase 13 in America/Toronto (DST-immune calendar count); got %d. A phase of 12 means a DST transition inside the cycle truncated one of the two spans.", phaseLocal)
 	}
 
 	// DST-immunity: the same calendar dates evaluated in UTC (no DST) must
@@ -90,20 +91,21 @@ func TestCycleSignals_InferUserLutealPhase_LutealLengthExactlyMinIsKept(t *testi
 		{Date: day("2025-01-29"), IsPeriod: true, Flow: models.FlowMedium},
 		{Date: day("2025-02-26"), IsPeriod: true, Flow: models.FlowMedium},
 
-		// Cycle 1 (Jan1->Jan29): coverline window Jan1-6, rise Jan20-22 ->
-		// ovulation Jan19. luteal = Jan29 - Jan19 = 10 (exactly minLutealPhaseDays).
+		// Cycle 1 (Jan1->Jan29, 28 days): coverline window Jan1-6, rise Jan19-21 ->
+		// ovulation Jan18 = cycle day 18. luteal = 28-18 = 10 (exactly
+		// minLutealPhaseDays).
 		{Date: day("2025-01-01"), BBT: new(36.20)},
 		{Date: day("2025-01-02"), BBT: new(36.20)},
 		{Date: day("2025-01-03"), BBT: new(36.20)},
 		{Date: day("2025-01-04"), BBT: new(36.20)},
 		{Date: day("2025-01-05"), BBT: new(36.20)},
 		{Date: day("2025-01-06"), BBT: new(36.20)},
+		{Date: day("2025-01-19"), BBT: new(36.50)},
 		{Date: day("2025-01-20"), BBT: new(36.50)},
 		{Date: day("2025-01-21"), BBT: new(36.50)},
-		{Date: day("2025-01-22"), BBT: new(36.50)},
 
-		// Cycle 2 (Jan29->Feb26): coverline window Jan29-Feb3, rise Feb13-15 ->
-		// ovulation Feb12. luteal = Feb26 - Feb12 = 14 (valid).
+		// Cycle 2 (Jan29->Feb26, 28 days): coverline window Jan29-Feb3, rise
+		// Feb12-14 -> ovulation Feb11 = cycle day 14. luteal = 28-14 = 14 (valid).
 		{Date: day("2025-01-29"), BBT: new(36.20)},
 		{Date: day("2025-01-30"), BBT: new(36.20)},
 		{Date: day("2025-01-31"), BBT: new(36.20)},
@@ -139,20 +141,21 @@ func TestCycleSignals_InferUserLutealPhase_LutealLengthExactlyTwentyIsKept(t *te
 		{Date: day("2025-01-29"), IsPeriod: true, Flow: models.FlowMedium},
 		{Date: day("2025-02-26"), IsPeriod: true, Flow: models.FlowMedium},
 
-		// Cycle 1 (Jan1->Jan29): coverline window Jan1-6, rise Jan10-12 ->
-		// ovulation Jan9. luteal = Jan29 - Jan9 = 20 (exactly the upper boundary).
+		// Cycle 1 (Jan1->Jan29, 28 days): coverline window Jan1-6, rise Jan9-11 ->
+		// ovulation Jan8 = cycle day 8. luteal = 28-8 = 20 (exactly the upper
+		// boundary).
 		{Date: day("2025-01-01"), BBT: new(36.20)},
 		{Date: day("2025-01-02"), BBT: new(36.20)},
 		{Date: day("2025-01-03"), BBT: new(36.20)},
 		{Date: day("2025-01-04"), BBT: new(36.20)},
 		{Date: day("2025-01-05"), BBT: new(36.20)},
 		{Date: day("2025-01-06"), BBT: new(36.20)},
+		{Date: day("2025-01-09"), BBT: new(36.50)},
 		{Date: day("2025-01-10"), BBT: new(36.50)},
 		{Date: day("2025-01-11"), BBT: new(36.50)},
-		{Date: day("2025-01-12"), BBT: new(36.50)},
 
-		// Cycle 2 (Jan29->Feb26): coverline window Jan29-Feb3, rise Feb13-15 ->
-		// ovulation Feb12. luteal = Feb26 - Feb12 = 14 (valid).
+		// Cycle 2 (Jan29->Feb26, 28 days): coverline window Jan29-Feb3, rise
+		// Feb12-14 -> ovulation Feb11 = cycle day 14. luteal = 28-14 = 14 (valid).
 		{Date: day("2025-01-29"), BBT: new(36.20)},
 		{Date: day("2025-01-30"), BBT: new(36.20)},
 		{Date: day("2025-01-31"), BBT: new(36.20)},

--- a/internal/services/cycles.go
+++ b/internal/services/cycles.go
@@ -144,7 +144,13 @@ func CalcOvulationDay(cycleLen, lutealPhase int) (int, bool) {
 // designed signal rather than a failure of this inverse. InferUserLutealPhase
 // filters its samples to the plausible window before any of them reaches a
 // prediction.
-// Regression: TestLutealPhaseRoundTrip_ReferenceVectors.
+//
+// Regression: TestInferredLutealPhaseRoundTripsThroughPrediction and
+// TestInferredLutealPhaseReachesTheOwnerSurfacesThroughTheBaseline. NOT
+// TestLutealPhaseRoundTrip_ReferenceVectors — that one mirrors the doc's Step 2a
+// table over this function and CalcOvulationDay, both of which stay correct when
+// the defect returns: it lived in how InferUserLutealPhase derives the argument,
+// so restoring the span reading leaves those vectors green.
 func calcLutealPhase(cycleLen, ovulationDay int) int {
 	return cycleLen - ovulationDay
 }

--- a/internal/services/cycles.go
+++ b/internal/services/cycles.go
@@ -94,6 +94,13 @@ func ResolveLutealPhase(value int) int {
 // periodStart is cycle day 1. Example: a 28-day cycle with a 14-day luteal
 // phase predicts ovulation on cycle day 14, so a cycle that starts on
 // March 10, 2026 maps to March 23, 2026.
+//
+// The luteal phase this consumes is the count of days that FOLLOW ovulation —
+// cycle days 15 through 28 in that example — and NOT the calendar span from the
+// ovulation date to the next period start, which counts the ovulation day itself
+// and is one day longer. calcLutealPhase is the inverse under exactly that
+// reading; the two directions have to move together, or an ovulation observed on
+// a cycle day trains a value that predicts the day before it.
 func CalcOvulationDay(cycleLen, lutealPhase int) (int, bool) {
 	if cycleLen < minLutealPhaseDays+minOvulationCycleDay {
 		return 0, false
@@ -123,6 +130,23 @@ func CalcOvulationDay(cycleLen, lutealPhase int) (int, bool) {
 		return 0, false
 	}
 	return ovDay, ovulationExact
+}
+
+// calcLutealPhase is the inverse of CalcOvulationDay's arithmetic: given a cycle
+// length and the one-based cycle day an ovulation was OBSERVED on, it returns
+// the luteal-phase parameter that makes CalcOvulationDay reproduce that same
+// cycle day. It is the single place the observed→parameter direction is spelled
+// out, so the personalized path cannot drift away from the predicting one.
+//
+// The round trip is exact while the result stays inside the range
+// CalcOvulationDay supports: below minLutealPhaseDays, or above the cycle
+// reserve, that function clamps and reports ovulationExact=false, which is the
+// designed signal rather than a failure of this inverse. InferUserLutealPhase
+// filters its samples to the plausible window before any of them reaches a
+// prediction.
+// Regression: TestLutealPhaseRoundTrip_ReferenceVectors.
+func calcLutealPhase(cycleLen, ovulationDay int) int {
+	return cycleLen - ovulationDay
 }
 
 // CycleWindowPrediction is the named-field result of PredictCycleWindow.

--- a/internal/services/cycles_reference_test.go
+++ b/internal/services/cycles_reference_test.go
@@ -139,6 +139,50 @@ func TestCalcOvulationDay_ReferenceVectors(t *testing.T) {
 	}
 }
 
+// TestLutealPhaseRoundTrip_ReferenceVectors pins the inverse direction of the
+// same arithmetic: given the cycle day an ovulation was OBSERVED on,
+// calcLutealPhase must return the parameter CalcOvulationDay maps back to that
+// very day. Every row is also a row of the "Step 2a" table in
+// docs/cycle-prediction.md.
+//
+// This crossing is the whole point. Each direction is self-consistent on its
+// own, so only a test that runs one into the other can catch them disagreeing
+// about whether the ovulation day itself belongs to the luteal phase — the
+// disagreement that put every personalized prediction one day early.
+func TestLutealPhaseRoundTrip_ReferenceVectors(t *testing.T) {
+	cases := []struct {
+		name              string
+		cycleLen          int
+		observedOvulation int
+		wantLuteal        int
+	}{
+		{"28-day cycle, ovulation on day 14 is the 14-day model default", 28, 14, 14},
+		{"28-day cycle, ovulation on day 15", 28, 15, 13},
+		{"short 21-day cycle, ovulation on day 8", 21, 8, 13},
+		{"long 35-day cycle, ovulation on day 21", 35, 21, 14},
+		{"long 40-day cycle, ovulation on day 26", 40, 26, 14},
+		{"30-day cycle, ovulation on day 20 lands on the 10-day floor", 30, 20, 10},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotLuteal := calcLutealPhase(tc.cycleLen, tc.observedOvulation)
+			if gotLuteal != tc.wantLuteal {
+				t.Fatalf("calcLutealPhase(%d,%d) = %d, want %d",
+					tc.cycleLen, tc.observedOvulation, gotLuteal, tc.wantLuteal)
+			}
+			gotDay, gotExact := CalcOvulationDay(tc.cycleLen, gotLuteal)
+			if !gotExact {
+				t.Errorf("CalcOvulationDay(%d,%d) reported a clamped estimate for a luteal phase derived from a real observation",
+					tc.cycleLen, gotLuteal)
+			}
+			if gotDay != tc.observedOvulation {
+				t.Fatalf("round trip broken: ovulation observed on cycle day %d inferred luteal %d, which predicts cycle day %d",
+					tc.observedOvulation, gotLuteal, gotDay)
+			}
+		})
+	}
+}
+
 // TestCyclePrediction_GoldenVectors asserts every vector in the shared fixture
 // against PredictCycleWindow (and the next-period formula), so the Go source of
 // truth and ovumcy-app's TypeScript port cannot drift apart without failing CI

--- a/internal/services/webhook_notify_service_test.go
+++ b/internal/services/webhook_notify_service_test.go
@@ -1123,8 +1123,8 @@ func TestNotifyDecisionMatchesDashboardWithInferredLutealPhase(t *testing.T) {
 		{Date: day("2025-01-29"), IsPeriod: true, Flow: models.FlowMedium},
 		{Date: day("2025-02-26"), IsPeriod: true, Flow: models.FlowMedium},
 
-		// Cycle 1 (Jan1→Jan29): coverline window Jan1-6, rise Jan19-21 →
-		// ovulation Jan18 (day before first high), luteal = Jan29-Jan18 = 11.
+		// Cycle 1 (Jan1→Jan29, 28 days): coverline window Jan1-6, rise Jan19-21 →
+		// ovulation Jan18 (day before first high) = cycle day 18, luteal = 28-18 = 10.
 		{Date: day("2025-01-01"), BBT: new(36.20)},
 		{Date: day("2025-01-02"), BBT: new(36.20)},
 		{Date: day("2025-01-03"), BBT: new(36.20)},
@@ -1135,8 +1135,8 @@ func TestNotifyDecisionMatchesDashboardWithInferredLutealPhase(t *testing.T) {
 		{Date: day("2025-01-20"), BBT: new(36.50)},
 		{Date: day("2025-01-21"), BBT: new(36.50)},
 
-		// Cycle 2 (Jan29→Feb26): coverline window Jan29-Feb3, rise Feb16-18 →
-		// ovulation Feb15, luteal = Feb26-Feb15 = 11.
+		// Cycle 2 (Jan29→Feb26, 28 days): coverline window Jan29-Feb3, rise Feb16-18 →
+		// ovulation Feb15 = cycle day 18, luteal = 28-18 = 10.
 		{Date: day("2025-01-29"), BBT: new(36.20)},
 		{Date: day("2025-01-30"), BBT: new(36.20)},
 		{Date: day("2025-01-31"), BBT: new(36.20)},
@@ -1148,10 +1148,10 @@ func TestNotifyDecisionMatchesDashboardWithInferredLutealPhase(t *testing.T) {
 		{Date: day("2025-02-18"), BBT: new(36.50)},
 	}
 
-	// now = Feb26 + 15 days: with a 28-day cycle and the inferred 11-day luteal
-	// phase, ovulation is projected at Feb26+17 = Mar15 — 2 days out, inside a
-	// 3-day lead window. The record's own stored LutealPhase (14) is
-	// deliberately different from the inferred value (11), so the assertion
+	// now = Feb26 + 15 days: with a 28-day cycle and the inferred 10-day luteal
+	// phase, ovulation is projected on cycle day 18 = Feb26+17 = Mar15 — 2 days
+	// out, inside a 3-day lead window. The record's own stored LutealPhase (14)
+	// is deliberately different from the inferred value (10), so the assertion
 	// only passes if the inference actually ran.
 	now := day("2025-02-26").AddDate(0, 0, 15)
 	last := day("2025-02-26")
@@ -1183,8 +1183,8 @@ func TestNotifyDecisionMatchesDashboardWithInferredLutealPhase(t *testing.T) {
 		LastPeriodStart: record.LastPeriodStart,
 	}
 	stats := NewStatsService(nil, nil).BuildCycleStatsFromLogs(&fullUser, logs, now, time.UTC)
-	if stats.LutealPhase != 11 {
-		t.Fatalf("test setup: expected dashboard path to infer luteal phase 11, got %d", stats.LutealPhase)
+	if stats.LutealPhase != 10 {
+		t.Fatalf("test setup: expected dashboard path to infer luteal phase 10, got %d", stats.LutealPhase)
 	}
 	today := DateAtLocation(now, time.UTC)
 	cycleLength := DashboardCycleReferenceLength(&fullUser, stats)


### PR DESCRIPTION
## What was wrong

The per-owner luteal inference did not round-trip. `InferUserLutealPhase` measured
`CalendarDaysBetween(ovulationDate, nextStart)`, which counts the ovulation day itself;
`CalcOvulationDay` consumes the count of days that *follow* ovulation, one day shorter.
Substituting is exact — `luteal = L − CD + 1`, so `ovDay = L − luteal = CD − 1`.

An ovulation observed on cycle day 15 therefore trained a value that predicted cycle day 14
on an identical next cycle. Both inference paths (BBT `inferBBTOvulationDate` and the
egg-white fallback) meet at that one line, so both were affected.

## Blast radius

The shifted parameter reaches `stats.LutealPhase` via `ApplyUserCycleBaseline`, so the
ovulation date **and both fertile-window edges** moved a day early on the dashboard, the
calendar grid, the stats cycle ribbon (`stats_cycle_ribbon.go:105`), `/api/v1`, webhook
ovulation reminders and the `.ics` feed. Only accounts with enough BBT / cervical-mucus
signal for `refined == true` were affected; the 14-day default path is untouched.

## What changed

Moved the **inference**, not the prediction. The prediction's reading is already encoded in
`defaultLutealPhaseDays = 14`, the stored `users.luteal_phase` column, `docs/cycle-prediction.md`,
the shared golden-vector fixture and ovumcy-app's `cycle-prediction-policy.ts`; moving it
would have shifted every account instead of fixing the broken path.

- `cycles.go` — `calcLutealPhase`, the declared inverse of `CalcOvulationDay`, and a doc
  comment on `CalcOvulationDay` naming which of the two readings it consumes.
- `cycle_signals.go` — the parameter is derived through that inverse from the same two
  calendar-day counts (11 changed lines, the whole production diff), and the plausibility
  window's constant now says which reading its 10 and 20 bound.
- `docs/cycle-prediction.md` — new "Step 2a", worked-example table mirrored 1:1 by the
  reference test, and the two ambiguous phrasings ("Days from ovulation to the next period")
  that made the drift possible.
- Both reference tests: `TestLutealPhaseRoundTrip_ReferenceVectors` (window math) and, on the
  projection vectors, a check that each one's luteal phase fits its cycle exactly rather than
  pinning the reserve clamp.

**The golden-vector fixture is unchanged** and verified still byte-identical with
`ovumcy-app/src/services/__fixtures__/cycle-prediction-golden-vectors.json` — prediction and
projection math did not move.

## Evidence

`TestInferredLutealPhaseRoundTripsThroughPrediction` is red on the parent commit:

```
round trip broken: an ovulation observed on cycle day 15 inferred luteal 14,
which predicts cycle day 14
```

All six sub-cases (BBT and mucus × 21/28/35/40-day cycles), plus
`...AcrossSeveralSamples` and `...AcrossDSTAndTimezones`, fail without the two production
hunks and pass with them. `...ReachesTheOwnerSurfacesThroughTheBaseline` drives the same
observation through `ApplyUserCycleBaseline` — the composition every surface calls — with a
deliberately stale `users.luteal_phase`, and pins the ovulation on March 12 rather than
March 11.

Seven pre-existing tests pinned the old convention and were updated: where a test pins a
filter boundary (10 and 20) the *fixture* moved so the boundary stays a boundary and the
`<` / `<=` mutant is still killed; where it pinned a value, the value and its comment
arithmetic were corrected.

Full `go test ./... -count=1` green; `golangci-lint run ./...` 0 issues.

## Residual risk the merge should be taken with, not a deferred finding

`users.luteal_phase` is a derived cache: `DayService.refreshDerivedCycleSettings` and
`ImportService.refreshDerivedCycleSettings` write `InferUserLutealPhase`'s result into it, and
`resolveUserCycleLengths` reads it whenever the live inference declines to refine. Rows written
before this change therefore hold the old convention. The read path prefers a fresh inference,
and a day save or an import rewrites the row, so the common case self-heals — but an account
whose logs stop supporting inference keeps the stale value until then. Correcting the stored
rows is a data change, not a code one; it belongs to a migration, not to this PR.

## Known sibling, not fixed here

`ovumcy-app`'s `src/services/cycle-history-service.ts:524` carries the identical defect
(`diffCalendarDays(ovulation, nextStart)` against the same `calcOvulationDay`). Different
repository, out of this PR's scope; owner ruled it a separate ovumcy-app PR after this one
merges. `ovumcy-web` itself has exactly one site of the class.

Separately, `stats_phase_insights.go:92` buckets completed cycles with
`defaultLutealPhaseDays` while the ribbon on the same page uses the personalized value — a
pre-existing divergence this fix widens by a day for personalized accounts. Whether the
historical bucketing should personalize is a product call, so it is left alone here.

## Rollback

`git revert` of the two commits. No schema, no migration, no fixture change; the production
diff is 11 lines.
