### PR TITLE
fix(predictions): outbound surfaces stop announcing a superseded ovulation

### DIFF
--- a/changelog.d/outbound-surfaces-stop-announcing-a-confirmed-ovulation.md
+++ b/changelog.d/outbound-surfaces-stop-announcing-a-confirmed-ovulation.md
@@ -1,0 +1,18 @@
+### Fixed
+
+- **A subscribed calendar and a webhook reminder no longer announce an ovulation your temperatures
+  have already placed.** When a sustained thermal shift is recorded, the dashboard, the month grid
+  and the stats chart all move onto the day the temperatures name. The two surfaces that leave the
+  instance did not: the `.ics` feed kept publishing an ovulation event on the projected day, and the
+  reminder sent to your webhook endpoint kept counting down to it.
+
+  Both exist to announce a day that is still ahead, so neither could simply be moved onto a day
+  already behind you. They now stay quiet for that cycle instead. The gap was widest exactly where
+  it mattered: on the projected day itself, the app on screen said the ovulation had happened three
+  days earlier while a calendar you had subscribed to marked it as today.
+
+  Only the cycle the shift belongs to is affected. The next projected cycle's ovulation event and
+  its reminder are unchanged, as are every period event and period reminder, and a cycle with no
+  thermal shift recorded behaves exactly as before. The suppression rules already in force —
+  predictions turned off, a pregnancy pause, an overdue cycle, or no completed cycle yet — are
+  untouched, and both surfaces still read them from the same place every other surface does.

