### PR TITLE
fix(boot): bound how long a boot pass may wait on storage

### DIFF
--- a/changelog.d/bound-boot-pass-storage-waits.md
+++ b/changelog.d/bound-boot-pass-storage-waits.md
@@ -1,0 +1,29 @@
+### Fixed
+
+- **A database that stops answering during startup now fails the start instead of hanging it.**
+  Ovumcy runs three repair and sentinel passes when it starts, after the migrations and before it
+  begins serving: the calendar-feed key-rotation check, the one-shot auth-email repair, and the
+  one-shot luteal-phase recompute. Each waited on storage with no time limit. A database that
+  accepts the call and then never answers — a SQLite file held by another process, a Postgres
+  endpoint that connects and stalls — left the server alive and silent for as long as that lasted:
+  no listener, no error, and a container healthcheck with nothing to report but "starting". An
+  operator can read a refusal; there is nothing to read in a hang.
+
+  Each pass now runs under a five-minute budget. The number is deliberately far above what any of
+  them costs — the heaviest reads every owner's day logs once, uncontended, because nothing is
+  serving yet — so reaching it means storage is stuck rather than slow. What happens then is
+  unchanged and still differs per pass: the feed-rotation check and the email repair stop the boot,
+  because a feed left armed or an account left unable to sign in is worse than an instance that
+  refuses to start, while the luteal-phase recompute logs the failure, leaves its marker unwritten
+  and lets the server start, since it maintains a cache with a safe fallback.
+
+### Internal
+
+- **The boot sequence is swept for unbounded passes rather than trusted.** A guard reads the window
+  in `main()` between the repositories being built and the dependencies being wired — which is what
+  makes something a boot pass: the database is open, the migrations have applied, no listener exists
+  — and holds every call it finds there to taking its context from the shared budget. A fourth pass
+  added to that window is covered without anyone remembering to extend a list. The guard fails if
+  the window yields fewer calls than the passes known to run there, so a sweep that reached nothing
+  cannot report success, and a companion test runs both checks against synthetic sources to prove
+  they can separate a bounded pass from one reaching for `context.Background()`.

--- a/changelog.d/bound-boot-pass-storage-waits.md
+++ b/changelog.d/bound-boot-pass-storage-waits.md
@@ -15,7 +15,11 @@
   unchanged and still differs per pass: the feed-rotation check and the email repair stop the boot,
   because a feed left armed or an account left unable to sign in is worse than an instance that
   refuses to start, while the luteal-phase recompute logs the failure, leaves its marker unwritten
-  and lets the server start, since it maintains a cache with a safe fallback.
+  and lets the server start, since it maintains a cache with a safe fallback. The budget is per
+  pass and the passes run in sequence, so the worst case for a start as a whole is fifteen minutes
+  rather than five — size a container healthcheck start period against that. The operator runbook
+  gains a troubleshooting entry naming the message, what to look at, and the fact that a start
+  cut short this way loses nothing: every pass is safe to interrupt and safe to repeat.
 
 ### Internal
 

--- a/cmd/ovumcy/boot_pass_budget_guard_test.go
+++ b/cmd/ovumcy/boot_pass_budget_guard_test.go
@@ -21,12 +21,18 @@ func TestBootPassContextCarriesAStorageBudget(t *testing.T) {
 	if !ok {
 		t.Fatal("a boot pass must run under a deadline; this context has none, so a database that never answers hangs the boot with no listener and no refusal")
 	}
+	// Bounded on BOTH sides against the declared constant. An upper bound alone
+	// would let the helper be rewritten with a literal far below it — one second
+	// passes "positive and under five minutes" while making the constant
+	// decorative and turning a slow-but-working start into a failing one, which
+	// is the exact risk the constant's rationale is written to avoid.
 	remaining := time.Until(deadline)
-	if remaining <= 0 {
-		t.Fatalf("the budget is already spent at construction (remaining %s)", remaining)
-	}
+	const slack = 30 * time.Second
 	if remaining > bootPassStorageBudget {
 		t.Fatalf("deadline is %s away, further than the declared budget of %s", remaining, bootPassStorageBudget)
+	}
+	if remaining < bootPassStorageBudget-slack {
+		t.Fatalf("deadline is only %s away against a declared budget of %s; the helper is not using the constant it documents", remaining, bootPassStorageBudget)
 	}
 }
 
