### PR TITLE
fix(cycle): the boot luteal recompute bounds its history at the owner's today

### DIFF
--- a/changelog.d/boot-recompute-bounds-luteal-history-at-today.md
+++ b/changelog.d/boot-recompute-bounds-luteal-history-at-today.md
@@ -1,0 +1,19 @@
+### Fixed
+
+- **The startup pass that repairs the learned luteal phase no longer counts a cycle start you
+  recorded ahead of time.** Ovumcy lets a cycle start be logged up to two days in the future, and
+  the personalised luteal phase is learned from completed cycles. The one-shot repair that runs at
+  startup read the whole stored history with no upper bound, so a start recorded for tomorrow was
+  taken as the end of the last completed cycle and the stored value was derived from a day that had
+  not happened yet.
+
+  Every surface that shows a prediction re-derives this value over a window that stops at your own
+  today, so the stored one and the live one disagreed by construction — which is the drift this
+  repair pass exists to remove, not to introduce. The pass now bounds its read at the same today, in
+  the account's own timezone, exactly as every other surface does. A start already in the past
+  counts as it always did.
+
+  The stored value is a fallback rather than a dead cache: predictions fall back to it whenever the
+  live inference has too little history to answer (fewer than three recorded cycle starts, or fewer
+  than two usable ovulation signals), including on the dashboard and in the outbound webhook
+  reminder. On those accounts the future-dated start reached what was actually shown.

--- a/changelog.d/boot-recompute-bounds-luteal-history-at-today.md
+++ b/changelog.d/boot-recompute-bounds-luteal-history-at-today.md
@@ -9,9 +9,11 @@
 
   Every surface that shows a prediction re-derives this value over a window that stops at your own
   today, so the stored one and the live one disagreed by construction — which is the drift this
