### PR TITLE
fix(predictions): every surface resolves the pregnancy pause on one today-bounded timeline

### DIFF
--- a/changelog.d/webhook-pause-today-bounded-timeline.md
+++ b/changelog.d/webhook-pause-today-bounded-timeline.md
@@ -1,0 +1,17 @@
+### Fixed
+
+- **A cycle start recorded for a future day no longer ends a pregnancy pause early — and no longer
+  ends it on the webhook alone.** A positive pregnancy test pauses predictions everywhere until a
+  cycle start is logged after it, and a cycle start may be entered up to two days ahead. Those two
+  rules met in the wrong place: the pause is resolved over whatever set of day logs the surface
+  handed the shared derivation, and only some surfaces bounded that set at today. The dashboard,
+  the calendar and the `.ics` feed fetch a range that ends today, so they went on showing the pause.
+  The webhook notification pass loads the whole stored history, so tomorrow's start lifted the pause
+  for it alone: an account could read "paused" on every screen while an outbound `period-soon`
+  notification left for their endpoint saying the predictions had resumed.
+
+  The bound now sits in the derivation every surface shares rather than in each caller's fetch, so
+  the pause — and the cycle statistics around it — are resolved over one timeline that ends on the
+  account's own today, in the account's own timezone. A day logged ahead of today still stores,
+  still displays, and still counts from the day it arrives; it simply no longer decides anything
+  before then. Nothing changes for an account whose recorded days are all in the past.

