### PR TITLE
fix(dashboard): the ovulation line names the detector's day

### DIFF
--- a/changelog.d/dashboard-ovulation-line-names-the-detectors-day.md
+++ b/changelog.d/dashboard-ovulation-line-names-the-detectors-day.md
@@ -1,0 +1,20 @@
+### Fixed
+
+- **The dashboard's ovulation line now names the day your temperatures point at.** When basal body
+  temperature is tracked and the readings show a sustained thermal shift, that shift confirms an
+  ovulation that has already happened and says which day it was. The month grid and the stats chart
+  both name that day. The dashboard line did not — it kept naming the day the cycle model had
+  projected before any temperature arrived.
+
+  The two disagreed most visibly on the projected day itself. The line rolls its estimate forward to
+  the next cycle only once the projected day is behind you, so on that day it stayed put and
+  announced an ovulation as happening now, while the calendar beside it marked the same ovulation
+  several days earlier. For someone reading the two together to time anything, that is the
+  difference between "today still counts" and "this window has closed".
+
+  The line now names the confirmed day, and — because that day is usually already behind you — it is
+  shown as past rather than announced as upcoming. Both surfaces resolve the day through one shared
+  reader, so a single shift can no longer produce two dates. Nothing here changes *whether* an
+  estimate is shown: an account with predictions turned off, a paused pregnancy estimate, or an
+  overdue cycle withholds the ovulation estimate exactly as before, and a recorded shift is not a way
+  around that. With no shift recorded, the projected day is shown unchanged.

--- a/changelog.d/dashboard-ovulation-line-names-the-detectors-day.md
+++ b/changelog.d/dashboard-ovulation-line-names-the-detectors-day.md
@@ -24,6 +24,12 @@
   already named, and both used to hide it while the calendar went on marking it — for irregular
   cycles, the very accounts the model serves worst.
 
+  One thing does stop appearing, and that is the point of the change: the dashboard's "ovulation is
+  coming" reminder no longer counts down to a day the temperatures have already placed behind you.
+  It counted down to the projection, so on the projected day it announced an ovulation as arriving
+  today while the calendar beside it marked the same one several days earlier. With no shift
+  recorded it counts down exactly as before.
+
   Nothing here changes *whether* an estimate is shown. An account with predictions turned off, a
   paused pregnancy estimate, an overdue cycle, or an account that has not completed a single cycle
   yet withholds the ovulation estimate exactly as before, on the dashboard and the calendar alike —

--- a/changelog.d/dashboard-ovulation-line-names-the-detectors-day.md
+++ b/changelog.d/dashboard-ovulation-line-names-the-detectors-day.md
@@ -14,7 +14,16 @@
 
   The line now names the confirmed day, and — because that day is usually already behind you — it is
   shown as past rather than announced as upcoming. Both surfaces resolve the day through one shared
-  reader, so a single shift can no longer produce two dates. Nothing here changes *whether* an
-  estimate is shown: an account with predictions turned off, a paused pregnancy estimate, or an
-  overdue cycle withholds the ovulation estimate exactly as before, and a recorded shift is not a way
-  around that. With no shift recorded, the projected day is shown unchanged.
+  reader, so a single shift can no longer produce two dates.
+
+  A measurement also outranks the two ways the dashboard expresses how uncertain a *projection* is: a
+  confirmed day is named as a day rather than widened into the range shown for irregular cycles, and
+  it is not withheld under "needs more cycles". Neither of those is about a day the temperatures have
+  already named, and both used to hide it while the calendar went on marking it — for irregular
+  cycles, the very accounts the model serves worst.
+
+  Nothing here changes *whether* an estimate is shown. An account with predictions turned off, a
+  paused pregnancy estimate, an overdue cycle, or an account that has not completed a single cycle
+  yet withholds the ovulation estimate exactly as before, on the dashboard and the calendar alike —
+  they now read that decision from one place instead of each applying it separately. With no shift
+  recorded, the projected day is shown unchanged.

--- a/changelog.d/dashboard-ovulation-line-names-the-detectors-day.md
+++ b/changelog.d/dashboard-ovulation-line-names-the-detectors-day.md
@@ -12,9 +12,11 @@
   several days earlier. For someone reading the two together to time anything, that is the
   difference between "today still counts" and "this window has closed".
 
-  The line now names the confirmed day, and — because that day is usually already behind you — it is
-  shown as past rather than announced as upcoming. Both surfaces resolve the day through one shared
-  reader, so a single shift can no longer produce two dates.
+  The line now names the confirmed day, which is usually already behind you, instead of announcing
+  one as upcoming. It does not raise the "date is already in the past" notice while doing so: that
+  notice is about an estimate the app is still pointing at after its day has gone by, and a measured
+  ovulation being behind you is simply what the rest of a cycle looks like. Both surfaces resolve the
+  day through one shared reader, so a single shift can no longer produce two dates.
 
   A measurement also outranks the two ways the dashboard expresses how uncertain a *projection* is: a
   confirmed day is named as a day rather than widened into the range shown for irregular cycles, and

--- a/internal/api/dashboard_confirmed_ovulation_test.go
+++ b/internal/api/dashboard_confirmed_ovulation_test.go
@@ -121,4 +121,14 @@ func TestDashboardNamesTheConfirmedDayForTheThinHistoryCohort(t *testing.T) {
 	if projected := services.LocalizedDateDisplay("en", today); strings.Contains(slot, projected) {
 		t.Fatalf("the ovulation slot still names the projected day %q: %q", projected, slot)
 	}
+
+	// The amber notice is about a projection the model still points at after the
+	// day has gone by. A measured ovulation is behind the owner for the whole
+	// luteal phase by design, so reading it as that notice would leave the
+	// warning standing for a fortnight of every cycle. The next period is
+	// fifteen days out in this fixture, so its own in-past branch cannot be what
+	// keeps this quiet.
+	if dashboardElementByDataAttr(document, "data-dashboard-prediction-past") != nil {
+		t.Fatal("a confirmed ovulation must not raise the stale-projection notice")
+	}
 }

--- a/internal/api/dashboard_confirmed_ovulation_test.go
+++ b/internal/api/dashboard_confirmed_ovulation_test.go
@@ -1,0 +1,124 @@
+package api
+
+// dashboard_confirmed_ovulation_test.go — the RENDERED ovulation slot, for the
+// one cohort whose divergence a context-level assertion cannot see.
+//
+// services.BuildDashboardCycleContext keeps DisplayOvulationDate once the
+// thermal detector has confirmed a day, but dashboard.html tests
+// DisplayOvulationNeedsData BEFORE the branch that names a date — so for an
+// irregular account with one or two completed cycles the caption won and the
+// date it carried was never reached, while the calendar grid (gated on
+// FertilityProjectionSuppressed alone) marked the detector's day. A test that
+// read the context alone was green through all of it.
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+	"github.com/ovumcy/ovumcy-web/internal/services"
+)
+
+// dashboardConfirmedOvulationBBT is the 3-over-6 series the shared detector
+// resolves: six undisturbed readings fill the coverline window on cycle days
+// 6..11, three elevated ones follow on days 12..14. The detector names the last
+// low day, cycle day 11.
+const (
+	dashboardConfirmedOvulationLowBBT  = 36.20
+	dashboardConfirmedOvulationHighBBT = 36.50
+)
+
+// TestDashboardNamesTheConfirmedDayForTheThinHistoryCohort builds the cohort
+// that meets dashboardNeedsOvulationData (irregular, one completed cycle) while
+// clearing the first-cycle fertility floor, records a thermal shift in the
+// current cycle, and reads the rendered slot.
+//
+// Anchors first: the slot must exist at all (the trying-to-conceive goal and a
+// cleared floor put it there), so a fixture that drifts out of the band fails
+// loudly instead of passing on an absent surface.
+func TestDashboardNamesTheConfirmedDayForTheThinHistoryCohort(t *testing.T) {
+	app, database, _ := newOnboardingTestAppWithLocation(t, time.UTC)
+	user := createOnboardingTestUser(t, database, "dashboard-confirmed-ovulation@example.com", "StrongPass1", true)
+
+	today := services.DateAtLocation(time.Now().UTC(), time.UTC)
+	const cycleLength = 28
+	const periodLength = 5
+	// Cycle day 14 today, so the model projects ovulation on today itself: the
+	// day the projection and the measurement disagree by three days.
+	cycleStart := today.AddDate(0, 0, -13)
+	previousStart := cycleStart.AddDate(0, 0, -cycleLength)
+	confirmedDay := cycleStart.AddDate(0, 0, 10)
+
+	if err := database.Model(&models.User{}).Where("id = ?", user.ID).Updates(map[string]any{
+		"cycle_length":      cycleLength,
+		"period_length":     periodLength,
+		"last_period_start": cycleStart,
+		"usage_goal":        models.UsageGoalTrying,
+		"irregular_cycle":   true,
+		"track_bbt":         true,
+	}).Error; err != nil {
+		t.Fatalf("update confirmed-ovulation cycle context: %v", err)
+	}
+
+	// Two starts, so exactly one completed cycle: under three (the withholding
+	// this test is about) and at least one (the floor that would withhold the
+	// slot entirely).
+	for _, start := range []time.Time{previousStart, cycleStart} {
+		for offset := range periodLength {
+			if err := database.Create(&models.DailyLog{
+				UserID:     user.ID,
+				Date:       start.AddDate(0, 0, offset),
+				IsPeriod:   true,
+				CycleStart: offset == 0,
+				Flow:       models.FlowMedium,
+			}).Error; err != nil {
+				t.Fatalf("create period log %s day %d: %v", start.Format("2006-01-02"), offset, err)
+			}
+		}
+	}
+	for offset := 5; offset <= 13; offset++ {
+		temperature := dashboardConfirmedOvulationLowBBT
+		if offset > 10 {
+			temperature = dashboardConfirmedOvulationHighBBT
+		}
+		value := temperature
+		if err := database.Create(&models.DailyLog{
+			UserID: user.ID,
+			Date:   cycleStart.AddDate(0, 0, offset),
+			BBT:    &value,
+		}).Error; err != nil {
+			t.Fatalf("create bbt log at cycle day %d: %v", offset+1, err)
+		}
+	}
+
+	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
+	request := httptest.NewRequest(http.MethodGet, "/dashboard", nil)
+	request.Header.Set("Accept-Language", "en")
+	request.Header.Set("Cookie", authCookie)
+	response := mustAppResponse(t, app, request)
+	assertStatusCode(t, response, http.StatusOK)
+
+	document := mustParseHTMLDocument(t, mustReadBodyString(t, response.Body))
+	header := dashboardElementByDataAttr(document, "data-dashboard-status-header")
+	if header == nil {
+		t.Fatal("fixture anchor: expected the dashboard status header")
+	}
+	ovulation := dashboardElementByDataAttr(header, "data-dashboard-ovulation")
+	if ovulation == nil {
+		t.Fatal("fixture anchor: expected the ovulation slot in the status line")
+	}
+
+	slot := normalizeHTMLText(htmlNodeText(ovulation))
+	if strings.Contains(slot, "completed cycles are needed") {
+		t.Fatalf("the ovulation slot withheld a measured day behind the thin-history caption: %q", slot)
+	}
+	if want := services.LocalizedDateDisplay("en", confirmedDay); !strings.Contains(slot, want) {
+		t.Fatalf("the ovulation slot = %q, want the detector's day %q", slot, want)
+	}
+	if projected := services.LocalizedDateDisplay("en", today); strings.Contains(slot, projected) {
+		t.Fatalf("the ovulation slot still names the projected day %q: %q", projected, slot)
+	}
+}

