### PR TITLE
fix(ci): judge each release-tag check in the run where it actually ran

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1774,8 +1774,9 @@ jobs:
     # That gate is skipped on this path (it is the tag path's substitute for the
     # `needs:` above, which cannot cross a workflow boundary), but the ceiling
     # has to cover a job the called workflow declares whether or not it runs: a
-    # scope requested below the ceiling fails the CALL, not the skipped job, and
-    # would stop `:latest` following `main` again. The publish job itself is
+    # scope this list does not carry fails the CALL, not the skipped job that
+    # asked for it, and would stop `:latest` following `main` again — so a
+    # permission ADDED over there is a line owed here. The publish job itself is
     # unaffected: its own permissions block lists neither, so it still receives
     # neither.
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1746,11 +1746,19 @@ jobs:
     # not wait for that probe. `!cancelled()` suppresses the implicit predicate
     # whatever that predicate ranges over; on its own it would then publish off
     # a FAILED gate, so the five results are required by name and judged here
-    # rather than inferred from anything. `success` and nothing else — `skipped`
-    # must not publish either, which is what keeps a docs-only push to `main`
-    # (there `run_e2e` is false, so `image-smoke` never boots the image) from
-    # publishing an image no smoke test looked at. Such a push leaves `latest`
-    # on the previous commit, which carries the identical image.
+    # rather than inferred from anything. `success` and nothing else: `skipped`
+    # must not publish, because a lane that did not run is not a lane that
+    # passed, and a required check reads the same either way.
+    #
+    # It is NOT true that a docs-only push leaves `image-smoke` skipped, which
+    # this comment used to say. `changes` only judges a diff for an event that
+    # carries a base — a pull request or a merge group — and `push` carries
+    # none, so it takes the fail-safe branch and `run_e2e` stays true there
+    # whatever the commit touched. `image-smoke` and `e2e-postgres-smoke`
+    # therefore boot the image on EVERY push to `main`: measured on 5049126f, a
+    # documentation-only merge, where `image-smoke` reports `success` in the
+    # push run. Only `run_core` is cleared on push, and it clears the other
+    # three lanes.
     if: >-
       ${{ !cancelled()
       && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
@@ -1761,14 +1769,17 @@ jobs:
       && needs.e2e-postgres-smoke.result == 'success'
       && needs.image-smoke.result == 'success' }}
     # A caller cannot grant a called workflow more than it holds, so this must
-    # match the permissions the publish job declares — plus `checks: read`, for
-    # the tag gate that workflow now runs ahead of the publish. That gate is
-    # skipped on this path (it is the tag path's substitute for the `needs:`
-    # above, which cannot cross a workflow boundary), but the ceiling has to
-    # cover a job the called workflow declares whether or not it runs. The
-    # publish job itself is unaffected: its own permissions block does not list
-    # `checks`, so it still receives none.
+    # match the permissions the publish job declares — plus `actions: read` and
+    # `checks: read`, for the tag gate that workflow runs ahead of the publish.
+    # That gate is skipped on this path (it is the tag path's substitute for the
+    # `needs:` above, which cannot cross a workflow boundary), but the ceiling
+    # has to cover a job the called workflow declares whether or not it runs: a
+    # scope requested below the ceiling fails the CALL, not the skipped job, and
+    # would stop `:latest` following `main` again. The publish job itself is
+    # unaffected: its own permissions block lists neither, so it still receives
+    # neither.
     permissions:
+      actions: read
       artifact-metadata: write
       attestations: write
       checks: read

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -197,7 +197,7 @@ jobs:
           heavy_suite_ids="$(suite_ids_for_events "push release workflow_dispatch")"
 
           if [ -z "$queue_suite_ids" ]; then
-            echo "::error::no merge-queue run exists for ${sha}. \`${QUEUE_CHECKS}\` are the lanes the push to \`main\` clears unconditionally, so the queue run is the only place their verdict is real — and a commit that reached \`main\` without one has never had those lanes run against its own diff. Merge it through the queue, or dispatch CI on \`main\` for it, then re-push the tag."
+            echo "::error::no merge-queue run exists for ${sha}. \`${QUEUE_CHECKS}\` are the lanes the push to \`main\` clears unconditionally, so the queue run is the only place their verdict is real, and this commit has none — nothing has run those lanes against its own diff. There is nothing to wait for and no run to start: a \`merge_group\` run exists only for a commit the queue built, so tag one that reached \`main\` through the queue."
             exit 1
           fi
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -68,8 +68,14 @@ jobs:
     if: ${{ github.ref_type == 'tag' }}
     runs-on: ubuntu-latest
     permissions:
-      # `checks: read` is the whole of the widening, and it lives here, not on
-      # the publish job below, which keeps exactly the permissions it had.
+      # `actions: read` and `checks: read` are the whole of the widening, and
+      # both live here, not on the publish job below, which keeps exactly the
+      # permissions it had. `actions: read` is what lets the step below ask
+      # which EVENT produced each run on the tagged commit; without it the only
+      # discriminator left is `head_branch`, which cannot tell the push run on
+      # `main` from a scheduled or manually dispatched one, and can recognise
+      # the merge-queue run only by a ref-name convention.
+      actions: read
       checks: read
       contents: read
 
@@ -110,112 +116,165 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-          # Exactly the five ci.yml's `publish-image` requires before it lets
-          # `:latest` follow `main`. Three of them would have made the RELEASE
-          # path more permissive than the rolling one: a commit whose
-          # `image-smoke` or `e2e-postgres-smoke` failed correctly holds
-          # `:latest` back, and tagging that same commit would then have shipped
-          # a signed, attested release image anyway.
+          # The five ci.yml's `publish-image` requires before it lets `:latest`
+          # follow `main`, split by WHERE each one's verdict is real. The split
+          # is not a preference about which run to trust; it is ci.yml's own
+          # gating read back.
           #
-          # Being contained in main is not enough on its own to imply these, and
-          # neither is the merge queue's verdict. Measured on 6a95d01d, whose
-          # two suites the endpoint below returns side by side: in the QUEUE
-          # suite (87906745947, head_branch `gh-readonly-queue/main/pr-542-…`)
-          # `image-smoke` is `skipped` — it gates on the event and the queue is
-          # not one — while `e2e-postgres-smoke` reports `success` there with
-          # its own steps gated off by `RUN_HEAVY`, which is a green with no
-          # work behind it. Only the suite that ran on `main` itself
-          # (87908743276) carries a real verdict for either. So the gate asks
-          # that suite, and no other.
-          REQUIRED_CHECKS: test race e2e e2e-postgres-smoke image-smoke
+          # `test`, `race` and `e2e` are thin gates over lanes that `changes`
+          # clears with `run_core`, and a `push` to `main` clears it
+          # UNCONDITIONALLY — "the merge queue already ran the core suite on
+          # this exact commit", ci.yml's own words where it does so. So in the
+          # push run all three report `success` in seconds with every lane
+          # beneath them skipped: measured at 4b3c01d7 at 4 s, 2 s and 4 s. That
+          # green carries no work, and it is that green on EVERY push, so
+          # nothing about a particular commit takes part in it. Their real
+          # verdict is in the `merge_group` run, which this rebase queue
+          # produces on the byte-identical SHA.
+          #
+          # `e2e-postgres-smoke` and `image-smoke` are the other half of the
+          # same sentence: they are exactly what the queue does NOT run.
+          # `image-smoke` gates on the event, so the queue run reports it
+          # `skipped`; `e2e-postgres-smoke`'s own `RUN_HEAVY` excludes
+          # `merge_group`, so it reports `success` there with every step gated
+          # off — 3 s against 240 s on push, same commit. Their real verdict is
+          # in the push, release or dispatch run, which is what `RUN_HEAVY` is.
+          #
+          # Reading a lane off the run where its own gate never looked at the
+          # diff is what the split exists to stop. This step used to read the
+          # `main`-branch suite for all five and accept `skipped` from it for
+          # all five, which is both halves of one contradiction: it refused the
+          # queue's verdict as untrustworthy, and then accepted a push-run green
+          # whose only justification WAS that the queue had already run.
+          QUEUE_CHECKS: test race e2e
+          HEAVY_CHECKS: e2e-postgres-smoke image-smoke
         run: |
           set -euo pipefail
 
           sha="$(git rev-parse "${GITHUB_SHA}^{commit}")"
 
-          # Which suites ran on `main` ITSELF. A merge-queue run lives on a
-          # `gh-readonly-queue/...` ref, so its head_branch is never `main`,
-          # and this is the only field that separates the two — the check_suite
-          # object nested in a check-run response carries an id and nothing
-          # else (probed 2026-08-21).
+          # Which runs exist for this commit, and under which EVENT. The event
+          # is the discriminator, not `head_branch`: a scheduled run and a
+          # manually dispatched one both carry `head_branch: main`, and a queue
+          # run is otherwise recognisable only by a ref-name convention.
+          # `check_suite_id` is what ties a run to the check runs below (probed
+          # 2026-08-31 on 5049126f: `CI merge_group 90335713116` and `CI push
+          # 90335932105` — one commit, two suites, side by side).
           #
-          # Asking for this FIRST is what closes the window between the merge
-          # landing and the push run's suite being created. In that window the
-          # queue suite is the only one on the sha, and it reports `image-smoke`
-          # as `skipped`, which the judging below accepts — so a tag pushed
-          # there would have published a release image for a commit `image-smoke`
-          # never looked at. A suite that exists but has not finished is already
-          # safe: its conclusions are null, mapped to `pending` below, and
-          # `pending` refuses. The hole was strictly the suite that did not
-          # exist yet, and an absent suite is now its own refusal.
-          main_suite_ids="$(
+          # This is what `actions: read` on the job above buys.
+          workflow_runs="$(
             gh api --paginate \
