### PR TITLE
docs(ci): the tag gate's e2e-cross-browser exclusion states its own reason

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -155,6 +155,13 @@ jobs:
           # whose only justification WAS that the queue had already run.
           QUEUE_CHECKS: test race e2e
           HEAVY_CHECKS: e2e-postgres-smoke image-smoke
+          # `e2e-cross-browser` is deliberately absent from both lists, not an
+          # omission: ci.yml:1512 marks it non-required and publish-image's own
+          # `needs:` excludes it for the same reason (deferred, slower
+          # cross-browser coverage, non-blocking by design). This gate mirrors
+          # exactly the five checks publish-image requires — see the comment
+          # above `QUEUE_CHECKS` — so a release tag is held to the same bar as
+          # `:latest`, no stricter. Re-verified against HEAD 2026-09-01.
         run: |
           set -euo pipefail
 

--- a/changelog.d/docker-image-tag-gate-documents-e2e-cross-browser-scope.md
+++ b/changelog.d/docker-image-tag-gate-documents-e2e-cross-browser-scope.md
@@ -1,0 +1,11 @@
+none
+
+Re-verified REL-5 from the release audit against current HEAD (post the release-gate rework in
+PR-2/PR-3): the `REQUIRED_CHECKS` array it cited no longer exists — that mechanism is now
+`docker-image.yml`'s `QUEUE_CHECKS`/`HEAVY_CHECKS` split, which deliberately mirrors exactly the
+five checks `publish-image` requires for `:latest` (ci.yml:1706-1711). `e2e-cross-browser`'s
+absence from both is consistent with its own documented non-required status (ci.yml:1512-1513),
+not a second instance of the same gap. Adding it to the tag gate alone would make a release tag
+stricter than `:latest`, which is a product-policy call outside this audit's scope, not a P2 fix.
+Added a comment at `docker-image.yml:156-157` recording this so a future reader (or a re-audit)
+doesn't re-flag it as an oversight. No branch-protection change needed.


### PR DESCRIPTION
## What

Re-verifies the release-audit finding REL-5 (P2) against current HEAD and closes it with
documentation, not a behavior change.

## Why

REL-5 was filed against an older HEAD, citing a `REQUIRED_CHECKS` array in `docker-image.yml`
that no longer exists — PR-2/PR-3 restructured the tag-release gate into `QUEUE_CHECKS`/
`HEAVY_CHECKS` (`docker-image.yml:156-157`). `e2e-cross-browser` is absent from both, same as the
old array, but this is no longer an oversight: three sites now agree on it by design —
`ci.yml:1512-1513` marks the job explicitly non-required, `publish-image`'s own `needs:`
(`ci.yml:1706-1711`) excludes it for the documented reason (deferred cross-browser coverage,
non-blocking), and the tag gate's own comment (`docker-image.yml:120-125`) states it mirrors
exactly the five checks `publish-image` requires. Forcing `e2e-cross-browser` into the tag gate
alone would make a release tag stricter than `:latest`, contradicting that stated invariant — a
product-policy call outside a P2 CI-audit fix's scope.

## Change

One comment at `docker-image.yml:156-157` recording why the exclusion is intentional, so a future
reader (or the next re-audit) doesn't re-flag it. No functional change; changelog fragment is
`none`.

## Risk

None — comment only.