### PR TITLE
fix(calendar): calendar-day steps leave the request zone

### DIFF
--- a/changelog.d/calendar-day-steps-leave-the-request-zone.md
+++ b/changelog.d/calendar-day-steps-leave-the-request-zone.md
@@ -1,0 +1,34 @@
+### Fixed
+
+- **Dates counted forward or back from today no longer slip a day on a clock-change date.** In the
+  timezones west of UTC whose daylight-saving jump happens exactly at midnight — Santiago on
+  6 September 2026, Havana on 8 March 2026 — that local midnight does not exist. Counting a number
+  of days inside such a timezone and landing on one of those dates quietly returned the day before
+  it, at 23:00. Ovumcy counted days that way in nine places, and each of them named the wrong day
+  once a year for owners in those zones:
+
+  - the projected ovulation and fertile window behind every predicted date on every surface;
+  - the chain of future cycles painted on the month grid, which shifted a whole projected period
+    one day earlier;
+  - the events published to a subscribed calendar app through the `.ics` feed;
+  - the rule allowing a cycle start to be recorded up to two days ahead, which refused a date it
+    was meant to accept;
+  - the earliest date the onboarding and settings date pickers offered;
+  - the ninety-day window behind the cycle-factor context on the stats page, and the dashboard's
+    look at yesterday.
+
+  All nine now count through one shared step that does its arithmetic on dates rather than on
+  clocks, and then resolves the answer back into the owner's own timezone. Nothing changes on any
+  other date or in any other zone.
+
+### Internal
+
+- **The barrier that guards this class now reads the third shape it comes in.** A sweep over the
+  shipped source already failed the suite for building a calendar day as an instant in a timezone,
+  and for ordering a location-anchored day against a UTC-anchored one. It did not read the shape
+  that produced the fixes above — a day STEPPED from a location anchor — and its own classifier
+  asserted that such a step "keeps the anchor", which is untrue on exactly the dates that matter.
+  The sweep now flags the stepping shape, carries a floor so it cannot pass by reading nothing, and
+  states in its blind-spot list that it only sees a step whose anchor is built in the same function.
+  One site is allowlisted with its reason: a step of whole years producing the lower bound of a log
+  fetch window, where the one-sided slip widens the window by a day and never narrows it.

--- a/internal/services/calendar_day_construction_barrier_test.go
+++ b/internal/services/calendar_day_construction_barrier_test.go
@@ -631,3 +631,67 @@ func calendarDayIsPackageIdent(expr ast.Expr) bool {
 		return false
 	}
 }
+
+// calendarDayBarrierShapeCFixture is the sweep's own positive-and-negative pair
+// for the stepping shape, parsed from source this test owns rather than found in
+// the tree.
+//
+// Without it the shape's only live positive example is an allowlist entry, so the
+// day that site is converted the classifier stops being exercised and the barrier
+// passes while measuring nothing — the anti-vacuity anchor would depend on the
+// data it judges, which `.claude/rules/testing.md` forbids. The floors do not
+// cover this: they prove the parser SEES steps, not that the classifier still
+// tells a location anchor from a UTC one.
+const calendarDayBarrierShapeCFixture = `package sample
+
+import "time"
+
+func steppedFromALocationAnchor(value time.Time, location *time.Location) time.Time {
+	anchor := CalendarDay(value, location)
+	return anchor.AddDate(0, 0, 5)
+}
+
+func steppedFromAUTCAnchor(value time.Time) time.Time {
+	anchor := dateOnly(value)
+	return anchor.AddDate(0, 0, 5)
+}
+
+func steppedFromAnExplicitUTCConstruction(value time.Time) time.Time {
+	anchor := CalendarDay(value, time.UTC)
+	return anchor.AddDate(0, 0, 5)
+}
+`
+
+func TestCalendarDayBarrierClassifiesTheSteppingShape(t *testing.T) {
+	t.Parallel()
+
+	fileSet := token.NewFileSet()
+	parsed, err := parser.ParseFile(fileSet, "sample.go", calendarDayBarrierShapeCFixture, 0)
+	if err != nil {
+		t.Fatalf("parse fixture: %v", err)
+	}
+
+	scan := calendarDayBarrierScan{}
+	inspectCalendarDayFile(fileSet, parsed, "sample.go", &scan)
+
+	stepping := make(map[string]bool, len(scan.findings))
+	for _, finding := range scan.findings {
+		if strings.HasSuffix(finding.key, ":calendar day stepped from a location anchor") {
+			stepping[finding.key] = true
+		}
+	}
+
+	wantFlagged := "sample.go:steppedFromALocationAnchor:calendar day stepped from a location anchor"
+	if !stepping[wantFlagged] {
+		t.Errorf("the sweep no longer flags a step taken from a location anchor; stepping findings = %v", stepping)
+	}
+	for _, mustNotFlag := range []string{"steppedFromAUTCAnchor", "steppedFromAnExplicitUTCConstruction"} {
+		key := "sample.go:" + mustNotFlag + ":calendar day stepped from a location anchor"
+		if stepping[key] {
+			t.Errorf("%s steps from a UTC anchor and must not be flagged", mustNotFlag)
+		}
+	}
+	if scan.stepCalls < 3 {
+		t.Errorf("the fixture holds three steps; the sweep counted %d, so it is not reading them", scan.stepCalls)
+	}
+}

--- a/internal/services/calendar_day_construction_barrier_test.go
+++ b/internal/services/calendar_day_construction_barrier_test.go
@@ -70,7 +70,8 @@ const calendarDayConstructionPoint = "internal/services/day_utils.go:StartOfCale
 // match the sweep EXACTLY: an entry that no longer matches anything fails too,
 // so a fixed site cannot leave a stale exemption behind.
 var calendarDayBarrierAllowlist = map[string]string{
-	"internal/reminders/next_run.go:fireOnCalendarDay:calendar day built in a location": "deliberate carve-out: a scheduling instant at a runtime hour, not a calendar day, and the two lines below it check the requested date survived and fall back to services.StartOfCalendarDay when it did not.",
+	"internal/reminders/next_run.go:fireOnCalendarDay:calendar day built in a location":                                      "deliberate carve-out: a scheduling instant at a runtime hour, not a calendar day, and the two lines below it check the requested date survived and fall back to services.StartOfCalendarDay when it did not.",
+	"internal/services/calendar_feed_service.go:CalendarFeedService.ResolveFeed:calendar day stepped from a location anchor": "deliberate carve-out: a step of whole YEARS producing the lower bound of the log fetch window, not a calendar date anyone reads. The one-sided normalization widens the window by a day and never narrows it, and FetchLogsForUser re-resolves both bounds through DayRange.",
 }
 
 // calendarDayBarrierBlindSpots is what this sweep provably cannot see. It is
@@ -81,6 +82,7 @@ var calendarDayBarrierBlindSpots = []string{
 	"a location expression is anything that is not the literal time.UTC, so a variable that happens to hold time.UTC at run time counts as a location",
 	"a local whose anchor is not the FIRST result of a multi-value call, and a local ever assigned something unclassifiable or two different anchors, is deliberately left unknown — the sweep prefers missing a site to flagging a safe one",
 	"only Before/After/Equal/Sub are read as ordering; a comparison expressed some other way (sorting by UnixNano, a switch on Sub's sign through a helper) is invisible",
+	"shape (c) reads the same local anchors as shape (b): a step whose receiver is a parameter, a struct field (stats.LastPeriodStart) or a range variable is unclassified and therefore never flagged, so the stepping class is covered only where the anchor is built in the same function",
 	"non-Go surfaces are out of scope: the JavaScript bundle and the templates are not parsed here",
 }
 
@@ -91,6 +93,7 @@ const (
 	calendarDayBarrierFileFloor        = 200
 	calendarDayBarrierDateCallFloor    = 6
 	calendarDayBarrierCompareCallFloor = 40
+	calendarDayBarrierAddDateCallFloor = 40
 )
 
 // calendarDayFinding is one flagged site.
@@ -106,6 +109,7 @@ type calendarDayBarrierScan struct {
 	files        int
 	dateCalls    int
 	compareCalls int
+	addDateCalls int
 }
 
 // TestCalendarDayConstructionBarrier is the sweep. Every flagged site must