--- a/internal/services/day_feedback_policy.go
+++ b/internal/services/day_feedback_policy.go
@@ -33,11 +33,20 @@ func (service *DayService) ResolveDayFeedback(ctx context.Context, user *models.
 
 	day = DateAtLocation(day, location)
 	today := DateAtLocation(now, location)
-	stats := BuildCycleStats(logs, today)
+	// The same today-bounded timeline BuildCycleStatsFromLogs derives from, for
+	// the same reason: ResolvePregnancyPause lifts a pause on ANY cycle start
+	// later than the positive test and has no today of its own, while manual
+	// entry permits a start two days ahead. On the raw set that start decides
+	// today, and this message would tell the owner their predictions had resumed
+	// while every other surface still showed the pause. The two warnings below
+	// keep the full set on purpose — each asks about the day being edited, not
+	// about what the account's timeline supports today.
+	timeline := filterLogsNotAfter(logs, today)
+	stats := BuildCycleStats(timeline, today)
 	// BuildCycleStats does not resolve the pregnancy pause itself (mirrors
 	// StatsService.BuildCycleStatsFromLogs); resolve it here so the save
 	// message can explain the paused predictions.
-	if _, paused := ResolvePregnancyPause(logs); paused {
+	if _, paused := ResolvePregnancyPause(timeline); paused {
 		stats.PregnancyPaused = true
 	}
 	entry, err := service.FetchLogByDate(ctx, user.ID, day, location)

--- a/internal/services/day_feedback_policy_test.go
+++ b/internal/services/day_feedback_policy_test.go
@@ -302,3 +302,46 @@ func TestResolveDayFeedbackFertileMessageOnWindowStartInUTCPlusZone(t *testing.T
 		t.Fatalf("expected fertile message on window start in UTC+9, got %q", state.MessageKey)
 	}
 }
+
+// TestResolveDayFeedbackKeepsThePauseWhenTomorrowsCycleStartIsLogged is this
+// policy's half of the one-timeline rule. It resolves the pregnancy pause from
+// its own read of the owner's whole stored history rather than through
+// BuildCycleStatsFromLogs, so bounding that derivation alone would have left
+// this surface reading a cycle start recorded for TOMORROW as today's
+// resumption — the save message announcing that predictions were back while the
+// dashboard beside it still showed the pause.
+func TestResolveDayFeedbackKeepsThePauseWhenTomorrowsCycleStartIsLogged(t *testing.T) {
+	logs := newDayLogRepositoryStub()
+	service := NewDayService(logs, &dayUserRepositoryStub{})
+
+	today := mustParseDayFeedbackDate(t, "2026-03-12")
+	logs.entries["2026-02-14"] = models.DailyLog{UserID: 10, Date: mustParseDayFeedbackDate(t, "2026-02-14"), IsPeriod: true, CycleStart: true}
+	logs.entries["2026-03-12"] = models.DailyLog{UserID: 10, Date: today, PregnancyTest: models.PregnancyTestPositive}
+	// Permitted by manualCycleStartFutureDays, and part of no timeline that has
+	// happened yet.
+	logs.entries["2026-03-13"] = models.DailyLog{UserID: 10, Date: mustParseDayFeedbackDate(t, "2026-03-13"), IsPeriod: true, CycleStart: true}
+
+	state, err := service.ResolveDayFeedback(context.Background(), &models.User{ID: 10}, today, today, time.UTC)
+	if err != nil {
+		t.Fatalf("ResolveDayFeedback() unexpected error: %v", err)
+	}
+	if state.MessageKey != daySaveMessagePregnancyPaused {
+		t.Fatalf("expected the pause to hold against a cycle start logged for tomorrow, got %q", state.MessageKey)
+	}
+
+	// Control: move that start into the past and the pause lifts here too, so
+	// this case cannot pass against a policy that simply always reports a pause.
+	resumedLogs := newDayLogRepositoryStub()
+	resumedService := NewDayService(resumedLogs, &dayUserRepositoryStub{})
+	resumedLogs.entries["2026-02-14"] = models.DailyLog{UserID: 10, Date: mustParseDayFeedbackDate(t, "2026-02-14"), IsPeriod: true, CycleStart: true}
+	resumedLogs.entries["2026-03-10"] = models.DailyLog{UserID: 10, Date: mustParseDayFeedbackDate(t, "2026-03-10"), PregnancyTest: models.PregnancyTestPositive}
+	resumedLogs.entries["2026-03-11"] = models.DailyLog{UserID: 10, Date: mustParseDayFeedbackDate(t, "2026-03-11"), IsPeriod: true, CycleStart: true}
+
+	resumedState, err := resumedService.ResolveDayFeedback(context.Background(), &models.User{ID: 10}, today, today, time.UTC)
+	if err != nil {
+		t.Fatalf("ResolveDayFeedback() after a real resumption: %v", err)
+	}
+	if resumedState.MessageKey == daySaveMessagePregnancyPaused {
+		t.Fatalf("a cycle start already in the past lifts the pause, got %q", resumedState.MessageKey)
+	}
+}

--- a/internal/services/pregnancy_pause_test.go
+++ b/internal/services/pregnancy_pause_test.go
@@ -169,3 +169,81 @@ func TestResolvePregnancyPauseIgnoresCycleStartWithoutPeriod(t *testing.T) {
 		t.Fatal("expected pause: a cycle-start flag without a period day must not lift it")
 	}
 }