-              "repos/${GITHUB_REPOSITORY}/commits/${sha}/check-suites?per_page=100" \
-              --jq '.check_suites[] | select(.head_branch == "main") | .id'
+              "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${sha}&per_page=100" \
+              --jq '.workflow_runs[] | [.event, (.check_suite_id | tostring)] | @tsv'
           )"
 
-          if [ -z "$main_suite_ids" ]; then
-            echo "::error::no check suite for ${sha} ran on \`main\` itself — only the merge queue's, if any. The lanes that judge a release image (\`image-smoke\`, \`e2e-postgres-smoke\`) run on the push to \`main\`, not in the queue, so this commit has no verdict from them yet. Wait for that run to finish, then re-push the tag."
+          echo "workflow runs on ${sha} (event, check suite):"
+          printf '%s\n' "$workflow_runs"
+
+          suite_ids_for_events() {
+            printf '%s\n' "$workflow_runs" | awk -F'\t' -v want="$1" '
+              BEGIN { n = split(want, a, " "); for (i = 1; i <= n; i++) keep[a[i]] = 1 }
+              keep[$1] { print $2 }
+            ' | sort -u
+          }
+
+          # `RUN_HEAVY` spelled out: the three events under which the image
+          # lanes actually execute. Keeping all three rather than `push` alone
+          # is what leaves an operator a way to produce that evidence for a
+          # commit whose push run was lost — dispatch CI on `main` and the lanes
+          # run, because an event carrying no base to diff against leaves
+          # `run_e2e` in the running direction.
+          queue_suite_ids="$(suite_ids_for_events "merge_group")"
+          heavy_suite_ids="$(suite_ids_for_events "push release workflow_dispatch")"
+
+          if [ -z "$queue_suite_ids" ]; then
+            echo "::error::no merge-queue run exists for ${sha}. \`${QUEUE_CHECKS}\` are the lanes the push to \`main\` clears unconditionally, so the queue run is the only place their verdict is real — and a commit that reached \`main\` without one has never had those lanes run against its own diff. Merge it through the queue, or dispatch CI on \`main\` for it, then re-push the tag."
+            exit 1
+          fi
+
+          if [ -z "$heavy_suite_ids" ]; then
+            echo "::error::no push, release or workflow_dispatch run exists for ${sha}. \`${HEAVY_CHECKS}\` are exactly the lanes the merge queue does not run, so those events are the only place their verdict is real. Wait for the push run to finish, or dispatch CI on \`main\` for this commit, then re-push the tag."
             exit 1
           fi
 
           # The endpoint's default `filter=latest` returns the most recent run
           # per name PER CHECK SUITE, so each of these names appears once per
-          # suite on the sha. Every row from a `main` suite is judged, never the
-          # first one found: taking the first would make the verdict depend on
-          # the order the API happened to return.
-          runs="$(
+          # suite on the sha. Every row is judged, never the first: taking the
+          # first would make the verdict depend on the order the API happened to
+          # return.
+          check_runs="$(
             gh api --paginate \
               "repos/${GITHUB_REPOSITORY}/commits/${sha}/check-runs?per_page=100" \
               --jq '.check_runs[] | [(.check_suite.id | tostring), .name, .conclusion // "pending"] | @tsv'
           )"
 
-          main_runs="$(
-            printf '%s\n' "$runs" | awk -F'\t' -v ids="$(printf '%s ' $main_suite_ids)" '
+          conclusions_in() {
+            printf '%s\n' "$check_runs" | awk -F'\t' -v ids="$(printf '%s ' $1)" -v want="$2" '
               BEGIN { n = split(ids, a, " "); for (i = 1; i <= n; i++) if (a[i] != "") keep[a[i]] = 1 }
-              keep[$1] { print $2 "\t" $3 }
+              keep[$1] && $2 == want { print $3 }
             '
-          )"
-
-          echo "check runs on ${sha} from a suite that ran on main:"
-          printf '%s\n' "$main_runs"
+          }
 
           failed=0
-          for name in $REQUIRED_CHECKS; do
-            conclusions="$(printf '%s\n' "$main_runs" | awk -F'\t' -v n="$name" '$1 == n { print $2 }')"
 
-            if [ -z "$conclusions" ]; then
-              echo "::error::no \`${name}\` check run exists for ${sha} in a suite that ran on \`main\`. A tag push starts no CI run of its own, so this commit's checks must already have run there."
+          # `success` and nothing else, in the run where the lane ran. `skipped`
+          # is refused here even where the lane may legitimately have been
+          # cleared for the diff: a release image is being signed off, the
+          # cleared lane is one of the five that hold `:latest` back, and this
+          # gate cannot tell a lane cleared by `changes` from one skipped
+          # because its run was cancelled. `pending` is not `skipped` either —
+          # a queued or still-running check is no verdict at all.
+          judge() {
+            judge_conclusions="$(conclusions_in "$1" "$2")"
+
+            if [ -z "$judge_conclusions" ]; then
+              echo "::error::no \`$2\` check run exists for ${sha} in $3. A tag push starts no CI run of its own, so this commit's checks must already have run there."
               failed=1
-              continue
+              return
             fi
 
-            # `skipped` passes, here and for the same reason ci.yml's own `test`
-            # gate accepts it: the `changes` job decided that run did not need
-            # the lane — a decision not to run, not a failure to run — and it
-            # clears a lane only for a diff that cannot reach it. Insisting on
-            # `success` would block a tag on a docs-only commit forever, since
-            # `image-smoke` gates on `run_e2e` and is skipped on the push there
-            # too. What made `skipped` unsafe was reading it off the QUEUE
-            # suite, which is no longer consulted. `pending` is not `skipped` —
-            # a queued or still-running check is no verdict, and this refuses.
             while IFS= read -r conclusion; do
+              [ -n "$conclusion" ] || continue
+              if [ "$conclusion" != "success" ]; then
+                echo "::error::a \`$2\` check run in $3 for ${sha} concluded \"${conclusion}\", and only \`success\` clears a release tag."
+                failed=1
+              fi
+            done <<< "$judge_conclusions"
+          }
+
+          for name in $QUEUE_CHECKS; do
+            judge "$queue_suite_ids" "$name" "the merge-queue run"
+          done
+
+          for name in $HEAVY_CHECKS; do
+            judge "$heavy_suite_ids" "$name" "the push, release or dispatch run"
+          done
+
+          # The push run's verdict for the queue-judged three is vacuous, not
+          # meaningless. Every lane under them is cleared there, so `success` is
+          # the only shape it can take, and `skipped` the only other one a
+          # cancelled run can leave. Anything else means a lane that was
+          # supposed to be cleared ran and failed, and this gate does not walk
+          # past that just because it reads the real verdict elsewhere.
+          for name in $QUEUE_CHECKS; do
+            while IFS= read -r conclusion; do
+              [ -n "$conclusion" ] || continue
               case "$conclusion" in
                 success|skipped) ;;
                 *)
-                  echo "::error::a \`${name}\` check run on ${sha} concluded \"${conclusion}\"."
+                  echo "::error::a \`${name}\` check run in the push, release or dispatch run for ${sha} concluded \"${conclusion}\" — every lane beneath it is cleared on that event, so nothing there should have been able to fail."
                   failed=1
                   ;;
               esac
-            done <<< "$conclusions"
+            done <<< "$(conclusions_in "$heavy_suite_ids" "$name")"
           done
 
           if [ "$failed" -ne 0 ]; then
-            echo "::error::refusing to publish a release image for ${GITHUB_REF_NAME}: the required checks on ${sha} are not green."
+            echo "::error::refusing to publish a release image for ${GITHUB_REF_NAME}: the required checks on ${sha} are not green in the run where their verdict is real."
             exit 1
           fi
 
-          echo "every required check (${REQUIRED_CHECKS}) passed on ${sha}."
+          echo "every required check passed where its verdict is real: ${QUEUE_CHECKS} in the merge-queue run, ${HEAVY_CHECKS} in the push, release or dispatch run."
 
   publish:
     needs:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -137,8 +137,12 @@ jobs:
           # `image-smoke` gates on the event, so the queue run reports it
           # `skipped`; `e2e-postgres-smoke`'s own `RUN_HEAVY` excludes
           # `merge_group`, so it reports `success` there with every step gated
-          # off — 3 s against 240 s on push, same commit. Their real verdict is
-          # in the push, release or dispatch run, which is what `RUN_HEAVY` is.
+          # off. Measured on 6a95d01d, whose two suites the endpoints below
+          # return side by side: `image-smoke` `skipped` in the queue suite
+          # (87906745947) and real in the one that ran on `main` (87908743276);
+          # and 3 s in the queue run against 240 s on push for the Postgres
+          # lane, same commit (2026-08-18, run 32081210308). Their real verdict
+          # is in the push, release or dispatch run, which is `RUN_HEAVY`.
           #
           # Reading a lane off the run where its own gate never looked at the
           # diff is what the split exists to stop. This step used to read the
@@ -157,9 +161,13 @@ jobs:
           # is the discriminator, not `head_branch`: a scheduled run and a
           # manually dispatched one both carry `head_branch: main`, and a queue
           # run is otherwise recognisable only by a ref-name convention.
-          # `check_suite_id` is what ties a run to the check runs below (probed
-          # 2026-08-31 on 5049126f: `CI merge_group 90335713116` and `CI push
-          # 90335932105` — one commit, two suites, side by side).
+          #
+          # It has to be asked HERE, of the runs, and carried down by
+          # `check_suite_id`, because the check-run response cannot answer it:
+          # the `check_suite` object nested in one carries an id and nothing
+          # else (probed 2026-08-21). Probed again 2026-08-31 on 5049126f,
+          # where this endpoint returns `CI merge_group 90335713116` and `CI
+          # push 90335932105` — one commit, two suites, side by side.
           #
           # This is what `actions: read` on the job above buys.
           workflow_runs="$(

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -184,6 +184,15 @@ jobs:
           # commit whose push run was lost — dispatch CI on `main` and the lanes
           # run, because an event carrying no base to diff against leaves
           # `run_e2e` in the running direction.
