### PR TITLE
fix(ci): mutation-merge fails loud, and checkouts stop persisting creds

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -34,6 +34,7 @@ jobs:
         if: env.RUN_GATE == 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           # The gate diffs the branch against its base, so it needs history.
           fetch-depth: 0
 
@@ -47,7 +48,19 @@ jobs:
       - name: Check changelog fragment
         if: env.RUN_GATE == 'true'
         env:
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
           BASE_REF: origin/${{ github.event.pull_request.base.ref }}
         run: |
-          git fetch --no-tags origin ${{ github.event.pull_request.base.ref }}
+          git fetch --no-tags origin "$PR_BASE_REF"
           go run ./scripts/changelogd check
+
+      - name: Fail on unhandled trigger
+        # RUN_GATE is exactly `pull_request AND not dependabot`, so this only
+        # fires if a future edit breaks that exhaustiveness, or an event this
+        # workflow's `on:` doesn't declare somehow reaches it. Without this,
+        # such a run has no step at all: the job goes green having verified
+        # nothing, and changelog-fragment is a required check.
+        if: env.RUN_GATE != 'true' && github.event_name != 'merge_group' && !(github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]')
+        run: |
+          echo "::error::changelog-fragment matched no known branch (event=${{ github.event_name }}, RUN_GATE=${{ env.RUN_GATE }}) — refusing to report success having verified nothing."
+          exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -172,6 +174,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -263,6 +267,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -337,6 +343,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       # The published binary is built by the Dockerfile's builder stage; every
       # job in this workflow builds and tests with the toolchain named by
@@ -580,6 +588,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -722,6 +732,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -758,6 +770,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -853,6 +867,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Download coverage artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -907,6 +923,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Setup Go
@@ -978,6 +995,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Detect whether browser e2e is needed
@@ -1261,6 +1279,8 @@ jobs:
       - name: Checkout
         if: env.RUN_E2E != 'false' && env.RUN_SHARDS != 'false'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         if: env.RUN_E2E != 'false' && env.RUN_SHARDS != 'false'
@@ -1415,6 +1435,8 @@ jobs:
       - name: Checkout
         if: env.RUN_E2E != 'false' && env.RUN_HEAVY == 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         if: env.RUN_E2E != 'false' && env.RUN_HEAVY == 'true'
@@ -1518,6 +1540,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -1624,6 +1648,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,6 +40,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         if: matrix.language == 'go'

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -85,6 +85,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           # The ancestry question is unanswerable on a shallow clone: with the
           # default depth of 1 there is no history for merge-base to walk and
           # the check would fail every tag, or worse, be "fixed" by weakening it
@@ -335,6 +336,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           # Full history so the scheduled/push run also re-checks commits that
           # were already merged, matching CodeQL/security's full-checkout scope.
           # gitleaks itself is pointed at full history via --log-opts=--all below.

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -69,6 +69,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -141,6 +143,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -39,6 +39,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -81,6 +83,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -109,6 +113,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Log in to Docker Hub
         # Skipped on fork PRs where the secret is unavailable; authenticated pulls
@@ -156,6 +162,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Log in to Docker Hub
         # Skipped on fork PRs where the secret is unavailable; authenticated pulls