--- a/internal/api/page_view_data_helpers.go
+++ b/internal/api/page_view_data_helpers.go
@@ -40,6 +40,7 @@ func (handler *Handler) buildDashboardViewData(ctx context.Context, user *models
 		"DisplayOvulationRangeEnd":              viewData.CycleContext.DisplayOvulationRangeEnd,
 		"DisplayOvulationUseRange":              viewData.CycleContext.DisplayOvulationUseRange,
 		"DisplayOvulationNeedsData":             viewData.CycleContext.DisplayOvulationNeedsData,
+		"DisplayOvulationConfirmed":             viewData.CycleContext.DisplayOvulationConfirmed,
 		"DisplayOvulationExact":                 viewData.CycleContext.DisplayOvulationExact,
 		"DisplayOvulationImpossible":            viewData.CycleContext.DisplayOvulationImpossible,
 		"NextPeriodEstimatePaused":              viewData.CycleContext.NextPeriodEstimatePaused,

--- a/internal/services/calendar_day_comparison_regression_test.go
+++ b/internal/services/calendar_day_comparison_regression_test.go
@@ -303,7 +303,7 @@ func TestBuildDashboardCycleContextKeepsTodaysOvulationOutOfThePastWarning(t *te
 				CurrentCycleDay:     14,
 			}
 
-			context := BuildDashboardCycleContext(user, stats, today, location)
+			context := BuildDashboardCycleContext(user, nil, stats, today, location)
 			if got := CalendarDayKey(context.DisplayOvulationDate); got != ovulationDay {
 				t.Fatalf("displayed ovulation date = %s, want %s", got, ovulationDay)
 			}

--- a/internal/services/calendar_days.go
+++ b/internal/services/calendar_days.go
@@ -415,10 +415,10 @@ func appendCurrentCycleBBTSignal(user *models.User, logs []models.DailyLog, stat
 		return
 	}
 
-	ovulationSignal := inferBBTOvulationDate(filterLogsNotAfter(logs, today), cycleStart, CalendarDay(stats.NextPeriodStart, location), location)
+	ovulationSignal, confirmed := ConfirmedCurrentCycleOvulation(user, logs, stats, today, location)
 	projectedKey := CalendarDayKey(stats.OvulationDate)
 	delete(ovulationMap, projectedKey)
-	if ovulationSignal.IsZero() {
+	if !confirmed {
 		tentativeOvulationMap[projectedKey] = true
 		return
 	}

--- a/internal/services/calendar_view_service.go
+++ b/internal/services/calendar_view_service.go
@@ -66,7 +66,7 @@ func (service *CalendarViewService) BuildCalendarPageViewData(ctx context.Contex
 	minMonth := CalendarMinimumNavigableMonth(user, location)
 	prevMonth, nextMonth := CalendarAdjacentMonthValuesWithinBounds(monthStart, minMonth)
 	dayStates := BuildCalendarDayStates(user, monthStart, logs, stats, now, location)
-	cycleContext := BuildDashboardCycleContext(user, stats, DateAtLocation(now, location), location)
+	cycleContext := BuildDashboardCycleContext(user, logs, stats, DateAtLocation(now, location), location)
 	cycleFactorExplanation, hasCycleFactorExplanation := buildStatsCycleFactorExplanation(user, statsLogs, stats, now, location)
 	predictionExplanation := BuildOwnerPredictionExplanation(user, cycleContext, hasCycleFactorExplanation && len(cycleFactorExplanation.HintFactorKeys) > 0)
 

--- a/internal/services/calendar_view_service.go
+++ b/internal/services/calendar_view_service.go
@@ -66,7 +66,12 @@ func (service *CalendarViewService) BuildCalendarPageViewData(ctx context.Contex
 	minMonth := CalendarMinimumNavigableMonth(user, location)
 	prevMonth, nextMonth := CalendarAdjacentMonthValuesWithinBounds(monthStart, minMonth)
 	dayStates := BuildCalendarDayStates(user, monthStart, logs, stats, now, location)
-	cycleContext := BuildDashboardCycleContext(user, logs, stats, DateAtLocation(now, location), location)
+	// statsLogs, not the grid's set: `logs` is the window around the MONTH being
+	// viewed (CalendarLogRange), so a past month excludes the current cycle
+	// entirely and the confirmation would answer "no shift" purely because of
+	// where the owner navigated. The cycle context describes the cycle the owner
+	// is in, and the stats window is anchored on now.
+	cycleContext := BuildDashboardCycleContext(user, statsLogs, stats, DateAtLocation(now, location), location)
 	cycleFactorExplanation, hasCycleFactorExplanation := buildStatsCycleFactorExplanation(user, statsLogs, stats, now, location)
 	predictionExplanation := BuildOwnerPredictionExplanation(user, cycleContext, hasCycleFactorExplanation && len(cycleFactorExplanation.HintFactorKeys) > 0)
 

--- a/internal/services/cycle_median_projection_test.go
+++ b/internal/services/cycle_median_projection_test.go
@@ -109,7 +109,7 @@ func TestMedianProjectionAgreesAcrossSurfaces(t *testing.T) {
 	assertDay("stats.NextPeriodStart", stats.NextPeriodStart, medianNext)
 
 	// 2. Dashboard hero displayed next-period.
-	cycleContext := BuildDashboardCycleContext(user, stats, today, loc)
+	cycleContext := BuildDashboardCycleContext(user, nil, stats, today, loc)
 	assertDay("DisplayNextPeriodStart", cycleContext.DisplayNextPeriodStart, medianNext)
 
 	// 3. Webhook period reminder anchor/event (lead wide enough to cover 28 days).

--- a/internal/services/cycle_signals.go
+++ b/internal/services/cycle_signals.go
@@ -142,6 +142,23 @@ func ConfirmedCurrentCycleOvulation(user *models.User, logs []models.DailyLog, s
 		return time.Time{}, false
 	}
 
+	// The gate lives HERE rather than at each surface, so the calendar and the
+	// dashboard cannot gate the same signal differently. It is the same
+	// predicate the calendar already wrapped this pass in
+	// (FertilityProjectionSuppressed = unpredictable · pregnancy-paused ·
+	// overdue, plus the first-cycle floor), read once instead of restated —
+	// prediction-display.md forbids a surface recombining the signals itself.
+
+	// The gate lives HERE rather than at each surface, so the calendar and the
+	// dashboard cannot gate the same signal differently. It is the same
+	// predicate the calendar already wrapped this pass in
+	// (FertilityProjectionSuppressed = unpredictable · pregnancy-paused ·
+	// overdue, plus the first-cycle floor), read once instead of restated —
+	// prediction-display.md forbids a surface recombining the signals itself.
+	if FertilityProjectionSuppressed(user, stats) {
+		return time.Time{}, false
+	}
+
 	cycleStart := CalendarDay(stats.LastPeriodStart, location)
 	if CalendarDaysBetween(cycleStart, today) < 0 {
 		return time.Time{}, false

--- a/internal/services/cycle_signals.go
+++ b/internal/services/cycle_signals.go
@@ -122,6 +122,38 @@ func deriveUserLutealPhase(logs []models.DailyLog, now time.Time, location *time
 	return defaultLutealPhaseDays
 }
 
+// ConfirmedCurrentCycleOvulation reports the day the shared "3-over-6" thermal
+// detector CONFIRMS for the owner's CURRENT cycle, and whether it found one.
+//
+// A detected shift names an ovulation that has already happened; it never
+// predicts one. Every surface that may show a confirmed ovulation resolves it
+// here — the calendar's solid marker and the dashboard's ovulation line — so the
+// two cannot name different days for one shift. That divergence is not
+// hypothetical: the grid and the stats chart named two days for one shift until
+// the marker was moved onto the detector's own date, and the dashboard line was
+// left behind on the model's date by that same change.
+//
+// The logs are bounded at the owner's today first: a reading recorded against a
+// future date must not confirm an ovulation that has not happened. The caller
+// supplies today so that a surface which has already resolved it does not
+// resolve a second, possibly different one.
+func ConfirmedCurrentCycleOvulation(user *models.User, logs []models.DailyLog, stats CycleStats, today time.Time, location *time.Location) (time.Time, bool) {
+	if user == nil || !user.TrackBBT || stats.LastPeriodStart.IsZero() || stats.OvulationDate.IsZero() || stats.NextPeriodStart.IsZero() {
+		return time.Time{}, false
+	}
+
+	cycleStart := CalendarDay(stats.LastPeriodStart, location)
+	if CalendarDaysBetween(cycleStart, today) < 0 {
+		return time.Time{}, false
+	}
+
+	signal := inferBBTOvulationDate(filterLogsNotAfter(logs, today), cycleStart, CalendarDay(stats.NextPeriodStart, location), location)
+	if signal.IsZero() {
+		return time.Time{}, false
+	}
+	return signal, true
+}
+
 func inferObservedOvulationDate(logs []models.DailyLog, cycleStart time.Time, nextStart time.Time, location *time.Location) time.Time {
 	bbtDate := inferBBTOvulationDate(logs, cycleStart, nextStart, location)
 	if !bbtDate.IsZero() {

--- a/internal/services/cycle_signals.go
+++ b/internal/services/cycle_signals.go
@@ -148,13 +148,6 @@ func ConfirmedCurrentCycleOvulation(user *models.User, logs []models.DailyLog, s
 	// (FertilityProjectionSuppressed = unpredictable · pregnancy-paused ·
 	// overdue, plus the first-cycle floor), read once instead of restated —
 	// prediction-display.md forbids a surface recombining the signals itself.
-
-	// The gate lives HERE rather than at each surface, so the calendar and the
-	// dashboard cannot gate the same signal differently. It is the same
-	// predicate the calendar already wrapped this pass in
-	// (FertilityProjectionSuppressed = unpredictable · pregnancy-paused ·
-	// overdue, plus the first-cycle floor), read once instead of restated —
-	// prediction-display.md forbids a surface recombining the signals itself.
 	if FertilityProjectionSuppressed(user, stats) {
 		return time.Time{}, false
 	}

--- a/internal/services/dashboard_confirmed_ovulation_test.go
+++ b/internal/services/dashboard_confirmed_ovulation_test.go
@@ -150,3 +150,60 @@ func TestDashboardOvulationLineLeavesSuppressionAlone(t *testing.T) {
 		t.Fatalf("suppressed account still renders an ovulation date (%s): a confirmed shift must not be a way around the gate", CalendarDayKey(context.DisplayOvulationDate))
 	}
 }
+
+// TestDashboardOvulationLineOutranksTheIrregularRange and its sibling below
+// cover the two ways the dashboard expresses PROJECTION uncertainty. Neither is
+// a suppression gate, and neither is about a day the temperatures have already
+// named — but both used to discard the confirmed date, leaving the calendar
+// marking a day the dashboard would not name. The calendar gates this signal on
+// FertilityProjectionSuppressed alone, which neither cohort here meets.
+func TestDashboardOvulationLineOutranksTheIrregularRange(t *testing.T) {
+	user, logs, stats, today := confirmedOvulationFixture(t)
+	// dashboardIrregularPredictionRangeEnabled: irregular, >= 3 completed
+	// cycles, and a real min/max spread.
+	user.IrregularCycle = true
+	stats.MinCycleLength = 25
+	stats.MaxCycleLength = 33
+
+	context := BuildDashboardCycleContext(user, logs, stats, today, time.UTC)
+
+	if context.DisplayOvulationUseRange {
+		t.Error("a confirmed ovulation must be named as a day, not widened into a range built from cycle-length spread")
+	}
+	if got := CalendarDayKey(context.DisplayOvulationDate); got != "2026-03-11" {
+		t.Fatalf("dashboard ovulation line = %s, want 2026-03-11 for an irregular account whose temperatures confirmed the day", got)
+	}
+}
+
+func TestDashboardOvulationLineOutranksTheThinHistoryWithholding(t *testing.T) {
+	user, logs, stats, today := confirmedOvulationFixture(t)
+	// dashboardNeedsOvulationData: irregular with fewer than three completed
+	// cycles. One completed cycle keeps the first-cycle floor from firing, so
+	// the calendar still marks the detector's day.
+	user.IrregularCycle = true
+	stats.CompletedCycleCount = 1
+
+	context := BuildDashboardCycleContext(user, logs, stats, today, time.UTC)
+
+	if got := CalendarDayKey(context.DisplayOvulationDate); got != "2026-03-11" {
+		t.Fatalf("dashboard ovulation line = %s, want 2026-03-11: \"needs more cycles\" is about a projection, not about a recorded thermal shift", got)
+	}
+}
+
+// TestConfirmedOvulationStopsAtTheFirstCycleFloor is the other side: the
+// calendar withholds the BBT pass entirely under FertilityProjectionSuppressed,
+// so the resolver must too, or the dashboard would name a day the grid refuses
+// to mark — the same divergence pointing the other way.
+func TestConfirmedOvulationStopsAtTheFirstCycleFloor(t *testing.T) {
+	user, logs, stats, today := confirmedOvulationFixture(t)
+	stats.CompletedCycleCount = 0
+
+	if _, ok := ConfirmedCurrentCycleOvulation(user, logs, stats, today, time.UTC); ok {
+		t.Fatal("with no completed cycle the fertility projection is suppressed on every surface, so nothing may be confirmed here either")
+	}
+
+	context := BuildDashboardCycleContext(user, logs, stats, today, time.UTC)
+	if got := CalendarDayKey(context.DisplayOvulationDate); got == "2026-03-11" {
+		t.Fatal("the dashboard must not name the detector's day while the calendar withholds it under the first-cycle floor")
+	}
+}

--- a/internal/services/dashboard_confirmed_ovulation_test.go
+++ b/internal/services/dashboard_confirmed_ovulation_test.go
@@ -114,6 +114,37 @@ func TestDashboardOvulationLineNamesTheConfirmedDay(t *testing.T) {
 	}
 }
 
+// TestConfirmedOvulationStopsTheCountdownBanner is the one thing this pass makes
+// STOP appearing, so it is asserted rather than left to be noticed. The banner
+// counts down to DisplayOvulationDate, and on the projected day it announced an
+// ovulation as arriving today while the calendar marked the same one several
+// days back — announcing a day the temperatures have already placed behind the
+// owner is the defect, not a side effect of fixing it. The control is the same
+// cycle with no thermal evidence, where the countdown is exactly as it was.
+func TestConfirmedOvulationStopsTheCountdownBanner(t *testing.T) {
+	user, logs, stats, today := confirmedOvulationFixture(t)
+
+	confirmedContext := BuildDashboardCycleContext(user, logs, stats, today, time.UTC)
+	if banner := BuildDashboardReminderBanner(confirmedContext, today, 3); banner.Show && banner.Kind == DashboardReminderBannerKindOvulation {
+		t.Fatalf("the banner counted down to an ovulation the temperatures placed behind the owner: %+v", banner)
+	}
+
+	// Same cycle, temperatures removed: the projected day is today, so the
+	// countdown must still be there — without this the assertion above would
+	// also pass for a banner that had simply stopped working.
+	periodOnly := make([]models.DailyLog, 0, len(logs))
+	for _, entry := range logs {
+		if entry.BBT == nil {
+			periodOnly = append(periodOnly, entry)
+		}
+	}
+	controlContext := BuildDashboardCycleContext(user, periodOnly, stats, today, time.UTC)
+	banner := BuildDashboardReminderBanner(controlContext, today, 3)
+	if !banner.Show || banner.Kind != DashboardReminderBannerKindOvulation {
+		t.Fatalf("control: with no shift recorded the ovulation countdown must still show, got %+v", banner)
+	}
+}
+
 // TestDashboardOvulationLineKeepsTheProjectionWithoutAShift is the control: the
 // same cycle with no thermal evidence must still name the projected day and
 // must not be reported as past. Without it the assertion above would also pass

--- a/internal/services/dashboard_confirmed_ovulation_test.go
+++ b/internal/services/dashboard_confirmed_ovulation_test.go
@@ -1,0 +1,152 @@
+package services
+
+// dashboard_confirmed_ovulation_test.go — the dashboard's ovulation line names
+// the day the temperatures point at, not the projection that day superseded.
+//
+// The calendar's solid marker and the stats chart both moved onto the
+// detector's own date; the dashboard line did not. It is fed by
+// DashboardUpcomingPredictions, which rolls its anchor to the NEXT cycle only
+// when CalendarDaysBetween(window.OvulationDate, today) > 0 — so on the very day
+// the projection fell on, the difference is zero, the anchor stays, and the line
+// announces an ovulation the recorded temperatures place several days earlier.
+// One shift, two dates, on the two surfaces an owner reads side by side.
+//
+// Both surfaces now resolve the day through ConfirmedCurrentCycleOvulation. The
+// substitution changes only WHICH day is named: whether a day may be named at
+// all stays with the suppression gates (prediction-display.md).
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+)
+
+// confirmedOvulationFixture builds the reproducing cycle: it starts 2026-03-01,
+// runs 28 days with a 14-day luteal phase, so the model projects ovulation on
+// cycle day 14 — 2026-03-14, which is also "today" in the test. Undisturbed
+// temperatures on cycle days 6..11 fill the coverline window and days 12..14 are
+// elevated, so the shared 3-over-6 detector names cycle day 11, 2026-03-11.
+func confirmedOvulationFixture(t *testing.T) (*models.User, []models.DailyLog, CycleStats, time.Time) {
+	t.Helper()
+
+	cycleStart := cyclesignalsCovDay(t, "2026-03-01")
+	logs := []models.DailyLog{
+		{Date: cycleStart, IsPeriod: true, CycleStart: true, Flow: models.FlowMedium},
+		{Date: cyclesignalsCovDay(t, "2026-03-02"), IsPeriod: true, Flow: models.FlowMedium},
+	}
+	for _, day := range []string{"2026-03-06", "2026-03-07", "2026-03-08", "2026-03-09", "2026-03-10", "2026-03-11"} {
+		logs = append(logs, cyclesignalsCovBBTLog(t, day, 36.20))
+	}
+	for _, day := range []string{"2026-03-12", "2026-03-13", "2026-03-14"} {
+		logs = append(logs, cyclesignalsCovBBTLog(t, day, 36.50))
+	}
+
+	user := &models.User{ID: 1, Role: models.RoleOwner, TrackBBT: true}
+	stats := CycleStats{
+		CompletedCycleCount: 3,
+		MedianCycleLength:   28,
+		AverageCycleLength:  28,
+		AveragePeriodLength: 5,
+		LutealPhase:         14,
+		CurrentCycleDay:     14,
+		LastPeriodStart:     cycleStart,
+		OvulationDate:       cyclesignalsCovDay(t, "2026-03-14"),
+		NextPeriodStart:     cyclesignalsCovDay(t, "2026-03-29"),
+	}
+	today := time.Date(2026, time.March, 14, 0, 0, 0, 0, time.UTC)
+	return user, logs, stats, today
+}
+
+// TestConfirmedCurrentCycleOvulationReadsTheDetectorsDay pins the shared
+// resolver before either surface is asked about it, so a failure below reads as
+// a surface defect rather than as a fixture that never confirmed anything.
+func TestConfirmedCurrentCycleOvulationReadsTheDetectorsDay(t *testing.T) {
+	user, logs, stats, today := confirmedOvulationFixture(t)
+
+	confirmed, ok := ConfirmedCurrentCycleOvulation(user, logs, stats, today, time.UTC)
+	if !ok {
+		t.Fatal("fixture: the 3-over-6 detector must confirm a shift in this cycle")
+	}
+	if got := CalendarDayKey(confirmed); got != "2026-03-11" {
+		t.Fatalf("fixture: confirmed ovulation = %s, want 2026-03-11", got)
+	}
+	if got := CalendarDayKey(stats.OvulationDate); got != "2026-03-14" {
+		t.Fatalf("fixture: the model must still project 2026-03-14, got %s", got)
+	}
+}
+
+func TestDashboardOvulationLineNamesTheConfirmedDay(t *testing.T) {
+	user, logs, stats, today := confirmedOvulationFixture(t)
+
+	context := BuildDashboardCycleContext(user, logs, stats, today, time.UTC)
+
+	if got := CalendarDayKey(context.DisplayOvulationDate); got != "2026-03-11" {
+		t.Fatalf("dashboard ovulation line = %s, want 2026-03-11: the temperatures confirm that day and the calendar marker already names it", got)
+	}
+	if !context.OvulationInPast {
+		t.Fatal("a confirmed ovulation three days behind the owner must render as past, not as still upcoming")
+	}
+}
+
+// TestDashboardOvulationLineKeepsTheProjectionWithoutAShift is the control: the
+// same cycle with no thermal evidence must still name the projected day and
+// must not be reported as past. Without it the assertion above would also pass
+// for a line that had simply stopped showing a projection.
+func TestDashboardOvulationLineKeepsTheProjectionWithoutAShift(t *testing.T) {
+	user, _, stats, today := confirmedOvulationFixture(t)
+
+	periodOnly := []models.DailyLog{
+		{Date: cyclesignalsCovDay(t, "2026-03-01"), IsPeriod: true, CycleStart: true, Flow: models.FlowMedium},
+		{Date: cyclesignalsCovDay(t, "2026-03-02"), IsPeriod: true, Flow: models.FlowMedium},
+	}
+
+	context := BuildDashboardCycleContext(user, periodOnly, stats, today, time.UTC)
+
+	if got := CalendarDayKey(context.DisplayOvulationDate); got != "2026-03-14" {
+		t.Fatalf("dashboard ovulation line = %s, want the projected 2026-03-14 when no shift is recorded", got)
+	}
+	if context.OvulationInPast {
+		t.Fatal("the projected day is today, so it must not be reported as past")
+	}
+}
+
+// TestDashboardAndCalendarNameOneDayForOneShift is the point of the shared
+// resolver: the two surfaces an owner reads side by side must not disagree.
+func TestDashboardAndCalendarNameOneDayForOneShift(t *testing.T) {
+	user, logs, stats, today := confirmedOvulationFixture(t)
+	user.WeekStartsOn = models.WeekStartMonday
+
+	context := BuildDashboardCycleContext(user, logs, stats, today, time.UTC)
+	monthStart := time.Date(2026, time.March, 1, 0, 0, 0, 0, time.UTC)
+	days := BuildCalendarDayStates(user, monthStart, logs, stats, today, time.UTC)
+
+	solid := make([]string, 0, 1)
+	for _, day := range days {
+		if day.IsOvulation {
+			solid = append(solid, day.DateString)
+		}
+	}
+
+	if len(solid) != 1 {
+		t.Fatalf("expected exactly one solid ovulation marker in the current cycle's month, got %v", solid)
+	}
+	if solid[0] != CalendarDayKey(context.DisplayOvulationDate) {
+		t.Fatalf("calendar marks %s while the dashboard line says %s — one shift must produce one day", solid[0], CalendarDayKey(context.DisplayOvulationDate))
+	}
+}
+
+// TestDashboardOvulationLineLeavesSuppressionAlone pins the boundary the
+// substitution must not cross: a confirmed observation changes WHICH day is
+// named, never whether one is named. An unpredictable-cycle account withholds
+// the ovulation estimate, and a recorded thermal shift must not reinstate it.
+func TestDashboardOvulationLineLeavesSuppressionAlone(t *testing.T) {
+	user, logs, stats, today := confirmedOvulationFixture(t)
+	user.UnpredictableCycle = true
+
+	context := BuildDashboardCycleContext(user, logs, stats, today, time.UTC)
+
+	if !context.DisplayOvulationDate.IsZero() {
+		t.Fatalf("suppressed account still renders an ovulation date (%s): a confirmed shift must not be a way around the gate", CalendarDayKey(context.DisplayOvulationDate))
+	}
+}

--- a/internal/services/dashboard_confirmed_ovulation_test.go
+++ b/internal/services/dashboard_confirmed_ovulation_test.go
@@ -175,6 +175,13 @@ func TestDashboardOvulationLineOutranksTheIrregularRange(t *testing.T) {
 	}
 }
 
+// TestDashboardOvulationLineOutranksTheThinHistoryWithholding pins the CONTEXT
+// only. It cannot see the surface: dashboard.html tests
+// DisplayOvulationNeedsData before the branch that names a date, so a date left
+// here is not yet a date the owner reads. The rendered slot is
+// TestDashboardNamesTheConfirmedDayForTheThinHistoryCohort's subject
+// (internal/api), and the two are a pair — this one alone was green through the
+// whole defect.
 func TestDashboardOvulationLineOutranksTheThinHistoryWithholding(t *testing.T) {
 	user, logs, stats, today := confirmedOvulationFixture(t)
 	// dashboardNeedsOvulationData: irregular with fewer than three completed

--- a/internal/services/dashboard_confirmed_ovulation_test.go
+++ b/internal/services/dashboard_confirmed_ovulation_test.go
@@ -76,6 +76,22 @@ func TestConfirmedCurrentCycleOvulationReadsTheDetectorsDay(t *testing.T) {
 	}
 }
 
+// TestConfirmedOvulationIgnoresACycleStartRecordedAhead pins the last guard in
+// the resolver. manualCycleStartFutureDays lets an owner record a cycle start up
+// to two days ahead, and a cycle that has not begun cannot have ovulated: the
+// window handed to the detector would run backwards from a start later than the
+// readings. The calendar reaches the resolver behind its own copy of this test,
+// so without this the guard is only exercised through a surface that can no
+// longer fail it.
+func TestConfirmedOvulationIgnoresACycleStartRecordedAhead(t *testing.T) {
+	user, logs, stats, today := confirmedOvulationFixture(t)
+	stats.LastPeriodStart = today.AddDate(0, 0, 2)
+
+	if _, ok := ConfirmedCurrentCycleOvulation(user, logs, stats, today, time.UTC); ok {
+		t.Fatal("a cycle start recorded ahead of today must confirm nothing")
+	}
+}
+
 func TestDashboardOvulationLineNamesTheConfirmedDay(t *testing.T) {
 	user, logs, stats, today := confirmedOvulationFixture(t)
 
@@ -84,8 +100,17 @@ func TestDashboardOvulationLineNamesTheConfirmedDay(t *testing.T) {
 	if got := CalendarDayKey(context.DisplayOvulationDate); got != "2026-03-11" {
 		t.Fatalf("dashboard ovulation line = %s, want 2026-03-11: the temperatures confirm that day and the calendar marker already names it", got)
 	}
-	if !context.OvulationInPast {
-		t.Fatal("a confirmed ovulation three days behind the owner must render as past, not as still upcoming")
+	// OvulationInPast drives the amber "date is already in the past" notice,
+	// which is about a PROJECTION the model still points at after its day has
+	// gone by. A measured ovulation is behind the owner for the whole luteal
+	// phase by design, so reporting it here would leave that warning standing
+	// for a fortnight of every cycle — and DashboardUpcomingPredictions rolls a
+	// projected ovulation forward the moment it is past, which is why this flag
+	// had no other way to be true. The line still NAMES the past day; it just
+	// does not flag it. Rendered pair:
+	// TestDashboardNamesTheConfirmedDayForTheThinHistoryCohort (internal/api).
+	if context.OvulationInPast {
+		t.Fatal("a confirmed ovulation must not raise the stale-projection notice")
 	}
 }
 

--- a/internal/services/dashboard_cycle.go
+++ b/internal/services/dashboard_cycle.go
@@ -322,7 +322,7 @@ func DashboardUpcomingPredictions(stats CycleStats, user *models.User, today tim
 	return prediction
 }
 
-func BuildDashboardCycleContext(user *models.User, stats CycleStats, today time.Time, location *time.Location) DashboardCycleContext {
+func BuildDashboardCycleContext(user *models.User, logs []models.DailyLog, stats CycleStats, today time.Time, location *time.Location) DashboardCycleContext {
 	// The tier is a property of the account's history, so it is resolved before
 	// the suppression branches and carried by every one of them: a context that
 	// reported "not awaiting" merely because predictions are off would disable
@@ -356,7 +356,7 @@ func BuildDashboardCycleContext(user *models.User, stats CycleStats, today time.
 	cycleDayWarning := DashboardCycleDayLooksLong(stats.CurrentCycleDay, cycleDayReference)
 	cycleStaleAnchor := DashboardCycleStaleAnchor(user, stats, location)
 	cycleDataStale := DashboardCycleDataLooksStale(cycleStaleAnchor, today, cycleDayReference)
-	display := buildDashboardPredictionDisplay(user, stats, today, location)
+	display := buildDashboardPredictionDisplay(user, logs, stats, today, location)
 
 	return DashboardCycleContext{
 		CycleDayReference:           cycleDayReference,
@@ -390,7 +390,7 @@ func BuildDashboardCycleContext(user *models.User, stats CycleStats, today time.
 // dashboard renders, withholding the whole projected window once
 // DashboardCycleOverdue reports the cycle is past its reference length by more
 // than a week.
-func buildDashboardPredictionDisplay(user *models.User, stats CycleStats, today time.Time, location *time.Location) dashboardPredictionDisplay {
+func buildDashboardPredictionDisplay(user *models.User, logs []models.DailyLog, stats CycleStats, today time.Time, location *time.Location) dashboardPredictionDisplay {
 	prediction := DashboardUpcomingPredictions(
 		stats,
 		user,
@@ -407,6 +407,25 @@ func buildDashboardPredictionDisplay(user *models.User, stats CycleStats, today 
 		ovulationNeedsData:  dashboardNeedsOvulationData(user, stats),
 		ovulationExact:      prediction.OvulationExact,
 		ovulationImpossible: prediction.OvulationImpossible,
+	}
+
+	// A detected thermal shift CONFIRMS an ovulation that has already happened,
+	// so the line names the day the temperatures point at — the same day the
+	// calendar's solid marker and the stats chart name — rather than a projection
+	// that observation has superseded. Both surfaces resolve it through
+	// ConfirmedCurrentCycleOvulation so they cannot disagree.
+	//
+	// This substitution deliberately sits ABOVE the suppression branches and
+	// changes only WHICH day is named, never whether a day is named at all: what
+	// may render is prediction-display.md's subject, and a confirmed observation
+	// must not become a way around a gate. dashboardOvulationInPast then reads
+	// the substituted date, so a confirmed ovulation already behind the owner is
+	// rendered as past instead of announced as upcoming — which is the whole
+	// defect: on the projected day itself the difference to today was zero, the
+	// anchor never shifted, and the line declared an ovulation the temperatures
+	// had placed several days earlier.
+	if confirmed, ok := ConfirmedCurrentCycleOvulation(user, logs, stats, today, location); ok {
+		display.ovulationDate = confirmed
 	}
 	// The prompt is not a projection: with no recorded start there is no date
 	// to withhold and nothing for the overdue signal to be about, so it answers

--- a/internal/services/dashboard_cycle.go
+++ b/internal/services/dashboard_cycle.go
@@ -45,6 +45,15 @@ type DashboardCycleContext struct {
 	DisplayOvulationRangeEnd    time.Time
 	DisplayOvulationUseRange    bool
 	DisplayOvulationNeedsData   bool
+	// DisplayOvulationConfirmed marks DisplayOvulationDate as a MEASUREMENT.
+	// The dashboard reads it before the "needs more cycles" branch: that caption
+	// is about a projection built on thin history, and the calendar grid — gated
+	// on FertilityProjectionSuppressed alone — already marks the detector's day
+	// for this same cohort. The hero ring and the reminder banner deliberately
+	// keep gating on DisplayOvulationNeedsData: the ring is projection
+	// arithmetic, and the banner counts down to a day still ahead, neither of
+	// which a past measurement answers.
+	DisplayOvulationConfirmed   bool
 	DisplayOvulationExact       bool
 	DisplayOvulationImpossible  bool
 	NextPeriodEstimatePaused    bool
@@ -382,6 +391,7 @@ func BuildDashboardCycleContext(user *models.User, logs []models.DailyLog, stats
 		DisplayOvulationRangeEnd:    display.ovulationRangeEnd,
 		DisplayOvulationUseRange:    display.ovulationUseRange,
 		DisplayOvulationNeedsData:   display.ovulationNeedsData,
+		DisplayOvulationConfirmed:   display.ovulationConfirmed,
 		DisplayOvulationExact:       display.ovulationExact,
 		DisplayOvulationImpossible:  display.ovulationImpossible,
 		NextPeriodEstimatePaused:    display.estimatePaused,
@@ -504,13 +514,6 @@ func applyDashboardPredictionRanges(display dashboardPredictionDisplay, user *mo
 	// leave the dashboard and the calendar naming different things again, for
 	// the cohort whose model is weakest. The next-period range above is
 	// untouched: that projection is still a projection.
-	// A confirmed ovulation outranks the range. The range expresses the SPREAD
-	// of a projection, and there is no projection left to express once the
-	// temperatures have named the day — it is built from cycle-length spread and
-	// need not even contain that day. Discarding a measurement for it would
-	// leave the dashboard and the calendar naming different things again, for
-	// the cohort whose model is weakest. The next-period range above is
-	// untouched: that projection is still a projection.
 	if display.ovulationConfirmed {
 		return display
 	}
@@ -535,6 +538,14 @@ func finalizeDashboardPredictionDisplay(display dashboardPredictionDisplay) dash
 		// cohort (irregular, one or two completed cycles) does not meet, so
 		// withholding here while the grid marks the day is the same divergence
 		// this pair of surfaces was just brought into agreement over.
+		//
+		// Keeping the date is only half of it: the dashboard template tests
+		// DisplayOvulationNeedsData BEFORE the branch that names a date, so the
+		// caption wins over any date this function leaves behind. The template
+		// therefore reads DisplayOvulationConfirmed alongside it. Regression:
+		// TestDashboardNamesTheConfirmedDayForTheThinHistoryCohort renders the
+		// page rather than reading the context, which is what a context-level
+		// assertion could not tell apart.
 		return display
 	}
 	display.ovulationDate = time.Time{}

--- a/internal/services/dashboard_cycle.go
+++ b/internal/services/dashboard_cycle.go
@@ -571,6 +571,16 @@ func dashboardNextPeriodInPast(display dashboardPredictionDisplay, today time.Ti
 }
 
 func dashboardOvulationInPast(display dashboardPredictionDisplay, today time.Time) bool {
+	// The amber notice is about a PROJECTION the model still points at after the
+	// day has gone by. A measured ovulation being behind the owner is the normal
+	// state of every cycle from the shift until the next period, so reading it as
+	// that notice would raise a standing false alarm — for about a fortnight per
+	// cycle, on exactly the accounts whose data is best. DashboardUpcomingPredictions
+	// rolls a projected ovulation forward the moment it is past, which is why this
+	// branch had no other way to be true before the confirmed day reached it.
+	if display.ovulationConfirmed {
+		return false
+	}
 	if display.ovulationUseRange {
 		// Both bounds come from DashboardOvulationRange, which builds them with
 		// CalendarDay in the request location, so this pair already shares

--- a/internal/services/dashboard_cycle.go
+++ b/internal/services/dashboard_cycle.go
@@ -66,10 +66,16 @@ type dashboardPredictionDisplay struct {
 	ovulationRangeStart  time.Time
 	ovulationRangeEnd    time.Time
 	ovulationUseRange    bool
-	ovulationNeedsData   bool
-	ovulationExact       bool
-	ovulationImpossible  bool
-	estimatePaused       bool
+	// ovulationConfirmed marks ovulationDate as a MEASUREMENT (a detected
+	// thermal shift) rather than a projection. The two representations that
+	// exist to express projection uncertainty — the irregular-cycle range and
+	// the thin-history "needs more cycles" withholding — read it and stand
+	// down, because neither is about a day the temperatures already named.
+	ovulationConfirmed  bool
+	ovulationNeedsData  bool
+	ovulationExact      bool
+	ovulationImpossible bool
+	estimatePaused      bool
 }
 
 func DashboardPredictionDisabled(user *models.User) bool {
@@ -426,6 +432,7 @@ func buildDashboardPredictionDisplay(user *models.User, logs []models.DailyLog, 
 	// had placed several days earlier.
 	if confirmed, ok := ConfirmedCurrentCycleOvulation(user, logs, stats, today, location); ok {
 		display.ovulationDate = confirmed
+		display.ovulationConfirmed = true
 	}
 	// The prompt is not a projection: with no recorded start there is no date
 	// to withhold and nothing for the overdue signal to be about, so it answers
@@ -490,6 +497,23 @@ func applyDashboardPredictionRanges(display dashboardPredictionDisplay, user *mo
 	if !dashboardIrregularPredictionRangeEnabled(user, stats) {
 		return display
 	}
+	// A confirmed ovulation outranks the range. The range expresses the SPREAD
+	// of a projection, and there is no projection left to express once the
+	// temperatures have named the day — it is built from cycle-length spread and
+	// need not even contain that day. Discarding a measurement for it would
+	// leave the dashboard and the calendar naming different things again, for
+	// the cohort whose model is weakest. The next-period range above is
+	// untouched: that projection is still a projection.
+	// A confirmed ovulation outranks the range. The range expresses the SPREAD
+	// of a projection, and there is no projection left to express once the
+	// temperatures have named the day — it is built from cycle-length spread and
+	// need not even contain that day. Discarding a measurement for it would
+	// leave the dashboard and the calendar naming different things again, for
+	// the cohort whose model is weakest. The next-period range above is
+	// untouched: that projection is still a projection.
+	if display.ovulationConfirmed {
+		return display
+	}
 	display.ovulationRangeStart, display.ovulationRangeEnd, display.ovulationUseRange = DashboardOvulationRange(
 		display.nextPeriodRangeStart,
 		display.nextPeriodRangeEnd,
@@ -504,7 +528,13 @@ func applyDashboardPredictionRanges(display dashboardPredictionDisplay, user *mo
 }
 
 func finalizeDashboardPredictionDisplay(display dashboardPredictionDisplay) dashboardPredictionDisplay {
-	if !display.ovulationNeedsData {
+	if !display.ovulationNeedsData || display.ovulationConfirmed {
+		// "Needs more cycles" is about a projection built on thin history. A
+		// detected thermal shift is not that projection, and the calendar gates
+		// the same signal on FertilityProjectionSuppressed alone — which this
+		// cohort (irregular, one or two completed cycles) does not meet, so
+		// withholding here while the grid marks the day is the same divergence
+		// this pair of surfaces was just brought into agreement over.
 		return display
 	}
 	display.ovulationDate = time.Time{}

--- a/internal/services/dashboard_cycle_coverage_test.go
+++ b/internal/services/dashboard_cycle_coverage_test.go
@@ -293,7 +293,7 @@ func TestDashboardCycleIrregularRangeRequiresIrregularFlag(t *testing.T) {
 		MaxCycleLength:      36,
 		AverageCycleLength:  30,
 	}
-	ctx := BuildDashboardCycleContext(user, stats, mustParseDashboardDay(t, "2026-03-20"), time.UTC)
+	ctx := BuildDashboardCycleContext(user, nil, stats, mustParseDashboardDay(t, "2026-03-20"), time.UTC)
 	if ctx.DisplayNextPeriodUseRange && ctx.DisplayOvulationUseRange {
 		t.Fatal("expected no irregular range when IrregularCycle=false")
 	}
@@ -310,7 +310,7 @@ func TestDashboardCycleIrregularRangeRequiresThreeCompletedCycles(t *testing.T) 
 		AverageCycleLength:  30,
 		NextPeriodStart:     mustParseDashboardDay(t, "2026-04-01"),
 	}
-	ctx := BuildDashboardCycleContext(user, stats, mustParseDashboardDay(t, "2026-03-20"), time.UTC)
+	ctx := BuildDashboardCycleContext(user, nil, stats, mustParseDashboardDay(t, "2026-03-20"), time.UTC)
 	if ctx.DisplayNextPeriodUseRange {
 		t.Fatal("expected no irregular prediction range with CompletedCycleCount=2")
 	}
@@ -327,7 +327,7 @@ func TestDashboardCycleIrregularRangeRequiresPositiveMinLength(t *testing.T) {
 		AverageCycleLength:  30,
 		NextPeriodStart:     mustParseDashboardDay(t, "2026-04-01"),
 	}
-	ctx := BuildDashboardCycleContext(user, stats, mustParseDashboardDay(t, "2026-03-20"), time.UTC)
+	ctx := BuildDashboardCycleContext(user, nil, stats, mustParseDashboardDay(t, "2026-03-20"), time.UTC)
 	if ctx.DisplayNextPeriodUseRange {
 		t.Fatal("expected no irregular range when MinCycleLength=0")
 	}
@@ -344,7 +344,7 @@ func TestDashboardCycleIrregularRangeRequiresMaxGeMin(t *testing.T) {
 		AverageCycleLength:  28,
 		NextPeriodStart:     mustParseDashboardDay(t, "2026-04-01"),
 	}
-	ctx := BuildDashboardCycleContext(user, stats, mustParseDashboardDay(t, "2026-03-20"), time.UTC)
+	ctx := BuildDashboardCycleContext(user, nil, stats, mustParseDashboardDay(t, "2026-03-20"), time.UTC)
 	if ctx.DisplayNextPeriodUseRange {
 		t.Fatal("expected no irregular range when MaxCycleLength < MinCycleLength")
 	}
@@ -413,7 +413,7 @@ func TestDashboardCycleNeedsNextPeriodDataRequiresIrregularFlag(t *testing.T) {
 		AverageCycleLength:  28,
 		NextPeriodStart:     mustParseDashboardDay(t, "2026-03-29"),
 	}
-	ctx := BuildDashboardCycleContext(user, stats, mustParseDashboardDay(t, "2026-03-10"), time.UTC)
+	ctx := BuildDashboardCycleContext(user, nil, stats, mustParseDashboardDay(t, "2026-03-10"), time.UTC)
 	if ctx.DisplayNextPeriodNeedsData {
 		t.Fatal("expected DisplayNextPeriodNeedsData=false when IrregularCycle=false")
 	}
@@ -430,7 +430,7 @@ func TestDashboardCycleNeedsNextPeriodDataRequiresFewCycles(t *testing.T) {
 		AverageCycleLength:  30,
 		NextPeriodStart:     mustParseDashboardDay(t, "2026-04-01"),
 	}
-	ctx := BuildDashboardCycleContext(user, stats, mustParseDashboardDay(t, "2026-03-20"), time.UTC)
+	ctx := BuildDashboardCycleContext(user, nil, stats, mustParseDashboardDay(t, "2026-03-20"), time.UTC)
 	if ctx.DisplayNextPeriodNeedsData {
 		t.Fatal("expected DisplayNextPeriodNeedsData=false when CompletedCycleCount=3")
 	}
@@ -447,7 +447,7 @@ func TestDashboardCycleNeedsNextPeriodDataRequiresNonZeroNextPeriod(t *testing.T
 		AverageCycleLength:  28,
 		NextPeriodStart:     time.Time{}, // also zero
 	}
-	ctx := BuildDashboardCycleContext(user, stats, mustParseDashboardDay(t, "2026-03-10"), time.UTC)
+	ctx := BuildDashboardCycleContext(user, nil, stats, mustParseDashboardDay(t, "2026-03-10"), time.UTC)
 	if ctx.DisplayNextPeriodNeedsData {
 		t.Fatal("expected DisplayNextPeriodNeedsData=false when nextPeriodStart resolves to zero")
 	}
@@ -492,7 +492,7 @@ func TestDashboardCycleNeedsOvulationDataRequiresIrregularFlag(t *testing.T) {
 		CompletedCycleCount: 1,
 		AverageCycleLength:  28,
 	}
-	ctx := BuildDashboardCycleContext(user, stats, mustParseDashboardDay(t, "2026-03-10"), time.UTC)
+	ctx := BuildDashboardCycleContext(user, nil, stats, mustParseDashboardDay(t, "2026-03-10"), time.UTC)
 	if ctx.DisplayOvulationNeedsData {
 		t.Fatal("expected DisplayOvulationNeedsData=false when IrregularCycle=false")
 	}
@@ -507,7 +507,7 @@ func TestDashboardCycleNeedsOvulationDataRequiresFewCycles(t *testing.T) {
 		MaxCycleLength:      36,
 		AverageCycleLength:  30,
 	}
-	ctx := BuildDashboardCycleContext(user, stats, mustParseDashboardDay(t, "2026-03-20"), time.UTC)
+	ctx := BuildDashboardCycleContext(user, nil, stats, mustParseDashboardDay(t, "2026-03-20"), time.UTC)
 	if ctx.DisplayOvulationNeedsData {
 		t.Fatal("expected DisplayOvulationNeedsData=false when CompletedCycleCount=3")
 	}
@@ -521,7 +521,7 @@ func TestDashboardCycleNeedsOvulationDataRequiresNonZeroLastPeriodStart(t *testi
 		CompletedCycleCount: 1,
 		AverageCycleLength:  28,
 	}
-	ctx := BuildDashboardCycleContext(user, stats, mustParseDashboardDay(t, "2026-03-10"), time.UTC)
+	ctx := BuildDashboardCycleContext(user, nil, stats, mustParseDashboardDay(t, "2026-03-10"), time.UTC)
 	if ctx.DisplayOvulationNeedsData {
 		t.Fatal("expected DisplayOvulationNeedsData=false when LastPeriodStart is zero")
 	}

--- a/internal/services/dashboard_cycle_mutation_round2_test.go
+++ b/internal/services/dashboard_cycle_mutation_round2_test.go
@@ -18,7 +18,7 @@ func TestBuildDashboardCycleContextFlagsNextPeriodNeedsDataForSparseIrregularUse
 	}
 	today := mustParseDashboardDay(t, "2026-03-10")
 
-	context := BuildDashboardCycleContext(user, stats, today, time.UTC)
+	context := BuildDashboardCycleContext(user, nil, stats, today, time.UTC)
 	if !context.DisplayNextPeriodNeedsData {
 		t.Fatalf("expected sparse irregular mode (IrregularCycle, <3 completed cycles, non-zero projected next period) to flag DisplayNextPeriodNeedsData=true")
 	}

--- a/internal/services/dashboard_cycle_mutation_round3_test.go
+++ b/internal/services/dashboard_cycle_mutation_round3_test.go
@@ -24,7 +24,7 @@ func TestMR3Dash_IrregularRangeEnabledWhenMinEqualsMax(t *testing.T) {
 		NextPeriodStart:     mr3dashDay(t, "2026-07-01"),
 	}
 
-	cycleContext := BuildDashboardCycleContext(user, stats, today, location)
+	cycleContext := BuildDashboardCycleContext(user, nil, stats, today, location)
 
 	if !cycleContext.DisplayNextPeriodUseRange {
 		t.Fatalf("expected irregular next-period range enabled when MinCycleLength==MaxCycleLength")

--- a/internal/services/dashboard_cycle_test.go
+++ b/internal/services/dashboard_cycle_test.go
@@ -86,7 +86,7 @@ func TestBuildDashboardCycleContext(t *testing.T) {
 	}
 	today := mustParseDashboardDay(t, "2026-03-11")
 
-	context := BuildDashboardCycleContext(user, stats, today, time.UTC)
+	context := BuildDashboardCycleContext(user, nil, stats, today, time.UTC)
 	if context.CycleDayReference != 28 {
 		t.Fatalf("expected cycle day reference 28, got %d", context.CycleDayReference)
 	}
@@ -140,7 +140,7 @@ func TestBuildDashboardCycleContextWithholdsTheWindowOnceTheCycleIsOverdue(t *te
 	}
 	today := mustParseDashboardDay(t, "2026-03-17")
 
-	context := BuildDashboardCycleContext(user, stats, today, time.UTC)
+	context := BuildDashboardCycleContext(user, nil, stats, today, time.UTC)
 	if context.CycleDayReference != 28 {
 		t.Fatalf("expected cycle day reference 28, got %d", context.CycleDayReference)
 	}
@@ -206,7 +206,7 @@ func TestBuildDashboardCycleContextKeepsTheWindowAtExactlyTheLateThreshold(t *te
 	}
 	today := mustParseDashboardDay(t, "2026-03-16")
 
-	context := BuildDashboardCycleContext(user, stats, today, time.UTC)
+	context := BuildDashboardCycleContext(user, nil, stats, today, time.UTC)
 	if context.CycleDayWarning {
 		t.Fatalf("expected cycle day 35 against a 28-day reference to stay inside the threshold")
 	}
@@ -246,7 +246,7 @@ func TestBuildDashboardCycleContextUsesRangeForIrregularMode(t *testing.T) {
 	}
 	today := mustParseDashboardDay(t, "2026-03-20")
 
-	context := BuildDashboardCycleContext(user, stats, today, time.UTC)
+	context := BuildDashboardCycleContext(user, nil, stats, today, time.UTC)
 	if !context.DisplayNextPeriodUseRange {
 		t.Fatalf("expected irregular mode to use prediction range")
 	}
@@ -380,7 +380,7 @@ func TestBuildDashboardCycleContextShowsDataDrivenRangeForRegularUserWithVariabi
 	}
 	today := mustParseDashboardDay(t, "2026-03-14")
 
-	context := BuildDashboardCycleContext(user, stats, today, time.UTC)
+	context := BuildDashboardCycleContext(user, nil, stats, today, time.UTC)
 	if !context.DisplayNextPeriodUseRange {
 		t.Fatalf("expected data-driven prediction range for a regular user with measurable variability")
 	}
@@ -465,7 +465,7 @@ func TestBuildDashboardCycleContextDisablesPredictionsForUnpredictableMode(t *te
 		MedianCycleLength: 28,
 	}
 
-	context := BuildDashboardCycleContext(user, stats, mustParseDashboardDay(t, "2026-03-13"), time.UTC)
+	context := BuildDashboardCycleContext(user, nil, stats, mustParseDashboardDay(t, "2026-03-13"), time.UTC)
 	if !context.PredictionDisabled {
 		t.Fatalf("expected unpredictable mode to disable dashboard predictions")
 	}
@@ -485,7 +485,7 @@ func TestBuildDashboardCycleContextPausesPredictionsForPregnancy(t *testing.T) {
 		PregnancyPaused:   true,
 	}
 
-	context := BuildDashboardCycleContext(user, stats, mustParseDashboardDay(t, "2026-03-13"), time.UTC)
+	context := BuildDashboardCycleContext(user, nil, stats, mustParseDashboardDay(t, "2026-03-13"), time.UTC)
 	if !context.PregnancyPaused {
 		t.Fatalf("expected pregnancy pause to be reflected on the cycle context")
 	}
@@ -504,7 +504,7 @@ func TestBuildDashboardCycleContextPregnancyPauseOutranksUnpredictableMode(t *te
 		PregnancyPaused: true,
 	}
 
-	context := BuildDashboardCycleContext(user, stats, mustParseDashboardDay(t, "2026-03-13"), time.UTC)
+	context := BuildDashboardCycleContext(user, nil, stats, mustParseDashboardDay(t, "2026-03-13"), time.UTC)
 	if !context.PregnancyPaused {
 		t.Fatalf("expected pregnancy pause to take priority over unpredictable mode")
 	}
@@ -520,7 +520,7 @@ func TestBuildDashboardCycleContextNeedsOvulationDataForIrregularModeWithFewerTh
 		OvulationDate:       mustParseDashboardDay(t, "2026-03-19"),
 	}
 
-	context := BuildDashboardCycleContext(user, stats, mustParseDashboardDay(t, "2026-03-10"), time.UTC)
+	context := BuildDashboardCycleContext(user, nil, stats, mustParseDashboardDay(t, "2026-03-10"), time.UTC)
 	if !context.DisplayOvulationNeedsData {
 		t.Fatalf("expected irregular mode with sparse data to defer ovulation estimate")
 	}

--- a/internal/services/dashboard_view_service.go
+++ b/internal/services/dashboard_view_service.go
@@ -145,7 +145,7 @@ func (service *DashboardViewService) BuildDashboardViewData(ctx context.Context,
 		return DashboardViewData{}, err
 	}
 
-	cycleContext := BuildDashboardCycleContext(user, stats, today, location)
+	cycleContext := BuildDashboardCycleContext(user, logs, stats, today, location)
 	cycleFactorExplanation, hasCycleFactorExplanation := buildStatsCycleFactorExplanation(user, logs, stats, now, location)
 	selectedSymptomID, rankedSymptoms, primarySymptoms, extraSymptoms, cycleStart, err := service.buildPickerViewState(
 		user,

--- a/internal/services/dashboard_view_service_suppression_test.go
+++ b/internal/services/dashboard_view_service_suppression_test.go
@@ -193,7 +193,7 @@ func TestBuildDashboardCycleContextPausesTheNextPeriodEstimateForAnOverdueIrregu
 				t.Fatalf("fixture: DashboardCycleOverdue = %v, want %v", got, testCase.wantOverdue)
 			}
 
-			cycleContext := BuildDashboardCycleContext(user, stats, today, time.UTC)
+			cycleContext := BuildDashboardCycleContext(user, nil, stats, today, time.UTC)
 			if cycleContext.NextPeriodEstimatePaused != testCase.wantOverdue {
 				t.Errorf("NextPeriodEstimatePaused = %v, want %v", cycleContext.NextPeriodEstimatePaused, testCase.wantOverdue)
 			}

--- a/internal/services/dashboard_view_service_test.go
+++ b/internal/services/dashboard_view_service_test.go
@@ -586,7 +586,7 @@ func TestResolveDashboardTimingFrameGatesTheOvulationEstimateOnEverySuppression(
 			if testCase.mutateStats != nil {
 				testCase.mutateStats(&stats)
 			}
-			frame := resolveDashboardTimingFrame(user, BuildDashboardCycleContext(user, stats, today, time.UTC), visibility)
+			frame := resolveDashboardTimingFrame(user, BuildDashboardCycleContext(user, nil, stats, today, time.UTC), visibility)
 			if frame.ShowOvulationEstimate != testCase.wantEstimate {
 				t.Fatalf("expected ovulation estimate=%v, got %v", testCase.wantEstimate, frame.ShowOvulationEstimate)
 			}

--- a/internal/services/late_cycle_policy_test.go
+++ b/internal/services/late_cycle_policy_test.go
@@ -143,7 +143,7 @@ func TestLateCycleNoticeStateMatrix(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			notice := BuildDashboardCycleContext(testCase.user, testCase.stats, today, time.UTC).LateCycle
+			notice := BuildDashboardCycleContext(testCase.user, nil, testCase.stats, today, time.UTC).LateCycle
 
 			expectVisible := testCase.expectVisible || testCase.expectKey != ""
 			if notice.Visible != expectVisible {

--- a/internal/services/prediction_first_cycle_floor_test.go
+++ b/internal/services/prediction_first_cycle_floor_test.go
@@ -172,7 +172,7 @@ func assertWebhookOvulationReminder(t *testing.T, user *models.User, logs []mode
 func assertDashboardOvulationBanner(t *testing.T, user *models.User, stats CycleStats, today time.Time, location *time.Location, testCase firstCycleFloorCase) {
 	t.Helper()
 
-	cycleContext := BuildDashboardCycleContext(user, stats, today, location)
+	cycleContext := BuildDashboardCycleContext(user, nil, stats, today, location)
 	if got, want := cycleContext.FertilitySuppressed, FertilityProjectionSuppressed(user, stats); got != want {
 		t.Errorf("banner: cycle context carries FertilitySuppressed = %v, want the shared predicate's %v", got, want)
 	}

--- a/internal/services/stats_page_view_service.go
+++ b/internal/services/stats_page_view_service.go
@@ -131,7 +131,7 @@ func (service *StatsService) BuildStatsPageViewData(ctx context.Context, user *m
 	showShortCycleNotice := shouldShowStatsShortCycleNotice(user, completedCycleLengths)
 	showLongCycleNotice := shouldShowStatsLongCycleNotice(user, completedCycleLengths)
 	showPerimenopauseHint := shouldShowStatsPerimenopauseHint(user)
-	cycleContext := BuildDashboardCycleContext(user, baseData.stats, DateAtLocation(now, location), location)
+	cycleContext := BuildDashboardCycleContext(user, baseData.logs, baseData.stats, DateAtLocation(now, location), location)
 	// The stats phase card reads the suppression the cycle context already
 	// resolved, not DashboardPredictionDisabled(user) on its own: the
 	// unpredictable-cycle setting is one signal among several, and a pregnancy

--- a/internal/templates/dashboard.html
+++ b/internal/templates/dashboard.html
@@ -92,7 +92,12 @@
                   {{t .Messages "dashboard.ovulation_unavailable"}}
                 {{else if .DisplayOvulationUseRange}}
                   {{printf (t .Messages "dashboard.ovulation_range") (formatLocalizedDate .Lang .DisplayOvulationRangeStart "display") (formatLocalizedDate .Lang .DisplayOvulationRangeEnd "display")}}
-                {{else if .DisplayOvulationNeedsData}}
+                {{/* "Needs more cycles" is about a projection built on thin
+                     history, so a day the temperatures already named outranks
+                     it — the calendar grid marks that day for this same cohort,
+                     and a caption here would be the two surfaces disagreeing
+                     again. */}}
+                {{else if and .DisplayOvulationNeedsData (not .DisplayOvulationConfirmed)}}
                   {{t .Messages "dashboard.ovulation_need_cycles"}}
                 {{else if .DisplayOvulationDate.IsZero}}
                   {{.NoDataLabel}}


### PR DESCRIPTION
**What.** A detected thermal shift confirms an ovulation that has already happened. The calendar
grid and the stats chart moved onto the detector's day; the dashboard line stayed on the model's
projection. Both surfaces now resolve it through one reader, `ConfirmedCurrentCycleOvulation`, and a
confirmed day outranks the two ways the dashboard expresses projection uncertainty — the
irregular-cycle range and the "needs more cycles" withholding.

**Why it was visible.** `DashboardUpcomingPredictions` rolls its anchor forward only once the
projected day is behind the owner, so on that day itself the line announced an ovulation the
temperatures had placed several days earlier, beside a calendar marking the earlier one.

**Risk.** Display only; no schema, no transport, no new surface. Whether an estimate may be shown is
unchanged — the resolver carries the same `FertilityProjectionSuppressed` gate the calendar wraps
its BBT pass in, so every suppressed cohort reads exactly as before. The hero ring and the reminder
banner keep gating on `DisplayOvulationNeedsData`: the ring is projection arithmetic, the banner
counts down to a day still ahead.

**Verified.** `go build ./...`, `go vet`, `go test ./internal/services/ ./internal/api/` on the
touched areas. The render-level regression reds on the thin-history caption when the template guard
is removed (checked by removing it, not asserted). Copy is untouched: a confirmed day still renders
under `dashboard.ovulation_estimate` — a separate PR.