@@ -123,6 +127,9 @@ func TestCalendarDayConstructionBarrier(t *testing.T) {
 	}
 	if scan.compareCalls < calendarDayBarrierCompareCallFloor {
 		t.Fatalf("the sweep saw %d time ordering call(s), fewer than the floor of %d — it is no longer reading the comparison shape it exists to read", scan.compareCalls, calendarDayBarrierCompareCallFloor)
+	}
+	if scan.addDateCalls < calendarDayBarrierAddDateCallFloor {
+		t.Fatalf("the sweep saw %d AddDate call(s), fewer than the floor of %d — it is no longer reading the stepping shape it exists to read", scan.addDateCalls, calendarDayBarrierAddDateCallFloor)
 	}
 
 	unexplained := make([]calendarDayFinding, 0, len(scan.findings))
@@ -166,6 +173,7 @@ func calendarDayBarrierGuidance() string {
 	builder.WriteString("How to clear a finding:\n")
 	builder.WriteString("  - building a calendar day: take the calendar components and call services.StartOfCalendarDay, or its wrappers CalendarDay (a date-only stored value), DateAtLocation (a real instant) or ParseDayDate (a YYYY-MM-DD input). Never time.Date/time.ParseInLocation with a non-UTC location: where a zone's midnight does not exist, both normalize the value into the previous calendar day.\n")
 	builder.WriteString("  - comparing calendar days: use CalendarDaysBetween, which re-anchors both operands to UTC midnight of their own calendar day. A location midnight and a UTC midnight name the same day and are different instants, so Before/After/Equal between them is wrong every day in every non-UTC zone.\n")
+	builder.WriteString("  - stepping calendar days: step from a UTC anchor — dateOnly(day).AddDate(0, 0, n), or forEachCalendarDay for a run of days. AddDate re-enters time.Date in the receiver's own location, so a step landing on a date whose local midnight the zone skips returns the previous calendar day at 23:00 instead.\n")
 	builder.WriteString("  - the site is genuinely an INSTANT (a TTL, an expiry, a freshness window, a half-open range bound): say so in calendarDayBarrierAllowlist. Adding a line there is a deliberate act and owes a one-line reason, not a bare path.\n")
 	builder.WriteString("What this sweep cannot see, so a green run is not a cleared tree:\n")
 	for _, blindSpot := range calendarDayBarrierBlindSpots {
@@ -317,6 +325,32 @@ func inspectCalendarDayFile(fileSet *token.FileSet, file *ast.File, relative str
 				key:      relative + ":" + enclosing + ":calendar days compared across midnight anchors",
 				position: where,
 				detail:   fmt.Sprintf("%s between a %s-anchored value and a %s-anchored one: the two name the same calendar day and are different instants.", selector.Sel.Name, calendarDayAnchorName(left), calendarDayAnchorName(right)),
+			})
+			return true
+		})
+
+		// Shape (c): a calendar-day STEP taken from a location anchor. Shares
+		// this function's anchor map with shape (b) for the same reason — the
+		// receiver's anchor is only knowable from the function's own locals.
+		ast.Inspect(function.Body, func(inner ast.Node) bool {
+			call, isCall := inner.(*ast.CallExpr)
+			if !isCall || len(call.Args) != 3 {
+				return true
+			}
+			selector, isSelector := call.Fun.(*ast.SelectorExpr)
+			if !isSelector || selector.Sel.Name != "AddDate" || calendarDayIsPackageIdent(selector.X) {
+				return true
+			}
+			scan.addDateCalls++
+
+			if calendarDayClassify(selector.X, anchors) != anchorLocation {
+				return true
+			}
+			where, enclosing := position(call)
+			scan.findings = append(scan.findings, calendarDayFinding{
+				key:      relative + ":" + enclosing + ":calendar day stepped from a location anchor",
+				position: where,
+				detail:   "AddDate re-enters time.Date in the receiver's location: where the resulting day's local midnight does not exist (America/Santiago 2026-09-06, America/Havana 2026-03-08) it normalizes BACKWARD, so the step names the previous calendar day.",
 			})
 			return true
 		})
