### PR TITLE
docs(cycle-prediction): give the round-trip invariant its exception

### DIFF
--- a/changelog.d/docs-luteal-clamp-caveat.md
+++ b/changelog.d/docs-luteal-clamp-caveat.md
@@ -1,0 +1,11 @@
+### Internal
+
+- **The cycle-prediction doc stated the personalized round trip as an equality it does not always
+  hold.** "An ovulation observed on cycle day N predicts cycle day N again" is true only while the
+  luteal phase that observation implies still fits the cycle; past that the reserve clamp applies and
+  the prediction is marked non-exact, which the step immediately above it already documented for its
+  own clamp. The invariant now carries the exception, and the worked-example table carries a row for
+  it — a mucus peak on the first day of a 21-day cycle, where the implied 19-day luteal phase is
+  clamped to 16 and ovulation is estimated on cycle day 5. That row is asserted by the same reference
+  test as the others, so the exception is demonstrated rather than only described. No behaviour
+  changes: the clamp is what the code already did.

--- a/changelog.d/docs-luteal-clamp-caveat.md
+++ b/changelog.d/docs-luteal-clamp-caveat.md
@@ -5,7 +5,7 @@
   luteal phase that observation implies still fits the cycle; past that the reserve clamp applies and
   the prediction is marked non-exact, which the step immediately above it already documented for its
   own clamp. The invariant now carries the exception, and the worked-example table carries a row for
-  it — a mucus peak on the first day of a 21-day cycle, where the implied 19-day luteal phase is
-  clamped to 16 and ovulation is estimated on cycle day 5. That row is asserted by the same reference
+  it — an ovulation observed on day 4 of a 15-day cycle, where the implied 11-day luteal phase is
+  clamped to 10 and ovulation is estimated on cycle day 5. That row is asserted by the same reference
   test as the others, so the exception is demonstrated rather than only described. No behaviour
   changes: the clamp is what the code already did.

--- a/docs/cycle-prediction.md
+++ b/docs/cycle-prediction.md
@@ -79,7 +79,14 @@ Both directions have to use one indexing, or an observation trains a value that
 predicts a different day than the one observed. What using one buys:
 
 > An ovulation observed on cycle day **N** predicts cycle day **N** again on a
-> next cycle of the same length.
+> next cycle of the same length — unless the luteal phase that observation
+> implies no longer fits the cycle, in which case Step 2's clamp applies and the
+> prediction is marked non-exact.
+
+The exception is not hypothetical, which is why the table below carries a row
+for it: a cervical-mucus peak on the first day of a short cycle implies a luteal
+phase the cycle cannot hold, and the reserve clamp is what stops the estimate
+from landing before cycle day 5.
 
 The table below is asserted row for row by
 `TestLutealPhaseRoundTrip_ReferenceVectors`. The invariant itself is a claim
@@ -100,6 +107,7 @@ out of the logs and worked out which argument to hand them.
 | 35 | day 21 | 14 | day 21 |
 | 40 | day 26 | 14 | day 26 |
 | 30 | day 20 | 10 (equal to the floor, not clamped to it) | day 20 |
+| 21 | day 2  | 19, clamped to 16 by Step 2 | day 5 (non-exact) |
 
 The parameter counts the days that *follow* ovulation, so it is one day shorter
 than the calendar span from the ovulation date to the next period start — that

--- a/docs/cycle-prediction.md
+++ b/docs/cycle-prediction.md
@@ -83,12 +83,11 @@ predicts a different day than the one observed. What using one buys:
 > implies no longer fits the cycle, in which case Step 2's clamp applies and the
 > prediction is marked non-exact.
 
-The exception is not hypothetical, which is why the table below carries a row
-for it: a cervical-mucus peak on the first day of a short cycle implies a luteal
-phase the cycle cannot hold, and the reserve clamp is what stops the estimate
-from landing before cycle day 5.
-
-The table below is asserted row for row by
+The exception is not hypothetical, so the table below carries a row for it: on a
+15-day cycle an ovulation observed on day 4 implies an 11-day luteal phase, which
+is physiologically ordinary and still more than that cycle can hold, and the
+reserve clamp is what stops the estimate from landing before cycle day 5. The
+table is asserted row for row by
 `TestLutealPhaseRoundTrip_ReferenceVectors`. The invariant itself is a claim
 about the *observation* path, so it is pinned where that path runs, by
 `TestInferredLutealPhaseRoundTripsThroughPrediction` and
@@ -107,7 +106,7 @@ out of the logs and worked out which argument to hand them.
 | 35 | day 21 | 14 | day 21 |
 | 40 | day 26 | 14 | day 26 |
 | 30 | day 20 | 10 (equal to the floor, not clamped to it) | day 20 |
-| 21 | day 2  | 19, clamped to 16 by Step 2 | day 5 (non-exact) |
+| 15 | day 4  | 11, clamped to 10 by Step 2 | day 5 (non-exact) |
 
 The parameter counts the days that *follow* ovulation, so it is one day shorter
 than the calendar span from the ovulation date to the next period start — that

