### PR TITLE
fix(calendar): the confirmed ovulation marker lands on the detector's day

### DIFF
--- a/changelog.d/calendar-bbt-marker-inferred-date.md
+++ b/changelog.d/calendar-bbt-marker-inferred-date.md
@@ -1,0 +1,17 @@
+### Fixed
+
+- **The calendar's confirmed ovulation day now falls on the day the temperatures point at.** When
+  basal body temperature is tracked and the recorded readings show a sustained thermal shift, that
+  shift confirms an ovulation that has already happened — it says which day it was, and it never
+  predicts a future one. The stats chart has always marked that day. The month grid did not: on a
+  detected shift it kept its solid ovulation marker on the day the cycle model had projected before
+  any temperature arrived, and the detector's answer was read only as a yes-or-no. The two surfaces
+  therefore named two different days for one shift whenever the observation and the projection
+  disagreed, which is the ordinary case rather than an unusual one — a cycle that ovulates later
+  than its own average is exactly the cycle a thermal shift is being read for.
+
+  The grid now moves the marker to the day the detector named and takes it off the projection it
+  supersedes; the fertile-window shading around the projected day is unchanged, since that window
+  remains a forecast and never claimed to be confirmed. The behaviour when no shift is found is
+  unchanged too: the projected day stays, drawn as tentative. One detector, one day, on the calendar
+  and in the chart alike.

--- a/internal/services/calendar_days.go
+++ b/internal/services/calendar_days.go
@@ -411,13 +411,21 @@ func appendCurrentCycleBBTSignal(user *models.User, logs []models.DailyLog, stat
 	}
 
 	ovulationSignal := inferBBTOvulationDate(filterLogsNotAfter(logs, today), cycleStart, CalendarDay(stats.NextPeriodStart, location), location)
-	if !ovulationSignal.IsZero() {
+	projectedKey := CalendarDayKey(stats.OvulationDate)
+	delete(ovulationMap, projectedKey)
+	if ovulationSignal.IsZero() {
+		tentativeOvulationMap[projectedKey] = true
 		return
 	}
 
-	key := CalendarDayKey(stats.OvulationDate)
-	delete(ovulationMap, key)
-	tentativeOvulationMap[key] = true
+	// A detected shift CONFIRMS an ovulation that has already happened; it never
+	// predicts one. So the solid marker belongs on the day the detector named,
+	// not on the projection that day just superseded. Leaving it on
+	// stats.OvulationDate is how the grid and the stats chart came to name two
+	// different days for one shift: probableOvulationMarkerIndex marks the same
+	// firstHighDay-1 day this inference returns, so the chart moved and only the
+	// grid stayed behind on the model's date.
+	ovulationMap[CalendarDayKey(ovulationSignal)] = true
 }
 
 func buildCalendarDayState(day time.Time, monthStart time.Time, todayKey string, latestLogByDate map[string]models.DailyLog, hasDataMap map[string]bool, predictions calendarPredictionMaps) CalendarDayState {

--- a/internal/services/calendar_days_test.go
+++ b/internal/services/calendar_days_test.go
@@ -759,6 +759,12 @@ func TestBuildCalendarDayStatesSeparatesFertilityEdgeAndPeak(t *testing.T) {
 	}
 }
 