+          #
+          # The event is the whole filter, and the `head_branch == "main"` test
+          # this step used to carry is deliberately gone rather than kept beside
+          # it. That test existed to exclude the queue's suite, which the event
+          # now names outright; as a second condition it would be wrong, since a
+          # `release` run's head_branch is the tag. And it would add nothing: a
+          # run selected here already has this commit as its head_sha, so it ran
+          # on this exact tree, and for all three events `changes` finds no base
+          # to diff against and leaves `run_e2e` true whatever ref carried it.
           queue_suite_ids="$(suite_ids_for_events "merge_group")"
           heavy_suite_ids="$(suite_ids_for_events "push release workflow_dispatch")"
 
@@ -207,6 +216,14 @@ jobs:
               "repos/${GITHUB_REPOSITORY}/commits/${sha}/check-runs?per_page=100" \
               --jq '.check_runs[] | [(.check_suite.id | tostring), .name, .conclusion // "pending"] | @tsv'
           )"
+
+          # Printed whole, and before any judgement: the errors below name one
+          # context at a time, and a refusal is only diagnosable next to what the
+          # suites actually carried — a renamed context and an absent one read
+          # identically otherwise. The suite column joins to the run listing
+          # above, which is where the event for each suite is.
+          echo "check runs on ${sha} (check suite, name, conclusion):"
+          printf '%s\n' "$check_runs"
 
           conclusions_in() {
             printf '%s\n' "$check_runs" | awk -F'\t' -v ids="$(printf '%s ' $1)" -v want="$2" '

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -139,10 +139,11 @@ jobs:
           # `merge_group`, so it reports `success` there with every step gated
           # off. Measured on 6a95d01d, whose two suites the endpoints below
           # return side by side: `image-smoke` `skipped` in the queue suite
-          # (87906745947) and real in the one that ran on `main` (87908743276);
-          # and 3 s in the queue run against 240 s on push for the Postgres
-          # lane, same commit (2026-08-18, run 32081210308). Their real verdict
-          # is in the push, release or dispatch run, which is `RUN_HEAVY`.
+          # (87906745947) and real in the one that ran on `main` (87908743276).
+          # And for the Postgres lane, 2026-08-18, same commit: 3 s in queue run
+          # 32081210308 with every step gated off, 240 s in push run 32081716803
+          # doing the work. Their real verdict is in the push, release or
+          # dispatch run, which is `RUN_HEAVY`.
           #
           # Reading a lane off the run where its own gate never looked at the
           # diff is what the split exists to stop. This step used to read the

--- a/changelog.d/release-gate-skip-needs-queue-evidence.md
+++ b/changelog.d/release-gate-skip-needs-queue-evidence.md
@@ -24,5 +24,10 @@
   from the push, release or manually dispatched run. `success` is the only conclusion that clears a
   tag in either half — `skipped` and a still-running check are both refusals now — and a failure
   anywhere still fails the workflow with no bypass, so a tag that cannot be verified does not
-  publish. The remedy for a blocked tag is unchanged: make the commit green, then delete and
-  re-push the tag.
+  publish.
+
+  A refused tag says which half refused it, because the two have different remedies. A missing or
+  unfinished push run is waited out, or produced by running CI on the commit by hand. A missing
+  merge-queue run is not: that run exists only for a commit the queue built, so nothing an operator
+  starts will create one, and the answer is to tag a commit that reached `main` through the queue.
+  Either way the tag is deleted and re-pushed once the evidence is there.

--- a/changelog.d/release-gate-skip-needs-queue-evidence.md
+++ b/changelog.d/release-gate-skip-needs-queue-evidence.md
@@ -1,0 +1,28 @@
+### Fixed
+
+- **A release tag can no longer be published off a green that ran nothing.** Before a `vX.Y.Z` tag
+  builds and signs an image, a gate re-derives the verdict CI left on the tagged commit: it must be
+  contained in `main`, and the five checks that hold the rolling `:latest` back — `test`, `race`,
+  `e2e`, `e2e-postgres-smoke`, `image-smoke` — must have passed on it. A tag push starts no CI run
+  of its own and branch protection guards merges rather than tags, so this gate is the whole of the
+  release path's judgement.
+
+  It was reading three of those five in the one place where they carry no verdict. A commit on
+  `main` is judged twice — once by the merge queue on the identical revision, once by the push that
+  follows the merge — and the push run deliberately clears the unit, race and browser lanes,
+  because the queue has just run them on that exact tree. Their gate jobs still report, and still
+  report green, in a handful of seconds with every lane beneath them skipped. The gate consulted
+  only the push run, so `test`, `race` and `e2e` cleared a release tag on a result that says
+  nothing about the commit, and would say the same for any commit. It also accepted `skipped` from
+  all five alike, which let a lane that never ran stand in for one that passed. The two readings
+  contradicted each other: the queue's verdict was refused as untrustworthy, and then a push-run
+  green whose only justification was "the queue already ran it" was accepted in its place.
+
+  Each check is now read where it actually executes. `test`, `race` and `e2e` are taken from the
+  merge-queue run on the same revision, and a commit that reached `main` without one is refused.
+  `e2e-postgres-smoke` and `image-smoke` are the lanes the queue does not run, so they are taken
+  from the push, release or manually dispatched run. `success` is the only conclusion that clears a
+  tag in either half — `skipped` and a still-running check are both refusals now — and a failure
+  anywhere still fails the workflow with no bypass, so a tag that cannot be verified does not
+  publish. The remedy for a blocked tag is unchanged: make the commit green, then delete and
+  re-push the tag.

--- a/scripts/releasegate/main_test.go
+++ b/scripts/releasegate/main_test.go
@@ -1,0 +1,562 @@
+// Package releasegate holds the release tag gate to the one thing it exists to
+// assert: that the five checks `:latest` waits for were really run on the
+// commit being tagged.
+//
+// `verify-release-tag` in .github/workflows/docker-image.yml is the only gate
+// on the release path — a tag push starts no CI run of its own, and branch
+// protection guards merges into `main`, not tags. It used to read the check
+// suite whose `head_branch` is `main` and accept `success` or `skipped` from it
+// for all five names alike. Both halves of that are wrong at once, and they
+// contradict each other:
+//
+//   - it refused the merge queue's suite as untrustworthy, in a comment that
+//     measured `image-smoke` reporting `skipped` there and `e2e-postgres-smoke`
+//     reporting a `success` with every step gated off by `RUN_HEAVY`;
+//   - and then it accepted `test`, `race` and `e2e` off the push suite, where
+//     ci.yml's `changes` job clears `run_core` UNCONDITIONALLY on the grounds
+//     that the queue has already run them. Measured at 4b3c01d7: 4 s, 2 s and
+//     4 s with every lane beneath them `skipped`. A green with no work behind
+//     it, on every push, for reasons that have nothing to do with the commit.
+//
+// So each of the five had a verdict read off a run whose own gate never looked
+// at that commit's diff. What the gate asks now is the same question per lane,
+// aimed at the run where the lane actually executes: `test`, `race` and `e2e`
+// at the `merge_group` run, which this rebase queue produces on the
+// byte-identical SHA; `e2e-postgres-smoke` and `image-smoke` at the push,
+// release or dispatch run, which is what their own `RUN_HEAVY` selects.
+//
+// The tests below run the gate's REAL shell — extracted from the workflow, over
+// stubbed API responses — rather than restating its rules in Go. A guard that
+// reimplements what it guards proves only that two copies agree, and the two
+// copies drift; and this failure was silent for as long as it existed, because
+// a release image nobody pulled is not a signal any workflow reads.
+package releasegate
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The workflow, the job, and the step whose script is under test. Each is
+// looked up by name and fails the suite when absent: a renamed step is a guard
+// that silently judges nothing, which is the shape of the defect itself.
+const (
+	gateWorkflow = ".github/workflows/docker-image.yml"
+	gateJob      = "verify-release-tag"
+	gateStep     = "Assert the required checks passed on the tagged commit"
+
+	rollingWorkflow = ".github/workflows/ci.yml"
+	rollingJob      = "publish-image"
+)
+
+// The two env keys the step splits the required checks across. They are read
+// off the workflow rather than restated, so the judgement below follows the
+// workflow's own list; these names are only how it is found.
+const (
+	queueChecksKey = "QUEUE_CHECKS"
+	heavyChecksKey = "HEAVY_CHECKS"
+)
+
+var (
+	jobHeader  = regexp.MustCompile(`(?m)^  [A-Za-z0-9_.-]+:[ \t]*$`)
+	stepHeader = regexp.MustCompile(`(?m)^      - name: `)
+	envEntry   = regexp.MustCompile(`^([A-Za-z_][A-Za-z0-9_]*): (.*)$`)
+	needsEntry = regexp.MustCompile(`^      - ([A-Za-z0-9_.-]+)$`)
+)
+
+// checkRun is one row of the check-runs endpoint as the gate's `--jq` projects
+// it: which suite it belongs to, the context name, and the conclusion.
+type checkRun struct {
+	suite      string
+	name       string
+	conclusion string
+}
+
+// scenario is a state of the API for one commit: which workflow runs exist and
+// under which event, and what check runs each of their suites carries.
+type scenario struct {
+	name string
+	// runs maps a check-suite id to the event that produced it, exactly what
+	// `actions/runs?head_sha=` reports.
+	runs map[string]string
+	// The `head_branch` of each suite, which is what the gate used to select on
+	// and no longer does. Kept in the fixtures because the pre-fix script reads
+	// it, so these same scenarios drive both shapes and show which one refuses.
+	branches map[string]string
+	checks   []checkRun
+	// wantRefusal is what the gate owes this state of the world.
+	wantRefusal bool
+}
+
+// The suite ids the fixtures use. Two suites on one commit is the normal shape
+// of a merged commit here, measured 2026-08-31 on 5049126f.
+const (
+	queueSuite    = "90335713116"
+	pushSuite     = "90335932105"
+	dispatchSuite = "90400000001"
+)
+
+// greenQueue and greenPush are the conclusions a normal merge leaves in each
+// suite: the queue ran the core lanes and skipped the image ones, the push did
+// the opposite. Both are correct, and neither is a verdict on its own.
+func greenQueue(suite string) []checkRun {
+	return []checkRun{
+		{suite, "test", "success"},
+		{suite, "race", "success"},
+		{suite, "e2e", "success"},
+		{suite, "e2e-postgres-smoke", "success"},
+		{suite, "image-smoke", "skipped"},
+	}
+}
+
+func greenPush(suite string) []checkRun {
+	return []checkRun{
+		{suite, "test", "success"},
+		{suite, "race", "success"},
+		{suite, "e2e", "success"},
+		{suite, "e2e-postgres-smoke", "success"},
+		{suite, "image-smoke", "success"},
+	}
+}
+
+// withConclusion returns the rows with one name's conclusion in one suite
+// replaced, so a fixture states its one difference from a green commit rather
+// than restating the whole world.
+func withConclusion(rows []checkRun, suite, name, conclusion string) []checkRun {
+	out := make([]checkRun, 0, len(rows))
+	for _, row := range rows {
+		if row.suite == suite && row.name == name {
+			row.conclusion = conclusion
+		}
+		out = append(out, row)
+	}
+	return out
+}
+
+// without removes one name from one suite entirely, which is what an absent
+// check run looks like.
+func without(rows []checkRun, suite, name string) []checkRun {
+	out := make([]checkRun, 0, len(rows))
+	for _, row := range rows {
+		if row.suite == suite && row.name == name {
+			continue
+		}
+		out = append(out, row)
+	}
+	return out
+}
+
+func merged() []checkRun {
+	return append(greenQueue(queueSuite), greenPush(pushSuite)...)
+}
+
+func bothRuns() map[string]string {
+	return map[string]string{queueSuite: "merge_group", pushSuite: "push"}
+}
+
+func bothBranches() map[string]string {
+	return map[string]string{
+		queueSuite: "gh-readonly-queue/main/pr-650-1bba31433dbbb1474f7d6e21e43ff2597ed4d8a2",
+		pushSuite:  "main",
+	}
+}
+
+// TestReleaseTagGateJudgesEachLaneWhereItActuallyRan runs the workflow's own
+// script over states of the API this repository has held and states it must
+// refuse. Three of these are the finding: a `skipped` accepted with no queue
+// run behind it, a queue-run failure hidden behind the push run's vacuous
+// green, and `image-smoke` skipped on the only event that runs it.
+func TestReleaseTagGateJudgesEachLaneWhereItActuallyRan(t *testing.T) {
+	script := stepScript(t)
+	env := stepEnv(t)
+
+	for _, testCase := range []scenario{
+		{
+			name:     "a normally merged commit, both runs present",
+			runs:     bothRuns(),
+			branches: bothBranches(),
+			checks:   merged(),
+		},
+		{
+			// The finding. `test` carries no verdict on the push run whatever
+			// it says, so a `skipped` there with no queue run behind it is a
+			// tag published on nothing at all.
+			name:        "`test` skipped on the push run and no merge-queue run exists",
+			runs:        map[string]string{pushSuite: "push"},
+			branches:    map[string]string{pushSuite: "main"},
+			checks:      withConclusion(greenPush(pushSuite), pushSuite, "test", "skipped"),
+			wantRefusal: true,
+		},
+		{
+			// The same `skipped`, with the evidence. Refusing this one too
+			// would be a gate that cannot be satisfied rather than a gate.
+			name:     "`test` skipped on the push run, the merge-queue run carries its verdict",
+			runs:     bothRuns(),
+			branches: bothBranches(),
+			checks:   withConclusion(merged(), pushSuite, "test", "skipped"),
+		},
+		{
+			// The vacuous green in full: the queue found a real race and the
+			// push run reports `success` for `race` regardless, because every
+			// lane beneath it is cleared there.
+			name:        "the merge-queue run failed a lane the push run reports green",
+			runs:        bothRuns(),
+			branches:    bothBranches(),
+			checks:      withConclusion(merged(), queueSuite, "race", "failure"),
+			wantRefusal: true,
+		},
+		{
+			// The image lanes run on push and nowhere else, so a `skipped`
+			// there is the absence of the only verdict that exists.
+			name:        "`image-smoke` skipped on the push run",
+			runs:        bothRuns(),
+			branches:    bothBranches(),
+			checks:      withConclusion(merged(), pushSuite, "image-smoke", "skipped"),
+			wantRefusal: true,
+		},
+		{
+			name:        "`e2e-postgres-smoke` still running on the push run",
+			runs:        bothRuns(),
+			branches:    bothBranches(),
+			checks:      withConclusion(merged(), pushSuite, "e2e-postgres-smoke", "pending"),
+			wantRefusal: true,
+		},
+		{
+			name:        "the push run has not been created yet",
+			runs:        map[string]string{queueSuite: "merge_group"},
+			branches:    map[string]string{queueSuite: bothBranches()[queueSuite]},
+			checks:      greenQueue(queueSuite),
+			wantRefusal: true,
+		},
+		{
+			// `RUN_HEAVY` is push, release and dispatch alike, so a dispatched
+			// run on `main` carries a real verdict for the image lanes and the
+			// gate takes it. This is the operator's way out when a push run is
+			// lost to the one-pending-run-per-group rule.
+			name:     "the push run was lost and CI was dispatched on main instead",
+			runs:     map[string]string{queueSuite: "merge_group", dispatchSuite: "workflow_dispatch"},
+			branches: map[string]string{queueSuite: bothBranches()[queueSuite], dispatchSuite: "main"},
+			checks:   append(greenQueue(queueSuite), greenPush(dispatchSuite)...),
+		},
+		{
+			name:        "`e2e` never reported in the merge-queue run",
+			runs:        bothRuns(),
+			branches:    bothBranches(),
+			checks:      without(merged(), queueSuite, "e2e"),
+			wantRefusal: true,
+		},
+		{
+			// A commit that reached `main` outside the queue has no run in
+			// which the core lanes ever judged its diff.
+			name:        "no run of any kind exists for the commit",
+			runs:        map[string]string{},
+			branches:    map[string]string{},
+			checks:      nil,
+			wantRefusal: true,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			output, err := runGate(t, script, env, testCase)
+
+			if testCase.wantRefusal && err == nil {
+				t.Fatalf("the gate published this tag and owed a refusal.\n%s", output)
+			}
+			if !testCase.wantRefusal && err != nil {
+				t.Fatalf("the gate refused a tag it owes: %v\n%s", err, output)
+			}
+		})
+	}
+}
+
+// TestReleaseTagGateRequiresExactlyWhatTheRollingPathRequires ties the two
+// halves of the split back to ci.yml. The release path must not be more
+// permissive than the rolling one — a commit whose `image-smoke` failed holds
+// `:latest` back, and tagging it must not ship a signed image anyway — and the
+// split is only a claim about WHERE each verdict is read, never about which
+// checks are owed. A name dropped from either half, or moved out of both,
+// silently narrows the gate; a name added to `publish-image` and to neither
+// half here leaves the release path behind the rolling one again.
+func TestReleaseTagGateRequiresExactlyWhatTheRollingPathRequires(t *testing.T) {
+	env := stepEnv(t)
+	queue := strings.Fields(env[queueChecksKey])
+	heavy := strings.Fields(env[heavyChecksKey])
+
+	if len(queue) == 0 || len(heavy) == 0 {
+		t.Fatalf("%s, step %q: %s=%q and %s=%q — an empty half is a set of checks nobody reads a verdict for",
+			gateWorkflow, gateStep, queueChecksKey, env[queueChecksKey], heavyChecksKey, env[heavyChecksKey])
+	}
+
+	seen := map[string]bool{}
+	for _, name := range append(append([]string{}, queue...), heavy...) {
+		if seen[name] {
+			t.Errorf("%s, step %q: %q is in both halves, so it is judged in a run where it does not run", gateWorkflow, gateStep, name)
+		}
+		seen[name] = true
+	}
+
+	got := append(append([]string{}, queue...), heavy...)
+	want := rollingNeeds(t)
+	sort.Strings(got)
+	sort.Strings(want)
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("%s, step %q gates a release on %v, while %s's %q gates `:latest` on %v — the release path may not be the more permissive of the two",
+			gateWorkflow, gateStep, got, rollingWorkflow, rollingJob, want)
+	}
+}
+
+// runGate executes the extracted script with `gh` and `git` shadowed by shell
+// functions serving the scenario. Functions rather than stub executables on
+// PATH: a bash function shadows an external command everywhere the script could
+// reach one, and needs no executable bit, which Windows does not carry.
+//
+// The stubs answer the endpoint, not the `--jq` — they emit the rows the gate's
+// own projection would produce. So these fixtures prove which rows the gate
+// judges and how, and NOT that its jq expressions are spelled right; the
+// endpoint each call goes to is pinned, because an unrecognised URL is an error
+// here rather than an empty answer.
+func runGate(t *testing.T, script string, env map[string]string, state scenario) (string, error) {
+	t.Helper()
+
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skipf("bash is required to run the gate's own script as the workflow runs it: %v", err)
+	}
+
+	dir := t.TempDir()
+	write := func(name, content string) string {
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+		return filepath.ToSlash(path)
+	}
+
+	var workflowRuns, checkRuns, mainSuites strings.Builder
+	for _, suite := range sortedKeys(state.runs) {
+		workflowRuns.WriteString(state.runs[suite] + "\t" + suite + "\n")
+	}
+	for _, suite := range sortedKeys(state.branches) {
+		if state.branches[suite] == "main" {
+			mainSuites.WriteString(suite + "\n")
+		}
+	}
+	for _, row := range state.checks {
+		checkRuns.WriteString(row.suite + "\t" + row.name + "\t" + row.conclusion + "\n")
+	}
+
+	preamble := "" +
+		"gh() {\n" +
+		"  url=\"\"\n" +
+		"  for arg in \"$@\"; do case \"$arg\" in repos/*) url=\"$arg\";; esac; done\n" +
+		"  case \"$url\" in\n" +
+		"    */actions/runs*) cat " + write("workflow_runs.tsv", workflowRuns.String()) + " ;;\n" +
+		"    */check-runs*) cat " + write("check_runs.tsv", checkRuns.String()) + " ;;\n" +
+		"    */check-suites*) cat " + write("main_suites.tsv", mainSuites.String()) + " ;;\n" +
+		"    *) echo \"the gate called an endpoint this fixture does not serve: $*\" >&2; return 1 ;;\n" +
+		"  esac\n" +
+		"}\n" +
+		"git() {\n" +
+		"  case \"${1:-}\" in\n" +
+		"    rev-parse) printf '%s\\n' \"$GITHUB_SHA\" ;;\n" +
+		"    *) echo \"the gate ran an unexpected git command: $*\" >&2; return 1 ;;\n" +
+		"  esac\n" +
+		"}\n"
+
+	command := exec.Command(bash, "-c", preamble+script)
+	command.Env = append(os.Environ(),
+		"GITHUB_SHA=5049126faa3152cced900c304c3640e4ec724ba5",
+		"GITHUB_REPOSITORY=ovumcy/ovumcy-web",
+		"GITHUB_REF_NAME=v2.0.0",
+		"GH_TOKEN=stub",
+	)
+	for key, value := range env {
+		command.Env = append(command.Env, key+"="+value)
+	}
+
+	done := make(chan struct{})
+	timer := time.AfterFunc(2*time.Minute, func() {
+		if command.Process != nil {
+			_ = command.Process.Kill()
+		}
+		close(done)
+	})
+	output, err := command.CombinedOutput()
+	if timer.Stop() {
+		close(done)
+	}
+	<-done
+
+	return string(output), err
+}
+
+func sortedKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// stepScript returns the `run:` block of the gate's judging step, dedented the
+// way GitHub hands it to bash.
+func stepScript(t *testing.T) string {
+	t.Helper()
+
+	block := stepBlock(t)
+	marker := "        run: |\n"
+	start := strings.Index(block, marker)
+	if start < 0 {
+		t.Fatalf("%s, step %q: no `run: |` block — the gate's script moved, and this guard would run nothing", gateWorkflow, gateStep)
+	}
+
+	var script []string
+	for _, line := range strings.Split(block[start+len(marker):], "\n") {
+		if strings.TrimSpace(line) == "" {
+			script = append(script, "")
+			continue
+		}
+		if !strings.HasPrefix(line, "          ") {
+			break
+		}
+		script = append(script, strings.TrimPrefix(line, "          "))
+	}
+	return strings.Join(script, "\n")
+}
+
+// stepEnv returns the step's `env:` mapping, minus the entries whose value is a
+// workflow expression — those are supplied by the harness instead.
+func stepEnv(t *testing.T) map[string]string {
+	t.Helper()
+
+	block := stepBlock(t)
+	marker := "        env:\n"
+	start := strings.Index(block, marker)
+	if start < 0 {
+		t.Fatalf("%s, step %q: no `env:` mapping — the check names the gate reads are declared there", gateWorkflow, gateStep)
+	}
+
+	env := map[string]string{}
+	for _, line := range strings.Split(block[start+len(marker):], "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		if !strings.HasPrefix(line, "          ") {
+			break
+		}
+		entry := strings.TrimPrefix(line, "          ")
+		if strings.HasPrefix(entry, "#") || strings.HasPrefix(entry, " ") {
+			continue
+		}
+		match := envEntry.FindStringSubmatch(entry)
+		if match == nil || strings.Contains(match[2], "${{") {
+			continue
+		}
+		env[match[1]] = strings.TrimSpace(match[2])
+	}
+
+	for _, key := range []string{queueChecksKey, heavyChecksKey} {
+		if env[key] == "" {
+			t.Fatalf("%s, step %q declares no %s. The gate reads each lane's verdict from the run where that lane executes, and this is where the two halves are named; a step without them is judging all five somewhere one of them never ran",
+				gateWorkflow, gateStep, key)
+		}
+	}
+	return env
+}
+
+// stepBlock returns the text of the judging step, from its `- name:` line to
+// the next step at the same indentation.
+func stepBlock(t *testing.T) string {
+	t.Helper()
+
+	block := jobBlock(t, gateWorkflow, gateJob)
+	header := "      - name: " + gateStep + "\n"
+	start := strings.Index(block, header)
+	if start < 0 {
+		t.Fatalf("%s, job %q: no step named %q — the gate was renamed or removed, and this guard would judge nothing", gateWorkflow, gateJob, gateStep)
+	}
+	rest := block[start+len(header):]
+
+	if next := stepHeader.FindStringIndex(rest); next != nil {
+		return rest[:next[0]]
+	}
+	return rest
+}
+
+// rollingNeeds reads `publish-image`'s dependency list, the set of checks
+// `:latest` waits for. The release gate is compared against it rather than
+// against a copy of it kept here.
+func rollingNeeds(t *testing.T) []string {
+	t.Helper()
+
+	block := jobBlock(t, rollingWorkflow, rollingJob)
+	marker := "    needs:\n"
+	start := strings.Index(block, marker)
+	if start < 0 {
+		t.Fatalf("%s, job %q: no `needs:` list", rollingWorkflow, rollingJob)
+	}
+
+	var needs []string
+	for _, line := range strings.Split(block[start+len(marker):], "\n") {
+		match := needsEntry.FindStringSubmatch(line)
+		if match == nil {
+			break
+		}
+		needs = append(needs, match[1])
+	}
+	if len(needs) == 0 {
+		t.Fatalf("%s, job %q lists no dependencies, so there is nothing to hold the release gate to", rollingWorkflow, rollingJob)
+	}
+	return needs
+}
+
+// jobBlock returns the text of one job, from its header to the next job header
+// at the same indentation. It fails closed: a renamed job is a failure here,
+// never a silently empty search.
+func jobBlock(t *testing.T, workflow, job string) string {
+	t.Helper()
+
+	raw, err := os.ReadFile(filepath.Join(repoRoot(t), filepath.FromSlash(workflow)))
+	if err != nil {
+		t.Fatalf("read %s: %v", workflow, err)
+	}
+	content := strings.ReplaceAll(string(raw), "\r\n", "\n")
+
+	header := "\n  " + job + ":\n"
+	start := strings.Index(content, header)
+	if start < 0 {
+		t.Fatalf("%s: no job named %q", workflow, job)
+	}
+	rest := content[start+len(header):]
+
+	if next := jobHeader.FindStringIndex(rest); next != nil {
+		return rest[:next[0]]
+	}
+	return rest
+}
+
+// repoRoot walks up from the test's working directory to the module root.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("go.mod not found above %s", dir)
+		}
+		dir = parent
+	}
+}