+
+// pauseParitySurfaceLogs names the log set each surface used to hand the shared
+// derivation. ResolvePregnancyPause itself has no today — it compares two dates
+// out of whatever set it is given — so before the bound moved into
+// BuildCycleStatsFromLogs the verdict was a property of the CALLER's fetch, not
+// of the owner's data. The dashboard and the .ics feed were correct by accident
+// of pre-bounding; the webhook notify pass passes the whole stored history.
+func pauseParitySurfaceLogs(history []models.DailyLog, today time.Time, location *time.Location) map[string][]models.DailyLog {
+	return map[string][]models.DailyLog{
+		"whole stored history (webhook notify pass)": history,
+		"bounded at today (dashboard, .ics feed)":    FilterLogsByDateRange(history, today.AddDate(-1, 0, 0), today, location),
+	}
+}
+
+// TestBuildCycleStatsFromLogsResolvesThePauseOnOneTodayBoundedTimeline is the
+// parity case: for one owner at one instant, the pause verdict must not depend
+// on which surface's fetch bound produced the log set, nor on the owner's zone.
+// A cycle start recorded for TOMORROW is permitted by manual entry
+// (manualCycleStartFutureDays) and belongs to no timeline that has happened, so
+// it may not lift a pause anywhere. The zones straddle the date line in both
+// directions, so a bound taken in UTC rather than in the owner's zone lands on
+// the wrong calendar day and shows up here.
+func TestBuildCycleStatsFromLogsResolvesThePauseOnOneTodayBoundedTimeline(t *testing.T) {
+	zones := []struct {
+		name string
+		hour int
+	}{
+		{"UTC", 12},
+		{"Pacific/Kiritimati", 11}, // UTC+14: the owner is already on the next date
+		{"Pacific/Niue", 2},        // UTC-11: the owner is still on the previous one
+		{"Asia/Tokyo", 23},         // local tomorrow, UTC today
+		{"America/Los_Angeles", 1}, // local yesterday, UTC today
+	}
+
+	for _, zone := range zones {
+		location, err := time.LoadLocation(zone.name)
+		if err != nil {
+			t.Fatalf("load %s: %v", zone.name, err)
+		}
+
+		now := time.Date(2026, time.March, 12, zone.hour, 0, 0, 0, time.UTC)
+		// Stored dates are canonical UTC-midnight, so the fixture names the
+		// owner's local calendar day in the shape the database holds.
+		today := DateAtLocation(now, location)
+		positive := ppDay(today.Year(), today.Month(), today.Day())
+		user := &models.User{}
+
+		paused := []models.DailyLog{
+			{Date: positive.AddDate(0, 0, -26), IsPeriod: true, CycleStart: true},
+			{Date: positive, PregnancyTest: models.PregnancyTestPositive},
+			{Date: positive.AddDate(0, 0, 1), IsPeriod: true, CycleStart: true},
+		}
+		for surface, logs := range pauseParitySurfaceLogs(paused, today, location) {
+			stats := BuildCycleStatsFromLogs(user, logs, now, location)
+			if !stats.PregnancyPaused {
+				t.Errorf("%s / %s: a cycle start logged for tomorrow lifted the pause", zone.name, surface)
+			}
+			if !PredictionsSuppressed(user, stats) {
+				t.Errorf("%s / %s: the pause must reach the shared suppression predicate", zone.name, surface)
+			}
+		}
+
+		// Control: a start already in the past is a real resumption and must lift
+		// the pause on every surface. Without it the case above would be green
+		// against a derivation that had simply started pausing unconditionally.
+		resumed := []models.DailyLog{
+			{Date: positive.AddDate(0, 0, -26), IsPeriod: true, CycleStart: true},
+			{Date: positive.AddDate(0, 0, -2), PregnancyTest: models.PregnancyTestPositive},
+			{Date: positive.AddDate(0, 0, -1), IsPeriod: true, CycleStart: true},
+		}
+		for surface, logs := range pauseParitySurfaceLogs(resumed, today, location) {
+			stats := BuildCycleStatsFromLogs(user, logs, now, location)
+			if stats.PregnancyPaused {
+				t.Errorf("%s / %s: a cycle start already in the past must lift the pause", zone.name, surface)
+			}
+		}
+	}
+}

