### PR TITLE
fix(ci): the coverage gate reaches the queue, and Trivy stops looking away

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -899,7 +899,13 @@ jobs:
     # state — the `test` gate judges coverage-merge for exactly that reason.
     needs:
       - coverage-merge
-    if: github.event_name == 'pull_request'
+    # REL-6: this is a REQUIRED check, but it used to run only on
+    # `pull_request` — in the merge_group suite that actually decides queue
+    # admission it reported `skipped`, and a skipped required check is
+    # satisfied. `coverage-merge` above carries no such restriction, so the
+    # profile this gate needs already exists in that suite; it just never
+    # consumed it.
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     permissions:
       contents: read
 
@@ -921,17 +927,46 @@ jobs:
           name: coverage-out
           path: .
 
-      - name: Fetch base branch
-        run: git fetch --no-tags origin ${{ github.event.pull_request.base.ref }}
+      - name: Determine base ref
+        # `pull_request.base.ref` does not exist under `merge_group` — the
+        # queue's base commit lives in `merge_group.base_sha` instead. Mirrors
+        # the same split (and the same fetch-if-absent caution) the `changes`
+        # job already makes below. Exported via $GITHUB_ENV, and every fetch
+        # uses a quoted shell variable rather than splicing the expression
+        # into the command directly.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          QUEUE_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "merge_group" ]; then
+            base="$QUEUE_BASE_SHA"
+            if [ -z "$base" ]; then
+              echo "::error::no base commit in the merge_group payload"
+              exit 1
+            fi
+            if ! git cat-file -e "${base}^{commit}" 2>/dev/null; then
+              git fetch --no-tags origin "$base" || true
+            fi
+            if ! git cat-file -e "${base}^{commit}" 2>/dev/null; then
+              echo "::error::merge_group base commit $base unreachable after fetch"
+              exit 1
+            fi
+            echo "BASE_REF=$base" >> "$GITHUB_ENV"
+          else
+            git fetch --no-tags origin "$PR_BASE_REF"
+            echo "BASE_REF=origin/$PR_BASE_REF" >> "$GITHUB_ENV"
+          fi
 
       - name: Enforce patch coverage
         # Fails when a modified, coverable Go line is not covered by tests. This
         # is the in-CI, self-contained replacement for the external codecov patch
         # status, which can stall and deadlock a required check. See
         # scripts/patchcov for the gate logic (test files and tooling excluded).
+        # BASE_REF comes from the step above, already resolved for the event.
         env:
           COVERAGE_FILE: coverage.out
-          BASE_REF: origin/${{ github.event.pull_request.base.ref }}
         run: go run ./scripts/patchcov
 
   changes:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -422,14 +422,16 @@ jobs:
 
       - name: Scan the image before publishing it
         # Same gate as security.yml's required `trivy-image` check — same
-        # scanner, severity threshold, `--ignore-unfixed` and `--exit-code 1`.
+        # scanner, severity threshold and `--exit-code 1`; no `--ignore-unfixed`
+        # here either, for the same reason as trivy-fs/trivy-image there — an
+        # unfixed CRITICAL must still hold the publish back.
         # That check lives in another workflow and so cannot be a `needs:` of
         # this job; repeating the scan here against the exact artifact is what
         # keeps an unscanned image from reaching the registry. Output is a table
         # rather than SARIF because the Security tab entry for this commit
         # already comes from `trivy-image`; a second upload under the same
         # category would only overwrite it.
-        run: docker run --rm -v /var/run/docker.sock:/var/run/docker.sock "${{ env.TRIVY_IMAGE }}" image --scanners vuln --skip-version-check --severity HIGH,CRITICAL --ignore-unfixed --format table --exit-code 1 ovumcy-publish-scan:${{ github.sha }}
+        run: docker run --rm -v /var/run/docker.sock:/var/run/docker.sock "${{ env.TRIVY_IMAGE }}" image --scanners vuln --skip-version-check --severity HIGH,CRITICAL --format table --exit-code 1 ovumcy-publish-scan:${{ github.sha }}
 
       # NOTHING PUBLIC EXISTS UNTIL THE SIGNATURE DOES. The push used to carry
       # `steps.meta.outputs.tags` — `vX.Y.Z`, `latest`, `main`, `sha-…` — so the

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -423,8 +423,10 @@ jobs:
       - name: Scan the image before publishing it
         # Same gate as security.yml's required `trivy-image` check — same
         # scanner, severity threshold and `--exit-code 1`; no `--ignore-unfixed`
-        # here either, for the same reason as trivy-fs/trivy-image there — an
-        # unfixed CRITICAL must still hold the publish back.
+        # here either. Not for Security-tab parity — this step's own output is
+        # a table, never uploaded there, see below — but so an unfixed
+        # CRITICAL still holds the publish back the same way it holds the
+        # required check back.
         # That check lives in another workflow and so cannot be a `needs:` of
         # this job; repeating the scan here against the exact artifact is what
         # keeps an unscanned image from reaching the registry. Output is a table

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -128,7 +128,10 @@ jobs:
           image: ${{ env.TRIVY_IMAGE }}
 
       - name: Run Trivy filesystem scan