@@ -38,7 +44,10 @@ func TestBootPassContextCarriesAStorageBudget(t *testing.T) {
 // database is open, the migrations have applied and no listener exists yet. So
 // the guard reads that window out of main()'s own body and holds whatever it
 // finds there to the budget. A fourth pass added to the window later is covered
-// without anyone remembering to extend a list.
+// without anyone remembering to extend a list — including one wired behind a
+// config flag, since collectBootPassCalls descends into nested blocks. What it
+// does not claim to cover is written on that function, and the floor below is
+// what keeps the gap from reading as success.
 //
 // The floor matters as much as the rule: a sweep that reached nothing and a
 // sweep that passed print the same nothing. If the window yields fewer calls
@@ -82,20 +91,7 @@ func TestEveryBootPassRunsOnTheBoundedContext(t *testing.T) {
 		t.Fatalf("could not locate the boot window in main(): %s at %d, %s at %d", windowOpens, opensAt, windowCloses, closesAt)
 	}
 
-	passNames := make([]string, 0, knownPasses)
-	for _, statement := range mainFunc.Body.List[opensAt+1 : closesAt] {
-		expression, ok := statement.(*ast.ExprStmt)
-		if !ok {
-			continue
-		}
-		call, ok := expression.X.(*ast.CallExpr)
-		if !ok {
-			continue
-		}
-		if identifier, ok := call.Fun.(*ast.Ident); ok {
-			passNames = append(passNames, identifier.Name)
-		}
-	}
+	passNames := collectBootPassCalls(mainFunc.Body.List[opensAt+1 : closesAt])
 
 	if len(passNames) < knownPasses {
 		t.Fatalf("the boot window yielded %d pass call(s) %v, fewer than the %d known to run there — the sweep did not reach what it is meant to guard", len(passNames), passNames, knownPasses)
@@ -113,6 +109,61 @@ func TestEveryBootPassRunsOnTheBoundedContext(t *testing.T) {
 			t.Errorf("boot pass %s() still reaches for context.Background(); an unbounded boot pass hangs the start instead of failing it", name)
 		}
 	}
+}
+
+// collectBootPassCalls returns, in order and without repeats, the names of the
+// package-local functions INVOKED AS STATEMENTS anywhere inside the given
+// statements — including inside an if, a for or a nested block, which is the
+// shape a conditional boot pass takes (the reminder scheduler two lines below
+// the window is exactly that).
+//
+// It deliberately looks at statements rather than at every call expression: a
+// boot pass is invoked, not passed as an argument, and collecting argument-level
+// calls would demand a budget of helpers that merely compute a parameter.
+//
+// The two statement shapes it recognises are a bare call and an assignment from
+// one. A pass wired in some third shape — a call inside a `switch` guard, say —
+// would not be seen, which is why the caller keeps a floor on the count rather
+// than trusting this to be exhaustive.
+func collectBootPassCalls(statements []ast.Stmt) []string {
+	names := make([]string, 0, 4)
+	seen := map[string]bool{}
+
+	record := func(expression ast.Expr) {
+		call, ok := expression.(*ast.CallExpr)
+		if !ok {
+			return
+		}
+		identifier, ok := call.Fun.(*ast.Ident)
+		if !ok || seen[identifier.Name] {
+			return
+		}
+		// The budget helper is the one name worth excluding by name: hoisting
+		// `ctx, cancel := bootPassContext()` into the window is a reasonable
+		// refactor, and without this the guard would record the helper as a pass
+		// and then report that bootPassContext does not take its context from
+		// bootPassContext — a failure describing nothing anyone can act on.
+		if identifier.Name == "bootPassContext" {
+			return
+		}
+		seen[identifier.Name] = true
+		names = append(names, identifier.Name)
+	}
+
+	for _, statement := range statements {
+		ast.Inspect(statement, func(current ast.Node) bool {
+			switch node := current.(type) {
+			case *ast.ExprStmt:
+				record(node.X)
+			case *ast.AssignStmt:
+				for _, value := range node.Rhs {
+					record(value)
+				}
+			}
+			return true
+		})
+	}
+	return names
 }
 
 // callsSelector reports whether the node contains a call whose function is a
@@ -149,6 +200,58 @@ func callsIdentifier(node ast.Node, name string) bool {
 		return true
 	})
 	return found
+}
+
+// TestCollectBootPassCallsReachesPassesInsideBlocks is the test for the claim
+// the sweep rests on. Reading only the top-level statements of the window would
+// find the three passes wired today and silently miss a fourth added behind a
+// config flag — the shape the reminder scheduler already uses two lines below
+// the window — so the guard would report success over an unbounded pass. Each
+// case names the shape it stands for.
+func TestCollectBootPassCallsReachesPassesInsideBlocks(t *testing.T) {
+	source := `package main
+func main() {
+	plainPass(repositories)
+	if config.Enabled {
+		conditionalPass(repositories)
+	}
+	outcome := assignedPass(repositories)
+	wrapper(argumentHelper())
+	log.Print(notAPass())
+	ctx, cancel := bootPassContext()
+	_ = outcome
+	_ = ctx
+	_ = cancel
+}
+`
+	file, err := parser.ParseFile(token.NewFileSet(), "synthetic.go", source, 0)
+	if err != nil {
+		t.Fatalf("parse synthetic source: %v", err)
+	}
+	body := file.Decls[0].(*ast.FuncDecl).Body
+
+	got := collectBootPassCalls(body.List)
+	want := []string{"plainPass", "conditionalPass", "assignedPass", "wrapper"}
+	if len(got) != len(want) {
+		t.Fatalf("collected %v, want %v", got, want)
+	}
+	for index, name := range want {
+		if got[index] != name {
+			t.Fatalf("collected %v, want %v", got, want)
+		}
+	}
+	// argumentHelper and notAPass are calls, but neither is INVOKED as a
+	// statement: one computes an argument, the other sits inside a selector
+	// call. Demanding a storage budget of those would make the guard fire on
+	// helpers that never touch storage.
+	for _, name := range got {
+		if name == "argumentHelper" || name == "notAPass" {
+			t.Fatalf("argument-level call %q must not be read as a boot pass", name)
+		}
+		if name == "bootPassContext" {
+			t.Fatal("the budget helper must not be read as a boot pass; hoisting it into the window would make the guard demand it take its context from itself")
+		}
+	}
 }
 
 // TestBootPassBudgetGuardWouldSeeAnUnboundedPass proves the sweep can fail,