--- a/internal/services/stats_service.go
+++ b/internal/services/stats_service.go
@@ -76,7 +76,25 @@ func (service *StatsService) BuildCycleStatsForRange(ctx context.Context, user *
 // dereferenced. Here the property is structural: there is no receiver to hold a
 // nil store, so a future line that needs one cannot compile into this function
 // unnoticed.
+//
+// The three passes run over ONE timeline, bounded at the owner's today. Only
+// BuildCycleStats bounded its own input (cycles.go, filterLogsNotAfter); the
+// baseline and the pregnancy pause were handed the raw set, so a day logged
+// ahead of today reached two of the three. ResolvePregnancyPause is where that
+// cost something: it lifts a pause on ANY cycle start later than the positive
+// test and has no today of its own, while manualCycleStartFutureDays lets an
+// owner record a start two days ahead. The surfaces that looked safe were safe
+// by accident — the dashboard and the .ics feed pre-bound the set they pass
+// (FilterLogsByDateRange, the fetched range), and the webhook notify pass, the
+// one surface that speaks to a destination outside the instance, passes the
+// whole stored history. So a positive test today plus a permitted start
+// tomorrow left the owner paused everywhere they could look and unpaused in the
+// payload leaving the instance. Bounding here rather than at each caller is what
+// makes "one timeline" a property of the derivation instead of a habit of three
+// call sites: suppression is the floor, and a floor one surface stands a day in
+// front of is not one.
 func BuildCycleStatsFromLogs(user *models.User, logs []models.DailyLog, now time.Time, location *time.Location) CycleStats {
+	logs = filterLogsNotAfter(logs, DateAtLocation(now, location))
 	stats := BuildCycleStats(logs, now)
 	stats = ApplyUserCycleBaseline(user, logs, stats, now, location)
 	if _, paused := ResolvePregnancyPause(logs); paused {

--- a/internal/services/webhook_notify_service_test.go
+++ b/internal/services/webhook_notify_service_test.go
@@ -1219,3 +1219,69 @@ func TestNotifyUsesOwnerPersistedTimezone(t *testing.T) {
 		t.Fatalf("expected 1 owner scanned, got %d", report.OwnersScanned)
 	}
 }
+
+// TestNotifyKeepsThePregnancyPauseWhenTomorrowsCycleStartIsLogged pins the one
+// surface that speaks outside the instance to the timeline the owner sees. The
+// notify pass loads the owner's WHOLE stored history, while the dashboard and
+// the .ics feed pass a set already bounded at today; ResolvePregnancyPause lifts
+// a pause on any cycle start later than the positive test and has no today of
+// its own, and manual entry permits a start up to two days ahead. So a positive
+// test today plus a start recorded for tomorrow left the owner reading "paused"
+// on every screen while this pass decided the pregnancy was over and sent
+// period-soon to their endpoint. Nothing may leave, and no watermark may be
+// claimed for what did not leave.
+func TestNotifyKeepsThePregnancyPauseWhenTomorrowsCycleStartIsLogged(t *testing.T) {
+	now := time.Date(2026, 3, 12, 9, 0, 0, 0, time.UTC)
+	today := notifyDay(2026, time.March, 12)
+	record := dueRecord(1, "https://a.example/hook", now, 26)
+
+	history := []models.DailyLog{
+		periodStartLog(1, *record.LastPeriodStart),
+		{UserID: 1, Date: today, PregnancyTest: models.PregnancyTestPositive},
+		// Permitted by manualCycleStartFutureDays (up to two days ahead), and not
+		// part of any timeline that has happened yet.
+		periodStartLog(1, today.AddDate(0, 0, 1)),
+	}
+
+	repo := &stubNotifyRepo{records: []models.WebhookNotifyRecord{record}}
+	deliverer := &stubDeliverer{}
+	service := newTestNotifyService(repo, stubLogReader{byUser: map[uint][]models.DailyLog{1: history}}, stubDecryptor{}, deliverer)
+
+	report, err := service.RunOnce(context.Background(), now, time.UTC, false)
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if report.Due != 0 || report.Sent != 0 {
+		t.Fatalf("a paused owner must produce no reminder at all, got due=%d sent=%d", report.Due, report.Sent)
+	}
+	if len(deliverer.deliveries()) != 0 {
+		t.Fatalf("delivered a reminder for a paused owner: %#v", deliverer.deliveries())
+	}
+	if len(repo.writes()) != 0 {
+		t.Fatalf("claimed a watermark for a reminder that never left: %#v", repo.writes())
+	}
+	if report.SkippedIdempotent != 0 {
+		t.Fatalf("the pause is a suppression, not a watermark skip (skipped=%d)", report.SkippedIdempotent)
+	}
+
+	// Control: the same owner, the same instant, with the positive test BEFORE
+	// the recorded cycle start. That is a real resumption, so the pass must speak
+	// — otherwise this case would be green against a pass that had simply
+	// stopped sending anything, or against a fixture that was never due.
+	resumedRecord := dueRecord(1, "https://a.example/hook", now, 26)
+	resumedHistory := []models.DailyLog{
+		{UserID: 1, Date: today.AddDate(0, 0, -30), PregnancyTest: models.PregnancyTestPositive},
+		periodStartLog(1, *resumedRecord.LastPeriodStart),
+	}
+	resumedRepo := &stubNotifyRepo{records: []models.WebhookNotifyRecord{resumedRecord}}
+	resumedDeliverer := &stubDeliverer{}
+	resumedService := newTestNotifyService(resumedRepo, stubLogReader{byUser: map[uint][]models.DailyLog{1: resumedHistory}}, stubDecryptor{}, resumedDeliverer)
+
+	resumedReport, err := resumedService.RunOnce(context.Background(), now, time.UTC, false)
+	if err != nil {
+		t.Fatalf("RunOnce after a real resumption: %v", err)
+	}
+	if resumedReport.Sent == 0 {
+		t.Fatalf("a cycle start already in the past lifts the pause, expected a reminder, got due=%d sent=%d", resumedReport.Due, resumedReport.Sent)
+	}
+}


### PR DESCRIPTION
Release audit PRIV-2 (P1), PR-7 of the v2.0.0 campaign.

**Wrong.** `ResolvePregnancyPause` lifts a pause on any cycle start later than the positive test and
has no `today` of its own; `manualCycleStartFutureDays` permits a start two days ahead. The verdict
was therefore a property of the caller's fetch. `BuildCycleStatsFromLogs` runs three passes over the
logs it is handed and only `BuildCycleStats` bounded its own input (`cycles.go`, `filterLogsNotAfter`)
— the baseline and the pause got the raw set. The dashboard and the `.ics` feed were safe only
because they pre-bind what they pass (`FilterLogsByDateRange`; the fetched range); the webhook notify
pass hands over the whole stored history (`ListByUser`). A positive test today plus a start recorded
for tomorrow left the owner reading "paused" on every screen while the one surface that speaks
outside the instance sent `period-soon` to their endpoint.

**Changed.** The bound moves into `BuildCycleStatsFromLogs`, at the owner's today in the owner's
zone — one timeline as a property of the derivation, not a habit of three call sites.
`ResolveDayFeedback` is the second site of the same class (it resolves the pause from its own read of
the full history) and takes the same bound; its two warnings keep the full set deliberately, since
each asks about the day being edited rather than about what the timeline supports today. No resolver
logic changed — `PredictionsSuppressed` is untouched, and every surface already called it.

**Evidence** — red before, green after, each with a control in which a start already in the past
does lift the pause:
- `TestNotifyKeepsThePregnancyPauseWhenTomorrowsCycleStartIsLogged` — no delivery, no watermark claim.
- `TestBuildCycleStatsFromLogsResolvesThePauseOnOneTodayBoundedTimeline` — the parity matrix: two
  surface bounds × five zones straddling the date line in both directions. Before the fix only the
  unbounded (webhook) column fails, in every zone.
- `TestResolveDayFeedbackKeepsThePauseWhenTomorrowsCycleStartIsLogged`.

**Reachability.** `BuildCycleStatsFromLogs` is the derivation behind the dashboard, `/stats`, the
`.ics` feed and the webhook pass; the change narrows its input and adds no call site. A day logged
ahead of today still stores and still displays — it stops deciding before it arrives.

**Rollback.** Revert the commit; nothing persisted changes.

**Campaign note.** §2 lists `internal/services/stats_service.go` as this PR's serialized file, and it
is held here — PR-8 rebases on top.