--- a/scripts/releasegate/main_test.go
+++ b/scripts/releasegate/main_test.go
@@ -422,7 +422,12 @@ func TestTheCallerCeilingCoversEveryScopeTheCalledWorkflowDeclares(t *testing.T)
 	// scopes it did read still compare cleanly, so a job whose block is written
 	// in a shape this reader walks past asks for whatever it likes and the
 	// guard reports green — the defect it exists to catch, one job over.
-	jobs := jobHeader.FindAllString(content[strings.Index(content, "\njobs:\n"):], -1)
+	jobsAt := strings.Index(content, "\njobs:\n")
+	if jobsAt < 0 {
+		t.Fatalf("%s has no `jobs:` key this reader can find, so it cannot count the jobs it is supposed to have read a block for", gateWorkflow)
+	}
+
+	jobs := jobHeader.FindAllString(content[jobsAt:], -1)
 	if len(blocks) != len(jobs) {
 		t.Fatalf("%s has %d jobs and %d job-level `permissions:` blocks this guard can read. Every job's block has to be readable here, because the ones it cannot see are the ones that widen unnoticed — write the block in the usual shape, or teach this reader the new one",
 			gateWorkflow, len(jobs), len(blocks))

--- a/scripts/releasegate/main_test.go
+++ b/scripts/releasegate/main_test.go
@@ -30,9 +30,14 @@
 // reimplements what it guards proves only that two copies agree, and the two
 // copies drift; and this failure was silent for as long as it existed, because
 // a release image nobody pulled is not a signal any workflow reads.
+//
+// The split is only correct while ci.yml still behaves the way it is read here,
+// so that reading is asserted too — the two premises live in another file, and
+// nothing else would notice them changing.
 package releasegate
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -53,6 +58,7 @@ const (
 
 	rollingWorkflow = ".github/workflows/ci.yml"
 	rollingJob      = "publish-image"
+	changesJob      = "changes"
 )
 
 // The two env keys the step splits the required checks across. They are read
@@ -83,13 +89,10 @@ type checkRun struct {
 type scenario struct {
 	name string
 	// runs maps a check-suite id to the event that produced it, exactly what
-	// `actions/runs?head_sha=` reports.
-	runs map[string]string
-	// The `head_branch` of each suite, which is what the gate used to select on
-	// and no longer does. Kept in the fixtures because the pre-fix script reads
-	// it, so these same scenarios drive both shapes and show which one refuses.
-	branches map[string]string
-	checks   []checkRun
+	// `actions/runs?head_sha=` reports. The event is the whole of what the gate
+	// selects on, so it is the whole of what a fixture states.
+	runs   map[string]string
+	checks []checkRun
 	// wantRefusal is what the gate owes this state of the world.
 	wantRefusal bool
 }
@@ -160,13 +163,6 @@ func bothRuns() map[string]string {
 	return map[string]string{queueSuite: "merge_group", pushSuite: "push"}
 }
 
-func bothBranches() map[string]string {
-	return map[string]string{
-		queueSuite: "gh-readonly-queue/main/pr-650-1bba31433dbbb1474f7d6e21e43ff2597ed4d8a2",
-		pushSuite:  "main",
-	}
-}
-
 // TestReleaseTagGateJudgesEachLaneWhereItActuallyRan runs the workflow's own
 // script over states of the API this repository has held and states it must
 // refuse. Three of these are the finding: a `skipped` accepted with no queue
@@ -178,10 +174,9 @@ func TestReleaseTagGateJudgesEachLaneWhereItActuallyRan(t *testing.T) {
 
 	for _, testCase := range []scenario{
 		{
-			name:     "a normally merged commit, both runs present",
-			runs:     bothRuns(),
-			branches: bothBranches(),
-			checks:   merged(),
+			name:   "a normally merged commit, both runs present",
+			runs:   bothRuns(),
+			checks: merged(),
 		},
 		{
 			// The finding. `test` carries no verdict on the push run whatever
@@ -189,17 +184,15 @@ func TestReleaseTagGateJudgesEachLaneWhereItActuallyRan(t *testing.T) {
 			// tag published on nothing at all.
 			name:        "`test` skipped on the push run and no merge-queue run exists",
 			runs:        map[string]string{pushSuite: "push"},
-			branches:    map[string]string{pushSuite: "main"},
 			checks:      withConclusion(greenPush(pushSuite), pushSuite, "test", "skipped"),
 			wantRefusal: true,
 		},
 		{
 			// The same `skipped`, with the evidence. Refusing this one too
 			// would be a gate that cannot be satisfied rather than a gate.
-			name:     "`test` skipped on the push run, the merge-queue run carries its verdict",
-			runs:     bothRuns(),
-			branches: bothBranches(),
-			checks:   withConclusion(merged(), pushSuite, "test", "skipped"),
+			name:   "`test` skipped on the push run, the merge-queue run carries its verdict",
+			runs:   bothRuns(),
+			checks: withConclusion(merged(), pushSuite, "test", "skipped"),
 		},
 		{
 			// The vacuous green in full: the queue found a real race and the
@@ -207,8 +200,25 @@ func TestReleaseTagGateJudgesEachLaneWhereItActuallyRan(t *testing.T) {
 			// lane beneath it is cleared there.
 			name:        "the merge-queue run failed a lane the push run reports green",
 			runs:        bothRuns(),
-			branches:    bothBranches(),
 			checks:      withConclusion(merged(), queueSuite, "race", "failure"),
+			wantRefusal: true,
+		},
+		{
+			// `skipped` in the QUEUE run, which is the half the fix moved the
+			// verdict to. The gate jobs carry `if: !cancelled()`, so they run
+			// and report even when every lane beneath them is cleared —
+			// `skipped` there means the run was cancelled outright, and a
+			// cancelled run is not a verdict. Without this fixture, restoring
+			// `success|skipped` on the queue half would read green here.
+			name:        "`test` skipped in the merge-queue run",
+			runs:        bothRuns(),
+			checks:      withConclusion(merged(), queueSuite, "test", "skipped"),
+			wantRefusal: true,
+		},
+		{
+			name:        "`e2e` still running in the merge-queue run",
+			runs:        bothRuns(),
+			checks:      withConclusion(merged(), queueSuite, "e2e", "pending"),
 			wantRefusal: true,
 		},
 		{
@@ -216,38 +226,33 @@ func TestReleaseTagGateJudgesEachLaneWhereItActuallyRan(t *testing.T) {
 			// there is the absence of the only verdict that exists.
 			name:        "`image-smoke` skipped on the push run",
 			runs:        bothRuns(),
-			branches:    bothBranches(),
 			checks:      withConclusion(merged(), pushSuite, "image-smoke", "skipped"),
 			wantRefusal: true,
 		},
 		{
 			name:        "`e2e-postgres-smoke` still running on the push run",
 			runs:        bothRuns(),
-			branches:    bothBranches(),
 			checks:      withConclusion(merged(), pushSuite, "e2e-postgres-smoke", "pending"),
 			wantRefusal: true,
 		},
 		{
 			name:        "the push run has not been created yet",
 			runs:        map[string]string{queueSuite: "merge_group"},
-			branches:    map[string]string{queueSuite: bothBranches()[queueSuite]},
 			checks:      greenQueue(queueSuite),
 			wantRefusal: true,
 		},
 		{
 			// `RUN_HEAVY` is push, release and dispatch alike, so a dispatched
-			// run on `main` carries a real verdict for the image lanes and the
-			// gate takes it. This is the operator's way out when a push run is
-			// lost to the one-pending-run-per-group rule.
-			name:     "the push run was lost and CI was dispatched on main instead",
-			runs:     map[string]string{queueSuite: "merge_group", dispatchSuite: "workflow_dispatch"},
-			branches: map[string]string{queueSuite: bothBranches()[queueSuite], dispatchSuite: "main"},
-			checks:   append(greenQueue(queueSuite), greenPush(dispatchSuite)...),
+			// run carries a real verdict for the image lanes and the gate takes
+			// it. This is the operator's way out when a push run is lost to the
+			// one-pending-run-per-group rule.
+			name:   "the push run was lost and CI was dispatched instead",
+			runs:   map[string]string{queueSuite: "merge_group", dispatchSuite: "workflow_dispatch"},
+			checks: append(greenQueue(queueSuite), greenPush(dispatchSuite)...),
 		},
 		{
 			name:        "`e2e` never reported in the merge-queue run",
 			runs:        bothRuns(),
-			branches:    bothBranches(),
 			checks:      without(merged(), queueSuite, "e2e"),
 			wantRefusal: true,
 		},
@@ -256,7 +261,6 @@ func TestReleaseTagGateJudgesEachLaneWhereItActuallyRan(t *testing.T) {
 			// which the core lanes ever judged its diff.
 			name:        "no run of any kind exists for the commit",
 			runs:        map[string]string{},
-			branches:    map[string]string{},
 			checks:      nil,
 			wantRefusal: true,
 		},
@@ -310,6 +314,41 @@ func TestReleaseTagGateRequiresExactlyWhatTheRollingPathRequires(t *testing.T) {
 	}
 }
 
+// TestTheSplitStillRestsOnWhatCiActuallyDoes asserts the two facts about ci.yml
+// the split is derived from. Neither lives in the workflow this package
+// otherwise reads, and neither would announce itself when it changed:
+//
+//   - `push` clears `run_core` unconditionally. That is the whole reason
+//     `test`, `race` and `e2e` are read from the merge-queue run. Were it to
+//     stop, those three would carry a real verdict on the push too and this
+//     gate would be refusing tags on a mechanism that no longer exists.
+//   - `push` carries no base to diff against, so `run_e2e` stays true. That is
+//     the whole reason `image-smoke` may be required to be `success` rather
+//     than tolerated as `skipped` on a documentation-only commit.
+func TestTheSplitStillRestsOnWhatCiActuallyDoes(t *testing.T) {
+	block := jobBlock(t, rollingWorkflow, changesJob)
+
+	for _, premise := range []struct {
+		text  string
+		claim string
+	}{
+		{
+			text: "if [ \"$EVENT_NAME\" = \"push\" ]; then\n            run_core=false",
+			claim: "a push to `main` no longer clears `run_core` unconditionally. " +
+				gateWorkflow + " reads `test`, `race` and `e2e` from the merge-queue run BECAUSE the push run's verdict for them is vacuous; if the push run now does that work, re-derive the split before changing it",
+		},
+		{
+			text: "carries no base to diff against",
+			claim: "a push to `main` now has a base to diff against, so `run_e2e` may go false there. " +
+				gateWorkflow + " requires `success` from `image-smoke` in the push run BECAUSE that lane runs on every push whatever the diff touched; if it can now be skipped, that requirement blocks a documentation-only release tag forever",
+		},
+	} {
+		if !strings.Contains(block, premise.text) {
+			t.Errorf("%s, job %q: %s", rollingWorkflow, changesJob, premise.claim)
+		}
+	}
+}
+
 // runGate executes the extracted script with `gh` and `git` shadowed by shell
 // functions serving the scenario. Functions rather than stub executables on
 // PATH: a bash function shadows an external command everywhere the script could
@@ -317,16 +356,13 @@ func TestReleaseTagGateRequiresExactlyWhatTheRollingPathRequires(t *testing.T) {
 //
 // The stubs answer the endpoint, not the `--jq` — they emit the rows the gate's
 // own projection would produce. So these fixtures prove which rows the gate
-// judges and how, and NOT that its jq expressions are spelled right; the
-// endpoint each call goes to is pinned, because an unrecognised URL is an error
-// here rather than an empty answer.
+// judges and how, and NOT that its jq expressions are spelled right. The
+// endpoints themselves are pinned hard: anything the gate asks for other than
+// the two it is written around is an error here, which is what makes a return
+// to the `check-suites`-by-`head_branch` shape fail loudly rather than be
+// served.
 func runGate(t *testing.T, script string, env map[string]string, state scenario) (string, error) {
 	t.Helper()
-
-	bash, err := exec.LookPath("bash")
-	if err != nil {
-		t.Skipf("bash is required to run the gate's own script as the workflow runs it: %v", err)
-	}
 
 	dir := t.TempDir()
 	write := func(name, content string) string {
@@ -334,41 +370,40 @@ func runGate(t *testing.T, script string, env map[string]string, state scenario)
 		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
 			t.Fatalf("write %s: %v", name, err)
 		}
-		return filepath.ToSlash(path)
+		return shellQuote(filepath.ToSlash(path))
 	}
 
-	var workflowRuns, checkRuns, mainSuites strings.Builder
+	var workflowRuns, checkRuns strings.Builder
 	for _, suite := range sortedKeys(state.runs) {
 		workflowRuns.WriteString(state.runs[suite] + "\t" + suite + "\n")
-	}
-	for _, suite := range sortedKeys(state.branches) {
-		if state.branches[suite] == "main" {
-			mainSuites.WriteString(suite + "\n")
-		}
 	}
 	for _, row := range state.checks {
 		checkRuns.WriteString(row.suite + "\t" + row.name + "\t" + row.conclusion + "\n")
 	}
 
-	preamble := "" +
-		"gh() {\n" +
-		"  url=\"\"\n" +
-		"  for arg in \"$@\"; do case \"$arg\" in repos/*) url=\"$arg\";; esac; done\n" +
-		"  case \"$url\" in\n" +
-		"    */actions/runs*) cat " + write("workflow_runs.tsv", workflowRuns.String()) + " ;;\n" +
-		"    */check-runs*) cat " + write("check_runs.tsv", checkRuns.String()) + " ;;\n" +
-		"    */check-suites*) cat " + write("main_suites.tsv", mainSuites.String()) + " ;;\n" +
-		"    *) echo \"the gate called an endpoint this fixture does not serve: $*\" >&2; return 1 ;;\n" +
-		"  esac\n" +
-		"}\n" +
-		"git() {\n" +
-		"  case \"${1:-}\" in\n" +
-		"    rev-parse) printf '%s\\n' \"$GITHUB_SHA\" ;;\n" +
-		"    *) echo \"the gate ran an unexpected git command: $*\" >&2; return 1 ;;\n" +
-		"  esac\n" +
-		"}\n"
+	preamble := strings.Join([]string{
+		`gh() {`,
+		`  url=""`,
+		`  for arg in "$@"; do case "$arg" in repos/*) url="$arg";; esac; done`,
+		`  case "$url" in`,
+		`    */actions/runs*) cat ` + write("workflow_runs.tsv", workflowRuns.String()) + ` ;;`,
+		`    */check-runs*) cat ` + write("check_runs.tsv", checkRuns.String()) + ` ;;`,
+		`    *) echo "the gate called an endpoint this fixture does not serve: $*" >&2; return 1 ;;`,
+		`  esac`,
+		`}`,
+		`git() {`,
+		`  case "${1:-}" in`,
+		`    rev-parse) printf '%s\n' "$GITHUB_SHA" ;;`,
+		`    *) echo "the gate ran an unexpected git command: $*" >&2; return 1 ;;`,
+		`  esac`,
+		`}`,
+		"",
+	}, "\n")
 
-	command := exec.Command(bash, "-c", preamble+script)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	command := exec.CommandContext(ctx, bashPath(t), "-c", preamble+script)
 	command.Env = append(os.Environ(),
 		"GITHUB_SHA=5049126faa3152cced900c304c3640e4ec724ba5",
 		"GITHUB_REPOSITORY=ovumcy/ovumcy-web",
@@ -379,20 +414,30 @@ func runGate(t *testing.T, script string, env map[string]string, state scenario)
 		command.Env = append(command.Env, key+"="+value)
 	}
 
-	done := make(chan struct{})
-	timer := time.AfterFunc(2*time.Minute, func() {
-		if command.Process != nil {
-			_ = command.Process.Kill()
-		}
-		close(done)
-	})
 	output, err := command.CombinedOutput()
-	if timer.Stop() {
-		close(done)
-	}
-	<-done
-
 	return string(output), err
+}
+
+// bashPath locates the shell the workflow's `shell: bash` steps are written
+// for. Absent it, there is nothing to run the gate's own script under, and a
+// skip is honest where a Go reimplementation would not be.
+func bashPath(t *testing.T) string {
+	t.Helper()
+
+	path, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skipf("bash is required to run the gate's own script as the workflow runs it: %v", err)
+	}
+	return path
+}
+
+// shellQuote makes a path safe to paste into the stub preamble. A temporary
+// directory is named after the test, and a name this file gains later may put a
+// space in it — unquoted, the stub would then `cat` two paths that do not
+// exist, and the resulting refusal would read as the gate's rather than the
+// harness's.
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", `'\''`) + "'"
 }
 
 func sortedKeys(m map[string]string) []string {

--- a/scripts/releasegate/main_test.go
+++ b/scripts/releasegate/main_test.go
@@ -370,7 +370,11 @@ func TestTheSplitStillRestsOnWhatCiActuallyDoes(t *testing.T) {
 				gateWorkflow + " reads `test`, `race` and `e2e` from the merge-queue run BECAUSE the push run's verdict for them is vacuous; if the push run now does that work, re-derive the split before changing it",
 		},
 		{
-			text: "carries no base to diff against",
+			// The `*)` arm, matched as code rather than by the verdict
+			// sentence beside it: the fact is that `push` reaches a branch
+			// which clears the base, and a message can be preserved through
+			// exactly the rework this premise needs to notice.
+			text: "            *)\n              base=\"\"",
 			claim: "a push to `main` now has a base to diff against, so `run_e2e` may go false there. " +
 				gateWorkflow + " requires `success` from `image-smoke` in the push run BECAUSE that lane runs on every push whatever the diff touched; if it can now be skipped, that requirement blocks a documentation-only release tag forever",
 		},
@@ -379,6 +383,87 @@ func TestTheSplitStillRestsOnWhatCiActuallyDoes(t *testing.T) {
 			t.Errorf("%s, job %q: %s", rollingWorkflow, changesJob, premise.claim)
 		}
 	}
+}
+
+// permissionRank orders the three values a scope can take. A caller grants a
+// ceiling, so `read` where the called job wants `write` is as broken as an
+// absent scope.
+var permissionRank = map[string]int{"none": 0, "read": 1, "write": 2}
+
+var permissionEntry = regexp.MustCompile(`^      ([a-z-]+): (none|read|write)$`)
+
+// TestTheCallerCeilingCoversEveryScopeTheCalledWorkflowDeclares is the guard for
+// a defect this very change nearly shipped: the gate gained `actions: read` and
+// ci.yml's `publish-image` — which reaches this workflow through
+// `uses: ./.github/workflows/docker-image.yml` — kept the ceiling it had.
+//
+// A reusable workflow's job cannot request a scope its caller does not hold, and
+// the refusal lands on the CALL rather than on the job that asked, so it does
+// not matter that the tag gate is skipped on that path. What it costs is the
+// whole publish: `:latest` stops following `main`, which is the failure closed
+// one pull request before this one. The comment at the caller says so; this is
+// what makes it true.
+func TestTheCallerCeilingCoversEveryScopeTheCalledWorkflowDeclares(t *testing.T) {
+	ceiling := declaredPermissions(t, jobBlock(t, rollingWorkflow, rollingJob))
+	if len(ceiling) == 0 {
+		t.Fatalf("%s, job %q declares no `permissions:` block, so it grants the called workflow the repository default and this comparison would pass over anything", rollingWorkflow, rollingJob)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(repoRoot(t), filepath.FromSlash(gateWorkflow)))
+	if err != nil {
+		t.Fatalf("read %s: %v", gateWorkflow, err)
+	}
+	content := strings.ReplaceAll(string(raw), "\r\n", "\n")
+
+	requested := map[string]string{}
+	for _, block := range strings.Split(content, "\n    permissions:\n")[1:] {
+		for scope, level := range declaredPermissions(t, "\n    permissions:\n"+block) {
+			if permissionRank[level] > permissionRank[requested[scope]] {
+				requested[scope] = level
+			}
+		}
+	}
+	if len(requested) == 0 {
+		t.Fatalf("%s declares no job-level `permissions:` at all, which this guard reads as its own failure rather than as nothing to check", gateWorkflow)
+	}
+
+	for _, scope := range sortedKeys(requested) {
+		if permissionRank[ceiling[scope]] < permissionRank[requested[scope]] {
+			t.Errorf("%s declares `%s: %s`, and %s's %q grants `%s: %s`. A caller cannot grant a called workflow more than it holds, and the shortfall fails the CALL, not the job that asked — so the publish stops entirely and `:latest` stops following `main`. Add the scope to that job's `permissions:` block",
+				gateWorkflow, scope, requested[scope], rollingWorkflow, rollingJob, scope, orNone(ceiling[scope]))
+		}
+	}
+}
+
+// declaredPermissions reads one `permissions:` mapping out of a job block.
+func declaredPermissions(t *testing.T, block string) map[string]string {
+	t.Helper()
+
+	marker := "    permissions:\n"
+	start := strings.Index(block, marker)
+	if start < 0 {
+		return nil
+	}
+
+	granted := map[string]string{}
+	for _, line := range strings.Split(block[start+len(marker):], "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "#") {
+			continue
+		}
+		match := permissionEntry.FindStringSubmatch(line)
+		if match == nil {
+			break
+		}
+		granted[match[1]] = match[2]
+	}
+	return granted
+}
+
+func orNone(level string) string {
+	if level == "" {
+		return "none"
+	}
+	return level
 }
 
 // runGate executes the extracted script with `gh` and `git` shadowed by shell

--- a/scripts/releasegate/main_test.go
+++ b/scripts/releasegate/main_test.go
@@ -460,7 +460,13 @@ func declaredPermissions(t *testing.T, block string) map[string]string {
 
 	granted := map[string]string{}
 	for _, line := range strings.Split(block[start+len(marker):], "\n") {
-		if strings.HasPrefix(strings.TrimSpace(line), "#") {
+		// Comments and blank lines are skipped, never stopped at. A blank line
+		// between grouped entries is legal and unremarkable, and stopping there
+		// would drop every scope below it — read as the called workflow's
+		// request that is the silent direction, since a scope nobody collected
+		// is a scope nobody checks the ceiling for. What ends the block is a key
+		// at the job's own indentation, which is not an entry and not blank.
+		if trimmed := strings.TrimSpace(line); trimmed == "" || strings.HasPrefix(trimmed, "#") {
 			continue
 		}
 		match := permissionEntry.FindStringSubmatch(line)

--- a/scripts/releasegate/main_test.go
+++ b/scripts/releasegate/main_test.go
@@ -415,8 +415,21 @@ func TestTheCallerCeilingCoversEveryScopeTheCalledWorkflowDeclares(t *testing.T)
 	}
 	content := strings.ReplaceAll(string(raw), "\r\n", "\n")
 
+	blocks := strings.Split(content, "\n    permissions:\n")[1:]
+
+	// One block per job, or this guard is covering only the jobs it happened to
+	// recognise. Finding SOME is the dangerous outcome, not finding none: the
+	// scopes it did read still compare cleanly, so a job whose block is written
+	// in a shape this reader walks past asks for whatever it likes and the
+	// guard reports green — the defect it exists to catch, one job over.
+	jobs := jobHeader.FindAllString(content[strings.Index(content, "\njobs:\n"):], -1)
+	if len(blocks) != len(jobs) {
+		t.Fatalf("%s has %d jobs and %d job-level `permissions:` blocks this guard can read. Every job's block has to be readable here, because the ones it cannot see are the ones that widen unnoticed — write the block in the usual shape, or teach this reader the new one",
+			gateWorkflow, len(jobs), len(blocks))
+	}
+
 	requested := map[string]string{}
-	for _, block := range strings.Split(content, "\n    permissions:\n")[1:] {
+	for _, block := range blocks {
 		for scope, level := range declaredPermissions(t, "\n    permissions:\n"+block) {
 			if permissionRank[level] > permissionRank[requested[scope]] {
 				requested[scope] = level

--- a/scripts/releasegate/main_test.go
+++ b/scripts/releasegate/main_test.go
@@ -236,6 +236,38 @@ func TestReleaseTagGateJudgesEachLaneWhereItActuallyRan(t *testing.T) {
 			wantRefusal: true,
 		},
 		{
+			// Every row is judged, never the newest or the first, and this is
+			// the case that decides which: a failed push run and a dispatched
+			// one that passed sit side by side, both of them heavy evidence.
+			// Taking either one alone would let a smoke failure be re-run away.
+			//
+			// The passing rows come FIRST in this fixture on purpose. A gate
+			// that stopped at the first match per name would read green over
+			// the failure and this scenario would prove nothing; with the
+			// failure last, only a gate that judges every row refuses.
+			name: "a failed push run and a later dispatch run that passed",
+			runs: map[string]string{
+				queueSuite:    "merge_group",
+				pushSuite:     "push",
+				dispatchSuite: "workflow_dispatch",
+			},
+			checks: append(
+				append(greenQueue(queueSuite), greenPush(dispatchSuite)...),
+				withConclusion(greenPush(pushSuite), pushSuite, "image-smoke", "failure")...),
+			wantRefusal: true,
+		},
+		{
+			// The heavy run's verdict for a queue-judged lane is vacuous, and
+			// vacuous is not the same as ignored: every lane beneath `test` is
+			// cleared on push, so a FAILURE there is a lane that ran when it
+			// should not have been able to, and the gate does not walk past it
+			// merely because it reads the real verdict elsewhere.
+			name:        "`test` failed in the push run, where its lanes are cleared",
+			runs:        bothRuns(),
+			checks:      withConclusion(merged(), pushSuite, "test", "failure"),
+			wantRefusal: true,
+		},
+		{
 			name:        "the push run has not been created yet",
 			runs:        map[string]string{queueSuite: "merge_group"},
 			checks:      greenQueue(queueSuite),


### PR DESCRIPTION
Release campaign PR-2 of 30 (`v2.0.0`), findings REL-2 (P1) and REL-4 (P2).

## The defect

`verify-release-tag` is the whole of the release path's judgement: a tag push starts no CI run of
its own, and branch protection guards merges into `main`, not tags. It re-derived the verdict from
the check suite whose `head_branch` is `main`, and accepted `success` or `skipped` from that one
suite for all five names alike.

A commit on `main` is judged twice — the merge-queue run on the identical revision, and the push
that follows the merge — and the push run deliberately clears the unit, race and browser lanes,
because the queue has just run them on that exact tree (`ci.yml`: "push to main: the merge queue
already ran the core suite on this exact commit"). Their gate jobs carry `if: !cancelled()`, so
they still execute and still report green: **4 s, 2 s and 4 s at `4b3c01d7`** with every lane
beneath them `skipped`. That green says nothing about the commit, and it is that green on every
push.

So the gate held two premises that contradict each other: the queue's suite was refused as
untrustworthy — the step's own comment measures `image-smoke` reporting `skipped` there and
`e2e-postgres-smoke` reporting a `success` with every step gated off by `RUN_HEAVY` — and then a
push-run green whose only justification *was* the queue's verdict was accepted in its place. REL-4
is the second half: `skipped` cleared a release tag for any of the five, so a lane that never ran
stood in for one that passed.

## The fix

Each check is read from the run where its own gate actually looked at the diff.

| checks | read from | why |
|---|---|---|
| `test`, `race`, `e2e` | the `merge_group` run | `run_core` is cleared unconditionally on push; this rebase queue produces the run on the byte-identical SHA |
| `e2e-postgres-smoke`, `image-smoke` | the push, release or dispatch run | exactly the lanes the queue does not run — their own `RUN_HEAVY` |

`success` is the only conclusion that clears a tag in either half; `skipped` and a still-running
check are both refusals. A missing run of either kind is its own refusal. The push run's rows for
the queue-judged three are still refused on anything but `success`/`skipped`, so a lane that was
supposed to be cleared and failed anyway is not walked past.

Suites are selected by the **event** that produced the run rather than by `head_branch`: a
scheduled and a manually dispatched run both carry `head_branch: main`, and the queue's run is
otherwise recognisable only by a ref-name convention. That is what `actions: read` on the job
buys.

## What changes in ci.yml, and why it is not incidental

A reusable workflow's job cannot request a scope its caller does not hold, and the shortfall fails
the **call**, not the job that asked — so it does not matter that the tag gate is skipped on the
`:latest` path. `publish-image`'s ceiling therefore gains `actions: read`; without it this PR would
have stopped `:latest` following `main`, which is the defect PR-1 closed. `scripts/releasegate` now
compares every scope any job in docker-image.yml declares against what that caller grants, ranking
`none` under `read` under `write`.

The same caller comment carried the claim this PR corrects in the gate: that a documentation-only
push leaves `image-smoke` skipped. It does not. `changes` judges a diff only for an event carrying
a base — a pull request or a merge group — and `push` carries none, so `run_e2e` stays true there
whatever the commit touched. Measured on `5049126f`, a documentation-only merge: `image-smoke` is
`success` in the push run. Requiring `success` there therefore blocks nothing. Fixing that in one
workflow and leaving it in the other is the shape this repository treats as a new defect.

## The guard

`scripts/releasegate` extracts the step's `env:` and `run:` from the workflow and executes **the
gate's real script** under bash over stubbed API responses, rather than restating its rules in Go —
a guard that reimplements what it guards proves only that two copies agree. Fourteen fixtures. It
also holds the union of the two halves to `publish-image`'s `needs:`, asserts the two facts about
ci.yml the split is derived from (`run_core` cleared unconditionally on push; the `*)` arm that
leaves `push` without a base), and holds the caller ceiling above — every scope any job in
docker-image.yml declares against what that caller grants, with a readable block required per job.

Driven against the previous script, three of those fixtures publish where they must refuse:

| fixture | before | after |
|---|---|---|
| `test` = `skipped` on the push run, no merge-queue run at all | exit 0 | exit 1 |
| merge-queue run failed `race`, push run reports all five green | exit 0 | exit 1 |
| `image-smoke` = `skipped` on the only event that runs it | exit 0 | exit 1 |

## Blast radius and rollback

The gate's new code is reached only by a `v*` tag push: the `workflow_call` path from `ci.yml`
skips that job entirely (`if: github.ref_type == 'tag'`). The ci.yml change is the exception and is
exercised on the next push to `main` — the ceiling is read on every call. Revert of this branch
restores both sides together; nothing here is irreversible.

Residual, outside this finding: `e2e-postgres-smoke` gates its work per step rather than per job,
so its `success` is not by itself proof of work. It is covered indirectly — `image-smoke` can only
be `success` when `run_e2e` was not false, which is the same condition the Postgres lane's work
gates on.

Deferred to PR-3 of this lane, deliberately: `jobBlock`/`repoRoot` are duplicated from
`scripts/publishgate`, and PR-3 would add a third copy. It introduces the shared workflow reader
and removes all three at once, rather than churning a file PR-1 just landed for a two-site
duplication.

## Checks run

- `go build ./...`; `go test ./scripts/... -count=1` — all packages ok except
  `scripts/backuprestoredoc`, which fails identically on `origin/main` in a second worktree on this
  machine (its Postgres container does not become reachable); untouched by this branch and judged
  by CI on Linux
- `actionlint -shellcheck=` — clean
- `staticcheck ./scripts/...`, `golangci-lint run --max-issues-per-linter=0 --max-same-issues=0 ./scripts/...` — 0 issues
- `go run ./scripts/changelogd check` — OK
- the caller-ceiling guard verified by removing the line it asserts: it fails and names both sides