--- a/changelog.d/mutation-merge-fails-loud-and-the-checkout-credential-sweep.md
+++ b/changelog.d/mutation-merge-fails-loud-and-the-checkout-credential-sweep.md
@@ -1,0 +1,29 @@
+### Security
+
+- **A mutation-testing shard that silently produced no report can no longer be folded into a
+  "complete" combined report.** The per-shard guard that catches a dead shard (OOM, disk
+  exhaustion, timeout) only failed that one shard; the merge step downstream ran regardless
+  (`if: always()`) and its own upload was `if-no-files-found: ignore`, so a 4-of-5 result still
+  published under the same canonical artifact name a complete run uses, with nothing recording the
+  gap. `mutationmerge` now takes an `-expect <n>` count — read from the same shard-count registry
+  `verify-shards` already checks the partition against — and refuses to merge (fails loudly) when
+  fewer shard reports arrive than the registry says are owed.
+
+- **The changelog-fragment gate no longer splices a PR's base-branch name directly into a shell
+  command, and no longer goes green having verified nothing.** `git fetch --no-tags origin ${{
+  github.event.pull_request.base.ref }}` interpolated an unescaped GitHub Actions expression
+  straight into `run:`; it's now a quoted shell variable, matching the pattern this codebase
+  already uses elsewhere (`ci.yml`'s `changes` job). The same raw-splice pattern was found, and
+  fixed, at the same job's sibling in `ci.yml` (patch-coverage's base-branch fetch) in a companion
+  PR. Separately, every real step in the job was gated on `env.RUN_GATE == 'true'` with no
+  unconditional fallback — a `RUN_GATE` that ever evaluated to anything else would report success
+  having run no check at all. A final step now asserts and fails on that case explicitly.
+
+- **Every `actions/checkout` step across the workflows now sets `persist-credentials: false`.**
+  It was present in exactly one of 26 occurrences across 8 files (`scorecard.yml`). None of the
+  other 25 push or otherwise need the persisted git token afterward — confirmed no workflow greps
+  for `git push`/`git commit`, and the repository is public, so the handful of anonymous
+  `git fetch`-after-checkout steps work unauthenticated either way. The sharpest of the 25:
+  `security.yml`'s trivy-image job checks out a PR's own ref and then builds and runs a container
+  from that PR's own `Dockerfile`; a persisted credential sitting on disk during that step is an
+  unnecessary exposure if a future PR changes what the build step actually reads.