--- a/internal/services/cycles_reference_test.go
+++ b/internal/services/cycles_reference_test.go
@@ -169,11 +169,12 @@ func TestLutealPhaseRoundTrip_ReferenceVectors(t *testing.T) {
 		{"long 35-day cycle, ovulation on day 21", 35, 21, 14, 21, true},
 		{"long 40-day cycle, ovulation on day 26", 40, 26, 14, 26, true},
 		{"30-day cycle, ovulation on day 20 lands on the 10-day floor", 30, 20, 10, 20, true},
-		// A mucus peak on cycle day 1 of a short cycle: ovulation is estimated at
-		// peak+1, the implied luteal phase is 19, which the plausibility window
-		// admits and a 21-day cycle cannot hold (its reserve caps it at 16). The
-		// round trip does NOT return day 2 here, and must not pretend to.
-		{"short 21-day cycle, an observation the cycle cannot hold", 21, 2, 19, 5, false},
+		// The exception the invariant carries. An ovulation observed on day 4 of a
+		// 15-day cycle implies an 11-day luteal phase: physiologically ordinary,
+		// admitted by the plausibility window, and still more than the cycle can
+		// hold, since the reserve caps the parameter at cycleLength-5 = 10. The
+		// round trip does NOT return day 4 here, and must not pretend to.
+		{"15-day cycle, an observation the cycle cannot hold", 15, 4, 11, 5, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/services/cycles_reference_test.go
+++ b/internal/services/cycles_reference_test.go
@@ -150,18 +150,30 @@ func TestCalcOvulationDay_ReferenceVectors(t *testing.T) {
 // about whether the ovulation day itself belongs to the luteal phase — the
 // disagreement that put every personalized prediction one day early.
 func TestLutealPhaseRoundTrip_ReferenceVectors(t *testing.T) {
+	// wantDay is the cycle day the round trip lands on and wantExact says whether
+	// it got there without Step 2's reserve clamp. They are separate fields
+	// because the last row is the exception the invariant carries: an observation
+	// can imply a luteal phase the cycle cannot hold, and there the clamp is the
+	// designed answer rather than a broken round trip.
 	cases := []struct {
 		name              string
 		cycleLen          int
 		observedOvulation int
 		wantLuteal        int
+		wantDay           int
+		wantExact         bool
 	}{
-		{"28-day cycle, ovulation on day 14 is the 14-day model default", 28, 14, 14},
-		{"28-day cycle, ovulation on day 15", 28, 15, 13},
-		{"short 21-day cycle, ovulation on day 8", 21, 8, 13},
-		{"long 35-day cycle, ovulation on day 21", 35, 21, 14},
-		{"long 40-day cycle, ovulation on day 26", 40, 26, 14},
-		{"30-day cycle, ovulation on day 20 lands on the 10-day floor", 30, 20, 10},
+		{"28-day cycle, ovulation on day 14 is the 14-day model default", 28, 14, 14, 14, true},
+		{"28-day cycle, ovulation on day 15", 28, 15, 13, 15, true},
+		{"short 21-day cycle, ovulation on day 8", 21, 8, 13, 8, true},
+		{"long 35-day cycle, ovulation on day 21", 35, 21, 14, 21, true},
+		{"long 40-day cycle, ovulation on day 26", 40, 26, 14, 26, true},
+		{"30-day cycle, ovulation on day 20 lands on the 10-day floor", 30, 20, 10, 20, true},
+		// A mucus peak on cycle day 1 of a short cycle: ovulation is estimated at
+		// peak+1, the implied luteal phase is 19, which the plausibility window
+		// admits and a 21-day cycle cannot hold (its reserve caps it at 16). The
+		// round trip does NOT return day 2 here, and must not pretend to.
+		{"short 21-day cycle, an observation the cycle cannot hold", 21, 2, 19, 5, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -171,13 +183,17 @@ func TestLutealPhaseRoundTrip_ReferenceVectors(t *testing.T) {
 					tc.cycleLen, tc.observedOvulation, gotLuteal, tc.wantLuteal)
 			}
 			gotDay, gotExact := CalcOvulationDay(tc.cycleLen, gotLuteal)
-			if !gotExact {
-				t.Errorf("CalcOvulationDay(%d,%d) reported a clamped estimate for a luteal phase derived from a real observation",
-					tc.cycleLen, gotLuteal)
+			if gotExact != tc.wantExact {
+				t.Errorf("CalcOvulationDay(%d,%d) exact = %t, want %t",
+					tc.cycleLen, gotLuteal, gotExact, tc.wantExact)
 			}
-			if gotDay != tc.observedOvulation {
-				t.Fatalf("round trip broken: ovulation observed on cycle day %d inferred luteal %d, which predicts cycle day %d",
-					tc.observedOvulation, gotLuteal, gotDay)
+			if gotDay != tc.wantDay {
+				t.Fatalf("round trip: ovulation observed on cycle day %d inferred luteal %d, which predicts cycle day %d, want %d",
+					tc.observedOvulation, gotLuteal, gotDay, tc.wantDay)
+			}
+			if tc.wantExact && gotDay != tc.observedOvulation {
+				t.Fatalf("round trip broken: an exact fit must land back on the observed cycle day %d, got %d",
+					tc.observedOvulation, gotDay)
 			}
 		})
 	}

--- a/internal/services/cycles_reference_test.go
+++ b/internal/services/cycles_reference_test.go
@@ -163,18 +163,18 @@ func TestLutealPhaseRoundTrip_ReferenceVectors(t *testing.T) {
 		wantDay           int
 		wantExact         bool
 	}{
-		{"28-day cycle, ovulation on day 14 is the 14-day model default", 28, 14, 14, 14, true},
-		{"28-day cycle, ovulation on day 15", 28, 15, 13, 15, true},
-		{"short 21-day cycle, ovulation on day 8", 21, 8, 13, 8, true},
-		{"long 35-day cycle, ovulation on day 21", 35, 21, 14, 21, true},
-		{"long 40-day cycle, ovulation on day 26", 40, 26, 14, 26, true},
-		{"30-day cycle, ovulation on day 20 lands on the 10-day floor", 30, 20, 10, 20, true},
+		{name: "28-day cycle, ovulation on day 14 is the 14-day model default", cycleLen: 28, observedOvulation: 14, wantLuteal: 14, wantDay: 14, wantExact: true},
+		{name: "28-day cycle, ovulation on day 15", cycleLen: 28, observedOvulation: 15, wantLuteal: 13, wantDay: 15, wantExact: true},
+		{name: "short 21-day cycle, ovulation on day 8", cycleLen: 21, observedOvulation: 8, wantLuteal: 13, wantDay: 8, wantExact: true},
+		{name: "long 35-day cycle, ovulation on day 21", cycleLen: 35, observedOvulation: 21, wantLuteal: 14, wantDay: 21, wantExact: true},
+		{name: "long 40-day cycle, ovulation on day 26", cycleLen: 40, observedOvulation: 26, wantLuteal: 14, wantDay: 26, wantExact: true},
+		{name: "30-day cycle, ovulation on day 20 lands on the 10-day floor", cycleLen: 30, observedOvulation: 20, wantLuteal: 10, wantDay: 20, wantExact: true},
 		// The exception the invariant carries. An ovulation observed on day 4 of a
 		// 15-day cycle implies an 11-day luteal phase: physiologically ordinary,
 		// admitted by the plausibility window, and still more than the cycle can
 		// hold, since the reserve caps the parameter at cycleLength-5 = 10. The
 		// round trip does NOT return day 4 here, and must not pretend to.
-		{"15-day cycle, an observation the cycle cannot hold", 15, 4, 11, 5, false},
+		{name: "15-day cycle, an observation the cycle cannot hold", cycleLen: 15, observedOvulation: 4, wantLuteal: 11, wantDay: 5, wantExact: false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## What was wrong

`docs/cycle-prediction.md` Step 2a — added by #645 — states the personalized round trip as an
unqualified equality:

> An ovulation observed on cycle day **N** predicts cycle day **N** again on a next cycle of the
> same length.

That holds only while the luteal phase the observation implies still fits the cycle. Past it,
Step 2's reserve clamp applies and the prediction is marked non-exact. Step 2 documents that clamp
for its own direction one screen above, so two adjacent sections of the same document disagreed in
rigour about the same arithmetic — and this is the file written so users, contributors and auditors
can check what the app computes.

## Reachable, not decorative

The cervical-mucus fallback estimates ovulation at peak + 1. A peak on cycle day 1 of a 21-day
cycle therefore implies ovulation on day 2 and a luteal phase of 19 — which
`InferUserLutealPhase`'s plausibility window (10–20) admits, and which the cycle cannot hold, since
`maxSupportedLutealPhase` is `cycleLength − 5` = 16. The estimate lands on cycle day 5, non-exact.

## What changed

- The invariant carries its exception.
- The worked-example table carries a row for it, so the exception is shown rather than described:
  `| 21 | day 2 | 19, clamped to 16 by Step 2 | day 5 (non-exact) |`.
- `TestLutealPhaseRoundTrip_ReferenceVectors` carries that row. Its case struct now separates the
  day the trip lands on from whether it got there exactly, and asserts the observed day only where
  the fit was exact. The previous shape treated any clamp as a failure — which is why this case
  could not have been added without the change.

**No behaviour changes.** The clamp is what `CalcOvulationDay` already did; only the description of
it moved.

## Evidence

`go test ./internal/services/ -count=1` green (229 s), `golangci-lint run ./...` 0 issues, changelog
gate OK. The new row passes as written, which is the point — it pins the clamped result rather than
asserting the round trip is unconditional.

## Rollback

`git revert` of the single commit. Documentation and one test table; no production code is touched.
