### PR TITLE
fix(dashboard): a measured ovulation drops the projection's qualifier

### DIFF
--- a/changelog.d/confirmed-ovulation-drops-the-projection-qualifier.md
+++ b/changelog.d/confirmed-ovulation-drops-the-projection-qualifier.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- **A recorded ovulation is no longer captioned "approximate".** The dashboard adds that marker when
+  the projection's arithmetic had to be squeezed — a luteal phase that does not fit inside a short
+  cycle gets clamped, and the resulting day is an approximation of an approximation. It is a
+  statement about the projection, and it kept riding along after the day on the line came from
+  recorded temperatures instead.
+
+  The marker is dropped for a day the temperatures named. Everything about it is unchanged for a
+  projected day, on the cycle-phase ring, and for an account with no thermal shift recorded — and
+  the line still reads "around <date>", because the reading places ovulation within about a day
+  rather than to the hour.

--- a/internal/api/dashboard_confirmed_ovulation_qualifier_test.go
+++ b/internal/api/dashboard_confirmed_ovulation_qualifier_test.go
@@ -1,0 +1,108 @@
+package api
+
+// dashboard_confirmed_ovulation_qualifier_test.go — the projection's own
+// qualifier does not follow a measured day onto the status line.
+//
+// The "approximately" marker rides DisplayOvulationExact, which reports whether
+// CalcOvulationDay had to CLAMP the luteal phase into a short cycle. That is a
+// property of the projection's arithmetic; a day the temperatures named did not
+// come out of it. Carrying the marker across the substitution captioned a
+// recorded reading as an approximation of itself.
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+	"github.com/ovumcy/ovumcy-web/internal/services"
+)
+
+// TestDashboardDropsTheProjectionQualifierFromAConfirmedDay needs the narrow
+// band where the header shows an INEXACT estimate at all, so it reuses the
+// inexact-ovulation fixture's shape: a 16-day reference cycle with the default
+// 14-day luteal phase forces the clamp (CalcOvulationDay caps the luteal phase
+// at cycleLength-5), a 3-day period keeps the cycle hero drawable, and one
+// previous cycle clears the first-cycle fertility floor. On top of that it
+// records a thermal shift, which is what the substitution needs.
+//
+// The hero's own qualifier is the anchor: it rides the same DisplayOvulationExact
+// and must still render, so a missing ovulation marker below is the substitution
+// dropping it rather than the fixture having drifted into an exact projection.
+func TestDashboardDropsTheProjectionQualifierFromAConfirmedDay(t *testing.T) {
+	app, database, _ := newOnboardingTestAppWithLocation(t, time.UTC)
+	user := createOnboardingTestUser(t, database, "dashboard-confirmed-qualifier@example.com", "StrongPass1", true)
+
+	today := services.DateAtLocation(time.Now().UTC(), time.UTC)
+	const cycleLength = 16
+	const periodLength = 3
+	cycleStart := today.AddDate(0, 0, -13)
+	confirmedDay := cycleStart.AddDate(0, 0, 10)
+
+	if err := database.Model(&models.User{}).Where("id = ?", user.ID).Updates(map[string]any{
+		"cycle_length":      cycleLength,
+		"period_length":     periodLength,
+		"last_period_start": cycleStart,
+		"usage_goal":        models.UsageGoalTrying,
+		"track_bbt":         true,
+	}).Error; err != nil {
+		t.Fatalf("update confirmed-qualifier cycle context: %v", err)
+	}
+	for _, start := range []time.Time{cycleStart.AddDate(0, 0, -cycleLength), cycleStart} {
+		for offset := range periodLength {
+			if err := database.Create(&models.DailyLog{
+				UserID:     user.ID,
+				Date:       start.AddDate(0, 0, offset),
+				IsPeriod:   true,
+				CycleStart: offset == 0,
+				Flow:       models.FlowMedium,
+			}).Error; err != nil {
+				t.Fatalf("create period log %s day %d: %v", start.Format("2006-01-02"), offset, err)
+			}
+		}
+	}
+	for offset := 5; offset <= 13; offset++ {
+		temperature := 36.20
+		if offset > 10 {
+			temperature = 36.50
+		}
+		value := temperature
+		if err := database.Create(&models.DailyLog{
+			UserID: user.ID,
+			Date:   cycleStart.AddDate(0, 0, offset),
+			BBT:    &value,
+		}).Error; err != nil {
+			t.Fatalf("create bbt log at cycle day %d: %v", offset+1, err)
+		}
+	}
+
+	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
+	request := httptest.NewRequest(http.MethodGet, "/dashboard", nil)
+	request.Header.Set("Accept-Language", "en")
+	request.Header.Set("Cookie", authCookie)
+	response := mustAppResponse(t, app, request)
+	assertStatusCode(t, response, http.StatusOK)
+
+	document := mustParseHTMLDocument(t, mustReadBodyString(t, response.Body))
+	header := dashboardElementByDataAttr(document, "data-dashboard-status-header")
+	if header == nil {
+		t.Fatal("fixture anchor: expected the dashboard status header")
+	}
+	ovulation := dashboardElementByDataAttr(header, "data-dashboard-ovulation")
+	if ovulation == nil {
+		t.Fatal("fixture anchor: expected the ovulation slot in the status line")
+	}
+	if dashboardElementByDataAttr(header, "data-dashboard-estimate-qualifier") == nil {
+		t.Fatal("fixture anchor: the projection must still be inexact, or this test proves nothing")
+	}
+
+	slot := normalizeHTMLText(htmlNodeText(ovulation))
+	if want := services.LocalizedDateDisplay("en", confirmedDay); !strings.Contains(slot, want) {
+		t.Fatalf("fixture anchor: the slot must name the detector's day %q, got %q", want, slot)
+	}
+	if dashboardElementByDataAttr(ovulation, "data-dashboard-ovulation-approximate") != nil {
+		t.Fatalf("a measured day carried the projection's approximate marker: %q", slot)
+	}
+}