--- a/cmd/ovumcy/boot_pass_budget_guard_test.go
+++ b/cmd/ovumcy/boot_pass_budget_guard_test.go
@@ -1,0 +1,190 @@
+package main
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestBootPassContextCarriesAStorageBudget is the direct assertion on the
+// helper: it must hand back a context that expires. Removing the WithTimeout —
+// the one edit that silently restores the old unbounded behaviour — leaves a
+// context with no deadline and fails here.
+func TestBootPassContextCarriesAStorageBudget(t *testing.T) {
+	ctx, cancel := bootPassContext()
+	defer cancel()
+
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("a boot pass must run under a deadline; this context has none, so a database that never answers hangs the boot with no listener and no refusal")
+	}
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		t.Fatalf("the budget is already spent at construction (remaining %s)", remaining)
+	}
+	if remaining > bootPassStorageBudget {
+		t.Fatalf("deadline is %s away, further than the declared budget of %s", remaining, bootPassStorageBudget)
+	}
+}
+
+// TestEveryBootPassRunsOnTheBoundedContext sweeps the boot sequence rather than
+// a list of names.
+//
+// A boot pass is defined by WHERE it runs — after the repositories exist and
+// before the dependencies are built, which is the window in main() where the
+// database is open, the migrations have applied and no listener exists yet. So
+// the guard reads that window out of main()'s own body and holds whatever it
+// finds there to the budget. A fourth pass added to the window later is covered
+// without anyone remembering to extend a list.
+//
+// The floor matters as much as the rule: a sweep that reached nothing and a
+// sweep that passed print the same nothing. If the window yields fewer calls
+// than the passes known to live there, the guard fails as unable to have
+// measured anything rather than reporting success.
+func TestEveryBootPassRunsOnTheBoundedContext(t *testing.T) {
+	const (
+		windowOpens  = "NewRepositories"
+		windowCloses = "BuildDependencies"
+		knownPasses  = 3
+	)
+
+	fileSet := token.NewFileSet()
+	file, err := parser.ParseFile(fileSet, "main.go", nil, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("parse main.go: %v", err)
+	}
+
+	functions := map[string]*ast.FuncDecl{}
+	for _, declaration := range file.Decls {
+		if function, ok := declaration.(*ast.FuncDecl); ok && function.Body != nil {
+			functions[function.Name.Name] = function
+		}
+	}
+	mainFunc, ok := functions["main"]
+	if !ok {
+		t.Fatal("main() not found in main.go; the sweep has no boot sequence to read")
+	}
+
+	opensAt, closesAt := -1, -1
+	for index, statement := range mainFunc.Body.List {
+		if opensAt < 0 && callsSelector(statement, windowOpens) {
+			opensAt = index
+		}
+		if opensAt >= 0 && callsSelector(statement, windowCloses) {
+			closesAt = index
+			break
+		}
+	}
+	if opensAt < 0 || closesAt < 0 {
+		t.Fatalf("could not locate the boot window in main(): %s at %d, %s at %d", windowOpens, opensAt, windowCloses, closesAt)
+	}
+
+	passNames := make([]string, 0, knownPasses)
+	for _, statement := range mainFunc.Body.List[opensAt+1 : closesAt] {
+		expression, ok := statement.(*ast.ExprStmt)
+		if !ok {
+			continue
+		}
+		call, ok := expression.X.(*ast.CallExpr)
+		if !ok {
+			continue
+		}
+		if identifier, ok := call.Fun.(*ast.Ident); ok {
+			passNames = append(passNames, identifier.Name)
+		}
+	}
+
+	if len(passNames) < knownPasses {
+		t.Fatalf("the boot window yielded %d pass call(s) %v, fewer than the %d known to run there — the sweep did not reach what it is meant to guard", len(passNames), passNames, knownPasses)
+	}
+
+	for _, name := range passNames {
+		function, ok := functions[name]
+		if !ok {
+			t.Fatalf("boot pass %s() is called in main() but not declared in main.go; extend the sweep to the file that holds it", name)
+		}
+		if !callsIdentifier(function.Body, "bootPassContext") {
+			t.Errorf("boot pass %s() does not take its context from bootPassContext(), so it runs unbounded against storage", name)
+		}
+		if callsSelector(function.Body, "Background") {
+			t.Errorf("boot pass %s() still reaches for context.Background(); an unbounded boot pass hangs the start instead of failing it", name)
+		}
+	}
+}
+
+// callsSelector reports whether the node contains a call whose function is a
+// selector ending in name — context.Background, db.NewRepositories and so on.
+func callsSelector(node ast.Node, name string) bool {
+	found := false
+	ast.Inspect(node, func(current ast.Node) bool {
+		call, ok := current.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if selector, ok := call.Fun.(*ast.SelectorExpr); ok && selector.Sel.Name == name {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+// callsIdentifier reports whether the node contains a call to a package-local
+// function of that name.
+func callsIdentifier(node ast.Node, name string) bool {
+	found := false
+	ast.Inspect(node, func(current ast.Node) bool {
+		call, ok := current.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if identifier, ok := call.Fun.(*ast.Ident); ok && identifier.Name == name {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+// TestBootPassBudgetGuardWouldSeeAnUnboundedPass proves the sweep can fail,
+// because a guard that only ever passes and a guard that cannot fail print the
+// same nothing. It runs the same two checks against synthetic sources: one pass
+// that takes its context from bootPassContext and one that reaches for
+// context.Background, and requires the guard to separate them.
+func TestBootPassBudgetGuardWouldSeeAnUnboundedPass(t *testing.T) {
+	for name, testCase := range map[string]struct {
+		body            string
+		wantBounded     bool
+		wantsBackground bool
+	}{
+		"bounded pass": {
+			body:        "ctx, cancel := bootPassContext(); defer cancel(); doWork(ctx)",
+			wantBounded: true,
+		},
+		"unbounded pass": {
+			body:            "doWork(context.Background())",
+			wantsBackground: true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			source := "package main\nfunc pass() {\n" + strings.ReplaceAll(testCase.body, "; ", "\n") + "\n}\n"
+			file, err := parser.ParseFile(token.NewFileSet(), "synthetic.go", source, 0)
+			if err != nil {
+				t.Fatalf("parse synthetic source: %v", err)
+			}
+			body := file.Decls[0].(*ast.FuncDecl).Body
+
+			if got := callsIdentifier(body, "bootPassContext"); got != testCase.wantBounded {
+				t.Errorf("callsIdentifier(bootPassContext) = %v, want %v", got, testCase.wantBounded)
+			}
+			if got := callsSelector(body, "Background"); got != testCase.wantsBackground {
+				t.Errorf("callsSelector(Background) = %v, want %v", got, testCase.wantsBackground)
+			}
+		})
+	}
+}

--- a/cmd/ovumcy/main.go
+++ b/cmd/ovumcy/main.go
@@ -148,6 +148,37 @@ func mustOpenDatabase(databaseConfig db.Config) *gorm.DB {
 	return database
 }
 
+// bootPassStorageBudget bounds how long any one boot repair or sentinel pass may
+// wait on storage before the boot stops waiting for it.
+//
+// The passes run after migrations and before any listener exists, each on its
+// own context. Without a deadline a database that accepts the call and then
+// never answers — a SQLite file locked by another process, a Postgres endpoint
+// that connects and stalls — leaves the process alive and silent forever: no
+// listener, no refusal, and a container healthcheck that can only keep
+// reporting "starting". That is strictly worse than failing, because an
+// operator can read a refusal and cannot read a hang.
+//
+// The value is deliberately far above any plausible pass, because the failure
+// this introduces is the opposite one: a budget set near the real cost turns a
+// slow start into a broken start. The heaviest of the three reads every owner's
+// day logs once, and on the SQLite baseline that is a handful of accounts over a
+// few thousand rows with the write lock uncontended, since nothing is serving
+// yet. Five minutes is around two orders of magnitude of headroom, so reaching
+// it means storage is stuck rather than slow — which is the case each pass's own
+// failure policy should then decide, and they decide it differently: the two
+// must* wrappers stop the boot, the luteal recompute logs and lets the server
+// start.
+const bootPassStorageBudget = 5 * time.Minute
+
+// bootPassContext returns the bounded context a boot pass runs under, together
+// with the cancel its caller must defer. It exists so the three passes cannot
+// drift apart on the budget or on whether they have one at all — three inline
+// copies of the same WithTimeout is the shape that drifts.
+func bootPassContext() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), bootPassStorageBudget)
+}
+
 // mustEnforceCalendarFeedKeyRotation runs the boot-time calendar-feed
 // key-rotation sentinel: when SECRET_KEY (or the feed-MAC label set) changed
 // since the previous boot, it disarms the legacy pre-032 feed rows whose
@@ -156,8 +187,10 @@ func mustOpenDatabase(databaseConfig db.Config) *gorm.DB {
 // services.CalendarFeedRotationSentinel; this wrapper only wires repositories,
 // fails the boot hard on an error, and prints the operator-facing line.
 func mustEnforceCalendarFeedKeyRotation(repositories *db.Repositories, secretKey []byte) {
+	ctx, cancel := bootPassContext()
+	defer cancel()
 	sentinel := services.NewCalendarFeedRotationSentinel(repositories.AppState, repositories.Users, secretKey)
-	outcome, err := sentinel.Enforce(context.Background())
+	outcome, err := sentinel.Enforce(ctx)
 	if err != nil {
 		log.Fatalf("calendar-feed key-rotation check failed: %v", err) // codecov:ignore -- reachable only when the DB fails between migration and this first read
 	}
@@ -173,8 +206,10 @@ func mustEnforceCalendarFeedKeyRotation(repositories *db.Repositories, secretKey
 // services.AuthEmailRenormalizer; this wrapper wires repositories, fails the
 // boot hard on a storage error, and prints the operator-facing line.
 func mustRenormalizeAuthEmails(repositories *db.Repositories) {
+	ctx, cancel := bootPassContext()
+	defer cancel()
 	renormalizer := services.NewAuthEmailRenormalizer(repositories.AppState, repositories.Users)
-	outcome, err := renormalizer.Run(context.Background())
+	outcome, err := renormalizer.Run(ctx)
 	if err != nil {
 		log.Fatalf("auth email renormalization failed: %v", err) // codecov:ignore -- reachable only when the DB fails between migration and this first read
 	}
@@ -195,8 +230,10 @@ func mustRenormalizeAuthEmails(repositories *db.Repositories) {
 // instance that will not start. It is logged, the marker stays unwritten, and the
 // next boot retries.
 func recomputeDerivedLutealPhases(repositories *db.Repositories, location *time.Location) {
+	ctx, cancel := bootPassContext()
+	defer cancel()
 	recomputer := services.NewLutealPhaseRecomputer(repositories.AppState, repositories.Users, repositories.DailyLogs, location)
-	outcome, err := recomputer.Run(context.Background())
+	outcome, err := recomputer.Run(ctx)
 	if err != nil {
 		log.Printf("luteal-phase recompute failed: %v (retried on the next start)", err)
 	}

--- a/cmd/ovumcy/main.go
+++ b/cmd/ovumcy/main.go
@@ -169,6 +169,20 @@ func mustOpenDatabase(databaseConfig db.Config) *gorm.DB {
 // failure policy should then decide, and they decide it differently: the two
 // must* wrappers stop the boot, the luteal recompute logs and lets the server
 // start.
+//
+// The budget is PER PASS and the passes run in sequence, so the boot's own worst
+// case is this value times the number of passes — fifteen minutes today, not
+// five. Size a healthcheck start period or a deployment timeout against that
+// product, not against this constant.
+//
+// It also makes every pass one that can stop half-done, which each pass must
+// already survive, and all three do: the feed sentinel records its epoch only
+// after disarming, so an interrupted run re-detects the rotation next boot; the
+// email repair leaves its marker unwritten and every rewrite is idempotent; the
+// luteal recompute counts a cut-off row as a failure, which withholds the marker
+// for the same reason. A pass added here that writes its marker first, or whose
+// per-row work is not idempotent, cannot take this budget as given — the budget
+// assumes interruptibility that such a pass would not have.
 const bootPassStorageBudget = 5 * time.Minute
 
 // bootPassContext returns the bounded context a boot pass runs under, together

--- a/docs/self-hosted.md
+++ b/docs/self-hosted.md
@@ -592,7 +592,7 @@ Two cases are left untouched, counted in the same log line, and cannot sign in u
 
 ### The server exits during startup instead of coming up
 
-Three passes run on every start, after the migrations and before the server begins serving: the calendar-feed key-rotation check, the auth-email repair described above, and the luteal-phase recompute. Each is allowed **five minutes** to get an answer from the database, so a database that accepts the connection and then stops responding ends the start with an error naming the pass instead of leaving the process alive, silent and not listening — which is what it used to do, and which a container healthcheck can only ever report as "starting".
+Three passes run on every start, after the migrations and before the server begins serving: the calendar-feed key-rotation check, the auth-email repair described above, and the luteal-phase recompute. Each pass is allowed **five minutes** end to end — not per query, so a pass making many individually fast queries can still reach it — after which a database that accepts the connection and then stops responding ends the start with an error naming the pass, instead of leaving the process alive, silent and not listening — which is what it used to do, and which a container healthcheck can only ever report as "starting".
 
 The log line names the pass and carries the storage error underneath it — typically `context deadline exceeded`, though the exact wording comes from the database driver and a Postgres server cancelling an in-flight statement may word it differently.
 

--- a/docs/self-hosted.md
+++ b/docs/self-hosted.md
@@ -590,6 +590,20 @@ Two cases are left untouched, counted in the same log line, and cannot sign in u
 - another account already answers to the same bare address (two accounts on one mailbox — previously possible because the duplicate check compared stored forms): the oldest account keeps the address; review the leftover with `ovumcy users list` (it shows the stored legacy form) and remove or re-home it deliberately — the repair never deletes anything;
 - the stored value cannot be reduced to a plain address at all (for example a quoted local part).
 
+### The server exits during startup instead of coming up
+
+Three passes run on every start, after the migrations and before the server begins serving: the calendar-feed key-rotation check, the auth-email repair described above, and the luteal-phase recompute. Each is allowed **five minutes** to get an answer from the database, so a database that accepts the connection and then stops responding ends the start with an error naming the pass instead of leaving the process alive, silent and not listening — which is what it used to do, and which a container healthcheck can only ever report as "starting".
+
+The log line names the pass and carries the storage error underneath it — typically `context deadline exceeded`, though the exact wording comes from the database driver and a Postgres server cancelling an in-flight statement may word it differently.
+
+Five minutes is roughly two orders of magnitude above what these passes cost on a healthy instance, so reaching it means storage is stuck rather than slow. Check the database first: for SQLite, whether another process still holds the file (a stray container, a backup job, a copy in progress); for Postgres, whether the endpoint is accepting connections and then stalling.
+
+A start cut short this way loses nothing, but not because the pass stopped cleanly — it stops wherever it was, and the accounts it had already reached stay changed. What makes that safe is that every change a pass makes is one it would make again, and the marker that would stop it from running next time is written only after a complete pass. So the interrupted pass simply runs again on the next start, re-reaches the rows it already fixed, agrees with them, and finishes the rest.
+
+Two of the three end the start on failure, deliberately: a calendar feed left armed after a key rotation, or an account left unable to sign in, is worse than an instance that refuses to come up. The luteal-phase recompute does not — it logs `luteal-phase recompute failed … (retried on the next start)` and lets the server start, because it maintains a derived cache with a safe fallback. A count that repeats across starts there is a durable fault worth investigating rather than a transient one to wait out.
+
+Because the budget is per pass and the passes are sequential, the worst case for the start as a whole is fifteen minutes. Size a container healthcheck start period or a deployment timeout against that, not against five.
+
 ## Common Operator Scenarios
 
 - Moving from local/private to public HTTPS:

--- a/internal/db/user_repository_luteal_phase_rows_test.go
+++ b/internal/db/user_repository_luteal_phase_rows_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"testing"
 
@@ -81,5 +82,36 @@ func TestListOwnerLutealPhaseRowsSurfacesAStorageFailure(t *testing.T) {
 	}
 	if rows != nil {
 		t.Fatalf("a failed listing must return no rows, got %+v", rows)
+	}
+}
+
+// TestListOwnerLutealPhaseRowsHonoursItsContext is what makes the boot pass's
+// storage budget more than decoration.
+//
+// cmd/ovumcy bounds every boot pass with a deadline, and a guard there proves
+// each pass RECEIVES a bounded context. Nothing there can prove the work stops
+// when it fires — that rests on this layer threading ctx into GORM through
+// WithContext, which is a property of the query and belongs here. A method
+// added later that builds its own query without it would leave the budget inert
+// while every check in cmd/ovumcy stayed green.
+func TestListOwnerLutealPhaseRowsHonoursItsContext(t *testing.T) {
+	database := openSQLiteForMigrationBootstrapTest(t, filepath.Join(t.TempDir(), "luteal-rows-ctx.db"))
+	repository := NewUserRepository(database)
+
+	if err := repository.Create(context.Background(), &models.User{
+		Email: "ctx@example.com", PasswordHash: "hash", Role: models.RoleOwner, LutealPhase: 15,
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	rows, err := repository.ListOwnerLutealPhaseRows(cancelled)
+	if err == nil {
+		t.Fatalf("a cancelled context must abort the listing, got %d row(s)", len(rows))
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want it to carry context.Canceled so a boot deadline actually cuts the pass short", err)
 	}
 }

--- a/internal/services/context_rooting_guard_test.go
+++ b/internal/services/context_rooting_guard_test.go
@@ -45,10 +45,14 @@ func TestServicesNeverReRootAContext(t *testing.T) {
 		t.Fatalf("glob package files: %v", err)
 	}
 
+	// message is the WHOLE sentence, not a fragment sharing a suffix. The two
+	// kinds this sweep reports have different consequences — a re-rooting call
+	// drops a deadline, an aliased import only hides one from the check — and a
+	// shared tail would accuse the second of the first's damage.
 	type violation struct {
-		file string
-		line int
-		call string
+		file    string
+		line    int
+		message string
 	}
 	var violations []violation
 	walked := 0
@@ -80,9 +84,9 @@ func TestServicesNeverReRootAContext(t *testing.T) {
 			}
 			if imported.Name != nil {
 				violations = append(violations, violation{
-					file: path,
-					line: fileSet.Position(imported.Pos()).Line,
-					call: "imports context under the name " + imported.Name.Name + ", which puts any re-rooting call in this file beyond the check below",
+					file:    path,
+					line:    fileSet.Position(imported.Pos()).Line,
+					message: "imports context under the name " + imported.Name.Name + " — this is not itself a dropped deadline, but it puts every call in this file beyond the spelling the check below matches on, so import context under its own name",
 				})
 			}
 		}
@@ -104,9 +108,9 @@ func TestServicesNeverReRootAContext(t *testing.T) {
 				return true
 			}
 			violations = append(violations, violation{
-				file: path,
-				line: fileSet.Position(call.Pos()).Line,
-				call: "re-roots the context with context." + selector.Sel.Name + "()",
+				file:    path,
+				line:    fileSet.Position(call.Pos()).Line,
+				message: "re-roots the context with context." + selector.Sel.Name + "() — a boot pass reached through here would ignore its storage budget, and a request-scoped call would ignore its cancellation; take a ctx parameter instead",
 			})
 			return true
 		})
@@ -124,6 +128,6 @@ func TestServicesNeverReRootAContext(t *testing.T) {
 	}
 
 	for _, found := range violations {
-		t.Errorf("%s:%d %s — a boot pass reached through here would ignore its storage budget, and a request-scoped call would ignore its cancellation", found.file, found.line, found.call)
+		t.Errorf("%s:%d %s", found.file, found.line, found.message)
 	}
 }

--- a/internal/services/context_rooting_guard_test.go
+++ b/internal/services/context_rooting_guard_test.go
@@ -1,0 +1,98 @@
+package services
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestServicesNeverReRootAContext refuses context.Background and context.TODO
+// anywhere in this package's production files.
+//
+// It is the middle link of the chain the boot-pass storage budget rides on.
+// cmd/ovumcy bounds each boot pass with a deadline and a guard there proves the
+// pass RECEIVES it; internal/db proves a cancelled context aborts the query. A
+// service in between that re-rooted to context.Background would break the chain
+// without breaking either of those tests: the deadline would never reach
+// storage, a stuck database would hang the boot exactly as it did before the
+// budget existed, and every test would stay green.
+//
+// The rule is not new, only unenforced here. persistence.md already requires a
+// ctx parameter over context.Background for repositories, and this package held
+// to it on its own — the sweep found zero occurrences when it was written, which
+// is why it can be an outright refusal rather than an allowlist. A service that
+// genuinely needs a detached context (a goroutine outliving its request) has to
+// say so here, and that is the point: it becomes a decision someone makes on
+// purpose rather than a line that slips in.
+func TestServicesNeverReRootAContext(t *testing.T) {
+	paths, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatalf("glob package files: %v", err)
+	}
+
+	type violation struct {
+		file string
+		line int
+		call string
+	}
+	var violations []violation
+	walked := 0
+	sawKnownFile := false
+
+	fileSet := token.NewFileSet()
+	for _, path := range paths {
+		if strings.HasSuffix(path, "_test.go") {
+			continue
+		}
+		walked++
+		if path == "luteal_phase_recompute.go" {
+			sawKnownFile = true
+		}
+
+		file, err := parser.ParseFile(fileSet, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+		ast.Inspect(file, func(node ast.Node) bool {
+			call, ok := node.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			selector, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			pkg, ok := selector.X.(*ast.Ident)
+			if !ok || pkg.Name != "context" {
+				return true
+			}
+			if selector.Sel.Name != "Background" && selector.Sel.Name != "TODO" {
+				return true
+			}
+			violations = append(violations, violation{
+				file: path,
+				line: fileSet.Position(call.Pos()).Line,
+				call: "context." + selector.Sel.Name + "()",
+			})
+			return true
+		})
+	}
+
+	// The floor. A sweep that parsed nothing and a sweep that found nothing
+	// print the same nothing, and a glob that silently matched no files is the
+	// ordinary way the first happens.
+	const minimumFiles = 20
+	if walked < minimumFiles {
+		t.Fatalf("walked only %d production file(s); the sweep is too small to have measured anything", walked)
+	}
+	if !sawKnownFile {
+		t.Fatal("luteal_phase_recompute.go was not among the files walked; the sweep is not reading the package it claims to")
+	}
+
+	for _, found := range violations {
+		t.Errorf("%s:%d re-roots the context with %s — a boot pass reached through here would ignore its storage budget, and a request-scoped call would ignore its cancellation", found.file, found.line, found.call)
+	}
+}

--- a/internal/services/context_rooting_guard_test.go
+++ b/internal/services/context_rooting_guard_test.go
@@ -27,6 +27,18 @@ import (
 // genuinely needs a detached context (a goroutine outliving its request) has to
 // say so here, and that is the point: it becomes a decision someone makes on
 // purpose rather than a line that slips in.
+// detachesFromTheCaller names the context constructors that leave a call
+// unreachable by the caller's deadline. Background and TODO are the obvious
+// pair. WithoutCancel is the one worth spelling out: it keeps the values and
+// drops cancellation and the deadline, so it reads like careful context
+// threading while doing exactly what the other two do — and a boot pass written
+// with it would ignore its storage budget while looking correct.
+var detachesFromTheCaller = map[string]bool{
+	"Background":    true,
+	"TODO":          true,
+	"WithoutCancel": true,
+}
+
 func TestServicesNeverReRootAContext(t *testing.T) {
 	paths, err := filepath.Glob("*.go")
 	if err != nil {
@@ -56,6 +68,25 @@ func TestServicesNeverReRootAContext(t *testing.T) {
 		if err != nil {
 			t.Fatalf("parse %s: %v", path, err)
 		}
+
+		// The detection below keys on the spelling `context.X`, so first make
+		// that spelling a property this guard enforces rather than one it
+		// assumes: an aliased or dot import would let a re-rooting call through
+		// under a different name. A rule keyed on a spelling is not keyed on the
+		// thing, and the tell is a class that grows by one pattern per audit.
+		for _, imported := range file.Imports {
+			if imported.Path == nil || imported.Path.Value != `"context"` {
+				continue
+			}
+			if imported.Name != nil {
+				violations = append(violations, violation{
+					file: path,
+					line: fileSet.Position(imported.Pos()).Line,
+					call: "imports context under the name " + imported.Name.Name + ", which puts any re-rooting call in this file beyond the check below",
+				})
+			}
+		}
+
 		ast.Inspect(file, func(node ast.Node) bool {
 			call, ok := node.(*ast.CallExpr)
 			if !ok {
@@ -69,13 +100,13 @@ func TestServicesNeverReRootAContext(t *testing.T) {
 			if !ok || pkg.Name != "context" {
 				return true
 			}
-			if selector.Sel.Name != "Background" && selector.Sel.Name != "TODO" {
+			if !detachesFromTheCaller[selector.Sel.Name] {
 				return true
 			}
 			violations = append(violations, violation{
 				file: path,
 				line: fileSet.Position(call.Pos()).Line,
-				call: "context." + selector.Sel.Name + "()",
+				call: "re-roots the context with context." + selector.Sel.Name + "()",
 			})
 			return true
 		})
@@ -93,6 +124,6 @@ func TestServicesNeverReRootAContext(t *testing.T) {
 	}
 
 	for _, found := range violations {
-		t.Errorf("%s:%d re-roots the context with %s — a boot pass reached through here would ignore its storage budget, and a request-scoped call would ignore its cancellation", found.file, found.line, found.call)
+		t.Errorf("%s:%d %s — a boot pass reached through here would ignore its storage budget, and a request-scoped call would ignore its cancellation", found.file, found.line, found.call)
 	}
 }

--- a/internal/services/context_rooting_guard_test.go
+++ b/internal/services/context_rooting_guard_test.go
@@ -9,24 +9,6 @@ import (
 	"testing"
 )
 
-// TestServicesNeverReRootAContext refuses context.Background and context.TODO
-// anywhere in this package's production files.
-//
-// It is the middle link of the chain the boot-pass storage budget rides on.
-// cmd/ovumcy bounds each boot pass with a deadline and a guard there proves the
-// pass RECEIVES it; internal/db proves a cancelled context aborts the query. A
-// service in between that re-rooted to context.Background would break the chain
-// without breaking either of those tests: the deadline would never reach
-// storage, a stuck database would hang the boot exactly as it did before the
-// budget existed, and every test would stay green.
-//
-// The rule is not new, only unenforced here. persistence.md already requires a
-// ctx parameter over context.Background for repositories, and this package held
-// to it on its own — the sweep found zero occurrences when it was written, which
-// is why it can be an outright refusal rather than an allowlist. A service that
-// genuinely needs a detached context (a goroutine outliving its request) has to
-// say so here, and that is the point: it becomes a decision someone makes on
-// purpose rather than a line that slips in.
 // detachesFromTheCaller names the context constructors that leave a call
 // unreachable by the caller's deadline. Background and TODO are the obvious
 // pair. WithoutCancel is the one worth spelling out: it keeps the values and
@@ -39,6 +21,27 @@ var detachesFromTheCaller = map[string]bool{
 	"WithoutCancel": true,
 }
 
+// TestServicesNeverReRootAContext refuses every constructor in
+// detachesFromTheCaller anywhere in this package's production files, and
+// refuses an aliased or dot import of context on top — without which the
+// spelling the call check matches on would be an assumption rather than a
+// property.
+//
+// It is the middle link of the chain the boot-pass storage budget rides on.
+// cmd/ovumcy bounds each boot pass with a deadline and a guard there proves the
+// pass RECEIVES it; internal/db proves a cancelled context aborts the query. A
+// service in between that re-rooted its context would break the chain without
+// breaking either of those tests: the deadline would never reach storage, a
+// stuck database would hang the boot exactly as it did before the budget
+// existed, and every test would stay green.
+//
+// The rule is not new, only unenforced here. persistence.md already requires a
+// ctx parameter over context.Background for repositories, and this package held
+// to it on its own — the sweep found zero occurrences when it was written, which
+// is why it can be an outright refusal rather than an allowlist. A service that
+// genuinely needs a detached context (a goroutine outliving its request) has to
+// say so here, and that is the point: it becomes a decision someone makes on
+// purpose rather than a line that slips in.
 func TestServicesNeverReRootAContext(t *testing.T) {
 	paths, err := filepath.Glob("*.go")
 	if err != nil {


### PR DESCRIPTION
Three passes run after `mustOpenDatabase` and before any listener exists —
`mustEnforceCalendarFeedKeyRotation`, `mustRenormalizeAuthEmails` and
`recomputeDerivedLutealPhases`. Each called its service with `context.Background()`, so a database
that accepts the call and never answers left the process alive and silent: no listener, no refusal,
and a container healthcheck with nothing to report but "starting". An operator can read a refusal
and cannot read a hang.

Raised as a finding while reviewing #647 and deliberately not fixed there: the exposure is identical
in all three, so patching only the new one would have left the trio inconsistent and implied the two
older passes had been checked.

## The change

One constant and one helper, then three call sites:

```go
const bootPassStorageBudget = 5 * time.Minute

func bootPassContext() (context.Context, context.CancelFunc) {
	return context.WithTimeout(context.Background(), bootPassStorageBudget)
}
```

Not three inline `WithTimeout` calls — that is the shape that drifts, and it is the same shape this
branch's predecessor removed from the luteal-phase writers.

**No failure policy changes.** A timeout is an error, and each pass already decides what an error
means: the feed-rotation sentinel and the email repair stop the boot, because a feed left armed or
an account left unable to sign in is worse than an instance that refuses to start; the luteal-phase
recompute logs it, leaves its marker unwritten and lets the server start, because it maintains a
cache with a safe fallback.

## The budget, and the risk that comes with it

The danger a deadline introduces is the opposite of the one it removes: set near the real cost, it
turns a slow start into a broken start. Five minutes is chosen for headroom, not for realism. The
heaviest of the three reads every owner's day logs once, on the SQLite baseline that is a handful of
accounts over a few thousand rows, and the write lock is uncontended because nothing is serving yet
— roughly two orders of magnitude below the budget. Reaching it means storage is stuck rather than
slow, which is the case each pass's own policy should then decide. The reasoning is in the
constant's comment, where the next person to consider lowering it will be standing.

## The guard sweeps the sequence, not a list of names

A boot pass is defined by **where** it runs: after the repositories exist and before the
dependencies are wired, the window in `main()` where the database is open, the migrations have
applied and no listener exists. `TestEveryBootPassRunsOnTheBoundedContext` reads that window out of
`main()`'s own AST and holds whatever it finds there to taking its context from the shared budget,
so a fourth pass added to the window later is covered without anyone remembering to extend a list.

It has a floor, because a sweep that reached nothing and a sweep that passed print the same nothing:
if the window yields fewer calls than the passes known to run there, the guard fails as unable to
have measured anything rather than reporting success.

And it was run against a mutant rather than assumed to work: with `mustRenormalizeAuthEmails`
reverted to `context.Background()`, the guard fails and names that pass on both of its checks — it
does not take its context from the budget, and it still reaches for `Background`. Restored, it
passes. `TestBootPassBudgetGuardWouldSeeAnUnboundedPass` keeps that separation pinned by running
both checks over synthetic sources.

`TestBootPassContextCarriesAStorageBudget` covers the helper directly: dropping the `WithTimeout` —
the one edit that silently restores the old behaviour — leaves a context with no deadline and fails
there.

## Gates

Run over the population `TESTING.md` names, not `./...` — `testing.md` rules the latter out because it
sweeps a stray `.go` under `node_modules/flatted` that has no `go.mod`:

```sh
go test ./cmd/... ./internal/... ./migrations/... ./scripts/... ./web/... -timeout 20m
```

`golangci-lint run ./...` clean. Patch coverage verified with CI's own gate rather than a weaker
local command: `COVERAGE_FILE=… BASE_REF=origin/main go run ./scripts/patchcov` reports OK.

The Postgres-backed tests cannot be judged on this machine right now: the testcontainer stopped
coming up part-way through this branch, failing four local runs in a row with `postgres test
database did not become reachable from host in time` after ~100 s per test, across
`TestOpenPostgres*`, `TestUserRepositoryCreateTranslatesPostgresUniqueViolation`,
`TestDeleteAccountAndRelatedDataRemovesAllUserRows` and the `*Postgres` day-service pair. None of
them touches this change and CI's own Postgres lanes pass, so CI is the judge for that slice.

## Rollback

Code only — no schema, no migration, no stored data touched. Reverting the commit restores the
previous unbounded waits; nothing persists that a rollback would have to undo.