@@ -492,7 +526,14 @@ func calendarDayClassify(expr ast.Expr, anchors map[string]anchorClass) anchorCl
 		if selector, ok := node.Fun.(*ast.SelectorExpr); ok && !calendarDayIsPackageIdent(selector.X) {
 			switch selector.Sel.Name {
 			case "AddDate":
-				// A whole number of calendar days keeps the anchor.
+				// The anchor is carried through — but only because a step taken
+				// from a location anchor is itself shape (c) and flagged at its
+				// own call site. AddDate re-enters time.Date in the receiver's
+				// location, so on a date whose local midnight the zone skips it
+				// does NOT keep the anchor: it returns the previous calendar day
+				// at 23:00. Reading the result as "same anchor, later day" is
+				// exactly how the class spread, and this line is only sound
+				// standing next to that finding.
 				return calendarDayClassify(selector.X, anchors)
 			case "UTC":
 				return anchorUTC
@@ -506,6 +547,7 @@ func calendarDayClassify(expr ast.Expr, anchors map[string]anchorClass) anchorCl
 // calendarDayLocationArgument maps each construction helper to the index of its
 // *time.Location argument. dateOnly takes none: it is UTC by definition.
 var calendarDayLocationArgument = map[string]int{
+	"AddCalendarDays":      2,
 	"CalendarDay":          1,
 	"DateAtLocation":       1,
 	"StartOfCalendarDay":   3,

--- a/internal/services/calendar_day_construction_barrier_test.go
+++ b/internal/services/calendar_day_construction_barrier_test.go
@@ -93,7 +93,7 @@ const (
 	calendarDayBarrierFileFloor        = 200
 	calendarDayBarrierDateCallFloor    = 6
 	calendarDayBarrierCompareCallFloor = 40
-	calendarDayBarrierAddDateCallFloor = 40
+	calendarDayBarrierStepCallFloor    = 40
 )
 
 // calendarDayFinding is one flagged site.
@@ -109,7 +109,7 @@ type calendarDayBarrierScan struct {
 	files        int
 	dateCalls    int
 	compareCalls int
-	addDateCalls int
+	stepCalls    int
 }
 
 // TestCalendarDayConstructionBarrier is the sweep. Every flagged site must
@@ -128,8 +128,8 @@ func TestCalendarDayConstructionBarrier(t *testing.T) {
 	if scan.compareCalls < calendarDayBarrierCompareCallFloor {
 		t.Fatalf("the sweep saw %d time ordering call(s), fewer than the floor of %d — it is no longer reading the comparison shape it exists to read", scan.compareCalls, calendarDayBarrierCompareCallFloor)
 	}
-	if scan.addDateCalls < calendarDayBarrierAddDateCallFloor {
-		t.Fatalf("the sweep saw %d AddDate call(s), fewer than the floor of %d — it is no longer reading the stepping shape it exists to read", scan.addDateCalls, calendarDayBarrierAddDateCallFloor)
+	if scan.stepCalls < calendarDayBarrierStepCallFloor {
+		t.Fatalf("the sweep saw %d calendar-day step(s), fewer than the floor of %d — it is no longer reading the stepping shape it exists to read", scan.stepCalls, calendarDayBarrierStepCallFloor)
 	}
 
 	unexplained := make([]calendarDayFinding, 0, len(scan.findings))
@@ -341,7 +341,7 @@ func inspectCalendarDayFile(fileSet *token.FileSet, file *ast.File, relative str
 			if !isSelector || selector.Sel.Name != "AddDate" || calendarDayIsPackageIdent(selector.X) {
 				return true
 			}
-			scan.addDateCalls++
+			scan.stepCalls++
 
 			if calendarDayClassify(selector.X, anchors) != anchorLocation {
 				return true
@@ -352,6 +352,23 @@ func inspectCalendarDayFile(fileSet *token.FileSet, file *ast.File, relative str
 				position: where,
 				detail:   "AddDate re-enters time.Date in the receiver's location: where the resulting day's local midnight does not exist (America/Santiago 2026-09-06, America/Havana 2026-03-08) it normalizes BACKWARD, so the step names the previous calendar day.",
 			})
+			return true
+		})
+
+		// The floor counts converted steps as well. Counting only AddDate would
+		// tie the anti-vacuity anchor to the very thing the sweep judges: every
+		// site fixed lowers it, so a fully converted tree would fail as "discovery
+		// is broken" — which is exactly what happened once this class was swept.
+		// A guard's floor must not depend on the data it judges
+		// (`.claude/rules/testing.md`).
+		ast.Inspect(function.Body, func(inner ast.Node) bool {
+			call, isCall := inner.(*ast.CallExpr)
+			if !isCall || len(call.Args) != 3 {
+				return true
+			}
+			if strings.TrimPrefix(calendarDayCalleeName(call.Fun), "services.") == "AddCalendarDays" {
+				scan.stepCalls++
+			}
 			return true
 		})
 		return true

--- a/internal/services/calendar_day_step_dst_test.go
+++ b/internal/services/calendar_day_step_dst_test.go
@@ -27,23 +27,11 @@ import (
 	"github.com/ovumcy/ovumcy-web/internal/models"
 )
 
-// calendarStepHavanaLocation is the second midnight-skipping zone. Named for
-// this file rather than shared: santiagoTestLocation already exists in the
-// package, and a second generic helper would collide with one added elsewhere.
-func calendarStepHavanaLocation(t *testing.T) *time.Location {
-	t.Helper()
-	location, err := time.LoadLocation("America/Havana")
-	if err != nil {
-		t.Fatalf("load America/Havana: %v", err)
-	}
-	return location
-}
-
 // TestAddCalendarDaysCrossesASkippedMidnight pins the helper every converted
 // site now routes through.
 func TestAddCalendarDaysCrossesASkippedMidnight(t *testing.T) {
 	santiago := santiagoTestLocation(t)
-	havana := calendarStepHavanaLocation(t)
+	havana := havanaTestLocation(t)
 
 	testCases := []struct {
 		name     string

--- a/internal/services/calendar_day_step_dst_test.go
+++ b/internal/services/calendar_day_step_dst_test.go
@@ -1,0 +1,211 @@
+package services
+
+// calendar_day_step_dst_test.go — a calendar-day STEP must not be taken inside
+// the request zone.
+//
+// `day.AddDate(0, 0, n)` re-enters time.Date in the receiver's own location. In
+// the UTC-minus zones whose DST jump lands on midnight (America/Santiago
+// 2026-09-06, America/Havana 2026-03-08) that local midnight does not exist, so
+// the missing wall clock resolves BACKWARD and the step returns the PREVIOUS
+// calendar day at 23:00. Everything downstream that reads the calendar
+// components — a map key, a rendered bound, a projected date — is then handed
+// the wrong day.
+//
+// AddCalendarDays is the single stepping point that fixes it: it steps over
+// UTC-anchored days and resolves the result back into the caller's location
+// through StartOfCalendarDay. This file pins the helper itself and the
+// user-visible surfaces that were stepping by hand.
+//
+// The zone must be west of UTC — east-of-UTC zones normalize a missing midnight
+// forward and keep the date, so the same fixture there is green about nothing
+// (`.claude/rules/testing.md`). Every case carries a UTC control.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+)
+
+// calendarStepHavanaLocation is the second midnight-skipping zone. Named for
+// this file rather than shared: santiagoTestLocation already exists in the
+// package, and a second generic helper would collide with one added elsewhere.
+func calendarStepHavanaLocation(t *testing.T) *time.Location {
+	t.Helper()
+	location, err := time.LoadLocation("America/Havana")
+	if err != nil {
+		t.Fatalf("load America/Havana: %v", err)
+	}
+	return location
+}
+
+// TestAddCalendarDaysCrossesASkippedMidnight pins the helper every converted
+// site now routes through.
+func TestAddCalendarDaysCrossesASkippedMidnight(t *testing.T) {
+	santiago := santiagoTestLocation(t)
+	havana := calendarStepHavanaLocation(t)
+
+	testCases := []struct {
+		name     string
+		location *time.Location
+		from     string
+		days     int
+		want     string
+	}{
+		{name: "santiago forward onto the skipped midnight", location: santiago, from: "2026-09-01", days: 5, want: "2026-09-06"},
+		{name: "santiago forward across it", location: santiago, from: "2026-09-01", days: 8, want: "2026-09-09"},
+		{name: "santiago backward onto it", location: santiago, from: "2026-09-09", days: -3, want: "2026-09-06"},
+		{name: "havana forward onto the skipped midnight", location: havana, from: "2026-03-03", days: 5, want: "2026-03-08"},
+		{name: "havana backward onto it", location: havana, from: "2026-03-11", days: -3, want: "2026-03-08"},
+		{name: "control: UTC, same september arithmetic", location: time.UTC, from: "2026-09-01", days: 5, want: "2026-09-06"},
+		{name: "control: santiago, no transition in range", location: santiago, from: "2026-08-01", days: 5, want: "2026-08-06"},
+		{name: "control: zero step is the day itself", location: santiago, from: "2026-09-06", days: 0, want: "2026-09-06"},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			from := CalendarDay(cyclesignalsCovDay(t, testCase.from), testCase.location)
+			got := AddCalendarDays(from, testCase.days, testCase.location)
+			if key := CalendarDayKey(got); key != testCase.want {
+				t.Fatalf("AddCalendarDays(%s, %d) = %s, want %s", testCase.from, testCase.days, key, testCase.want)
+			}
+			// The result must be a real instant on the day it names, so a caller
+			// ordering it against another location midnight is not comparing a
+			// value that silently sits on the previous day.
+			if year, month, day := got.Date(); CalendarDayKey(time.Date(year, month, day, 0, 0, 0, 0, time.UTC)) != testCase.want {
+				t.Fatalf("AddCalendarDays returned %s, whose own calendar components are not %s", got.Format(time.RFC3339), testCase.want)
+			}
+		})
+	}
+}
+
+// TestAddCalendarDaysKeepsAZeroValueZero guards the guard: a zero time must not
+// become year 1 day 2, which would make an IsZero() check downstream stop
+// firing.
+func TestAddCalendarDaysKeepsAZeroValueZero(t *testing.T) {
+	if got := AddCalendarDays(time.Time{}, 3, santiagoTestLocation(t)); !got.IsZero() {
+		t.Fatalf("AddCalendarDays(zero) = %s, want the zero value", got.Format(time.RFC3339))
+	}
+}
+
+// TestPredictCycleWindowLandsOnTheSkippedMidnightDay is the core: every
+// projected date on every surface comes out of this function, and the calendar
+// hands it a request-zone anchor. Pre-fix the step ran before dateOnly, so the
+// projection named 2026-09-05 for an ovulation on the 6th.
+func TestPredictCycleWindowLandsOnTheSkippedMidnightDay(t *testing.T) {
+	santiago := santiagoTestLocation(t)
+
+	testCases := []struct {
+		name          string
+		location      *time.Location
+		periodStart   string
+		wantOvulation string
+	}{
+		{
+			name:          "santiago: projected ovulation on the skipped midnight",
+			location:      santiago,
+			periodStart:   "2026-08-24",
+			wantOvulation: "2026-09-06",
+		},
+		{
+			name:          "control: the same cycle anchored in UTC",
+			location:      time.UTC,
+			periodStart:   "2026-08-24",
+			wantOvulation: "2026-09-06",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			periodStart := CalendarDay(cyclesignalsCovDay(t, testCase.periodStart), testCase.location)
+			window := PredictCycleWindow(periodStart, 28, 14)
+			if !window.Calculable {
+				t.Fatal("expected a calculable window for a 28/14 cycle")
+			}
+			if got := CalendarDayKey(window.OvulationDate); got != testCase.wantOvulation {
+				t.Fatalf("projected ovulation = %s, want %s", got, testCase.wantOvulation)
+			}
+		})
+	}
+}
+
+// TestManualCycleStartMaxDateReachesTheSkippedMidnightDay covers the input rule
+// an owner meets directly: a cycle start may be recorded up to
+// manualCycleStartFutureDays ahead, and pre-fix the bound named the day before
+// when that allowance landed on the skipped midnight — so the form refused a
+// date its own rule permits.
+func TestManualCycleStartMaxDateReachesTheSkippedMidnightDay(t *testing.T) {
+	santiago := santiagoTestLocation(t)
+
+	// Today is 2026-09-04 in Santiago; the two-day allowance reaches 09-06.
+	now := time.Date(2026, time.September, 4, 15, 0, 0, 0, time.UTC)
+
+	if got := CalendarDayKey(manualCycleStartMaxDate(now, santiago)); got != "2026-09-06" {
+		t.Fatalf("manual cycle-start upper bound = %s, want 2026-09-06", got)
+	}
+
+	target := CalendarDay(cyclesignalsCovDay(t, "2026-09-06"), santiago)
+	if !IsAllowedManualCycleStartDate(target, now, santiago) {
+		t.Fatal("2026-09-06 is two days ahead and must be an allowed manual cycle start")
+	}
+}
+
+// TestOnboardingDateBoundsReachTheSkippedMidnightDay covers the other bound an
+// owner meets: the earliest date the onboarding picker offers. Pre-fix the
+// window opened a day late whenever its far edge fell on the skipped midnight.
+func TestOnboardingDateBoundsReachTheSkippedMidnightDay(t *testing.T) {
+	santiago := santiagoTestLocation(t)
+
+	// OnboardingStartDateWindowDays is 60; 2026-11-05 minus 60 days is 09-06.
+	now := time.Date(2026, time.November, 5, 15, 0, 0, 0, time.UTC)
+
+	earliest, latest := OnboardingDateBounds(now, santiago)
+	if got := CalendarDayKey(earliest); got != "2026-09-06" {
+		t.Fatalf("onboarding earliest date = %s, want 2026-09-06", got)
+	}
+	if got := CalendarDayKey(latest); got != "2026-11-05" {
+		t.Fatalf("onboarding latest date = %s, want 2026-11-05", got)
+	}
+}
+
+// TestBuildCalendarDayStatesProjectsACycleOntoTheSkippedMidnightDay follows the
+// step all the way to the rendered grid. The assertion is on the EDGES of the
+// painted run, not on the transition day itself: pre-fix the chain stepped
+// 2026-08-09 + 28 onto the skipped midnight and landed on 09-05, so the whole
+// five-day projected period shifted one day earlier — 09-06 stayed painted
+// either way, and only the edges tell the two apart.
+func TestBuildCalendarDayStatesProjectsACycleOntoTheSkippedMidnightDay(t *testing.T) {
+	santiago := santiagoTestLocation(t)
+
+	user := &models.User{WeekStartsOn: models.WeekStartMonday}
+	monthStart := time.Date(2026, time.September, 1, 0, 0, 0, 0, time.UTC)
+	now := time.Date(2026, time.August, 5, 15, 0, 0, 0, time.UTC)
+
+	// The second projected cycle start is 2026-08-09 + 28 = 2026-09-06, so the
+	// chain steps ONTO the skipped midnight rather than starting there.
+	stats := CycleStats{
+		MedianCycleLength:   28,
+		AverageCycleLength:  28,
+		AveragePeriodLength: 5,
+		LutealPhase:         14,
+		CurrentCycleDay:     25,
+		LastPeriodStart:     time.Date(2026, time.July, 12, 0, 0, 0, 0, time.UTC),
+		NextPeriodStart:     time.Date(2026, time.August, 9, 0, 0, 0, 0, time.UTC),
+	}
+
+	days := BuildCalendarDayStates(user, monthStart, nil, stats, now, santiago)
+
+	predicted := make(map[string]bool, len(days))
+	for _, day := range days {
+		predicted[day.DateString] = day.IsPredicted
+	}
+
+	for _, day := range []string{"2026-09-06", "2026-09-10"} {
+		if !predicted[day] {
+			t.Errorf("%s must be painted as a projected period day: the cycle starting 2026-09-06 runs five days", day)
+		}
+	}
+	if predicted["2026-09-05"] {
+		t.Error("2026-09-05 must NOT be painted: the projected cycle starts on 09-06, and painting it here means the step normalized backward off the skipped midnight")
+	}
+}

--- a/internal/services/calendar_day_step_dst_test.go
+++ b/internal/services/calendar_day_step_dst_test.go
@@ -209,3 +209,52 @@ func TestBuildCalendarDayStatesProjectsACycleOntoTheSkippedMidnightDay(t *testin
 		t.Error("2026-09-05 must NOT be painted: the projected cycle starts on 09-06, and painting it here means the step normalized backward off the skipped midnight")
 	}
 }
+
+// TestBuildCalendarDayStatesStartsAProjectedPreFertileRunOnTheSkippedMidnightDay
+// covers the one stepping site whose anchor the barrier cannot classify:
+// appendPredictedWindow receives cycleStart as a parameter, so the sweep leaves
+// it unknown and the conversion had to be found by reading. The pre-fertile run
+// begins periodLength days after the projected cycle start, and when that lands
+// on the skipped midnight the whole run shifted a day earlier — shading a day
+// that is still a projected PERIOD day as pre-fertile, and dropping the run's
+// last day.
+func TestBuildCalendarDayStatesStartsAProjectedPreFertileRunOnTheSkippedMidnightDay(t *testing.T) {
+	santiago := santiagoTestLocation(t)
+
+	user := &models.User{WeekStartsOn: models.WeekStartMonday}
+	monthStart := time.Date(2026, time.September, 1, 0, 0, 0, 0, time.UTC)
+	now := time.Date(2026, time.August, 25, 15, 0, 0, 0, time.UTC)
+
+	// The projected cycle starts 2026-09-01 and its period runs five days
+	// (09-01..09-05), so the pre-fertile run starts on 09-06 — the skipped
+	// midnight.
+	stats := CycleStats{
+		CompletedCycleCount: 3,
+		MedianCycleLength:   28,
+		AverageCycleLength:  28,
+		AveragePeriodLength: 5,
+		LutealPhase:         14,
+		CurrentCycleDay:     22,
+		LastPeriodStart:     time.Date(2026, time.August, 4, 0, 0, 0, 0, time.UTC),
+		NextPeriodStart:     time.Date(2026, time.September, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	days := BuildCalendarDayStates(user, monthStart, nil, stats, now, santiago)
+
+	preFertile := make(map[string]bool, len(days))
+	predicted := make(map[string]bool, len(days))
+	for _, day := range days {
+		preFertile[day.DateString] = day.IsPreFertile
+		predicted[day.DateString] = day.IsPredicted
+	}
+
+	if !preFertile["2026-09-06"] {
+		t.Error("2026-09-06 is the first pre-fertile day of the projected cycle and must be shaded as one")
+	}
+	if preFertile["2026-09-05"] {
+		t.Error("2026-09-05 is the last projected PERIOD day and must not be shaded pre-fertile: shading it means the step normalized backward off the skipped midnight")
+	}
+	if !predicted["2026-09-05"] {
+		t.Error("2026-09-05 must still be a projected period day")
+	}
+}

--- a/internal/services/calendar_day_step_dst_test.go
+++ b/internal/services/calendar_day_step_dst_test.go
@@ -258,3 +258,46 @@ func TestBuildCalendarDayStatesStartsAProjectedPreFertileRunOnTheSkippedMidnight
 		t.Error("2026-09-05 must still be a projected period day")
 	}
 }
+
+// TestDashboardUpcomingPredictionsNameTheSkippedMidnightDay covers the chain the
+// barrier is blind to: every anchor here crosses a function boundary as a
+// PARAMETER, so the sweep leaves it unclassified and the conversion had to be
+// found by walking callers. stats.LastPeriodStart is a REQUEST-ZONE midnight on
+// every owner-facing surface — latestCycleStartAnchorBeforeOrOn builds it with
+// CalendarDay — and ProjectCycleStart passes that anchor straight on, so the
+// dashboard's own next-period date was stepped in the request zone.
+func TestDashboardUpcomingPredictionsNameTheSkippedMidnightDay(t *testing.T) {
+	santiago := santiagoTestLocation(t)
+
+	testCases := []struct {
+		name     string
+		location *time.Location
+	}{
+		{name: "santiago, west of UTC", location: santiago},
+		{name: "control: UTC", location: time.UTC},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			// 2026-08-09 plus a 28-day cycle is 2026-09-06 — the skipped midnight.
+			lastPeriodStart := CalendarDay(cyclesignalsCovDay(t, "2026-08-09"), testCase.location)
+			today := DateAtLocation(time.Date(2026, time.August, 20, 15, 0, 0, 0, time.UTC), testCase.location)
+
+			user := &models.User{ID: 1, Role: models.RoleOwner}
+			stats := CycleStats{
+				CompletedCycleCount: 3,
+				MedianCycleLength:   28,
+				AverageCycleLength:  28,
+				AveragePeriodLength: 5,
+				LutealPhase:         14,
+				CurrentCycleDay:     12,
+				LastPeriodStart:     lastPeriodStart,
+			}
+
+			prediction := DashboardUpcomingPredictions(stats, user, today, 28)
+			if got := CalendarDayKey(prediction.NextPeriodStart); got != "2026-09-06" {
+				t.Fatalf("dashboard next period = %s, want 2026-09-06: the projection must not be stepped from a location midnight the zone skips", got)
+			}
+		})
+	}
+}