--- a/scripts/mutation.sh
+++ b/scripts/mutation.sh
@@ -285,10 +285,21 @@ merge_shards() {
   local base="${1:?merge-shards requires a slug base (internal_api | internal_services)}"
   local in_dir="${2:-.tmp/mutation-shards}"
   local out_file="${3:-$TMP_DIR/${base}.json}"
+  # -expect reuses the SHARDED_PKGS registry above as the single source of
+  # truth for how many shards this base owes — the same count verify-shards
+  # already checks the partition against — so a shard whose guard failed and
+  # whose upload was skipped makes the merge fail loudly instead of quietly
+  # publishing a partial report under the complete report's name.
+  local expect
+  expect="$(shard_pkg_field "$base" count)" || {
+    echo "error: '$base' is not a registered sharded package (see SHARDED_PKGS)" >&2
+    exit 1
+  }
   go run ./scripts/mutationmerge \
     -in "$in_dir" \
     -glob "${base}_*.json" \
-    -out "$out_file"
+    -out "$out_file" \
+    -expect "$expect"
 }
 
 main() {

--- a/scripts/mutationmerge/main.go
+++ b/scripts/mutationmerge/main.go
@@ -18,7 +18,7 @@
 // that means the partition and the merge have gone out of sync, so this
 // fails loudly rather than silently keeping one copy.
 //
-// Usage: mutationmerge -in <dir> -glob <pattern> -out <file>
+// Usage: mutationmerge -in <dir> -glob <pattern> -out <file> [-expect <n>]
 package main
 
 import (
@@ -44,10 +44,11 @@ func main() {
 	inDir := flag.String("in", "", "directory to search for shard JSON reports")
 	pattern := flag.String("glob", "*.json", "glob (relative to -in) matching shard report files")
 	outPath := flag.String("out", "", "path to write the merged JSON report")
+	expect := flag.Int("expect", 0, "expected number of shard report files; 0 disables the check")
 	flag.Parse()
 
 	if *inDir == "" || *outPath == "" {
-		fatalf("usage: mutationmerge -in <dir> -glob <pattern> -out <file>")
+		fatalf("usage: mutationmerge -in <dir> -glob <pattern> -out <file> [-expect <n>]")
 	}
 
 	matches, err := findShardFiles(*inDir, *pattern)
@@ -56,6 +57,16 @@ func main() {
 	}
 	if len(matches) == 0 {
 		fatalf("no shard report files matched %s under %s — nothing to merge", *pattern, *inDir)
+	}
+	// A shard whose "Verify mutation output was produced" guard fails still
+	// leaves the merge free to run (mutation-merge's own `if: always()`), and
+	// its upload is `if-no-files-found: ignore` — so a missing shard is
+	// otherwise invisible here: mergeReports below only checks go_module
+	// agreement and file_name overlap, neither of which a missing FILE trips.
+	// Without this, the merge would fold N-1 shards into a report published
+	// under the same canonical name a complete run uses, reading as whole.
+	if *expect > 0 && len(matches) != *expect {
+		fatalf("found %d shard report(s) under %s, expected %d — a shard's guard likely failed and its upload was skipped; refusing to publish a partial report as if it were complete", len(matches), *inDir, *expect)
 	}
 
 	merged, err := mergeReports(matches)


### PR DESCRIPTION
## What (PR-22, REL-8 + REL-9 + REL-10, all re-verified against current HEAD)

Three independent fixes, one PR per the release plan's grouping.

**REL-8** — `mutation.yml`'s per-shard guard ("Verify mutation output was produced") only fails the
one shard that dies; the merge job downstream runs `if: always()` and its upload is
`if-no-files-found: ignore`, so a 4-of-5 result still published under the same canonical artifact
name a complete run uses, with `mergeReports` (which only checks `go_module` agreement and
`file_name` overlap) having no way to notice a file went missing.

**REL-9** — `changelog.yml` spliced `${{ github.event.pull_request.base.ref }}` directly into a
`run:` shell command, unescaped. The same pattern (same class, unflagged) exists at `ci.yml:925`
inside `patch-coverage` — fixed in the companion PR (#664) since that's the same job REL-6 already
touches. Separately, every real step in `changelog-fragment` gates on `env.RUN_GATE == 'true'` with
no unconditional fallback: a `RUN_GATE` that ever evaluates to anything else reports success having
run nothing, on a required check.

**REL-10** — `persist-credentials: false` was present on 1 of 26 `actions/checkout` steps across 8
workflow files (`scorecard.yml` only). Recounted from scratch against current HEAD (unchanged from
the audit's figure). None of the 25 remaining push, and the repo is public, so anonymous fetches
after checkout don't need the credential either.

## Change

- `scripts/mutationmerge/main.go`: new `-expect <n>` flag, checked after `findShardFiles` and
  before merging — fails loud on a count mismatch instead of silently merging a partial set.
  `scripts/mutation.sh`'s `merge_shards()` now sources the expected count from the existing
  `SHARDED_PKGS` registry (the same one `verify-shards` already checks the partition against), so
  there's one source of truth for shard counts, not a second hardcoded one.
- `changelog.yml`: `git fetch --no-tags origin "$PR_BASE_REF"` (quoted var) instead of the raw
  splice; added a `Fail on unhandled trigger` step.
- `persist-credentials: false` added to the `with:` of all 25 checkout steps that lacked it, across
  `ci.yml`, `security.yml`, `docker-image.yml`, `mutation.yml`, `changelog.yml`, `codeql.yml`,
  `gitleaks.yml`. Mechanical, same one-line addition everywhere.

## Verified

- `scripts/mutationmerge`: `go build`/`go vet` clean; smoke-tested `-expect` both matching (merges)
  and mismatching (fails loud with a clear message) against a throwaway fixture.
- `scripts/mutation.sh`: `bash -n` syntax-clean.
- All 9 touched workflow files still parse as valid YAML after the sweep (`yaml.safe_load` over
  every file in `.github/workflows/`).
- Recounted `actions/checkout@` occurrences directly against this branch: 26, matching the audit;
  confirmed none of the 26 jobs `git push`/`git commit` (grepped), and confirmed repo visibility is
  `PUBLIC` via `gh repo view`.

## Risk

Medium. REL-8 changes advisory-only tooling (mutation testing isn't a required check) — a shard
gap now fails the job visibly instead of publishing silently, which is the intended tightening.
REL-9's RUN_GATE fallback only fires on a scenario not currently reachable (the workflow's `on:`
declares only `pull_request`/`merge_group`), so it's a robustness addition, not a behavior change
for today's traffic. REL-10 is credential-hygiene with no functional effect on any job that doesn't
push (verified none do). Rollback: revert this commit.