--- a/internal/templates/dashboard.html
+++ b/internal/templates/dashboard.html
@@ -102,7 +102,14 @@
                 {{else if .DisplayOvulationDate.IsZero}}
                   {{.NoDataLabel}}
                 {{else}}
-                  {{printf (t .Messages "dashboard.ovulation_estimate") (formatLocalizedDate .Lang .DisplayOvulationDate "display")}}{{if not .DisplayOvulationExact}} <span class="journal-muted" data-dashboard-ovulation-approximate>{{t .Messages "dashboard.ovulation_approximate"}}</span>{{end}}
+                {{/* The approximate marker rides DisplayOvulationExact, which
+                     reports whether CalcOvulationDay had to CLAMP the luteal
+                     phase into a short cycle — a property of the projection's
+                     arithmetic. A measured day did not come out of that
+                     arithmetic, so the marker says nothing about it, and a
+                     recorded shift captioned "approximately" reads as the app
+                     doubting a reading the owner took. */}}
+                  {{printf (t .Messages "dashboard.ovulation_estimate") (formatLocalizedDate .Lang .DisplayOvulationDate "display")}}{{if and (not .DisplayOvulationExact) (not .DisplayOvulationConfirmed)}} <span class="journal-muted" data-dashboard-ovulation-approximate>{{t .Messages "dashboard.ovulation_approximate"}}</span>{{end}}
                 {{end}}
               </span>
             </span>


### PR DESCRIPTION
**What.** The "approximate" marker beside the dashboard's ovulation date rides
`DisplayOvulationExact`, which reports one thing: whether `CalcOvulationDay` had to CLAMP the luteal
phase into a cycle too short to hold it. That is a property of the projection's arithmetic. Once the
line names a day the temperatures recorded, the marker followed the substitution and captioned a
reading as an approximation of itself.

**Scope.** The marker is dropped only for a confirmed day. The estimate wording stays — a thermal
shift places ovulation within about a day, not to the hour, and the medical-safety invariant wants
every ovulation surface carrying an estimate qualifier; a "confirmed" copy line is a separate
decision with its own strings in six languages. The cycle-phase ring keeps the marker: it is drawn
from cycle-length arithmetic, which is exactly what the clamp is about.

**Risk.** One template condition. No new i18n key, no Go behaviour change, nothing outside the
dashboard status line.

**Verified.** `go test ./internal/api/` over the dashboard family. The render regression carries the
hero's own qualifier as its anchor, so the fixture is proved inexact in the same run that finds the
ovulation marker gone; removing the guard reds it on the real page ("around <date> (approximate)"),
checked rather than asserted.