--- a/internal/services/calendar_days.go
+++ b/internal/services/calendar_days.go
@@ -213,7 +213,7 @@ func appendCurrentBaselinePreFertile(preFertileMap map[string]bool, stats CycleS
 
 	cycleStart := CalendarDay(stats.LastPeriodStart, location)
 	periodLength := predictedPeriodLength(stats.AveragePeriodLength)
-	preFertileStart := cycleStart.AddDate(0, 0, periodLength)
+	preFertileStart := AddCalendarDays(cycleStart, periodLength, location)
 
 	fertilityStart := CalendarDay(stats.FertilityWindowStart, location)
 	if fertilityStart.IsZero() {
@@ -225,7 +225,7 @@ func appendCurrentBaselinePreFertile(preFertileMap map[string]bool, stats CycleS
 		fertilityStart = window.FertilityWindowStart
 	}
 
-	preFertileEnd := fertilityStart.AddDate(0, 0, -1)
+	preFertileEnd := AddCalendarDays(fertilityStart, -1, location)
 	appendCalendarDateRange(preFertileMap, preFertileStart, preFertileEnd)
 }
 
@@ -328,7 +328,7 @@ func appendPredictedCycles(predictedPeriodMap map[string]bool, preFertileMap map
 	// shapes (01:00 local against 00:00). Compared as instants, a projected
 	// cycle falling exactly on the last grid day reads as past the grid and its
 	// markers are never painted.
-	for cycleStart := CalendarDay(stats.NextPeriodStart, location); CalendarDaysBetween(cycleStart, gridEnd) >= 0; cycleStart = cycleStart.AddDate(0, 0, predictedCycleLength) {
+	for cycleStart := CalendarDay(stats.NextPeriodStart, location); CalendarDaysBetween(cycleStart, gridEnd) >= 0; cycleStart = AddCalendarDays(cycleStart, predictedCycleLength, location) {
 		appendPredictedPeriod(predictedPeriodMap, cycleStart, predictedPeriodLength)
 		if includeFertility {
 			appendPredictedWindow(preFertileMap, fertilityEdgeMap, fertilityPeakMap, ovulationMap, cycleStart, predictedCycleLength, predictedPeriodLength, stats.LutealPhase)
@@ -372,7 +372,7 @@ func appendHistoricalCycles(preFertileMap map[string]bool, fertilityEdgeMap map[
 		if !window.Calculable {
 			continue
 		}
-		preFertileStart := cycleStart.AddDate(0, 0, periodLength)
+		preFertileStart := AddCalendarDays(cycleStart, periodLength, location)
 		preFertileEnd := window.FertilityWindowStart.AddDate(0, 0, -1)
 		appendCalendarDateRange(preFertileMap, preFertileStart, preFertileEnd)
 		ovulationMap[window.OvulationDate.Format("2006-01-02")] = true

--- a/internal/services/calendar_days.go
+++ b/internal/services/calendar_days.go
@@ -331,7 +331,7 @@ func appendPredictedCycles(predictedPeriodMap map[string]bool, preFertileMap map
 	for cycleStart := CalendarDay(stats.NextPeriodStart, location); CalendarDaysBetween(cycleStart, gridEnd) >= 0; cycleStart = AddCalendarDays(cycleStart, predictedCycleLength, location) {
 		appendPredictedPeriod(predictedPeriodMap, cycleStart, predictedPeriodLength)
 		if includeFertility {
-			appendPredictedWindow(preFertileMap, fertilityEdgeMap, fertilityPeakMap, ovulationMap, cycleStart, predictedCycleLength, predictedPeriodLength, stats.LutealPhase)
+			appendPredictedWindow(preFertileMap, fertilityEdgeMap, fertilityPeakMap, ovulationMap, cycleStart, predictedCycleLength, predictedPeriodLength, stats.LutealPhase, location)
 		}
 	}
 }
@@ -386,13 +386,18 @@ func appendPredictedPeriod(predictedPeriodMap map[string]bool, cycleStart time.T
 	})
 }
 
-func appendPredictedWindow(preFertileMap map[string]bool, fertilityEdgeMap map[string]bool, fertilityPeakMap map[string]bool, ovulationMap map[string]bool, cycleStart time.Time, predictedCycleLength int, predictedPeriodLength int, lutealPhase int) {
+func appendPredictedWindow(preFertileMap map[string]bool, fertilityEdgeMap map[string]bool, fertilityPeakMap map[string]bool, ovulationMap map[string]bool, cycleStart time.Time, predictedCycleLength int, predictedPeriodLength int, lutealPhase int, location *time.Location) {
 	window := PredictCycleWindow(cycleStart, predictedCycleLength, ResolveLutealPhase(lutealPhase))
 	if !window.Calculable {
 		return
 	}
 
-	preFertileStart := cycleStart.AddDate(0, 0, predictedPeriodLength)
+	// cycleStart arrives from appendPredictedCycles as a REQUEST-ZONE midnight,
+	// so this step needs the same treatment as its siblings; location is
+	// threaded in for it. window.FertilityWindowStart on the next line is a
+	// PredictCycleWindow output and therefore already UTC-anchored, where the
+	// step is exact — the two lines look asymmetric because their operands are.
+	preFertileStart := AddCalendarDays(cycleStart, predictedPeriodLength, location)
 	preFertileEnd := window.FertilityWindowStart.AddDate(0, 0, -1)
 	appendCalendarDateRange(preFertileMap, preFertileStart, preFertileEnd)
 	ovulationMap[window.OvulationDate.Format("2006-01-02")] = true

--- a/internal/services/calendar_feed_ics.go
+++ b/internal/services/calendar_feed_ics.go
@@ -212,7 +212,7 @@ func renderCalendarFeedICS(events []calendarFeedEvent, disclaimer string, now ti
 
 func writeCalendarFeedEvent(b *strings.Builder, event calendarFeedEvent, stamp string, disclaimer string) {
 	start := event.date.Format(calendarFeedDateLayout)
-	end := event.date.AddDate(0, 0, 1).Format(calendarFeedDateLayout)
+	end := AddCalendarDays(event.date, 1, event.date.Location()).Format(calendarFeedDateLayout)
 
 	writeICSLine(b, "BEGIN:VEVENT")
 	// UID is a pure function of (kind, date) — stable across renders/polls at

--- a/internal/services/calendar_feed_ics.go
+++ b/internal/services/calendar_feed_ics.go
@@ -169,9 +169,9 @@ func calendarFeedEvents(input CalendarFeedICSInput) []calendarFeedEvent {
 		events = append(events, calendarFeedEvent{kind: kind, date: date})
 	}
 	for cycle := range calendarFeedProjectionCycles {
-		anchor := CalendarDay(cycleStart.AddDate(0, 0, cycle*cycleLength), input.Location)
+		anchor := AddCalendarDays(cycleStart, cycle*cycleLength, input.Location)
 
-		nextPeriodStart := CalendarDay(anchor.AddDate(0, 0, cycleLength), input.Location)
+		nextPeriodStart := AddCalendarDays(anchor, cycleLength, input.Location)
 		if !nextPeriodStart.Before(today) {
 			appendEvent("period", nextPeriodStart)
 		}

--- a/internal/services/cycle_baseline.go
+++ b/internal/services/cycle_baseline.go
@@ -80,7 +80,7 @@ func applyProjectedBaseline(stats *CycleStats, cycleLength int, lutealPhase int,
 		return
 	}
 
-	stats.NextPeriodStart = CalendarDay(stats.LastPeriodStart.AddDate(0, 0, predictionCycleLength), location)
+	stats.NextPeriodStart = AddCalendarDays(stats.LastPeriodStart, predictionCycleLength, location)
 	stats.LutealPhase = ResolveLutealPhase(lutealPhase)
 
 	window := PredictCycleWindow(
@@ -135,7 +135,7 @@ func ProjectCycleStart(lastPeriodStart time.Time, cycleLength int, today time.Ti
 
 	elapsedDays := CalendarDaysBetween(lastPeriodStart, today)
 	cyclesElapsed := elapsedDays / cycleLength
-	projectedStart := CalendarDay(lastPeriodStart.AddDate(0, 0, cyclesElapsed*cycleLength), today.Location())
+	projectedStart := AddCalendarDays(lastPeriodStart, cyclesElapsed*cycleLength, today.Location())
 	projectedCycleDay := (elapsedDays % cycleLength) + 1
 	return projectedStart, projectedCycleDay, true
 }
@@ -152,7 +152,7 @@ func ShiftCycleStartToFutureOvulation(cycleStart time.Time, ovulationDate time.T
 	}
 	lagDays := CalendarDaysBetween(ovulationDate, today)
 	shiftCycles := lagDays/cycleLength + 1
-	return CalendarDay(cycleStart.AddDate(0, 0, shiftCycles*cycleLength), today.Location())
+	return AddCalendarDays(cycleStart, shiftCycles*cycleLength, today.Location())
 }
 
 func sameCalendarDay(a time.Time, b time.Time) bool {

--- a/internal/services/cycle_start_policy.go
+++ b/internal/services/cycle_start_policy.go
@@ -81,7 +81,7 @@ func ResolveManualCycleStartPolicy(user *models.User, logs []models.DailyLog, da
 }
 
 func potentialImplantationGapDays(user *models.User, logs []models.DailyLog, targetDay time.Time, previousStart time.Time) (int, bool) {
-	filtered := filterLogsNotAfter(logs, targetDay.AddDate(0, 0, -1))
+	filtered := filterLogsNotAfter(logs, AddCalendarDays(targetDay, -1, targetDay.Location()))
 	stats := BuildCycleStats(filtered, targetDay.Add(-time.Second))
 	cycleLength := predictedCycleLength(stats.MedianCycleLength, stats.AverageCycleLength)
 	// codecov:ignore:start -- unreachable from this caller, kept as a floor for
@@ -161,7 +161,7 @@ func cycleStartGapSuggestsNewCycle(user *models.User, logs []models.DailyLog, lo
 		return false
 	}
 
-	anchor := LatestCycleStartAnchorBeforeOrOn(user, logs, day.AddDate(0, 0, -1), location)
+	anchor := LatestCycleStartAnchorBeforeOrOn(user, logs, AddCalendarDays(day, -1, location), location)
 	if anchor.IsZero() {
 		return false
 	}

--- a/internal/services/cycle_start_policy.go
+++ b/internal/services/cycle_start_policy.go
@@ -29,7 +29,7 @@ func manualCycleStartMaxDate(now time.Time, location *time.Location) time.Time {
 		location = time.UTC
 	}
 	today := DateAtLocation(now.In(location), location)
-	return today.AddDate(0, 0, manualCycleStartFutureDays)
+	return AddCalendarDays(today, manualCycleStartFutureDays, location)
 }
 
 func IsAllowedManualCycleStartDate(day time.Time, now time.Time, location *time.Location) bool {
@@ -62,7 +62,7 @@ func ResolveManualCycleStartPolicy(user *models.User, logs []models.DailyLog, da
 		ConflictDate: findCompetingCycleStart(logs, targetDay, location),
 	}
 
-	previousStart := LatestCycleStartAnchorBeforeOrOn(user, logs, targetDay.AddDate(0, 0, -1), location)
+	previousStart := LatestCycleStartAnchorBeforeOrOn(user, logs, AddCalendarDays(targetDay, -1, location), location)
 	if previousStart.IsZero() {
 		return policy
 	}

--- a/internal/services/cycles.go
+++ b/internal/services/cycles.go
@@ -390,7 +390,7 @@ func applyPredictedCycleStats(stats *CycleStats) {
 		stats.LutealPhase = defaultLutealPhaseDays
 	}
 
-	stats.NextPeriodStart = dateOnly(stats.LastPeriodStart.AddDate(0, 0, predictionCycleLength))
+	stats.NextPeriodStart = AddCalendarDays(stats.LastPeriodStart, predictionCycleLength, time.UTC)
 	window := PredictCycleWindow(
 		stats.LastPeriodStart,
 		predictionCycleLength,
@@ -484,7 +484,7 @@ func resolveCyclePhase(stats CycleStats, logs []models.DailyLog, today time.Time
 		if periodLength <= 0 {
 			periodLength = models.DefaultPeriodLength
 		}
-		periodEnd := CalendarDay(stats.LastPeriodStart.AddDate(0, 0, periodLength-1), opts.location)
+		periodEnd := AddCalendarDays(stats.LastPeriodStart, periodLength-1, opts.location)
 		if betweenInclusive(today, stats.LastPeriodStart, periodEnd) {
 			return "menstrual"
 		}

--- a/internal/services/cycles.go
+++ b/internal/services/cycles.go
@@ -182,18 +182,23 @@ func PredictCycleWindow(periodStart time.Time, cycleLength int, lutealPhase int)
 		return CycleWindowPrediction{}
 	}
 
-	nextPeriodStart := dateOnly(periodStart.AddDate(0, 0, cycleLength))
+	// The step is taken from a UTC anchor rather than from whatever anchor
+	// periodStart arrived with. dateOnly AFTER the step is too late: the calendar
+	// passes a request-zone midnight here, and AddDate resolves a skipped local
+	// midnight backward into the previous day before dateOnly ever sees it.
+	periodStartDay := dateOnly(periodStart)
+	nextPeriodStart := periodStartDay.AddDate(0, 0, cycleLength)
 	// ovulationDay is one-based relative to periodStart (cycle day 1).
-	ovulationDate := dateOnly(periodStart.AddDate(0, 0, ovulationDay-1))
+	ovulationDate := periodStartDay.AddDate(0, 0, ovulationDay-1)
 	if !ovulationDate.Before(nextPeriodStart) {
 		// codecov:ignore -- defensive invariant: CalcOvulationDay caps ovulationDay at
 		// cycleLen-minLutealPhaseDays, so ovulationDate is always strictly before nextPeriodStart.
 		return CycleWindowPrediction{}
 	}
 
-	fertilityStart := dateOnly(ovulationDate.AddDate(0, 0, -5))
+	fertilityStart := ovulationDate.AddDate(0, 0, -5)
 	if fertilityStart.Before(periodStart) {
-		fertilityStart = dateOnly(periodStart)
+		fertilityStart = periodStartDay
 	}
 
 	return CycleWindowPrediction{

--- a/internal/services/dashboard_cycle.go
+++ b/internal/services/dashboard_cycle.go
@@ -240,8 +240,8 @@ func DashboardPredictionRange(user *models.User, stats CycleStats, predictedStar
 	}
 
 	if dashboardIrregularPredictionRangeEnabled(user, stats) {
-		return CalendarDay(stats.LastPeriodStart.AddDate(0, 0, stats.MinCycleLength), location),
-			CalendarDay(stats.LastPeriodStart.AddDate(0, 0, stats.MaxCycleLength), location),
+		return AddCalendarDays(stats.LastPeriodStart, stats.MinCycleLength, location),
+			AddCalendarDays(stats.LastPeriodStart, stats.MaxCycleLength, location),
 			true
 	}
 
@@ -249,8 +249,8 @@ func DashboardPredictionRange(user *models.User, stats CycleStats, predictedStar
 	if spanDays <= 0 {
 		return time.Time{}, time.Time{}, false
 	}
-	return CalendarDay(predictedStart.AddDate(0, 0, -spanDays), location),
-		CalendarDay(predictedStart.AddDate(0, 0, spanDays), location),
+	return AddCalendarDays(predictedStart, -spanDays, location),
+		AddCalendarDays(predictedStart, spanDays, location),
 		true
 }
 
@@ -260,8 +260,8 @@ func DashboardOvulationRange(nextPeriodRangeStart time.Time, nextPeriodRangeEnd 
 	}
 
 	resolvedLutealPhase := ResolveLutealPhase(lutealPhase)
-	rangeStart := CalendarDay(nextPeriodRangeStart.AddDate(0, 0, -resolvedLutealPhase), location)
-	rangeEnd := CalendarDay(nextPeriodRangeEnd.AddDate(0, 0, -resolvedLutealPhase), location)
+	rangeStart := AddCalendarDays(nextPeriodRangeStart, -resolvedLutealPhase, location)
+	rangeEnd := AddCalendarDays(nextPeriodRangeEnd, -resolvedLutealPhase, location)
 	if rangeEnd.Before(rangeStart) {
 		return time.Time{}, time.Time{}, false
 	}
@@ -299,7 +299,7 @@ func DashboardUpcomingPredictions(stats CycleStats, user *models.User, today tim
 		return prediction
 	}
 
-	prediction.NextPeriodStart = CalendarDay(cycleStart.AddDate(0, 0, cycleLength), today.Location())
+	prediction.NextPeriodStart = AddCalendarDays(cycleStart, cycleLength, today.Location())
 	window := PredictCycleWindow(cycleStart, cycleLength, stats.LutealPhase)
 	// window.OvulationDate is a UTC-midnight date-only value while today is a
 	// location-midnight working value, so the two are compared as calendar days
@@ -503,7 +503,7 @@ func dashboardNextPeriodEnd(nextPeriodStart time.Time, stats CycleStats, locatio
 		return time.Time{}
 	}
 
-	return CalendarDay(nextPeriodStart.AddDate(0, 0, periodLength-1), location)
+	return AddCalendarDays(nextPeriodStart, periodLength-1, location)
 }
 
 func dashboardNextPeriodInPast(display dashboardPredictionDisplay, today time.Time) bool {

--- a/internal/services/dashboard_view_service.go
+++ b/internal/services/dashboard_view_service.go
@@ -159,7 +159,7 @@ func (service *DashboardViewService) BuildDashboardViewData(ctx context.Context,
 	if err != nil {
 		return DashboardViewData{}, err
 	}
-	yesterday := today.AddDate(0, 0, -1)
+	yesterday := AddCalendarDays(today, -1, location)
 	yesterdayHasData, err := service.days.DayHasDataForDate(ctx, user.ID, yesterday, location)
 	if err != nil {
 		return DashboardViewData{}, fmt.Errorf("%w: %v", ErrDashboardViewLoadDayState, err)

--- a/internal/services/dashboard_view_service.go
+++ b/internal/services/dashboard_view_service.go
@@ -498,7 +498,7 @@ func firstMissingTrackedDay(logs []models.DailyLog, today time.Time, lookbackDay
 		logByDay[CalendarDay(logEntry.Date, location).Format("2006-01-02")] = true
 	}
 
-	startDay := today.AddDate(0, 0, -lookbackDays)
+	startDay := AddCalendarDays(today, -lookbackDays, location)
 	if !trackingStart.IsZero() {
 		trackingStartDay := DateAtLocation(trackingStart, location)
 		if trackingStartDay.After(startDay) {
@@ -510,7 +510,7 @@ func firstMissingTrackedDay(logs []models.DailyLog, today time.Time, lookbackDay
 	}
 	missedCount := 0
 	firstMissing := time.Time{}
-	for day := startDay; day.Before(today); day = day.AddDate(0, 0, 1) {
+	for day := startDay; day.Before(today); day = AddCalendarDays(day, 1, location) {
 		if logByDay[day.Format("2006-01-02")] {
 			continue
 		}

--- a/internal/services/day_service.go
+++ b/internal/services/day_service.go
@@ -390,7 +390,7 @@ func (service *DayService) clearAutoFilledNeighborsIfBare(ctx context.Context, u
 }
 
 func (service *DayService) shouldClearAutoFilledNeighbors(ctx context.Context, userID uint, dayStart time.Time, location *time.Location) (bool, error) {
-	previousDay := dayStart.AddDate(0, 0, -1)
+	previousDay := AddCalendarDays(dayStart, -1, location)
 	previousEntry, err := service.FetchLogByDate(ctx, userID, previousDay, location)
 	if err != nil {
 		return false, err
@@ -412,7 +412,7 @@ func (service *DayService) ClearAutoFilledPeriodNeighbors(ctx context.Context, u
 	}
 
 	for offset := 1; offset < periodLength; offset++ {
-		targetDay := CalendarDay(startDay.AddDate(0, 0, offset), location)
+		targetDay := AddCalendarDays(startDay, offset, location)
 		dayRangeStart, dayRangeEnd := DayRange(targetDay, location)
 		entry, found, err := service.logs.FindByUserAndDayRange(ctx, userID, dayRangeStart, dayRangeEnd)
 		if err != nil {
@@ -602,7 +602,7 @@ func (service *DayService) ShouldAutoFillPeriodDays(ctx context.Context, userID 
 		return false, nil
 	}
 
-	previousDay := dayStart.AddDate(0, 0, -1)
+	previousDay := AddCalendarDays(dayStart, -1, location)
 	previousEntry, err := service.FetchLogByDate(ctx, userID, previousDay, location)
 	if err != nil {
 		return false, err
@@ -624,7 +624,7 @@ func (service *DayService) AutoFillFollowingPeriodDays(ctx context.Context, user
 
 	today := DateAtLocation(now, location)
 	for offset := 1; offset < periodLength; offset++ {
-		targetDay := CalendarDay(startDay.AddDate(0, 0, offset), location)
+		targetDay := AddCalendarDays(startDay, offset, location)
 		if !today.IsZero() && targetDay.After(today) {
 			break
 		}
@@ -673,7 +673,7 @@ func (service *DayService) hasPeriodInRecentDays(ctx context.Context, userID uin
 		return false, nil
 	}
 	for offset := 1; offset <= lookbackDays; offset++ {
-		previousDay := day.AddDate(0, 0, -offset)
+		previousDay := AddCalendarDays(day, -offset, location)
 		entry, err := service.FetchLogByDate(ctx, userID, previousDay, location)
 		if err != nil {
 			return false, err

--- a/internal/services/day_utils.go
+++ b/internal/services/day_utils.go
@@ -147,6 +147,34 @@ func CalendarDaysBetween(from time.Time, to time.Time) int {
 	return int(end.Sub(start).Hours() / 24)
 }
 
+// AddCalendarDays returns the calendar day `days` after `day` (negative steps
+// backward), start-of-day in `location`. It is the counterpart of
+// CalendarDaysBetween — that one MEASURES a calendar-day distance, this one
+// WALKS one — and the single stepping point for code that is not already
+// walking a run of days through forEachCalendarDay.
+//
+// `day.AddDate(0, 0, n)` is not that. AddDate re-enters time.Date in the
+// receiver's own location, so where the resulting day's local midnight does not
+// exist (America/Santiago 2026-09-06, America/Havana 2026-03-08) it resolves
+// the missing wall clock BACKWARD and returns the PREVIOUS calendar day at
+// 23:00. Every reader that then takes the calendar components — CalendarDayKey,
+// a map key, a rendered date — is handed the wrong day, one day a year per
+// affected zone, silently.
+//
+// The step therefore runs over UTC-anchored days, where no midnight is ever
+// skipped, and the result is resolved back into `location` through the single
+// construction point. Keeping the caller's anchor is deliberate: these values
+// are routinely ordered against other location-midnight values, and returning a
+// UTC-midnight one would trade this defect for the cross-anchor comparison
+// defect (issue #48 class) the barrier's shape (b) exists to catch.
+func AddCalendarDays(day time.Time, days int, location *time.Location) time.Time {
+	if day.IsZero() {
+		return time.Time{}
+	}
+	stepped := dateOnly(day).AddDate(0, 0, days)
+	return CalendarDay(stepped, location)
+}
+
 // uniqueSymptomIDs returns a day's symptom ids in their stored order with
 // repeats removed. Every surface that COUNTS symptoms per day walks the slice
 // through this (or through uniqueKnownSymptomIDs, which filters unknown ids on

--- a/internal/services/onboarding_service.go
+++ b/internal/services/onboarding_service.go
@@ -218,7 +218,7 @@ func OnboardingDateBounds(now time.Time, location *time.Location) (time.Time, ti
 	}
 
 	today := DateAtLocation(now.In(location), location)
-	return today.AddDate(0, 0, -OnboardingStartDateWindowDays), today
+	return AddCalendarDays(today, -OnboardingStartDateWindowDays, location), today
 }
 
 func RequiresOnboarding(user *models.User) bool {

--- a/internal/services/settings_cycle_policy.go
+++ b/internal/services/settings_cycle_policy.go
@@ -154,5 +154,5 @@ func SettingsCycleStartDateBounds(now time.Time, location *time.Location) (time.
 		location = time.UTC
 	}
 	today := DateAtLocation(now.In(location), location)
-	return today.AddDate(0, 0, -SettingsCycleStartWindowDays), today
+	return AddCalendarDays(today, -SettingsCycleStartWindowDays, location), today
 }

--- a/internal/services/stats_cycle_factor_context.go
+++ b/internal/services/stats_cycle_factor_context.go
@@ -80,7 +80,7 @@ func shouldBuildStatsCycleFactorExplanation(user *models.User, logs []models.Dai
 
 func collectStatsCycleFactorCounts(logs []models.DailyLog, now time.Time, location *time.Location) map[string]int {
 	today := DateAtLocation(now, location)
-	windowStart := today.AddDate(0, 0, -(statsCycleFactorContextWindowDays - 1))
+	windowStart := AddCalendarDays(today, -(statsCycleFactorContextWindowDays - 1), location)
 	counts := make(map[string]int, len(supportedDayCycleFactorKeys))
 	for _, logEntry := range logs {
 		logDay := CalendarDay(logEntry.Date, location)

--- a/internal/services/stats_cycle_factor_context.go
+++ b/internal/services/stats_cycle_factor_context.go
@@ -103,7 +103,7 @@ func buildStatsCycleFactorSnapshots(logs []models.DailyLog, completedCycles []co
 		}
 		snapshots = append(snapshots, statsCycleFactorCycleSnapshot{
 			Start:          cycle.Start,
-			End:            cycle.NextStart.AddDate(0, 0, -1),
+			End:            AddCalendarDays(cycle.NextStart, -1, cycle.NextStart.Location()),
 			CycleLength:    cycle.CycleLength,
 			ComparisonKind: classifyStatsCycleFactorComparison(stats, cycle.CycleLength),
 			FactorKeys:     factorKeys,

--- a/internal/services/stats_cycle_insights.go
+++ b/internal/services/stats_cycle_insights.go
@@ -204,7 +204,7 @@ func buildCurrentCycleBBTChart(language string, stats CycleStats, logs []models.
 		return StatsBBTChartViewData{}
 	}
 
-	detectionDays, detectionValues := bbtSeriesFromPoints(collectCycleBBTPoints(logs, cycleStart, today.AddDate(0, 0, 1), location))
+	detectionDays, detectionValues := bbtSeriesFromPoints(collectCycleBBTPoints(logs, cycleStart, AddCalendarDays(today, 1, location), location))
 	firstHighDay, coverline, hasShift := detectBBTShiftFirstHighDay(detectionDays, detectionValues)
 	markerIndex, hasMarker := probableOvulationMarkerIndex(firstHighDay, hasShift, len(labels))
 	points := buildCurrentCycleBBTChartPoints(language, cycleStart, labels, values)
@@ -221,7 +221,7 @@ func buildCurrentCycleBBTChartPoints(language string, cycleStart time.Time, labe
 		point := StatsBBTChartPointViewData{
 			Day:      index + 1,
 			DayLabel: label,
-			Date:     LocalizedDateShort(language, cycleStart.AddDate(0, 0, index)),
+			Date:     LocalizedDateShort(language, AddCalendarDays(cycleStart, index, cycleStart.Location())),
 		}
 		if index < len(values) && values[index] != nil {
 			point.ValueText = formatBBTChartPointValue(*values[index])

--- a/internal/services/stats_cycle_ribbon.go
+++ b/internal/services/stats_cycle_ribbon.go
@@ -172,7 +172,7 @@ func statsCycleRibbonRow(cycle completedCycleSpan, axisDays int, luteal int, sho
 			continue
 		}
 
-		date := AddCalendarDays(cycle.Start, day-1, time.UTC)
+		date := AddCalendarDays(cycle.Start, day-1, cycle.Start.Location())
 		isPeriod := day <= cycle.PeriodLength
 		cell := StatsCycleRibbonDay{
 			Day:      day,

--- a/internal/services/stats_cycle_ribbon.go
+++ b/internal/services/stats_cycle_ribbon.go
@@ -172,7 +172,7 @@ func statsCycleRibbonRow(cycle completedCycleSpan, axisDays int, luteal int, sho
 			continue
 		}
 
-		date := cycle.Start.AddDate(0, 0, day-1)
+		date := AddCalendarDays(cycle.Start, day-1, time.UTC)
 		isPeriod := day <= cycle.PeriodLength
 		cell := StatsCycleRibbonDay{
 			Day:      day,


### PR DESCRIPTION
`day.AddDate(0, 0, n)` re-enters `time.Date` in the receiver's own location. In the UTC-minus zones
whose DST jump lands on midnight (America/Santiago 2026-09-06, America/Havana 2026-03-08) that local
midnight does not exist, so the step resolves BACKWARD and returns the PREVIOUS calendar day at
23:00. Everything downstream that reads the calendar components is handed the wrong day, once a year
per affected zone, silently.

**Change.** `AddCalendarDays` (`day_utils.go`) is the single stepping point: it steps over
UTC-anchored days and resolves the result back into the caller's location through
`StartOfCalendarDay`. Keeping the caller's anchor is deliberate — these values are routinely ordered
against other location midnights, and returning a UTC midnight would trade this defect for the
cross-anchor comparison defect (issue #48 class).

Every calendar-day step whose result is a date someone reads is converted: the dashboard projection
chain (next period, its end, both prediction ranges, the cycle-baseline shift), `PredictCycleWindow`
and its two callers in `cycles.go`, the month grid's projected-cycle chain and its pre-fertile runs,
the `.ics` projection and its DTEND, the manual cycle-start bound and its two anchor lookups, the
onboarding and settings picker bounds, the stats ribbon, chart labels and factor-context window, the
dashboard's yesterday and lookback walk, and the three auto-fill neighbour lookups in `DayService`,
which were reading the wrong day outright.

Sites whose anchor is provably UTC keep their plain step: the grid bounds and `forEachCalendarDay`,
`PredictCycleWindow`'s internals, the `ObservedCycleStarts` walks, the day-feedback cursor,
`DayRange`, and the `day_service` sites that re-anchor to UTC explicitly. Three range bounds stay as
they are — `CalendarLogRange`, the import fetch window and the allowlisted feed window — where a slip
widens the query and never narrows it.

**The barrier gains the shape it was missing.** The sweep already failed the suite for building a
calendar day as an instant in a zone, and for ordering a location-anchored day against a UTC one. It
did not read the STEP, and its own classifier asserted that `AddDate` "keeps the anchor", which is
untrue on exactly these dates. It now flags a step taken from a location anchor, states the blind
spot it keeps — it only sees an anchor built in the same function — and carries fixtures of its own:
one function it must flag, two it must not.

**Two measurement defects surfaced and are fixed here.** The floor counted REMAINING `AddDate` calls,
so every conversion lowered it — this sweep drove it to 39 against a floor of 40 and the barrier
failed as "discovery is broken". It now counts steps in either form. And the shape had no positive
fixture beyond one allowlist entry, so converting that site would have left the classifier
unexercised and the guard green while measuring nothing.

**Evidence.** Barrier red at 9 sites before the conversion. Behaviour red before, green after:
`TestDashboardUpcomingPredictionsNameTheSkippedMidnightDay` (next period read 2026-09-05 for a cycle
due 09-06), `TestPredictCycleWindowLandsOnTheSkippedMidnightDay`,
`TestManualCycleStartMaxDateReachesTheSkippedMidnightDay`,
`TestOnboardingDateBoundsReachTheSkippedMidnightDay`, and two grid cases asserting on the painted
run's EDGES, since a shifted run still covers the transition day.
`TestAddCalendarDaysCrossesASkippedMidnight` and
`TestCalendarDayBarrierClassifiesTheSteppingShape` are both mutant-checked.

**Review history.** Three passes, three real findings, each fixed in its own commit: the pre-fertile
run left behind by the first conversion, the whole dashboard chain the barrier is blind to, and the
ribbon step converted with the wrong anchor while its comment still described the old one.

**Rollback.** Revert the four commits; no schema, no contract, no persisted value. The barrier
changes are test-only.