--- a/internal/services/calendar_feed_ics.go
+++ b/internal/services/calendar_feed_ics.go
@@ -182,7 +182,14 @@ func calendarFeedEvents(input CalendarFeedICSInput) []calendarFeedEvent {
 		// needs a calendar-day comparison, or the ovulation event disappears from
 		// the feed on the ovulation day itself in every UTC-minus zone (issue #48
 		// class).
-		if includeOvulation && window.Calculable && CalendarDaysBetween(window.OvulationDate, today) <= 0 {
+		// A confirmed thermal shift outranks the projection it supersedes. The feed
+		// publishes an ovulation only while it is still ahead, so once the current
+		// cycle's shift has named the day, this cycle's projected event is a second
+		// date for one shift going out to a calendar client that keeps it —
+		// ConfirmedOvulationSupersedes bounds that to the confirmation's own cycle,
+		// so the later projected cycles here are untouched.
+		if includeOvulation && window.Calculable && CalendarDaysBetween(window.OvulationDate, today) <= 0 &&
+			!ConfirmedOvulationSupersedes(user, input.Logs, stats, window.OvulationDate, today, input.Location) {
 			appendEvent("ovulation", CalendarDay(window.OvulationDate, input.Location))
 		}
 	}

--- a/internal/services/cycle_signals.go
+++ b/internal/services/cycle_signals.go
@@ -164,6 +164,32 @@ func ConfirmedCurrentCycleOvulation(user *models.User, logs []models.DailyLog, s
 	return signal, true
 }
 
+// ConfirmedOvulationSupersedes reports whether a PROJECTED ovulation day is one
+// the owner's temperatures have already answered.
+//
+// The on-screen surfaces replace such a day with the measured one. The two
+// surfaces that leave the instance — the .ics feed and the webhook reminder —
+// cannot: both exist to announce a day that is still ahead, and a shift confirms
+// a day that is behind. Announcing the projection anyway is how they came to
+// name a different day than the dashboard and the grid for one shift, on the day
+// the difference is largest: the projected day itself.
+//
+// The bound is the confirmation's own window. ConfirmedCurrentCycleOvulation
+// reads the CURRENT cycle only, so a projection that has already rolled into the
+// next cycle is about a day this shift says nothing about, and suppressing it
+// would withhold a reminder the account is owed. Callers pass each projected day
+// they are about to announce rather than deciding per surface: a rule restated
+// twice is a rule that can disagree with itself.
+func ConfirmedOvulationSupersedes(user *models.User, logs []models.DailyLog, stats CycleStats, projected time.Time, today time.Time, location *time.Location) bool {
+	if projected.IsZero() {
+		return false
+	}
+	if _, confirmed := ConfirmedCurrentCycleOvulation(user, logs, stats, today, location); !confirmed {
+		return false
+	}
+	return CalendarDaysBetween(projected, CalendarDay(stats.NextPeriodStart, location)) > 0
+}
+
 func inferObservedOvulationDate(logs []models.DailyLog, cycleStart time.Time, nextStart time.Time, location *time.Location) time.Time {
 	bbtDate := inferBBTOvulationDate(logs, cycleStart, nextStart, location)
 	if !bbtDate.IsZero() {

--- a/internal/services/cycle_signals.go
+++ b/internal/services/cycle_signals.go
@@ -184,10 +184,16 @@ func ConfirmedOvulationSupersedes(user *models.User, logs []models.DailyLog, sta
 	if projected.IsZero() {
 		return false
 	}
-	if _, confirmed := ConfirmedCurrentCycleOvulation(user, logs, stats, today, location); !confirmed {
+	// The window bound answers first because it is the cheap half. The feed asks
+	// this once per projected cycle, and only the current one can ever be the
+	// subject; running the detector first re-read the owner's whole history —
+	// filterLogsNotAfter copies the slice — for every later cycle, to reach an
+	// answer this line then discarded.
+	if CalendarDaysBetween(projected, CalendarDay(stats.NextPeriodStart, location)) <= 0 {
 		return false
 	}
-	return CalendarDaysBetween(projected, CalendarDay(stats.NextPeriodStart, location)) > 0
+	_, confirmed := ConfirmedCurrentCycleOvulation(user, logs, stats, today, location)
+	return confirmed
 }
 
 func inferObservedOvulationDate(logs []models.DailyLog, cycleStart time.Time, nextStart time.Time, location *time.Location) time.Time {

--- a/internal/services/outbound_confirmed_ovulation_test.go
+++ b/internal/services/outbound_confirmed_ovulation_test.go
@@ -112,6 +112,25 @@ func TestConfirmedOvulationLeavesTheNextCyclesProjectionAlone(t *testing.T) {
 	}
 }
 
+// TestConfirmedOvulationSupersedesNothingWithoutAProjectedDay covers the branch
+// the webhook reaches. decideDueReminders asks this BEFORE
+// decideOvulationReminder's own OvulationImpossible gate, and
+// DashboardUpcomingPredictions leaves OvulationDate zero exactly there — a
+// cycle too short to seat the luteal phase at all.
+//
+// The guard is load-bearing rather than defensive: a zero date is year 1, so the
+// window bound below it reads as comfortably before this cycle's end and passes,
+// the detector then confirms, and the answer would come back true for a day that
+// does not exist.
+func TestConfirmedOvulationSupersedesNothingWithoutAProjectedDay(t *testing.T) {
+	user, logs, now := outboundConfirmedFixture(t, true)
+	stats := BuildCycleStatsFromLogs(user, logs, now, time.UTC)
+
+	if ConfirmedOvulationSupersedes(user, logs, stats, time.Time{}, now, time.UTC) {
+		t.Fatal("a projection with no day of its own cannot be one a shift superseded")
+	}
+}
+
 func TestCalendarFeedWithholdsAnOvulationTheTemperaturesHaveAnswered(t *testing.T) {
 	user, logs, now := outboundConfirmedFixture(t, true)
 

--- a/internal/services/outbound_confirmed_ovulation_test.go
+++ b/internal/services/outbound_confirmed_ovulation_test.go
@@ -1,0 +1,170 @@
+package services
+
+// outbound_confirmed_ovulation_test.go — the two surfaces that leave the
+// instance stop announcing an ovulation the temperatures have already answered.
+//
+// The on-screen surfaces replace the projected day with the measured one. The
+// .ics feed and the webhook reminder cannot: both exist to announce a day still
+// ahead. Left alone they kept publishing the projection, so on the projected day
+// itself the owner read the measured day on the dashboard and the grid and the
+// projected day in a subscribed calendar and in a payload leaving the instance —
+// two dates for one shift, at the moment the gap between them is largest.
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+)
+
+// outboundConfirmedFixture builds three 28-day cycles — two completed, which
+// clears the first-cycle fertility floor — and a thermal shift in the third.
+// Undisturbed readings on cycle days 6..11 fill the coverline window and days
+// 12..14 are elevated, so the shared 3-over-6 detector names cycle day 11,
+// 2026-03-11, while the model projects cycle day 14: 2026-03-14, which is also
+// "today". withShift=false returns the same cycles with no temperatures at all,
+// the control every assertion below is read against.
+func outboundConfirmedFixture(t *testing.T, withShift bool) (*models.User, []models.DailyLog, time.Time) {
+	t.Helper()
+
+	user := &models.User{
+		ID:           1,
+		Role:         models.RoleOwner,
+		TrackBBT:     true,
+		CycleLength:  28,
+		PeriodLength: 5,
+	}
+
+	logs := make([]models.DailyLog, 0, 24)
+	for _, start := range []string{"2026-01-04", "2026-02-01", "2026-03-01"} {
+		cycleStart := mustParseDashboardDay(t, start)
+		for offset := range 5 {
+			logs = append(logs, models.DailyLog{
+				UserID:     user.ID,
+				Date:       cycleStart.AddDate(0, 0, offset),
+				IsPeriod:   true,
+				CycleStart: offset == 0,
+				Flow:       models.FlowMedium,
+			})
+		}
+	}
+	if withShift {
+		for _, day := range []string{"2026-03-06", "2026-03-07", "2026-03-08", "2026-03-09", "2026-03-10", "2026-03-11"} {
+			logs = append(logs, outboundBBTLog(t, user.ID, day, 36.20))
+		}
+		for _, day := range []string{"2026-03-12", "2026-03-13", "2026-03-14"} {
+			logs = append(logs, outboundBBTLog(t, user.ID, day, 36.50))
+		}
+	}
+
+	return user, logs, mustParseDashboardDay(t, "2026-03-14")
+}
+
+func outboundBBTLog(t *testing.T, userID uint, day string, temperature float64) models.DailyLog {
+	t.Helper()
+
+	value := temperature
+	return models.DailyLog{UserID: userID, Date: mustParseDashboardDay(t, day), BBT: &value}
+}
+
+// TestOutboundFixtureConfirmsTheShift pins the fixture before either surface is
+// asked about it, so a failure below reads as a surface defect rather than as a
+// fixture that never confirmed anything — and pins the control, so an assertion
+// that a date is absent cannot pass on a feed that never carried it.
+func TestOutboundFixtureConfirmsTheShift(t *testing.T) {
+	user, logs, now := outboundConfirmedFixture(t, true)
+	stats := BuildCycleStatsFromLogs(user, logs, now, time.UTC)
+
+	if got := CalendarDayKey(stats.OvulationDate); got != "2026-03-14" {
+		t.Fatalf("fixture: the model must project 2026-03-14, got %s", got)
+	}
+	confirmed, ok := ConfirmedCurrentCycleOvulation(user, logs, stats, now, time.UTC)
+	if !ok {
+		t.Fatal("fixture: the detector must confirm a shift in this cycle")
+	}
+	if got := CalendarDayKey(confirmed); got != "2026-03-11" {
+		t.Fatalf("fixture: confirmed ovulation = %s, want 2026-03-11", got)
+	}
+
+	_, controlLogs, _ := outboundConfirmedFixture(t, false)
+	controlStats := BuildCycleStatsFromLogs(user, controlLogs, now, time.UTC)
+	if _, ok := ConfirmedCurrentCycleOvulation(user, controlLogs, controlStats, now, time.UTC); ok {
+		t.Fatal("control: temperatures were removed, so nothing may be confirmed")
+	}
+}
+
+// TestConfirmedOvulationLeavesTheNextCyclesProjectionAlone is the bound. The
+// confirmation reads the CURRENT cycle only, so a projection that has rolled
+// past this cycle's end is about a day the shift says nothing about — withholding
+// it would withdraw a reminder the account is owed rather than de-duplicate one.
+func TestConfirmedOvulationLeavesTheNextCyclesProjectionAlone(t *testing.T) {
+	user, logs, now := outboundConfirmedFixture(t, true)
+	stats := BuildCycleStatsFromLogs(user, logs, now, time.UTC)
+
+	thisCycle := mustParseDashboardDay(t, "2026-03-14")
+	if !ConfirmedOvulationSupersedes(user, logs, stats, thisCycle, now, time.UTC) {
+		t.Fatal("this cycle's projected day is exactly what the shift supersedes")
+	}
+	nextCycle := mustParseDashboardDay(t, "2026-04-11")
+	if ConfirmedOvulationSupersedes(user, logs, stats, nextCycle, now, time.UTC) {
+		t.Fatal("the next cycle's projection is not this shift's subject")
+	}
+}
+
+func TestCalendarFeedWithholdsAnOvulationTheTemperaturesHaveAnswered(t *testing.T) {
+	user, logs, now := outboundConfirmedFixture(t, true)
+
+	body := string(BuildCalendarFeedICS(CalendarFeedICSInput{
+		User:       user,
+		Logs:       logs,
+		Now:        now,
+		Location:   time.UTC,
+		Disclaimer: "Predictions are estimates, not medical advice or a method of contraception.",
+	}))
+	if strings.Contains(body, "DTSTART;VALUE=DATE:20260314") {
+		t.Fatalf("the feed published the projected ovulation the shift superseded:\n%s", body)
+	}
+	// The bound, on the surface rather than on the helper: the next projected
+	// cycle's ovulation still ships, so this is a superseded day dropped and not
+	// the ovulation half of the feed going quiet.
+	if !strings.Contains(body, "DTSTART;VALUE=DATE:20260411") {
+		t.Fatalf("the next cycle's projected ovulation must still ship:\n%s", body)
+	}
+
+	_, controlLogs, _ := outboundConfirmedFixture(t, false)
+	control := string(BuildCalendarFeedICS(CalendarFeedICSInput{
+		User:       user,
+		Logs:       controlLogs,
+		Now:        now,
+		Location:   time.UTC,
+		Disclaimer: "Predictions are estimates, not medical advice or a method of contraception.",
+	}))
+	if !strings.Contains(control, "DTSTART;VALUE=DATE:20260314") {
+		t.Fatalf("control: with no shift recorded the projected day must still ship:\n%s", control)
+	}
+}
+
+func TestWebhookReminderWithholdsAnOvulationTheTemperaturesHaveAnswered(t *testing.T) {
+	user, logs, now := outboundConfirmedFixture(t, true)
+
+	for _, reminder := range DecideDueReminders(user, enabledWebhookSettings(3), logs, now, time.UTC) {
+		if reminder.Type == DueReminderTypeOvulation {
+			t.Fatalf("the pass sent the projected ovulation %s the shift superseded", CalendarDayKey(reminder.EventDate))
+		}
+	}
+
+	_, controlLogs, _ := outboundConfirmedFixture(t, false)
+	var sawOvulation bool
+	for _, reminder := range DecideDueReminders(user, enabledWebhookSettings(3), controlLogs, now, time.UTC) {
+		if reminder.Type == DueReminderTypeOvulation {
+			sawOvulation = true
+			if got := CalendarDayKey(reminder.EventDate); got != "2026-03-14" {
+				t.Fatalf("control: ovulation reminder for %s, want 2026-03-14", got)
+			}
+		}
+	}
+	if !sawOvulation {
+		t.Fatal("control: with no shift recorded the ovulation reminder must still be due")
+	}
+}

--- a/internal/services/webhook_reminder.go
+++ b/internal/services/webhook_reminder.go
@@ -217,7 +217,15 @@ func decideDueReminders(user *models.User, settings WebhookReminderSettings, log
 	// and this pass sends it to an endpoint outside the instance
 	// (FertilityProjectionSuppressed). The period reminder keeps its own path —
 	// it is anchored on a recorded cycle start and rides the estimate flag.
-	if !FertilityProjectionSuppressed(user, stats) {
+	// A confirmed thermal shift outranks the projection it supersedes. This
+	// reminder says an ovulation is COMING; once the temperatures have named the
+	// day it happened on, sending the projected day puts a second date for one
+	// shift outside the instance, where the dashboard and the grid have already
+	// moved onto the measured one. ConfirmedOvulationSupersedes bounds that to
+	// the confirmation's own cycle, so a projection that has rolled into the next
+	// one still sends.
+	if !FertilityProjectionSuppressed(user, stats) &&
+		!ConfirmedOvulationSupersedes(user, logs, stats, prediction.OvulationDate, today, location) {
 		due, ok, watermarked := decideOvulationReminder(stats, settings, prediction, today, cycleLength, leadDays)
 		if ok {
 			reminders = append(reminders, due)


### PR DESCRIPTION
**What.** The day named for one thermal shift was resolved through the detector on three surfaces
and left as the projection on two. The `.ics` feed and the webhook reminder both leave the instance,
and on the projected day itself they carried a date the dashboard and the grid had already moved
three days back — a calendar client keeps that copy long after the app has corrected itself.

**Why not the measured day.** Both exist to announce a day still AHEAD, and a shift confirms one
behind. They withhold that cycle's projected ovulation instead. `ConfirmedOvulationSupersedes` is the
one rule they read, bounded by the confirmation's own window: a projection already rolled into the
next cycle is about a day this shift says nothing about, and withholding it would withdraw a
reminder the account is owed rather than de-duplicate one.

**Risk.** Both surfaces send outside the instance, so the change is a withholding, never a new
value: no payload field, no event kind, no UID shape moves. Period events and reminders are
untouched, and every suppression gate is read where it already was.

**Verified.** `go build ./...`, `go vet`, `go test ./internal/services/` over the webhook, feed,
reminder and prediction families. Controls carry each assertion: the same fixture with the
temperatures removed still ships the projected day on both surfaces, and the next cycle's projected
ovulation ships in the feed beside the withheld one — so neither can pass on an ovulation half that
has simply gone quiet.
