### PR TITLE
test(e2e): the onboarding picker spec survives the first of the month

### DIFF
--- a/changelog.d/e2e-onboarding-picker-survives-the-first-of-the-month.md
+++ b/changelog.d/e2e-onboarding-picker-survives-the-first-of-the-month.md
@@ -1,0 +1,14 @@
+none
+
+Test-only fix. The onboarding step-1 picker spec asserted today's grid cell AFTER
+pressing the "yesterday" shortcut. Selecting a date moves the grid to that date's
+month, and the grid renders one month with no neighbouring days — so on the first
+of a month "yesterday" is the previous month and today's cell leaves the DOM. The
+spec passed on 30 or 31 days of every month and failed on the first: green for
+months, then red on 2026-09-01 against a `main` whose last run, six hours earlier,
+had been green with the same code.
+
+The cell assertions now run before the shortcut, and the shortcut half gains an
+assertion that the grid followed the selection into the previous month — the
+behaviour that made the old ordering fail is now pinned rather than merely
+avoided. No product code changes.

--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -196,14 +196,16 @@ test.describe('Onboarding flow', () => {
       localeText('en', 'onboarding.step1.yesterday')
     );
 
-    const yesterday = shiftISODate(today, -1);
-    await onboardingShortcut(page, 'yesterday').focus();
-    await page.keyboard.press('Enter');
-    await expect(transport).toHaveValue(yesterday);
-    await expect(onboardingDayCell(page, yesterday)).toHaveAttribute('aria-pressed', 'true');
-
     // Grid cells are real buttons with the date as their accessible name and a
     // tap target well above the 24 px floor.
+    //
+    // This runs BEFORE the yesterday shortcut on purpose. Selecting a date moves
+    // the grid to that date's month, so on the first of a month "yesterday" is
+    // the previous month and today's cell leaves the DOM entirely — the grid
+    // renders one month, without the neighbouring days. Asserted after the
+    // shortcut, this block passed on 30 or 31 days of the month and failed on
+    // the first, which is how it went green for months and then broke on
+    // 2026-09-01 with no code change behind it.
     const todayCell = onboardingDayCell(page, today);
     expect(await todayCell.evaluate((node) => node.tagName)).toBe('BUTTON');
     const expectedName = await page.evaluate(
@@ -218,6 +220,15 @@ test.describe('Onboarding flow', () => {
     const cellBox = await todayCell.boundingBox();
     expect(cellBox!.width).toBeGreaterThanOrEqual(24);
     expect(cellBox!.height).toBeGreaterThanOrEqual(24);
+
+    const yesterday = shiftISODate(today, -1);
+    await onboardingShortcut(page, 'yesterday').focus();
+    await page.keyboard.press('Enter');
+    await expect(transport).toHaveValue(yesterday);
+    await expect(onboardingDayCell(page, yesterday)).toHaveAttribute('aria-pressed', 'true');
+    // The grid followed the selection: on the first of a month that is the
+    // previous month, and the shortcut must still land on the right day.
+    await expect(picker).toHaveAttribute('data-onboarding-visible-month', yesterday.slice(0, 7));
 
     await selectOnboardingStartDate(page, today);
     await onboardingStepOneSubmit(page).click();


### PR DESCRIPTION
`main` is red on `e2e-shard (2)` right now, with no code change behind it, and it takes every open
PR down with it.

**What broke.** The step-1 onboarding spec asserts today's grid cell AFTER pressing the "yesterday"
shortcut. `selectOnboardingDate` moves the visible month to the selected date's month, and the grid
renders one month with no neighbouring days — so on the first of a month "yesterday" is the previous
month and today's cell leaves the DOM. The spec passed on 30 or 31 days of every month and failed on
the first.

**Measured, not inferred.** `main`'s last run before midnight (2026-08-31T23:51Z) was green; a
`workflow_dispatch` of the SAME commit at 2026-09-01T01:45Z failed on this test
([run 33459963709](https://github.com/ovumcy/ovumcy-web/actions/runs/33459963709)). Two unrelated
open PRs — #657 and #658, one of which touches no UI at all — failed identically, which is what
ruled the branches out before this fix was written.

**Change.** The cell assertions move above the shortcut. The shortcut half gains an assertion that
the grid followed the selection into the previous month, so the behaviour that broke the old
ordering is pinned rather than stepped around. No product code changes — the picker is correct, the
spec assumed one month.

**Rollback.** Revert the commit; test-only, and the suite returns to failing one day in thirty.