-  repair pass exists to remove, not to introduce. The pass now bounds its read at the same today, in
-  the account's own timezone, exactly as every other surface does. A start already in the past
-  counts as it always did.
+  repair pass exists to remove, not to introduce. The bound now sits in the single calculation all
+  three writers of that value share — a day save, a restore from backup, and the startup repair — so
+  none of them can count a day that has not happened. Bounding only the startup pass would have been
+  worse than bounding none: it would have corrected the value, and the next saved day would have put
+  the future-dated one straight back. A start already in the past counts as it always did.
 
   The stored value is a fallback rather than a dead cache: predictions fall back to it whenever the
   live inference has too little history to answer (fewer than three recorded cycle starts, or fewer

--- a/internal/services/cycle_signals.go
+++ b/internal/services/cycle_signals.go
@@ -102,8 +102,21 @@ func InferUserLutealPhase(logs []models.DailyLog, location *time.Location) (int,
 // of them, which is the drift this function exists to close. Callers that need
 // the value for DISPLAY read it through ApplyUserCycleBaseline, which re-infers
 // over the log window it was handed.
-func deriveUserLutealPhase(logs []models.DailyLog, location *time.Location) int {
-	if lutealPhase, refined := InferUserLutealPhase(logs, location); refined {
+//
+// The today bound lives HERE, not in each writer's fetch. The column summarizes
+// OBSERVED cycles, and manualCycleStartFutureDays lets an owner record a cycle
+// start up to two days ahead; ObservedCycleStarts takes such a start as the
+// boundary of the last observed cycle, so an unbounded read derives the column
+// from a day that has not happened yet. Bounding one writer would be worse than
+// bounding none: the boot recompute would correct the column and the next day
+// save would put the future-dated value straight back, which is precisely the
+// disagreement the paragraph above promises cannot happen. `now` is a required
+// parameter for the same reason — a writer cannot omit the bound by forgetting
+// it. Same shape as the pregnancy pause (`prediction-display.md`): the bound
+// belongs to the derivation, never to the caller's fetch.
+func deriveUserLutealPhase(logs []models.DailyLog, now time.Time, location *time.Location) int {
+	observed := filterLogsNotAfter(logs, DateAtLocation(now, location))
+	if lutealPhase, refined := InferUserLutealPhase(observed, location); refined {
 		return lutealPhase
 	}
 	return defaultLutealPhaseDays

--- a/internal/services/day_service.go
+++ b/internal/services/day_service.go
@@ -287,7 +287,7 @@ func (service *DayService) UpsertDayEntryWithAutoFillAt(ctx context.Context, use
 		return models.DailyLog{}, err
 	}
 
-	service.refreshDerivedCycleSettings(ctx, userID, location)
+	service.refreshDerivedCycleSettings(ctx, userID, now, location)
 	return entry, nil
 }
 
@@ -439,7 +439,11 @@ func (service *DayService) DeleteDayEntry(ctx context.Context, userID uint, day 
 	if err := service.DeleteDailyLogByDate(ctx, userID, day, location); err != nil {
 		return ErrDeleteDayFailed
 	}
-	service.refreshDerivedCycleSettings(ctx, userID, location)
+	// DeleteDayEntry carries no instant of its own — the transport never needed
+	// one — and the derived column must still be bounded at the owner's today.
+	// Reading the clock here keeps that bound rather than threading `now` through
+	// the delete route for this one line.
+	service.refreshDerivedCycleSettings(ctx, userID, time.Now(), location)
 	return nil
 }
 
@@ -492,7 +496,7 @@ func (service *DayService) MarkCycleStartManually(ctx context.Context, userID ui
 	}); err != nil {
 		return err
 	}
-	service.refreshDerivedCycleSettings(ctx, userID, location)
+	service.refreshDerivedCycleSettings(ctx, userID, now, location)
 
 	return nil
 }
@@ -715,7 +719,7 @@ func (service *DayService) clearCompetingCycleStarts(ctx context.Context, userID
 	return nil
 }
 
-func (service *DayService) refreshDerivedCycleSettings(ctx context.Context, userID uint, location *time.Location) {
+func (service *DayService) refreshDerivedCycleSettings(ctx context.Context, userID uint, now time.Time, location *time.Location) {
 	if service == nil || service.users == nil || service.logs == nil {
 		return
 	}
@@ -727,7 +731,7 @@ func (service *DayService) refreshDerivedCycleSettings(ctx context.Context, user
 	}
 
 	if err := service.users.UpdateByID(ctx, userID, map[string]any{
-		"luteal_phase": deriveUserLutealPhase(logs, location),
+		"luteal_phase": deriveUserLutealPhase(logs, now, location),
 	}); err != nil {
 		log.Printf("refreshDerivedCycleSettings: update luteal_phase for user %d failed: %v", userID, err)
 	}

--- a/internal/services/day_service_coverage_test.go
+++ b/internal/services/day_service_coverage_test.go
@@ -609,7 +609,7 @@ func TestDayService_RefreshDerivedCycleSettings_NilUsersNoOp(t *testing.T) {
 		users: nil,
 	}
 
-	service.refreshDerivedCycleSettings(context.Background(), 10, time.UTC)
+	service.refreshDerivedCycleSettings(context.Background(), 10, time.Now(), time.UTC)
 
 	if logs.listCalls != 0 {
 		t.Fatalf("expected the nil-users guard to return before reading logs, got %d ListByUser call(s)", logs.listCalls)
@@ -625,7 +625,7 @@ func TestDayService_RefreshDerivedCycleSettings_NilLogsNoOp(t *testing.T) {
 		users: users,
 	}
 
-	service.refreshDerivedCycleSettings(context.Background(), 10, time.UTC)
+	service.refreshDerivedCycleSettings(context.Background(), 10, time.Now(), time.UTC)
 
 	if users.updateCalls != 0 {
 		t.Fatalf("expected the nil-logs guard to write nothing, got %d UpdateByID call(s)", users.updateCalls)
@@ -659,7 +659,7 @@ func TestDayService_RefreshDerivedCycleSettings_EmptyLogSetPersistsDefaultLuteal
 	users := &dayserviceCovUserStub{settings: models.User{PeriodLength: 5}}
 	service := dayserviceCovNewService(logs, users)
 
-	service.refreshDerivedCycleSettings(context.Background(), 10, time.UTC)
+	service.refreshDerivedCycleSettings(context.Background(), 10, time.Now(), time.UTC)
 
 	if logs.listCalls != 1 {
 		t.Fatalf("expected the refresh to read the log set exactly once, got %d call(s)", logs.listCalls)

--- a/internal/services/import_service.go
+++ b/internal/services/import_service.go
@@ -158,7 +158,10 @@ func (service *ImportService) ImportJSON(ctx context.Context, userID uint, raw [
 		return ImportResult{}, err
 	}
 
-	service.refreshDerivedCycleSettings(ctx, userID, location)
+	// A restore carries no instant of its own; the derived column must still be
+	// bounded at the owner's today, so the clock is read here rather than
+	// threaded through the import route for this one line.
+	service.refreshDerivedCycleSettings(ctx, userID, time.Now(), location)
 
 	return ImportResult{Added: added, Skipped: skipped, Rejected: rejected}, nil
 }
@@ -429,7 +432,7 @@ func resolveImportSymptomIDs(flags ExportSymptomFlags, otherNames []string, buil
 // refreshDerivedCycleSettings recomputes the owner's luteal-phase estimate once
 // after a bulk restore. Mirrors DayService.refreshDerivedCycleSettings; kept as
 // a best-effort side effect (a failure here never fails the import).
-func (service *ImportService) refreshDerivedCycleSettings(ctx context.Context, userID uint, location *time.Location) {
+func (service *ImportService) refreshDerivedCycleSettings(ctx context.Context, userID uint, now time.Time, location *time.Location) {
 	if service == nil || service.users == nil || service.logs == nil {
 		return
 	}
@@ -437,5 +440,5 @@ func (service *ImportService) refreshDerivedCycleSettings(ctx context.Context, u
 	if err != nil {
 		return
 	}
-	_ = service.users.UpdateByID(ctx, userID, map[string]any{"luteal_phase": deriveUserLutealPhase(logs, location)})
+	_ = service.users.UpdateByID(ctx, userID, map[string]any{"luteal_phase": deriveUserLutealPhase(logs, now, location)})
 }

--- a/internal/services/import_service_coverage_test.go
+++ b/internal/services/import_service_coverage_test.go
@@ -143,11 +143,11 @@ func TestImportServiceEmptySymptomNamesIgnored(t *testing.T) {
 // nil logs, the guard must also write NOTHING, so a fall-through cannot hide
 // behind "it did not panic".
 func TestImportServiceRefreshNilGuards(t *testing.T) {
-	(&ImportService{}).refreshDerivedCycleSettings(context.Background(), 1, time.UTC)
+	(&ImportService{}).refreshDerivedCycleSettings(context.Background(), 1, time.Now(), time.UTC)
 
 	users := &importRecordingUsers{}
 	NewImportService(nil, users, &importStubReconciler{}, nil).
-		refreshDerivedCycleSettings(context.Background(), 1, time.UTC)
+		refreshDerivedCycleSettings(context.Background(), 1, time.Now(), time.UTC)
 	if len(users.updates) != 0 {
 		t.Fatalf("expected the nil-logs guard to write nothing, got %d update(s)", len(users.updates))
 	}
@@ -176,7 +176,7 @@ func TestImportServiceRefreshUpdatesOnSuccess(t *testing.T) {
 	users := &importRecordingUsers{}
 	// listErr nil => ListByUser succeeds; the refresh must proceed to UpdateByID.
 	svc := &ImportService{logs: &importStubLogs{}, users: users}
-	svc.refreshDerivedCycleSettings(context.Background(), 7, time.UTC)
+	svc.refreshDerivedCycleSettings(context.Background(), 7, time.Now(), time.UTC)
 
 	if len(users.updates) != 1 {
 		t.Fatalf("expected one luteal_phase update on the success path, got %d", len(users.updates))

--- a/internal/services/import_service_mutation_test.go
+++ b/internal/services/import_service_mutation_test.go
@@ -154,20 +154,20 @@ func TestImportMut_RefreshNilGuardsShortCircuitPerClause(t *testing.T) {
 	// this clause and dereferences service.users on a nil receiver.
 	assertNoPanic("nil receiver", func() {
 		var svc *ImportService
-		svc.refreshDerivedCycleSettings(ctx, 1, time.UTC)
+		svc.refreshDerivedCycleSettings(ctx, 1, time.Now(), time.UTC)
 	})
 
 	// Clause 2: users == nil (logs non-nil and returning data). Negating
 	// `service.users == nil` lets the method reach users.UpdateByID on nil.
 	assertNoPanic("nil users", func() {
 		svc := &ImportService{logs: importmutDataLogs{}, users: nil}
-		svc.refreshDerivedCycleSettings(ctx, 1, time.UTC)
+		svc.refreshDerivedCycleSettings(ctx, 1, time.Now(), time.UTC)
 	})
 
 	// Clause 3: logs == nil (users non-nil). Negating `service.logs == nil`
 	// lets the method reach logs.ListByUser on nil.
 	assertNoPanic("nil logs", func() {
 		svc := &ImportService{logs: nil, users: importStubUsers{}}
-		svc.refreshDerivedCycleSettings(ctx, 1, time.UTC)
+		svc.refreshDerivedCycleSettings(ctx, 1, time.Now(), time.UTC)
 	})
 }

--- a/internal/services/luteal_phase_recompute.go
+++ b/internal/services/luteal_phase_recompute.go
@@ -105,6 +105,12 @@ type LutealPhaseRecomputer struct {
 	users            lutealPhaseRecomputeUserStore
 	logs             lutealPhaseRecomputeLogStore
 	fallbackLocation *time.Location
+	// now is the clock the per-owner today is read from. It exists so the pass
+	// can be driven from a fixed instant in tests; production leaves it at
+	// time.Now. It is not a constructor parameter because a boot pass has no
+	// request to take an instant from, and widening the exported signature for
+	// a test seam would push that decision onto every caller.
+	now func() time.Time
 }
 
 // NewLutealPhaseRecomputer wires the pass. fallbackLocation is the zone used for
@@ -119,7 +125,7 @@ func NewLutealPhaseRecomputer(
 	if fallbackLocation == nil {
 		fallbackLocation = time.UTC
 	}
-	return &LutealPhaseRecomputer{appState: appState, users: users, logs: logs, fallbackLocation: fallbackLocation}
+	return &LutealPhaseRecomputer{appState: appState, users: users, logs: logs, fallbackLocation: fallbackLocation, now: time.Now}
 }
 
 // Run executes the pass and returns the outcome for the startup line. It returns
@@ -147,7 +153,19 @@ func (recomputer *LutealPhaseRecomputer) Run(ctx context.Context) (LutealPhaseRe
 			continue
 		}
 
-		derived := deriveUserLutealPhase(logs, resolveOwnerLocation(row.Timezone, recomputer.fallbackLocation))
+		// Bound the history at the owner's own today before deriving. The column
+		// is a summary of OBSERVED cycles, and manualCycleStartFutureDays lets an
+		// owner record a cycle start up to two days ahead; ObservedCycleStarts
+		// takes such a start as the boundary of the last observed cycle, so an
+		// unbounded read derives the column from a day that has not happened yet.
+		// The display path re-infers over a today-bounded window, so leaving this
+		// one unbounded makes the stored value and the live inference disagree BY
+		// CONSTRUCTION — which is the drift this pass exists to remove, not to
+		// create. The bound is the same shape every other surface uses
+		// (filterLogsNotAfter against the owner's calendar day).
+		location := resolveOwnerLocation(row.Timezone, recomputer.fallbackLocation)
+		today := DateAtLocation(recomputer.now(), location)
+		derived := deriveUserLutealPhase(filterLogsNotAfter(logs, today), location)
 		if derived == row.LutealPhase {
 			continue
 		}

--- a/internal/services/luteal_phase_recompute.go
+++ b/internal/services/luteal_phase_recompute.go
@@ -158,19 +158,10 @@ func (recomputer *LutealPhaseRecomputer) Run(ctx context.Context) (LutealPhaseRe
 			continue
 		}
 
-		// Bound the history at the owner's own today before deriving. The column
-		// is a summary of OBSERVED cycles, and manualCycleStartFutureDays lets an
-		// owner record a cycle start up to two days ahead; ObservedCycleStarts
-		// takes such a start as the boundary of the last observed cycle, so an
-		// unbounded read derives the column from a day that has not happened yet.
-		// The display path re-infers over a today-bounded window, so leaving this
-		// one unbounded makes the stored value and the live inference disagree BY
-		// CONSTRUCTION — which is the drift this pass exists to remove, not to
-		// create. The bound is the same shape every other surface uses
-		// (filterLogsNotAfter against the owner's calendar day).
+		// deriveUserLutealPhase bounds the history at the owner's own today; this
+		// pass supplies the instant and the zone it is read in.
 		location := resolveOwnerLocation(row.Timezone, recomputer.fallbackLocation)
-		today := DateAtLocation(passNow, location)
-		derived := deriveUserLutealPhase(filterLogsNotAfter(logs, today), location)
+		derived := deriveUserLutealPhase(logs, passNow, location)
 		if derived == row.LutealPhase {
 			continue
 		}

--- a/internal/services/luteal_phase_recompute.go
+++ b/internal/services/luteal_phase_recompute.go
@@ -145,6 +145,11 @@ func (recomputer *LutealPhaseRecomputer) Run(ctx context.Context) (LutealPhaseRe
 		return LutealPhaseRecomputeOutcome{}, err
 	}
 
+	// One instant for the whole pass: the owners' calendar days are resolved
+	// from it in their own zones, but a pass that re-read the clock per owner
+	// could straddle midnight and bound two owners at two different days.
+	passNow := recomputer.now()
+
 	var outcome LutealPhaseRecomputeOutcome
 	for _, row := range rows {
 		logs, err := recomputer.logs.ListByUser(ctx, row.ID)
@@ -164,7 +169,7 @@ func (recomputer *LutealPhaseRecomputer) Run(ctx context.Context) (LutealPhaseRe
 		// create. The bound is the same shape every other surface uses
 		// (filterLogsNotAfter against the owner's calendar day).
 		location := resolveOwnerLocation(row.Timezone, recomputer.fallbackLocation)
-		today := DateAtLocation(recomputer.now(), location)
+		today := DateAtLocation(passNow, location)
 		derived := deriveUserLutealPhase(filterLogsNotAfter(logs, today), location)
 		if derived == row.LutealPhase {
 			continue

--- a/internal/services/luteal_phase_recompute_test.go
+++ b/internal/services/luteal_phase_recompute_test.go
@@ -352,10 +352,10 @@ func TestDeriveUserLutealPhaseIsTheOneRuleTheCacheIsWrittenBy(t *testing.T) {
 	// contract is exactly two branches, and both are pinned here so a future
 	// edit cannot quietly change what an un-inferable account stores.
 	refinable := lutealRoundTripLogs(t, lutealRecomputeOrigin, 28, []int{14, 14}, lutealSignalEggWhite)
-	if got := deriveUserLutealPhase(refinable, time.UTC); got != 14 {
+	if got := deriveUserLutealPhase(refinable, time.Now(), time.UTC); got != 14 {
 		t.Fatalf("deriveUserLutealPhase on refinable logs = %d, want 14", got)
 	}
-	if got := deriveUserLutealPhase(nil, time.UTC); got != defaultLutealPhaseDays {
+	if got := deriveUserLutealPhase(nil, time.Now(), time.UTC); got != defaultLutealPhaseDays {
 		t.Fatalf("deriveUserLutealPhase with no logs = %d, want %d", got, defaultLutealPhaseDays)
 	}
 }
@@ -519,5 +519,44 @@ func TestLutealPhaseRecomputeUsesACycleStartOnceItHasHappened(t *testing.T) {
 	}
 	if outcome.Corrected != 1 || outcome.Failed != 0 {
 		t.Fatalf("outcome = %+v, want one correction", outcome)
+	}
+}
+
+// TestEveryWriterOfTheColumnBoundsTheHistoryAtToday is the class guard for the
+// pair above. The column has three writers — a day save, a bulk restore and this
+// boot pass — and deriveUserLutealPhase is the single rule all three route
+// through, which is why the today bound lives there rather than in one caller's
+// fetch. Bounding one writer alone would be worse than bounding none: the boot
+// pass would correct the column and the next day save would put the
+// future-dated value straight back.
+//
+// The day-save path is exercised here because it is the one that runs most
+// often; the restore path shares the same derivation call and the compiler now
+// requires an instant from both, so neither can silently drop the bound.
+func TestEveryWriterOfTheColumnBoundsTheHistoryAtToday(t *testing.T) {
+	logs, fourthStart := lutealRecomputeFutureStartLogs(t)
+	assertInferenceSupports(t, logs, 15, true)
+
+	logStore := newDayLogRepositoryStub()
+	for _, entry := range logs {
+		entry.UserID = 10
+		logStore.entries[CalendarDayKey(entry.Date)] = entry
+	}
+	users := &dayUserRepositoryStub{settings: models.User{LutealPhase: 14}}
+	service := NewDayService(logStore, users)
+
+	// Today is the day before the fourth start: the owner recorded it ahead,
+	// exactly as manualCycleStartFutureDays permits.
+	service.refreshDerivedCycleSettings(context.Background(), 10, fourthStart.AddDate(0, 0, -1), time.UTC)
+	if users.settings.LutealPhase != 14 {
+		t.Fatalf("a day save derived luteal_phase = %d from a cycle start recorded ahead, want 14", users.settings.LutealPhase)
+	}
+
+	// Control: once that start is in the past it is observed history and must
+	// move the column, or the bound would be a blanket refusal to read the last
+	// cycle rather than a today bound.
+	service.refreshDerivedCycleSettings(context.Background(), 10, fourthStart.AddDate(0, 0, 1), time.UTC)
+	if users.settings.LutealPhase != 15 {
+		t.Fatalf("a day save after that start has happened derived luteal_phase = %d, want 15", users.settings.LutealPhase)
 	}
 }

--- a/internal/services/luteal_phase_recompute_test.go
+++ b/internal/services/luteal_phase_recompute_test.go
@@ -425,3 +425,99 @@ func TestLutealPhaseRecomputeReportsAMarkerItCouldNotWrite(t *testing.T) {
 		t.Fatal("a failed Set must leave no marker behind")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// The pass reads OBSERVED history, and manualCycleStartFutureDays lets an owner
+// record a cycle start up to two days ahead. ObservedCycleStarts takes such a
+// start as the boundary of the last observed cycle, so an unbounded read
+// derives the cached column from a day that has not happened yet — while the
+// display path re-infers over a today-bounded window. The two then disagree by
+// construction, which is the drift this pass exists to remove.
+// ---------------------------------------------------------------------------
+
+// lutealRecomputeFutureStartLogs builds three 28-day cycles whose ovulation
+// falls on cycle day 14 (luteal 14 in each), then a FOURTH cycle start 32 days
+// after the third. Read unbounded, that fourth start closes a third cycle and
+// contributes a luteal sample of 32-14 = 18, pulling the average to 15. Read
+// bounded at a today before it, the fourth start is not history yet and the
+// answer stays 14. It returns the logs and that fourth start's date.
+func lutealRecomputeFutureStartLogs(t *testing.T) ([]models.DailyLog, time.Time) {
+	t.Helper()
+
+	starts := []time.Time{
+		lutealRecomputeOrigin,
+		lutealRecomputeOrigin.AddDate(0, 0, 28),
+		lutealRecomputeOrigin.AddDate(0, 0, 56),
+	}
+	fourthStart := starts[2].AddDate(0, 0, 32)
+
+	logs := make([]models.DailyLog, 0, len(starts)*3+2)
+	for _, start := range starts {
+		logs = append(logs,
+			models.DailyLog{Date: start, IsPeriod: true, CycleStart: true, Flow: models.FlowMedium},
+			models.DailyLog{Date: start.AddDate(0, 0, 1), IsPeriod: true, Flow: models.FlowMedium},
+			// Egg-white peak on cycle day 13 puts ovulation on cycle day 14.
+			models.DailyLog{Date: start.AddDate(0, 0, 12), CervicalMucus: models.CervicalMucusEggWhite},
+		)
+	}
+	logs = append(logs,
+		models.DailyLog{Date: fourthStart, IsPeriod: true, CycleStart: true, Flow: models.FlowMedium},
+		models.DailyLog{Date: fourthStart.AddDate(0, 0, 1), IsPeriod: true, Flow: models.FlowMedium},
+	)
+	return logs, fourthStart
+}
+
+// runLutealRecomputeAt drives one pass with the clock pinned to `now`.
+func runLutealRecomputeAt(t *testing.T, logs []models.DailyLog, storedLutealPhase int, now time.Time) (*stubLutealRecomputeUserStore, LutealPhaseRecomputeOutcome) {
+	t.Helper()
+
+	appState := &stubLutealRecomputeAppState{}
+	users := &stubLutealRecomputeUserStore{rows: []models.LutealPhaseRecomputeRow{{ID: 7, LutealPhase: storedLutealPhase}}}
+	logStore := &stubLutealRecomputeLogStore{logs: map[uint][]models.DailyLog{7: logs}}
+
+	recomputer := NewLutealPhaseRecomputer(appState, users, logStore, time.UTC)
+	recomputer.now = func() time.Time { return now }
+
+	outcome, err := recomputer.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	return users, outcome
+}
+
+func TestLutealPhaseRecomputeIgnoresACycleStartRecordedAhead(t *testing.T) {
+	logs, fourthStart := lutealRecomputeFutureStartLogs(t)
+
+	// Anti-vacuity: the unbounded reading of these same logs really does answer
+	// 15, so a green result below is the bound working rather than a fixture
+	// that could only ever say 14.
+	assertInferenceSupports(t, logs, 15, true)
+
+	// Today is the day before the fourth start: the owner recorded it ahead,
+	// exactly as manualCycleStartFutureDays permits.
+	users, outcome := runLutealRecomputeAt(t, logs, 14, fourthStart.AddDate(0, 0, -1))
+
+	if len(users.updates) != 0 {
+		t.Fatalf("a cycle start recorded ahead must not move the stored column, got %+v", users.updates)
+	}
+	if outcome.Corrected != 0 || outcome.Failed != 0 {
+		t.Fatalf("outcome = %+v, want no correction and no failure", outcome)
+	}
+}
+
+func TestLutealPhaseRecomputeUsesACycleStartOnceItHasHappened(t *testing.T) {
+	logs, fourthStart := lutealRecomputeFutureStartLogs(t)
+	assertInferenceSupports(t, logs, 15, true)
+
+	// The control for the case above: the same start, one day in the PAST, is
+	// observed history and must move the column. Without this pair the bound
+	// could be a blanket refusal to read the last cycle at all.
+	users, outcome := runLutealRecomputeAt(t, logs, 14, fourthStart.AddDate(0, 0, 1))
+
+	if len(users.updates) != 1 || users.updates[0] != (lutealPhaseUpdate{userID: 7, value: 15}) {
+		t.Fatalf("a cycle start already in the past must move the column to 15, got %+v", users.updates)
+	}
+	if outcome.Corrected != 1 || outcome.Failed != 0 {
+		t.Fatalf("outcome = %+v, want one correction", outcome)
+	}
+}


### PR DESCRIPTION
The one-shot boot pass derived `users.luteal_phase` from an unbounded `ListByUser` read.
`manualCycleStartFutureDays` permits a cycle start up to two days ahead, `ObservedCycleStarts` takes
such a start as the boundary of the last observed cycle, and the column was therefore derived from a
day that had not happened yet. Every display path re-infers over a today-bounded window, so the
stored value and the live inference disagreed BY CONSTRUCTION — the drift this pass exists to
remove.

**Change.** The read is bounded with `filterLogsNotAfter` against the owner's own calendar day,
resolved through the `resolveOwnerLocation` already used one line below. The clock enters through an
unexported `now` field defaulted to `time.Now` rather than a new constructor parameter: a boot pass
has no request to take an instant from, and widening the exported signature for a test seam would
push that decision onto every caller. It is read once per pass, so a long pass cannot straddle
midnight and bound two owners at two different days.

**Blast radius is wider than the pass.** The column is a FALLBACK, not a dead cache:
`resolveUserCycleLengths` returns `ResolveLutealPhase(user.LutealPhase)` and `ApplyUserCycleBaseline`
overrides it only when `InferUserLutealPhase` answers ok. On an account with fewer than three
recorded starts or fewer than two usable ovulation signals the stored value is what the dashboard
renders, and `userFromNotifyRecord` carries it onto the webhook egress path the same way. The
original report assumed display always re-infers; it does not.

**Evidence.** Red before, green after:
`TestLutealPhaseRecomputeIgnoresACycleStartRecordedAhead` — unbounded, a start recorded for tomorrow
writes 15 over a correct 14. `TestLutealPhaseRecomputeUsesACycleStartOnceItHasHappened` is the
control that the bound is not a blanket refusal to read the last cycle. Both rest on an
`assertInferenceSupports` anchor pinning that the same logs really do read 15 unbounded, so neither
can pass vacuously.

**Rollback.** Revert the two commits; no schema, no migration. The column self-heals on the next day
save, which routes through the same `deriveUserLutealPhase`.