-        run: docker run --rm -v "${{ github.workspace }}:/work" -w /work "${{ env.TRIVY_IMAGE }}" fs --scanners vuln --skip-version-check --severity HIGH,CRITICAL --ignore-unfixed --include-dev-deps --skip-dirs .tmp --skip-dirs web/static --format sarif --output .tmp/security/trivy-fs.sarif --exit-code 1 .
+        # No --ignore-unfixed: this SARIF is also what the Security tab shows
+        # (upload step below), so a CRITICAL with no upstream fix yet must
+        # stay visible in both the gate and the tab, not disappear from each.
+        run: docker run --rm -v "${{ github.workspace }}:/work" -w /work "${{ env.TRIVY_IMAGE }}" fs --scanners vuln --skip-version-check --severity HIGH,CRITICAL --include-dev-deps --skip-dirs .tmp --skip-dirs web/static --format sarif --output .tmp/security/trivy-fs.sarif --exit-code 1 .
 
       - name: Upload Trivy filesystem SARIF
         if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
@@ -197,7 +200,9 @@ jobs:
           image: ${{ env.TRIVY_IMAGE }}
 
       - name: Run Trivy image scan
-        run: docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v "${{ github.workspace }}:/work" -w /work "${{ env.TRIVY_IMAGE }}" image --scanners vuln --skip-version-check --severity HIGH,CRITICAL --ignore-unfixed --format sarif --output .tmp/security/trivy-image.sarif --exit-code 1 ovumcy-security:${{ github.sha }}
+        # No --ignore-unfixed: same reason as trivy-fs above — this SARIF feeds
+        # the Security tab, so an unfixed CRITICAL must stay visible there too.
+        run: docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v "${{ github.workspace }}:/work" -w /work "${{ env.TRIVY_IMAGE }}" image --scanners vuln --skip-version-check --severity HIGH,CRITICAL --format sarif --output .tmp/security/trivy-image.sarif --exit-code 1 ovumcy-security:${{ github.sha }}
 
       - name: Pull Trivy image for SBOM
         # Generate CycloneDX SBOM below runs `if: always()` so it still executes

--- a/changelog.d/patch-coverage-runs-in-the-queue-and-trivy-stops-hiding-fixed-cves.md
+++ b/changelog.d/patch-coverage-runs-in-the-queue-and-trivy-stops-hiding-fixed-cves.md
@@ -1,0 +1,16 @@
+### Security
+
+- **The patch-coverage gate now runs in the merge queue, not only on the pull request.** It is a
+  required branch-protection check, but it carried `if: github.event_name == 'pull_request'`, so
+  the merge-queue suite that actually decides admission reported it `skipped` — and a skipped
+  required check counts as satisfied. A queued change could merge having never had its patch
+  coverage judged there. The job now also runs on `merge_group`, with its base-ref resolution
+  branched the same way the `changes` job already splits it (`pull_request.base.ref` does not
+  exist under `merge_group`; the queue's base lives in `merge_group.base_sha` instead).
+
+- **The three Trivy invocations that gate a build no longer hide unfixed CRITICAL/HIGH findings
+  from themselves or from the Security tab.** `--ignore-unfixed` was set on the filesystem scan and
+  the image scan (both required checks, both writing SARIF that gets uploaded), and on the
+  pre-publish re-scan before `:latest`/a release tag goes out. A CRITICAL vulnerability with no
+  upstream fix yet — the ordinary case for a fresh CVE — tripped none of them and never reached the
+  Security tab either. All three now scan and gate on the full HIGH/CRITICAL set.


### PR DESCRIPTION
## What (PR-21, REL-6 + REL-7, both re-verified against current HEAD)

**REL-6** — `patch-coverage` (`ci.yml:893`) is a required branch-protection context but carried
`if: github.event_name == 'pull_request'`. In the `merge_group` suite that actually decides queue
admission it reported `skipped`, and a skipped required check counts as satisfied — a queued
change could merge having never had its patch coverage judged there.

**REL-7** — `--ignore-unfixed` was set on trivy-fs (`security.yml:131`) and trivy-image
(`security.yml:200`), both required checks whose SARIF is uploaded to the Security tab, and on the
pre-publish re-scan (`docker-image.yml:432`). A CRITICAL with no upstream fix yet — the normal
state for a fresh CVE — tripped none of the three gates and never reached the Security tab either.

## Change

- `patch-coverage`'s `if:` now also matches `merge_group`. Its `Fetch base branch` step is replaced
  with a `Determine base ref` step that branches on event: `pull_request.base.ref` doesn't exist
  under `merge_group` (the queue's base lives in `merge_group.base_sha`), mirroring the same split
  and fetch-if-absent caution the `changes` job already uses. `BASE_REF` is now exported via
  `$GITHUB_ENV` from a quoted shell variable, not spliced into the command — same class of fix as a
  raw-splice sibling found at the same line during this audit (folded in here since it's the same
  job; see the R3 session notes for the analogous `changelog.yml` fix in the companion PR).
- Dropped `--ignore-unfixed` from all three Trivy invocations.

## Risk

Medium (required-check semantics + release gate). `patch-coverage` running in the queue means a
patch-coverage regression can now block a merge it previously slipped through — intended, matches
what the check was always supposed to enforce. Rollback: revert this commit.

Disclosed trade-off from REL-7: this repo has no `.trivyignore`/per-CVE suppression mechanism
(confirmed absent). A HIGH/CRITICAL CVE with no upstream fix yet — the normal state right after
disclosure — now blocks `trivy-fs`/`trivy-image` (both required) and the pre-publish scan until
Trivy's DB marks a fix available. That's the intended tightening REL-7 asks for, not a defect; a
suppression mechanism is a separate feature, out of this P2 fix's scope.

## Verified

- Re-read the current `patch-coverage`, `changes`, and Trivy steps against HEAD before editing;
  line numbers in this body match what's on `main` today, not the stale audit's numbers.
- `coverage-merge` (the artifact this gate downloads) already runs unconditionally on
  `merge_group`, so the profile exists there — confirmed no upstream gap.