+// This fixture's projected ovulation day and the detector's confirmed day are
+// the SAME date (Mar 15), so it says only that a shift leaves a solid marker
+// standing somewhere — it cannot see which of the two days carries it. The day
+// the marker lands on is pinned by
+// TestBuildCalendarDayStatesMovesConfirmedOvulationToTheDetectorsDay below,
+// whose two dates differ on purpose.
 func TestBuildCalendarDayStatesKeepsConfirmedOvulationWhenBBTHasShift(t *testing.T) {
 	monthStart := time.Date(2026, time.March, 1, 0, 0, 0, 0, time.UTC)
 	now := time.Date(2026, time.March, 18, 0, 0, 0, 0, time.UTC)
@@ -793,6 +799,72 @@ func TestBuildCalendarDayStatesKeepsConfirmedOvulationWhenBBTHasShift(t *testing
 	}
 	if ovulationDay.IsTentativeOvulation {
 		t.Fatalf("expected tentative ovulation marker to stay off when BBT shift exists")
+	}
+}
+
+// A detected BBT shift confirms an ovulation that already happened, so the grid
+// must mark the day the shared 3-over-6 detector named — not the day the model
+// projected before the temperatures arrived. The two surfaces that read one
+// detector are checked against each other here: the calendar's solid marker and
+// the stats chart's marker index.
+func TestBuildCalendarDayStatesMovesConfirmedOvulationToTheDetectorsDay(t *testing.T) {
+	monthStart := time.Date(2026, time.March, 1, 0, 0, 0, 0, time.UTC)
+	cycleStart := time.Date(2026, time.March, 1, 0, 0, 0, 0, time.UTC)
+	now := time.Date(2026, time.March, 20, 0, 0, 0, 0, time.UTC)
+
+	// Cycle day 1 is Mar 1, so a 28-day cycle with a 14-day luteal phase projects
+	// ovulation onto cycle day 14 (Mar 14). The recorded temperatures put the
+	// 3-over-6 shift on cycle days 18-20 (Mar 18-20), which confirms cycle day 17
+	// (Mar 17) — three days off the projection, on purpose.
+	logs := []models.DailyLog{
+		// 6-day coverline window (max 36.43) on cycle days 12-17.
+		{Date: time.Date(2026, time.March, 12, 7, 0, 0, 0, time.UTC), BBT: new(36.40)},
+		{Date: time.Date(2026, time.March, 13, 7, 0, 0, 0, time.UTC), BBT: new(36.42)},
+		{Date: time.Date(2026, time.March, 14, 7, 0, 0, 0, time.UTC), BBT: new(36.41)},
+		{Date: time.Date(2026, time.March, 15, 7, 0, 0, 0, time.UTC), BBT: new(36.39)},
+		{Date: time.Date(2026, time.March, 16, 7, 0, 0, 0, time.UTC), BBT: new(36.43)},
+		{Date: time.Date(2026, time.March, 17, 7, 0, 0, 0, time.UTC), BBT: new(36.42)},
+		// Three-day rise, the third at least 0.2 °C over the coverline.
+		{Date: time.Date(2026, time.March, 18, 7, 0, 0, 0, time.UTC), BBT: new(36.66)},
+		{Date: time.Date(2026, time.March, 19, 7, 0, 0, 0, time.UTC), BBT: new(36.67)},
+		{Date: time.Date(2026, time.March, 20, 7, 0, 0, 0, time.UTC), BBT: new(36.69)},
+	}
+
+	stats := CycleStats{
+		CompletedCycleCount:  1,
+		LastPeriodStart:      cycleStart,
+		NextPeriodStart:      time.Date(2026, time.March, 29, 0, 0, 0, 0, time.UTC),
+		OvulationDate:        time.Date(2026, time.March, 14, 0, 0, 0, 0, time.UTC),
+		FertilityWindowStart: time.Date(2026, time.March, 9, 0, 0, 0, 0, time.UTC),
+		FertilityWindowEnd:   time.Date(2026, time.March, 14, 0, 0, 0, 0, time.UTC),
+	}
+
+	days := BuildCalendarDayStates(&models.User{TrackBBT: true}, monthStart, logs, stats, now, time.UTC)
+
+	confirmedDay := findCalendarDayStateByDateString(t, days, "2026-03-17")
+	if !confirmedDay.IsOvulation {
+		t.Fatalf("expected the detector's day to carry the solid ovulation marker, got %#v", confirmedDay)
+	}
+	if confirmedDay.IsTentativeOvulation {
+		t.Fatalf("expected the confirmed day to be solid, not tentative, got %#v", confirmedDay)
+	}
+
+	projectedDay := findCalendarDayStateByDateString(t, days, "2026-03-14")
+	if projectedDay.IsOvulation {
+		t.Fatalf("expected the superseded projection to lose the ovulation marker, got %#v", projectedDay)
+	}
+	if projectedDay.IsTentativeOvulation {
+		t.Fatalf("expected the superseded projection to carry no ovulation marker at all, got %#v", projectedDay)
+	}
+
+	// Same logs, same detector: the stats chart marker must name the same day.
+	chart := buildCurrentCycleBBTChart("en", stats, logs, now, time.UTC)
+	if !chart.HasMarker {
+		t.Fatalf("expected the stats chart to carry a marker for the same logs")
+	}
+	chartMarkerDate := CalendarDayKey(cycleStart.AddDate(0, 0, chart.MarkerIndex))
+	if chartMarkerDate != "2026-03-17" {
+		t.Fatalf("stats chart marker is on %s, calendar marker on 2026-03-17", chartMarkerDate)
 	}
 }
 


### PR DESCRIPTION
Release audit MED-2 (P1), PR-6 of the v2.0.0 campaign.

**Wrong.** `appendCurrentCycleBBTSignal` called the shared 3-over-6 detector and read its answer as a
yes-or-no: on a detected shift it returned, discarding the date `inferBBTOvulationDate` had just
computed and leaving the solid `Ovulation` marker on `stats.OvulationDate` — the model's projection.
The stats chart marks the detector's day (`probableOvulationMarkerIndex`, the same `firstHighDay-1`
convention), so the grid and the chart named two different days for one shift whenever observation
and projection disagreed. `services-cycle.md` forbids that for this detector by name; BBT confirms an
ovulation that has already happened and predicts nothing.

**Changed.** The solid marker moves onto the inferred date and comes off the superseded projection.
The no-shift branch is unchanged (projection stays, drawn tentative). Fertile-window shading is
untouched: it is a forecast and makes no confirmed claim, and no surface reads it as one.

**Evidence.** `TestBuildCalendarDayStatesMovesConfirmedOvulationToTheDetectorsDay` — projection
Mar 14, shift on Mar 18-20, detector Mar 17 — fails on the old code at the calendar marker and
passes here, and checks the calendar's day against the chart marker built from the same logs.
The pre-existing `...KeepsConfirmedOvulationWhenBBTHasShift` is green either way: its two dates
coincide, so it cannot see which day carries the marker. It gains a note saying so.

**Reachability.** One caller, `buildCalendarPredictionMaps`, behind the fertility floor and the
suppression gate; the month grid is the only surface reached. No new call site.

**Rollback.** Revert the commit.
