### PR TITLE
fix(api): the cycle patch stops rewriting what it was not sent

### DIFF
--- a/changelog.d/the-cycle-patch-stops-resetting-what-it-was-not-sent.md
+++ b/changelog.d/the-cycle-patch-stops-resetting-what-it-was-not-sent.md
@@ -1,0 +1,22 @@
+### Fixed
+
+- **Breaking (API shape): `PATCH /api/v1/users/current/cycle` no longer rewrites the settings a
+  request never mentioned.** A JSON save that carried the cycle geometry alone was read as a full
+  snapshot, so every member it did not name was written back as that member's zero value. The
+  expensive one was the tracking mode: an owner tracking to **avoid pregnancy** was silently moved
+  to general health tracking, which reframes the fertile window, the badges and the summaries
+  across every surface — a mode the product otherwise changes only on an explicit owner action.
+  The age bracket was wiped to unspecified the same way, and the three cycle flags were cleared.
+  The endpoint is now the partial update its verb promises: a member the body carries is written
+  (including one carrying `false` or `""`, which is a value, not an absence), and a member it omits
+  is left exactly as it stands. What changes for a client that was relying on the old behaviour: to
+  clear a flag or a bracket, send it explicitly rather than leaving it out.
+
+  The dashboard's mode quick switch is fixed on the same edge — it used to take a one-column path
+  whenever the two lengths were missing, so a flag travelling beside the mode was dropped — and its
+  success body no longer echoes the stored `usage_goal`, which made it the one save whose `200`
+  a client validating against the published `OkResponse` schema rejected.
+
+  The settings form is unaffected. It submits every control it owns on every save, and an unchecked
+  box submits nothing at all, so a form body has no absent members to honour and is still read as
+  the full snapshot it is — the toggles keep switching off.

--- a/changelog.d/the-cycle-patch-stops-resetting-what-it-was-not-sent.md
+++ b/changelog.d/the-cycle-patch-stops-resetting-what-it-was-not-sent.md
@@ -12,6 +12,11 @@
   is left exactly as it stands. What changes for a client that was relying on the old behaviour: to
   clear a flag or a bracket, send it explicitly rather than leaving it out.
 
+  The save now writes only the columns the request named, rather than the whole row, so this holds
+  between two overlapping requests as well as inside one: a save of the cycle lengths can no longer
+  put back the tracking mode as it stood when that request began, undoing a mode switch made from
+  another tab in between.
+
   The dashboard's mode quick switch is fixed on the same edge — it used to take a one-column path
   whenever the two lengths were missing, so a flag travelling beside the mode was dropped — and its
   success body no longer echoes the stored `usage_goal`, which made it the one save whose `200`

--- a/changelog.d/the-cycle-patch-stops-resetting-what-it-was-not-sent.md
+++ b/changelog.d/the-cycle-patch-stops-resetting-what-it-was-not-sent.md
@@ -10,7 +10,9 @@
   The endpoint is now the partial update its verb promises: a member the body carries is written
   (including one carrying `false` or `""`, which is a value, not an absence), and a member it omits
   is left exactly as it stands. What changes for a client that was relying on the old behaviour: to
-  clear a flag or a bracket, send it explicitly rather than leaving it out.
+  clear a flag or a bracket, send it explicitly rather than leaving it out. The one body that is
+  refused rather than accepted is one naming no member at all: it asks for no change, and a save
+  that changed nothing should not be recorded as one.
 
   The save now writes only the columns the request named, rather than the whole row, so this holds
   between two overlapping requests as well as inside one: a save of the cycle lengths can no longer

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -942,6 +942,10 @@ components:
         the two lengths alone rewrote `usage_goal` to `health` and `age_group`
         to unknown.
 
+        A body that names none of these members is refused with `400
+        invalid settings input` rather than answered `200`: it asks for no
+        change, and a save that changed nothing must not be recorded as one.
+
         The bundled settings form is not affected and is not described by this
         schema: it submits every control it owns on every save, and an unchecked
         box submits nothing at all, so a form body carries no absence to honour

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -933,6 +933,19 @@ components:
 
     CycleSettings:
       type: object
+      description: |
+        A partial update, as the verb says: a member this body does not carry
+        keeps the value the account already holds, and only what is actually
+        sent can change. A member carrying a zero value (`false`, `""`) is
+        present and is written — absence and a zero value are different answers.
+        Until v2.0.0 an absent member was read as its zero value, so a save of
+        the two lengths alone rewrote `usage_goal` to `health` and `age_group`
+        to unknown.
+
+        The bundled settings form is not affected and is not described by this
+        schema: it submits every control it owns on every save, and an unchecked
+        box submits nothing at all, so a form body carries no absence to honour
+        and is read as the full snapshot it is.
       properties:
         cycle_length:
           type: integer
@@ -965,13 +978,12 @@ components:
           type: string
           enum: [health, avoid_pregnancy, trying_to_conceive]
           description: >-
-            A body carrying `usage_goal` and neither `cycle_length` nor
-            `period_length` is a goal-only update: it writes that one column and
-            leaves every other cycle field untouched (this is what the dashboard
-            quick switch sends). Any other body is a full cycle save and must
-            carry both lengths. The goal is only ever changed by an explicit
-            owner action — nothing logged on a day, including a positive
-            pregnancy test, rewrites it.
+            A body carrying `usage_goal` and no other member at all is the
+            dashboard quick switch: it writes that one column directly. Any
+            other body takes the ordinary partial path above, which reaches the
+            same result for the members it carries. The goal is only ever
+            changed by an explicit owner action — nothing logged on a day,
+            including a positive pregnancy test, rewrites it.
         last_period_start:
           type: string
           format: date
@@ -2127,6 +2139,12 @@ paths:
     patch:
       tags: [settings]
       summary: Update cycle settings (owner only).
+      description: >-
+        Partial: the request body carries the members to change, and every
+        member it omits keeps its stored value. `CycleSettings` states what a
+        present member and an absent one each mean. The success body is
+        `OkResponse` and carries nothing else — including on the goal-only
+        quick switch, which echoed the stored goal back until v2.0.0.
       requestBody:
         required: true
         content:

--- a/e2e/calendar.spec.ts
+++ b/e2e/calendar.spec.ts
@@ -623,9 +623,10 @@ test.describe('Calendar page', () => {
     const csrf = (await page.locator('meta[name="csrf-token"]').getAttribute('content')) ?? '';
 
     async function patchUsageGoal(goal: string): Promise<void> {
-      // parseCycleSettingsInput validates cycle_length / period_length even
-      // on a partial JSON patch — resend the full default snapshot with the
-      // UsageGoal override.
+      // A body carrying the goal and nothing else takes the dashboard quick
+      // switch's one-column path. This spec wants the ordinary partial save, so
+      // it sends the geometry alongside the goal; every member it omits would
+      // keep its stored value either way.
       const response = await page.request.patch('/api/v1/users/current/cycle', {
         headers: { ...apiOriginHeader(page), 'X-CSRF-Token': csrf, 'Content-Type': 'application/json' },
         data: {

--- a/internal/api/handlers_settings_cycle.go
+++ b/internal/api/handlers_settings_cycle.go
@@ -20,7 +20,7 @@ func (handler *Handler) UpdateCycleSettings(c fiber.Ctx) error {
 		return handler.updateUsageGoalOnly(c, user, usageGoal)
 	}
 
-	input, parseError := handler.parseCycleSettingsInput(c)
+	input, parseError := handler.parseCycleSettingsInput(c, user)
 	if parseError != "" {
 		return handler.failMutation(c, cycleSettingsMutation, settingsValidationErrorSpec(parseError))
 	}
@@ -52,7 +52,10 @@ func (handler *Handler) updateUsageGoalOnly(c fiber.Ctx, user *models.User, rawU
 	handler.logMutationSuccess(c, cycleSettingsMutation)
 
 	if acceptsJSON(c) {
-		return c.JSON(fiber.Map{"ok": true, "usage_goal": usageGoal})
+		// The stored goal is not echoed back: OkResponse declares
+		// `additionalProperties: false`, so an extra member here is a response a
+		// client validating against the published schema rejects.
+		return c.JSON(fiber.Map{"ok": true})
 	}
 	if isHTMX(c) {
 		// The mode reframes fertile-window copy, badges and summaries across the

--- a/internal/api/handlers_settings_cycle_helpers.go
+++ b/internal/api/handlers_settings_cycle_helpers.go
@@ -16,7 +16,9 @@ import (
 // pointer per member so an absent member is distinguishable from a zero one. It
 // is the single declaration of the member set: the JSON arm binds into it and
 // the form arm reads its json tags, so a member added here reaches both without
-// a second list to keep in step.
+// a second list to keep in step. patchCarriesOnlyUsageGoal is the one place that
+// still names the members by hand, and it is held to this shape by the sweep
+// TestGoalOnlyShortcutYieldsToEveryOtherMember rather than by derivation.
 type cycleSettingsPatchProbe struct {
 	CycleLength        *int    `json:"cycle_length"`
 	PeriodLength       *int    `json:"period_length"`

--- a/internal/api/handlers_settings_cycle_helpers.go
+++ b/internal/api/handlers_settings_cycle_helpers.go
@@ -115,6 +115,14 @@ func (handler *Handler) parseCycleSettingsInput(c fiber.Ctx, user *models.User) 
 			return services.CycleSettingsUpdate{}, "invalid settings input"
 		}
 		resolved := handler.settingsService.ResolveCycleSettingsPatch(user, patch)
+		// A body naming no member at all is refused rather than answered 200.
+		// Before the save became partial it was refused too — as an out-of-range
+		// cycle_length — and accepting it now would audit a cycle-settings change
+		// that did not happen, which is the one thing the mutation log must not
+		// say. SaveCycleSettings keeps its own empty-update floor underneath.
+		if resolved.Present == (services.CycleSettingsMembers{}) && !resolved.LastPeriodStartSet {
+			return services.CycleSettingsUpdate{}, "invalid settings input"
+		}
 		update, err := handler.settingsService.ValidateCycleSettings(resolved, time.Now().In(location), location)
 		if err != nil {
 			return services.CycleSettingsUpdate{}, cycleSettingsValidationErrorKey(err)

--- a/internal/api/handlers_settings_cycle_helpers.go
+++ b/internal/api/handlers_settings_cycle_helpers.go
@@ -7,71 +7,123 @@ import (
 	"time"
 
 	"github.com/gofiber/fiber/v3"
+	"github.com/ovumcy/ovumcy-web/internal/models"
 	"github.com/ovumcy/ovumcy-web/internal/services"
 )
 
+// cycleSettingsMemberNames are the wire names of every member this endpoint
+// writes, in one place: both the goal-only predicate and the JSON patch read
+// presence over the same set, so a member added to one and not the other cannot
+// go unnoticed.
+var cycleSettingsMemberNames = []string{
+	"cycle_length",
+	"period_length",
+	"auto_period_fill",
+	"irregular_cycle",
+	"unpredictable_cycle",
+	"age_group",
+	"usage_goal",
+	"last_period_start",
+}
+
 // goalOnlyCycleSettingsRequest reports whether the request body carries the
-// usage goal and no cycle geometry at all. It is a question about the shape of
-// the request, not about the domain: what a goal-only save means is decided by
-// SettingsService.SaveUsageGoal. Presence is read field by field — a zero
-// cycle_length submitted explicitly is still a (rejected) full save, never a
-// silent partial one.
+// usage goal and NOTHING else. It is a question about the shape of the request,
+// not about the domain: what a goal-only save means is decided by
+// SettingsService.SaveUsageGoal, which writes that one column. The predicate
+// used to admit any body without the two lengths, so a mode switch arriving
+// with `irregular_cycle` beside it dropped that flag on the floor.
 func goalOnlyCycleSettingsRequest(c fiber.Ctx) (string, bool) {
+	patch, ok := cycleSettingsPatchFromJSON(c)
+	if ok {
+		if patch.UsageGoal == nil {
+			return "", false
+		}
+		if patch.CycleLength != nil || patch.PeriodLength != nil || patch.AutoPeriodFill != nil ||
+			patch.IrregularCycle != nil || patch.UnpredictableCycle != nil || patch.AgeGroup != nil ||
+			patch.LastPeriodStart != nil {
+			return "", false
+		}
+		return strings.TrimSpace(*patch.UsageGoal), true
+	}
 	if hasJSONBody(c) {
-		probe := struct {
-			CycleLength  *int    `json:"cycle_length"`
-			PeriodLength *int    `json:"period_length"`
-			UsageGoal    *string `json:"usage_goal"`
-		}{}
-		if err := c.Bind().Body(&probe); err != nil {
-			return "", false
-		}
-		if probe.UsageGoal == nil || probe.CycleLength != nil || probe.PeriodLength != nil {
-			return "", false
-		}
-		return strings.TrimSpace(*probe.UsageGoal), true
+		return "", false
 	}
 
 	args := c.Request().PostArgs()
-	if !args.Has("usage_goal") || args.Has("cycle_length") || args.Has("period_length") {
+	if !args.Has("usage_goal") {
 		return "", false
+	}
+	for _, member := range cycleSettingsMemberNames {
+		if member != "usage_goal" && args.Has(member) {
+			return "", false
+		}
 	}
 	return strings.TrimSpace(string(args.Peek("usage_goal"))), true
 }
 
-func (handler *Handler) parseCycleSettingsInput(c fiber.Ctx) (services.CycleSettingsUpdate, string) {
+// cycleSettingsPatchFromJSON reads a JSON body member by member. The second
+// result is false when the request carries no JSON body or the body does not
+// decode; a body that decodes to nothing at all is still a valid (empty) patch.
+func cycleSettingsPatchFromJSON(c fiber.Ctx) (services.CycleSettingsPatch, bool) {
+	if !hasJSONBody(c) {
+		return services.CycleSettingsPatch{}, false
+	}
+	probe := struct {
+		CycleLength        *int    `json:"cycle_length"`
+		PeriodLength       *int    `json:"period_length"`
+		AutoPeriodFill     *bool   `json:"auto_period_fill"`
+		IrregularCycle     *bool   `json:"irregular_cycle"`
+		UnpredictableCycle *bool   `json:"unpredictable_cycle"`
+		AgeGroup           *string `json:"age_group"`
+		UsageGoal          *string `json:"usage_goal"`
+		LastPeriodStart    *string `json:"last_period_start"`
+	}{}
+	if err := c.Bind().Body(&probe); err != nil {
+		return services.CycleSettingsPatch{}, false
+	}
+	return services.CycleSettingsPatch(probe), true
+}
+
+func (handler *Handler) parseCycleSettingsInput(c fiber.Ctx, user *models.User) (services.CycleSettingsUpdate, string) {
 	input := cycleSettingsInput{}
 	location := handler.requestLocation(c)
 
 	if hasJSONBody(c) {
-		if err := c.Bind().Body(&input); err != nil {
+		patch, ok := cycleSettingsPatchFromJSON(c)
+		if !ok {
 			return services.CycleSettingsUpdate{}, "invalid settings input"
 		}
-		input.LastPeriodStart = strings.TrimSpace(input.LastPeriodStart)
-		if input.LastPeriodStart != "" {
-			input.LastPeriodStartSet = true
-		}
-	} else {
-		cycleLength, err := strconv.Atoi(strings.TrimSpace(c.FormValue("cycle_length")))
+		resolved := handler.settingsService.ResolveCycleSettingsPatch(user, patch)
+		update, err := handler.settingsService.ValidateCycleSettings(resolved, time.Now().In(location), location)
 		if err != nil {
-			return services.CycleSettingsUpdate{}, "invalid settings input"
+			return services.CycleSettingsUpdate{}, cycleSettingsValidationErrorKey(err)
 		}
-		periodLength, err := strconv.Atoi(strings.TrimSpace(c.FormValue("period_length")))
-		if err != nil {
-			return services.CycleSettingsUpdate{}, "invalid settings input"
-		}
-		input = cycleSettingsInput{
-			CycleLength:        cycleLength,
-			PeriodLength:       periodLength,
-			AutoPeriodFill:     services.ParseBoolLike(c.FormValue("auto_period_fill")),
-			IrregularCycle:     services.ParseBoolLike(c.FormValue("irregular_cycle")),
-			UnpredictableCycle: services.ParseBoolLike(c.FormValue("unpredictable_cycle")),
-			AgeGroup:           strings.TrimSpace(c.FormValue("age_group")),
-			UsageGoal:          strings.TrimSpace(c.FormValue("usage_goal")),
-			LastPeriodStart:    strings.TrimSpace(c.FormValue("last_period_start")),
-			LastPeriodStartSet: c.Request().PostArgs().Has("last_period_start"),
-		}
+		return update, ""
 	}
+
+	// The settings form submits every control it owns on every save, and an
+	// unchecked box submits nothing at all, so absence carries no meaning here:
+	// a form body is read as the full snapshot it is.
+	cycleLength, err := strconv.Atoi(strings.TrimSpace(c.FormValue("cycle_length")))
+	if err != nil {
+		return services.CycleSettingsUpdate{}, "invalid settings input"
+	}
+	periodLength, err := strconv.Atoi(strings.TrimSpace(c.FormValue("period_length")))
+	if err != nil {
+		return services.CycleSettingsUpdate{}, "invalid settings input"
+	}
+	input = cycleSettingsInput{
+		CycleLength:        cycleLength,
+		PeriodLength:       periodLength,
+		AutoPeriodFill:     services.ParseBoolLike(c.FormValue("auto_period_fill")),
+		IrregularCycle:     services.ParseBoolLike(c.FormValue("irregular_cycle")),
+		UnpredictableCycle: services.ParseBoolLike(c.FormValue("unpredictable_cycle")),
+		AgeGroup:           strings.TrimSpace(c.FormValue("age_group")),
+		UsageGoal:          strings.TrimSpace(c.FormValue("usage_goal")),
+		LastPeriodStart:    strings.TrimSpace(c.FormValue("last_period_start")),
+		LastPeriodStartSet: c.Request().PostArgs().Has("last_period_start"),
+	}
+
 	update, err := handler.settingsService.ValidateCycleSettings(services.CycleSettingsValidationInput{
 		CycleLength:        input.CycleLength,
 		PeriodLength:       input.PeriodLength,
@@ -84,19 +136,23 @@ func (handler *Handler) parseCycleSettingsInput(c fiber.Ctx) (services.CycleSett
 		LastPeriodStartSet: input.LastPeriodStartSet,
 	}, time.Now().In(location), location)
 	if err != nil {
-		switch {
-		case errors.Is(err, services.ErrSettingsCycleLengthOutOfRange):
-			return services.CycleSettingsUpdate{}, "cycle length must be between 15 and 90"
-		case errors.Is(err, services.ErrSettingsPeriodLengthOutOfRange):
-			return services.CycleSettingsUpdate{}, "period length must be between 1 and 14"
-		case errors.Is(err, services.ErrSettingsPeriodLengthIncompatible):
-			return services.CycleSettingsUpdate{}, "period length is incompatible with cycle length"
-		case errors.Is(err, services.ErrSettingsCycleStartDateInvalid):
-			return services.CycleSettingsUpdate{}, "invalid cycle start date"
-		default:
-			return services.CycleSettingsUpdate{}, "invalid settings input"
-		}
+		return services.CycleSettingsUpdate{}, cycleSettingsValidationErrorKey(err)
 	}
 
 	return update, ""
+}
+
+func cycleSettingsValidationErrorKey(err error) string {
+	switch {
+	case errors.Is(err, services.ErrSettingsCycleLengthOutOfRange):
+		return "cycle length must be between 15 and 90"
+	case errors.Is(err, services.ErrSettingsPeriodLengthOutOfRange):
+		return "period length must be between 1 and 14"
+	case errors.Is(err, services.ErrSettingsPeriodLengthIncompatible):
+		return "period length is incompatible with cycle length"
+	case errors.Is(err, services.ErrSettingsCycleStartDateInvalid):
+		return "invalid cycle start date"
+	default:
+		return "invalid settings input"
+	}
 }

--- a/internal/api/handlers_settings_cycle_helpers.go
+++ b/internal/api/handlers_settings_cycle_helpers.go
@@ -106,7 +106,6 @@ func cycleSettingsPatchFromJSON(c fiber.Ctx) (services.CycleSettingsPatch, bool)
 }
 
 func (handler *Handler) parseCycleSettingsInput(c fiber.Ctx, user *models.User) (services.CycleSettingsUpdate, string) {
-	input := cycleSettingsInput{}
 	location := handler.requestLocation(c)
 
 	if hasJSONBody(c) {
@@ -141,7 +140,7 @@ func (handler *Handler) parseCycleSettingsInput(c fiber.Ctx, user *models.User) 
 	if err != nil {
 		return services.CycleSettingsUpdate{}, "invalid settings input"
 	}
-	input = cycleSettingsInput{
+	update, err := handler.settingsService.ValidateCycleSettings(services.CycleSettingsValidationInput{
 		CycleLength:        cycleLength,
 		PeriodLength:       periodLength,
 		AutoPeriodFill:     services.ParseBoolLike(c.FormValue("auto_period_fill")),
@@ -149,20 +148,8 @@ func (handler *Handler) parseCycleSettingsInput(c fiber.Ctx, user *models.User) 
 		UnpredictableCycle: services.ParseBoolLike(c.FormValue("unpredictable_cycle")),
 		AgeGroup:           strings.TrimSpace(c.FormValue("age_group")),
 		UsageGoal:          strings.TrimSpace(c.FormValue("usage_goal")),
-		LastPeriodStart:    strings.TrimSpace(c.FormValue("last_period_start")),
+		LastPeriodStartRaw: strings.TrimSpace(c.FormValue("last_period_start")),
 		LastPeriodStartSet: c.Request().PostArgs().Has("last_period_start"),
-	}
-
-	update, err := handler.settingsService.ValidateCycleSettings(services.CycleSettingsValidationInput{
-		CycleLength:        input.CycleLength,
-		PeriodLength:       input.PeriodLength,
-		AutoPeriodFill:     input.AutoPeriodFill,
-		IrregularCycle:     input.IrregularCycle,
-		UnpredictableCycle: input.UnpredictableCycle,
-		AgeGroup:           input.AgeGroup,
-		UsageGoal:          input.UsageGoal,
-		LastPeriodStartRaw: input.LastPeriodStart,
-		LastPeriodStartSet: input.LastPeriodStartSet,
 		// A form body is a full snapshot by construction, so every member is
 		// present and every column is the form's to write.
 		Present: services.AllCycleSettingsMembers(),

--- a/internal/api/handlers_settings_cycle_helpers.go
+++ b/internal/api/handlers_settings_cycle_helpers.go
@@ -155,6 +155,9 @@ func (handler *Handler) parseCycleSettingsInput(c fiber.Ctx, user *models.User) 
 		UsageGoal:          input.UsageGoal,
 		LastPeriodStartRaw: input.LastPeriodStart,
 		LastPeriodStartSet: input.LastPeriodStartSet,
+		// A form body is a full snapshot by construction, so every member is
+		// present and every column is the form's to write.
+		Present: services.AllCycleSettingsMembers(),
 	}, time.Now().In(location), location)
 	if err != nil {
 		return services.CycleSettingsUpdate{}, cycleSettingsValidationErrorKey(err)

--- a/internal/api/handlers_settings_cycle_helpers.go
+++ b/internal/api/handlers_settings_cycle_helpers.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"errors"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -11,19 +12,53 @@ import (
 	"github.com/ovumcy/ovumcy-web/internal/services"
 )
 
-// cycleSettingsMemberNames are the wire names of every member this endpoint
-// writes, in one place: both the goal-only predicate and the JSON patch read
-// presence over the same set, so a member added to one and not the other cannot
-// go unnoticed.
-var cycleSettingsMemberNames = []string{
-	"cycle_length",
-	"period_length",
-	"auto_period_fill",
-	"irregular_cycle",
-	"unpredictable_cycle",
-	"age_group",
-	"usage_goal",
-	"last_period_start",
+// cycleSettingsPatchProbe is the wire shape of a cycle-settings body, one
+// pointer per member so an absent member is distinguishable from a zero one. It
+// is the single declaration of the member set: the JSON arm binds into it and
+// the form arm reads its json tags, so a member added here reaches both without
+// a second list to keep in step.
+type cycleSettingsPatchProbe struct {
+	CycleLength        *int    `json:"cycle_length"`
+	PeriodLength       *int    `json:"period_length"`
+	AutoPeriodFill     *bool   `json:"auto_period_fill"`
+	IrregularCycle     *bool   `json:"irregular_cycle"`
+	UnpredictableCycle *bool   `json:"unpredictable_cycle"`
+	AgeGroup           *string `json:"age_group"`
+	UsageGoal          *string `json:"usage_goal"`
+	LastPeriodStart    *string `json:"last_period_start"`
+}
+
+// cycleSettingsMemberNames are those wire names, derived rather than retyped.
+var cycleSettingsMemberNames = cycleSettingsProbeMemberNames()
+
+func cycleSettingsProbeMemberNames() []string {
+	probeType := reflect.TypeOf(cycleSettingsPatchProbe{})
+	names := make([]string, 0, probeType.NumField())
+	for index := range probeType.NumField() {
+		if name := probeType.Field(index).Tag.Get("json"); name != "" {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+// patchCarriesOnlyUsageGoal reports whether the goal is the one member the body
+// names. It is a separate function so the sweep can drive it field by field:
+// a member added to cycleSettingsPatchProbe and forgotten here would send a body
+// carrying it back down the one-column path, dropping it — the very defect the
+// partial save exists to end. Regression:
+// TestGoalOnlyShortcutYieldsToEveryOtherMember.
+func patchCarriesOnlyUsageGoal(patch services.CycleSettingsPatch) bool {
+	if patch.UsageGoal == nil {
+		return false
+	}
+	return patch.CycleLength == nil &&
+		patch.PeriodLength == nil &&
+		patch.AutoPeriodFill == nil &&
+		patch.IrregularCycle == nil &&
+		patch.UnpredictableCycle == nil &&
+		patch.AgeGroup == nil &&
+		patch.LastPeriodStart == nil
 }
 
 // goalOnlyCycleSettingsRequest reports whether the request body carries the
@@ -35,12 +70,7 @@ var cycleSettingsMemberNames = []string{
 func goalOnlyCycleSettingsRequest(c fiber.Ctx) (string, bool) {
 	patch, ok := cycleSettingsPatchFromJSON(c)
 	if ok {
-		if patch.UsageGoal == nil {
-			return "", false
-		}
-		if patch.CycleLength != nil || patch.PeriodLength != nil || patch.AutoPeriodFill != nil ||
-			patch.IrregularCycle != nil || patch.UnpredictableCycle != nil || patch.AgeGroup != nil ||
-			patch.LastPeriodStart != nil {
+		if !patchCarriesOnlyUsageGoal(patch) {
 			return "", false
 		}
 		return strings.TrimSpace(*patch.UsageGoal), true
@@ -68,16 +98,7 @@ func cycleSettingsPatchFromJSON(c fiber.Ctx) (services.CycleSettingsPatch, bool)
 	if !hasJSONBody(c) {
 		return services.CycleSettingsPatch{}, false
 	}
-	probe := struct {
-		CycleLength        *int    `json:"cycle_length"`
-		PeriodLength       *int    `json:"period_length"`
-		AutoPeriodFill     *bool   `json:"auto_period_fill"`
-		IrregularCycle     *bool   `json:"irregular_cycle"`
-		UnpredictableCycle *bool   `json:"unpredictable_cycle"`
-		AgeGroup           *string `json:"age_group"`
-		UsageGoal          *string `json:"usage_goal"`
-		LastPeriodStart    *string `json:"last_period_start"`
-	}{}
+	probe := cycleSettingsPatchProbe{}
 	if err := c.Bind().Body(&probe); err != nil {
 		return services.CycleSettingsPatch{}, false
 	}

--- a/internal/api/input_types.go
+++ b/internal/api/input_types.go
@@ -60,18 +60,6 @@ type changePasswordInput struct {
 	ConfirmPassword string `json:"confirm_password" form:"confirm_password"`
 }
 
-type cycleSettingsInput struct {
-	CycleLength        int    `json:"cycle_length" form:"cycle_length"`
-	PeriodLength       int    `json:"period_length" form:"period_length"`
-	AutoPeriodFill     bool   `json:"auto_period_fill" form:"auto_period_fill"`
-	IrregularCycle     bool   `json:"irregular_cycle" form:"irregular_cycle"`
-	UnpredictableCycle bool   `json:"unpredictable_cycle" form:"unpredictable_cycle"`
-	AgeGroup           string `json:"age_group" form:"age_group"`
-	UsageGoal          string `json:"usage_goal" form:"usage_goal"`
-	LastPeriodStart    string `json:"last_period_start" form:"last_period_start"`
-	LastPeriodStartSet bool   `json:"-" form:"-"`
-}
-
 type profileSettingsInput struct {
 	DisplayName string `json:"display_name" form:"display_name"`
 }

--- a/internal/api/settings_cycle_partial_patch_test.go
+++ b/internal/api/settings_cycle_partial_patch_test.go
@@ -1,0 +1,219 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/ovumcy/ovumcy-web/internal/models"
+)
+
+func patchCycleSettingsJSON(t *testing.T, app *fiber.App, authCookie string, body string) *http.Response {
+	t.Helper()
+
+	request := httptest.NewRequest(http.MethodPatch, "/api/v1/users/current/cycle", strings.NewReader(body))
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("Cookie", authCookie)
+
+	response, err := app.Test(request, testConfigNoTimeout)
+	if err != nil {
+		t.Fatalf("cycle settings request failed: %v", err)
+	}
+	return response
+}
+
+// TestCycleSettingsPatchKeepsWhatTheBodyDidNotCarry is the finding itself: a
+// JSON save of the cycle geometry alone used to rewrite every member it did not
+// mention to that member's zero value. The costly one is `usage_goal`: an owner
+// tracking to avoid pregnancy was silently moved to general health tracking,
+// which reframes the fertile window, the badges and the summaries on every
+// surface — a mode the product only ever changes on an explicit owner action.
+// `age_group` and the three flags went the same way.
+func TestCycleSettingsPatchKeepsWhatTheBodyDidNotCarry(t *testing.T) {
+	app, database := newOnboardingTestApp(t)
+	user := createOnboardingTestUser(t, database, "cycle-patch-keeps@example.com", "StrongPass1", true)
+	if err := database.Model(&models.User{}).Where("id = ?", user.ID).Updates(map[string]any{
+		"cycle_length":        30,
+		"period_length":       6,
+		"usage_goal":          models.UsageGoalAvoid,
+		"age_group":           models.AgeGroup40To45,
+		"irregular_cycle":     true,
+		"auto_period_fill":    true,
+		"unpredictable_cycle": false,
+	}).Error; err != nil {
+		t.Fatalf("set initial cycle values: %v", err)
+	}
+	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
+
+	response := patchCycleSettingsJSON(t, app, authCookie, `{"cycle_length":29,"period_length":5}`)
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", response.StatusCode)
+	}
+
+	persisted := models.User{}
+	if err := database.First(&persisted, user.ID).Error; err != nil {
+		t.Fatalf("load persisted user: %v", err)
+	}
+	if persisted.CycleLength != 29 || persisted.PeriodLength != 5 {
+		t.Fatalf("expected the submitted lengths, got cycle %d period %d", persisted.CycleLength, persisted.PeriodLength)
+	}
+	if persisted.UsageGoal != models.UsageGoalAvoid {
+		t.Fatalf("a save that never named the goal changed it to %q", persisted.UsageGoal)
+	}
+	if persisted.AgeGroup != models.AgeGroup40To45 {
+		t.Fatalf("a save that never named the age bracket changed it to %q", persisted.AgeGroup)
+	}
+	if !persisted.IrregularCycle || !persisted.AutoPeriodFill {
+		t.Fatalf("a save that named neither flag cleared them: irregular=%v auto_fill=%v", persisted.IrregularCycle, persisted.AutoPeriodFill)
+	}
+}
+
+// TestCycleSettingsPatchWritesEveryMemberItDoesCarry is the other half: partial
+// must not become inert. A member present in the body still wins over the stored
+// value, including one carrying a zero value, which is exactly the case a
+// presence check exists to tell apart from absence.
+func TestCycleSettingsPatchWritesEveryMemberItDoesCarry(t *testing.T) {
+	app, database := newOnboardingTestApp(t)
+	user := createOnboardingTestUser(t, database, "cycle-patch-writes@example.com", "StrongPass1", true)
+	if err := database.Model(&models.User{}).Where("id = ?", user.ID).Updates(map[string]any{
+		"usage_goal":       models.UsageGoalAvoid,
+		"age_group":        models.AgeGroup40To45,
+		"irregular_cycle":  true,
+		"auto_period_fill": true,
+	}).Error; err != nil {
+		t.Fatalf("set initial cycle values: %v", err)
+	}
+	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
+
+	response := patchCycleSettingsJSON(t, app, authCookie, `{"cycle_length":28,"period_length":5,"usage_goal":"trying_to_conceive","age_group":"","irregular_cycle":false,"auto_period_fill":false}`)
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", response.StatusCode)
+	}
+
+	persisted := models.User{}
+	if err := database.First(&persisted, user.ID).Error; err != nil {
+		t.Fatalf("load persisted user: %v", err)
+	}
+	if persisted.UsageGoal != models.UsageGoalTrying {
+		t.Fatalf("expected the submitted goal, got %q", persisted.UsageGoal)
+	}
+	if persisted.AgeGroup != models.AgeGroupUnknown {
+		t.Fatalf("expected the explicitly cleared age bracket, got %q", persisted.AgeGroup)
+	}
+	if persisted.IrregularCycle || persisted.AutoPeriodFill {
+		t.Fatalf("expected both flags explicitly cleared, got irregular=%v auto_fill=%v", persisted.IrregularCycle, persisted.AutoPeriodFill)
+	}
+}
+
+// TestUsageGoalSwitchKeepsWhatRidesBesideIt pins the goal-only shortcut's own
+// edge. It used to admit any body without the two lengths, so a body carrying
+// the goal AND a flag took the one-column path and dropped the flag — the same
+// silent partial save, arriving from the other side.
+func TestUsageGoalSwitchKeepsWhatRidesBesideIt(t *testing.T) {
+	app, database := newOnboardingTestApp(t)
+	user := createOnboardingTestUser(t, database, "cycle-goal-plus-flag@example.com", "StrongPass1", true)
+	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
+
+	response := patchCycleSettingsJSON(t, app, authCookie, `{"usage_goal":"avoid_pregnancy","irregular_cycle":true}`)
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", response.StatusCode)
+	}
+
+	persisted := models.User{}
+	if err := database.First(&persisted, user.ID).Error; err != nil {
+		t.Fatalf("load persisted user: %v", err)
+	}
+	if persisted.UsageGoal != models.UsageGoalAvoid {
+		t.Fatalf("expected the submitted goal, got %q", persisted.UsageGoal)
+	}
+	if !persisted.IrregularCycle {
+		t.Fatalf("the flag beside the goal was dropped")
+	}
+}
+
+// TestUsageGoalOnlySaveAnswersTheDeclaredOkShape pins the response against the
+// schema that describes it: `OkResponse` declares `additionalProperties: false`,
+// so the echoed `usage_goal` made this the one save whose success body a client
+// validating against docs/openapi.yaml rejects.
+func TestUsageGoalOnlySaveAnswersTheDeclaredOkShape(t *testing.T) {
+	app, database := newOnboardingTestApp(t)
+	user := createOnboardingTestUser(t, database, "cycle-goal-only-shape@example.com", "StrongPass1", true)
+	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
+
+	response := patchCycleSettingsJSON(t, app, authCookie, `{"usage_goal":"avoid_pregnancy"}`)
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", response.StatusCode)
+	}
+
+	body := map[string]any{}
+	if err := json.NewDecoder(response.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response body: %v", err)
+	}
+	if len(body) != 1 {
+		t.Fatalf("expected exactly the declared `ok` member, got %v", body)
+	}
+	if ok, present := body["ok"].(bool); !present || !ok {
+		t.Fatalf("expected `ok: true`, got %v", body["ok"])
+	}
+
+	persisted := models.User{}
+	if err := database.First(&persisted, user.ID).Error; err != nil {
+		t.Fatalf("load persisted user: %v", err)
+	}
+	if persisted.UsageGoal != models.UsageGoalAvoid {
+		t.Fatalf("expected the goal-only save to persist, got %q", persisted.UsageGoal)
+	}
+}
+
+// TestCycleSettingsFormSaveStaysAFullSnapshot is the counterweight to the three
+// above: presence is only meaningful where the transport can express it. The
+// settings form submits every control it owns, and an unchecked box submits
+// nothing at all, so a form body has no absent members to honour — reading one
+// as a patch would leave an owner unable to switch a toggle off.
+func TestCycleSettingsFormSaveStaysAFullSnapshot(t *testing.T) {
+	app, database := newOnboardingTestApp(t)
+	user := createOnboardingTestUser(t, database, "cycle-form-snapshot@example.com", "StrongPass1", true)
+	if err := database.Model(&models.User{}).Where("id = ?", user.ID).Updates(map[string]any{
+		"irregular_cycle":  true,
+		"auto_period_fill": true,
+	}).Error; err != nil {
+		t.Fatalf("set initial cycle values: %v", err)
+	}
+	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
+
+	request := httptest.NewRequest(http.MethodPatch, "/api/v1/users/current/cycle", strings.NewReader(url.Values{
+		"cycle_length":  {"28"},
+		"period_length": {"5"},
+		"usage_goal":    {models.UsageGoalHealth},
+		"age_group":     {""},
+	}.Encode()))
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("Cookie", authCookie)
+
+	response, err := app.Test(request, testConfigNoTimeout)
+	if err != nil {
+		t.Fatalf("cycle settings request failed: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", response.StatusCode)
+	}
+
+	persisted := models.User{}
+	if err := database.First(&persisted, user.ID).Error; err != nil {
+		t.Fatalf("load persisted user: %v", err)
+	}
+	if persisted.IrregularCycle || persisted.AutoPeriodFill {
+		t.Fatalf("an unchecked box did not clear its flag: irregular=%v auto_fill=%v", persisted.IrregularCycle, persisted.AutoPeriodFill)
+	}
+}

--- a/internal/api/settings_cycle_partial_patch_test.go
+++ b/internal/api/settings_cycle_partial_patch_test.go
@@ -144,6 +144,10 @@ func TestCycleSettingsFormSaveRefusesNonNumericLengths(t *testing.T) {
 			_ = response.Body.Close()
 			t.Fatalf("expected status 400 for %v, got %d", form, response.StatusCode)
 		}
+		if key := errorKeyFromEnvelope(t, response.Body); key != "invalid settings input" {
+			_ = response.Body.Close()
+			t.Fatalf("expected the settings refusal for %v, got error key %q", form, key)
+		}
 		_ = response.Body.Close()
 	}
 }
@@ -287,6 +291,10 @@ func TestCycleSettingsPatchRefusesABodyThatNamesNothing(t *testing.T) {
 			_ = response.Body.Close()
 			t.Fatalf("expected status 400 for %s, got %d", body, response.StatusCode)
 		}
+		if key := errorKeyFromEnvelope(t, response.Body); key != "invalid settings input" {
+			_ = response.Body.Close()
+			t.Fatalf("expected the settings refusal for %s, got error key %q", body, key)
+		}
 		_ = response.Body.Close()
 	}
 }
@@ -304,6 +312,9 @@ func TestCycleSettingsPatchRefusesAMalformedBody(t *testing.T) {
 
 	if response.StatusCode != http.StatusBadRequest {
 		t.Fatalf("expected status 400 for a malformed body, got %d", response.StatusCode)
+	}
+	if key := errorKeyFromEnvelope(t, response.Body); key != "invalid settings input" {
+		t.Fatalf("expected the settings refusal, got error key %q", key)
 	}
 
 	persisted := models.User{}

--- a/internal/api/settings_cycle_partial_patch_test.go
+++ b/internal/api/settings_cycle_partial_patch_test.go
@@ -5,11 +5,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/gofiber/fiber/v3"
 	"github.com/ovumcy/ovumcy-web/internal/models"
+	"github.com/ovumcy/ovumcy-web/internal/services"
 )
 
 func patchCycleSettingsJSON(t *testing.T, app *fiber.App, authCookie string, body string) *http.Response {
@@ -215,5 +217,34 @@ func TestCycleSettingsFormSaveStaysAFullSnapshot(t *testing.T) {
 	}
 	if persisted.IrregularCycle || persisted.AutoPeriodFill {
 		t.Fatalf("an unchecked box did not clear its flag: irregular=%v auto_fill=%v", persisted.IrregularCycle, persisted.AutoPeriodFill)
+	}
+}
+
+// TestGoalOnlyShortcutYieldsToEveryOtherMember is the no-allowlist sweep behind
+// the goal-only shortcut: for EVERY member the wire shape declares other than
+// the goal itself, a body carrying that member beside the goal must leave the
+// one-column path. It derives its roster from cycleSettingsPatchProbe rather
+// than a list, so a member added to the shape and forgotten in the predicate
+// fails here by name instead of being silently dropped by the shortcut.
+func TestGoalOnlyShortcutYieldsToEveryOtherMember(t *testing.T) {
+	goal := models.UsageGoalAvoid
+	probeType := reflect.TypeOf(cycleSettingsPatchProbe{})
+
+	for index := range probeType.NumField() {
+		field := probeType.Field(index)
+		if field.Name == "UsageGoal" {
+			continue
+		}
+
+		patch := services.CycleSettingsPatch{UsageGoal: &goal}
+		member := reflect.ValueOf(&patch).Elem().FieldByName(field.Name)
+		if !member.IsValid() {
+			t.Fatalf("%s is declared on the wire shape but not on services.CycleSettingsPatch", field.Name)
+		}
+		member.Set(reflect.New(member.Type().Elem()))
+
+		if patchCarriesOnlyUsageGoal(patch) {
+			t.Fatalf("a body carrying %s beside the goal still took the one-column path, which drops it", field.Tag.Get("json"))
+		}
 	}
 }

--- a/internal/api/settings_cycle_partial_patch_test.go
+++ b/internal/api/settings_cycle_partial_patch_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -93,7 +94,7 @@ func TestCycleSettingsPatchWritesEveryMemberItDoesCarry(t *testing.T) {
 	}
 	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
 
-	response := patchCycleSettingsJSON(t, app, authCookie, `{"cycle_length":28,"period_length":5,"usage_goal":"trying_to_conceive","age_group":"","irregular_cycle":false,"auto_period_fill":false}`)
+	response := patchCycleSettingsJSON(t, app, authCookie, `{"cycle_length":28,"period_length":5,"usage_goal":"trying_to_conceive","age_group":"","irregular_cycle":false,"auto_period_fill":false,"unpredictable_cycle":true}`)
 	defer func() { _ = response.Body.Close() }()
 	if response.StatusCode != http.StatusOK {
 		t.Fatalf("expected status 200, got %d", response.StatusCode)
@@ -111,6 +112,57 @@ func TestCycleSettingsPatchWritesEveryMemberItDoesCarry(t *testing.T) {
 	}
 	if persisted.IrregularCycle || persisted.AutoPeriodFill {
 		t.Fatalf("expected both flags explicitly cleared, got irregular=%v auto_fill=%v", persisted.IrregularCycle, persisted.AutoPeriodFill)
+	}
+	if !persisted.UnpredictableCycle {
+		t.Fatal("expected the submitted unpredictable-cycle flag to be written")
+	}
+}
+
+// TestCycleSettingsFormSaveRefusesNonNumericLengths covers the form transport's
+// own two refusals: it parses the lengths itself rather than binding them, so a
+// non-numeric value has to be answered there and not carried into validation as
+// a zero.
+func TestCycleSettingsFormSaveRefusesNonNumericLengths(t *testing.T) {
+	app, database := newOnboardingTestApp(t)
+	user := createOnboardingTestUser(t, database, "cycle-form-nonnumeric@example.com", "StrongPass1", true)
+	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
+
+	for _, form := range []url.Values{
+		{"cycle_length": {"twenty-eight"}, "period_length": {"5"}},
+		{"cycle_length": {"28"}, "period_length": {"five"}},
+	} {
+		request := httptest.NewRequest(http.MethodPatch, "/api/v1/users/current/cycle", strings.NewReader(form.Encode()))
+		request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		request.Header.Set("Accept", "application/json")
+		request.Header.Set("Cookie", authCookie)
+
+		response, err := app.Test(request, testConfigNoTimeout)
+		if err != nil {
+			t.Fatalf("cycle settings request failed: %v", err)
+		}
+		if response.StatusCode != http.StatusBadRequest {
+			_ = response.Body.Close()
+			t.Fatalf("expected status 400 for %v, got %d", form, response.StatusCode)
+		}
+		_ = response.Body.Close()
+	}
+}
+
+// TestCycleSettingsValidationErrorKeyNamesEveryMappedFailure pins the mapper
+// including its default arm, which no request can reach: every sentinel the
+// policy declares gets its own key, and anything else falls back to the generic
+// refusal rather than leaking the error's own text.
+func TestCycleSettingsValidationErrorKeyNamesEveryMappedFailure(t *testing.T) {
+	for err, want := range map[error]string{
+		services.ErrSettingsCycleLengthOutOfRange:          "cycle length must be between 15 and 90",
+		services.ErrSettingsPeriodLengthOutOfRange:         "period length must be between 1 and 14",
+		services.ErrSettingsPeriodLengthIncompatible:       "period length is incompatible with cycle length",
+		services.ErrSettingsCycleStartDateInvalid:          "invalid cycle start date",
+		errors.New("an error the policy does not declare"): "invalid settings input",
+	} {
+		if got := cycleSettingsValidationErrorKey(err); got != want {
+			t.Fatalf("expected %q for %v, got %q", want, err, got)
+		}
 	}
 }
 
@@ -217,6 +269,49 @@ func TestCycleSettingsFormSaveStaysAFullSnapshot(t *testing.T) {
 	}
 	if persisted.IrregularCycle || persisted.AutoPeriodFill {
 		t.Fatalf("an unchecked box did not clear its flag: irregular=%v auto_fill=%v", persisted.IrregularCycle, persisted.AutoPeriodFill)
+	}
+}
+
+// TestCycleSettingsPatchRefusesABodyThatNamesNothing covers the empty answer.
+// Before the save became partial an empty body was refused as an out-of-range
+// cycle_length; accepting it now would answer 200 and write a mutation-log entry
+// for a cycle-settings change that did not happen.
+func TestCycleSettingsPatchRefusesABodyThatNamesNothing(t *testing.T) {
+	app, database := newOnboardingTestApp(t)
+	user := createOnboardingTestUser(t, database, "cycle-patch-empty@example.com", "StrongPass1", true)
+	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
+
+	for _, body := range []string{`{}`, `{"unrelated":1}`} {
+		response := patchCycleSettingsJSON(t, app, authCookie, body)
+		if response.StatusCode != http.StatusBadRequest {
+			_ = response.Body.Close()
+			t.Fatalf("expected status 400 for %s, got %d", body, response.StatusCode)
+		}
+		_ = response.Body.Close()
+	}
+}
+
+// TestCycleSettingsPatchRefusesAMalformedBody pins the other refusal the member
+// probe can produce: a body that does not decode at all is a request problem,
+// not a goal-only save, and must not fall through to either path.
+func TestCycleSettingsPatchRefusesAMalformedBody(t *testing.T) {
+	app, database := newOnboardingTestApp(t)
+	user := createOnboardingTestUser(t, database, "cycle-patch-malformed@example.com", "StrongPass1", true)
+	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
+
+	response := patchCycleSettingsJSON(t, app, authCookie, `{"usage_goal":`)
+	defer func() { _ = response.Body.Close() }()
+
+	if response.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected status 400 for a malformed body, got %d", response.StatusCode)
+	}
+
+	persisted := models.User{}
+	if err := database.First(&persisted, user.ID).Error; err != nil {
+		t.Fatalf("load persisted user: %v", err)
+	}
+	if persisted.UsageGoal != models.UsageGoalHealth {
+		t.Fatalf("a malformed body changed the stored goal to %q", persisted.UsageGoal)
 	}
 }
 

--- a/internal/api/settings_cycle_regressions_test.go
+++ b/internal/api/settings_cycle_regressions_test.go
@@ -255,8 +255,19 @@ func TestSettingsCycleGoalOnlyPatchAnswersEveryCaller(t *testing.T) {
 	if err := json.Unmarshal([]byte(mustReadBodyString(t, jsonResponse.Body)), &payload); err != nil {
 		t.Fatalf("decode goal-only JSON response: %v", err)
 	}
-	if payload["usage_goal"] != models.UsageGoalTrying {
-		t.Fatalf("expected the stored goal echoed back, got %v", payload["usage_goal"])
+	// The stored goal is deliberately NOT echoed: `OkResponse` declares
+	// `additionalProperties: false`. That the save happened is asserted against
+	// the database below, and the response shape against the schema in
+	// TestUsageGoalOnlySaveAnswersTheDeclaredOkShape.
+	if _, echoed := payload["usage_goal"]; echoed {
+		t.Fatalf("the goal-only save echoed a member the OkResponse schema forbids: %v", payload)
+	}
+	afterJSON := models.User{}
+	if err := database.Select("usage_goal").First(&afterJSON, user.ID).Error; err != nil {
+		t.Fatalf("load persisted user: %v", err)
+	}
+	if afterJSON.UsageGoal != models.UsageGoalTrying {
+		t.Fatalf("expected the JSON caller's goal %q to be stored, got %q", models.UsageGoalTrying, afterJSON.UsageGoal)
 	}
 
 	formRequest := httptest.NewRequest(http.MethodPatch, "/api/v1/users/current/cycle", strings.NewReader(url.Values{

--- a/internal/api/settings_mutation_handlers_test.go
+++ b/internal/api/settings_mutation_handlers_test.go
@@ -303,12 +303,12 @@ func TestStepupReauthMaxAgeConstant(t *testing.T) {
 
 // --- handlers_settings_cycle_helpers.go ---
 
-// TestUpdateCycleSettings_JSONBodyPersistsLastPeriodStart pins the JSON-body
-// `input.LastPeriodStart != ""` decision (handlers_settings_cycle_helpers.go:22):
-// a non-empty last_period_start supplied via a JSON body must mark the field as
-// set so it is validated and persisted. Negating to `== ""` drops the flag for a
-// real date, so the start date is silently ignored. Uses a no-CSRF app to isolate
-// JSON body parsing/negotiation (per the testing rules).
+// TestUpdateCycleSettings_JSONBodyPersistsLastPeriodStart pins the non-empty
+// decision in `SettingsService.ResolveCycleSettingsPatch`: a non-empty
+// last_period_start supplied via a JSON body must mark the field as set so it is
+// validated and persisted. Negating it drops the flag for a real date, so the
+// start date is silently ignored. Uses a no-CSRF app to isolate JSON body
+// parsing/negotiation (per the testing rules).
 func TestUpdateCycleSettings_JSONBodyPersistsLastPeriodStart(t *testing.T) {
 	app, database := newOnboardingTestApp(t)
 	user := createOnboardingTestUser(t, database, "settings-cycle-json@example.com", "StrongPass1", true)

--- a/internal/services/settings_cycle_partial_write_test.go
+++ b/internal/services/settings_cycle_partial_write_test.go
@@ -1,0 +1,96 @@
+package services
+
+import (
+	"context"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+)
+
+// TestSaveCycleSettingsWritesOnlyTheMembersItWasGiven is the persistence half of
+// the partial save. Resolving an omitted member from the stored record and then
+// writing it back is not the same as leaving it alone: the value written is the
+// one read when this request authenticated, so a save that named only the cycle
+// geometry would revert a tracking mode another request set in between —
+// reverting a setting it never mentioned, which is the whole defect.
+func TestSaveCycleSettingsWritesOnlyTheMembersItWasGiven(t *testing.T) {
+	repo := &stubSettingsTrackingUserRepo{}
+	service := NewSettingsService(repo)
+
+	update := CycleSettingsUpdate{
+		Present:     CycleSettingsMembers{CycleLength: true, PeriodLength: true},
+		CycleLength: 29,
+		// Carried but not named: a correct save must not write these.
+		UsageGoal: models.UsageGoalHealth,
+		AgeGroup:  models.AgeGroupUnknown,
+	}
+	update.PeriodLength = 5
+
+	if err := service.SaveCycleSettings(context.Background(), 42, update); err != nil {
+		t.Fatalf("SaveCycleSettings() unexpected error: %v", err)
+	}
+
+	assertUpdatedColumns(t, repo.updates, []string{"cycle_length", "period_length"})
+}
+
+// TestSaveCycleSettingsWritesTheAnchorItWasGiven pins the one member that
+// carries its own presence flag rather than riding in CycleSettingsMembers.
+func TestSaveCycleSettingsWritesTheAnchorItWasGiven(t *testing.T) {
+	repo := &stubSettingsTrackingUserRepo{}
+	service := NewSettingsService(repo)
+	anchor := time.Date(2026, time.February, 10, 0, 0, 0, 0, time.UTC)
+
+	update := CycleSettingsUpdate{
+		Present:            CycleSettingsMembers{UsageGoal: true},
+		UsageGoal:          models.UsageGoalAvoid,
+		LastPeriodStartSet: true,
+		LastPeriodStart:    &anchor,
+	}
+
+	if err := service.SaveCycleSettings(context.Background(), 42, update); err != nil {
+		t.Fatalf("SaveCycleSettings() unexpected error: %v", err)
+	}
+
+	assertUpdatedColumns(t, repo.updates, []string{"last_period_start", "usage_goal"})
+}
+
+// TestSaveCycleSettingsNamingNothingReachesNoRepository covers the empty answer:
+// a body that named no member asked for no change, which is not an error and
+// must not become one at the driver, where an empty update is a different
+// question entirely.
+func TestSaveCycleSettingsNamingNothingReachesNoRepository(t *testing.T) {
+	repo := &stubSettingsTrackingUserRepo{}
+	service := NewSettingsService(repo)
+
+	if err := service.SaveCycleSettings(context.Background(), 42, CycleSettingsUpdate{}); err != nil {
+		t.Fatalf("SaveCycleSettings() unexpected error: %v", err)
+	}
+	if repo.updates != nil {
+		t.Fatalf("a save naming no member still reached the repository with %v", repo.updates)
+	}
+	if repo.updatedUserID != 0 {
+		t.Fatalf("a save naming no member still named a user: %d", repo.updatedUserID)
+	}
+}
+
+func assertUpdatedColumns(t *testing.T, updates map[string]any, want []string) {
+	t.Helper()
+
+	got := make([]string, 0, len(updates))
+	for column := range updates {
+		got = append(got, column)
+	}
+	sort.Strings(got)
+	sort.Strings(want)
+
+	if len(got) != len(want) {
+		t.Fatalf("expected exactly %v written, got %v", want, got)
+	}
+	for index := range want {
+		if got[index] != want[index] {
+			t.Fatalf("expected exactly %v written, got %v", want, got)
+		}
+	}
+}

--- a/internal/services/settings_cycle_partial_write_test.go
+++ b/internal/services/settings_cycle_partial_write_test.go
@@ -75,6 +75,27 @@ func TestSaveCycleSettingsNamingNothingReachesNoRepository(t *testing.T) {
 	}
 }
 
+// TestResolveCycleSettingsPatchWithoutAStoredRecordNamesOnlyWhatItCarries
+// covers the operand the handler always supplies and a future caller might not:
+// with no stored record to resolve against, the members the body carries still
+// win and the rest stay unnamed rather than being invented from a zero user.
+func TestResolveCycleSettingsPatchWithoutAStoredRecordNamesOnlyWhatItCarries(t *testing.T) {
+	service := NewSettingsService(nil)
+	goal := models.UsageGoalTrying
+
+	resolved := service.ResolveCycleSettingsPatch(nil, CycleSettingsPatch{UsageGoal: &goal})
+
+	if resolved.UsageGoal != models.UsageGoalTrying {
+		t.Fatalf("expected the carried goal, got %q", resolved.UsageGoal)
+	}
+	if resolved.Present != (CycleSettingsMembers{UsageGoal: true}) {
+		t.Fatalf("expected only the goal named, got %+v", resolved.Present)
+	}
+	if resolved.LastPeriodStartSet {
+		t.Fatal("expected the anchor to stay unnamed")
+	}
+}
+
 func assertUpdatedColumns(t *testing.T, updates map[string]any, want []string) {
 	t.Helper()
 

--- a/internal/services/settings_cycle_policy.go
+++ b/internal/services/settings_cycle_policy.go
@@ -27,6 +27,79 @@ type CycleSettingsValidationInput struct {
 	LastPeriodStartSet bool
 }
 
+// CycleSettingsPatch is a cycle-settings body read member by member: a nil field
+// was not in the body at all, which is a different fact from a field carrying a
+// zero value. Only a transport that can express the difference builds one — an
+// HTML form cannot, since an unchecked box is simply not submitted and would
+// read as "leave it alone", so the form surface keeps sending a full snapshot.
+type CycleSettingsPatch struct {
+	CycleLength        *int
+	PeriodLength       *int
+	AutoPeriodFill     *bool
+	IrregularCycle     *bool
+	UnpredictableCycle *bool
+	AgeGroup           *string
+	UsageGoal          *string
+	// A nil LastPeriodStart leaves the stored anchor alone; a non-nil empty
+	// string clears it. The two are distinct answers and neither is the other's
+	// default.
+	LastPeriodStart *string
+}
+
+// ResolveCycleSettingsPatch answers what a partial cycle save means: every
+// member the body omitted keeps the value the account already holds, and only
+// what was actually sent can change. Absence used to mean the field's zero
+// value, so a caller saving the cycle lengths alone silently rewrote
+// `usage_goal` to `health` — turning an owner tracking to avoid pregnancy into
+// one tracking for general health, which reframes the fertile window across
+// every surface — and wiped `age_group` back to unknown the same way.
+//
+// It lives here rather than in the transport layer because what an absent field
+// means is a question about the account, not about HTTP: the resolution reads
+// the stored record.
+func (service *SettingsService) ResolveCycleSettingsPatch(current *models.User, patch CycleSettingsPatch) CycleSettingsValidationInput {
+	stored := models.User{}
+	if current != nil {
+		stored = *current
+	}
+
+	resolved := CycleSettingsValidationInput{
+		CycleLength:        stored.CycleLength,
+		PeriodLength:       stored.PeriodLength,
+		AutoPeriodFill:     stored.AutoPeriodFill,
+		IrregularCycle:     stored.IrregularCycle,
+		UnpredictableCycle: stored.UnpredictableCycle,
+		AgeGroup:           stored.AgeGroup,
+		UsageGoal:          stored.UsageGoal,
+	}
+	if patch.CycleLength != nil {
+		resolved.CycleLength = *patch.CycleLength
+	}
+	if patch.PeriodLength != nil {
+		resolved.PeriodLength = *patch.PeriodLength
+	}
+	if patch.AutoPeriodFill != nil {
+		resolved.AutoPeriodFill = *patch.AutoPeriodFill
+	}
+	if patch.IrregularCycle != nil {
+		resolved.IrregularCycle = *patch.IrregularCycle
+	}
+	if patch.UnpredictableCycle != nil {
+		resolved.UnpredictableCycle = *patch.UnpredictableCycle
+	}
+	if patch.AgeGroup != nil {
+		resolved.AgeGroup = *patch.AgeGroup
+	}
+	if patch.UsageGoal != nil {
+		resolved.UsageGoal = *patch.UsageGoal
+	}
+	if patch.LastPeriodStart != nil {
+		resolved.LastPeriodStartRaw = *patch.LastPeriodStart
+		resolved.LastPeriodStartSet = true
+	}
+	return resolved
+}
+
 func (service *SettingsService) ValidateCycleSettings(input CycleSettingsValidationInput, now time.Time, location *time.Location) (CycleSettingsUpdate, error) {
 	if !IsValidOnboardingCycleLength(input.CycleLength) {
 		return CycleSettingsUpdate{}, ErrSettingsCycleLengthOutOfRange

--- a/internal/services/settings_cycle_policy.go
+++ b/internal/services/settings_cycle_policy.go
@@ -40,9 +40,11 @@ type CycleSettingsPatch struct {
 	UnpredictableCycle *bool
 	AgeGroup           *string
 	UsageGoal          *string
-	// A nil LastPeriodStart leaves the stored anchor alone; a non-nil empty
-	// string clears it. The two are distinct answers and neither is the other's
-	// default.
+	// A nil LastPeriodStart leaves the stored anchor alone, and so does an
+	// empty string: that is what the JSON surface has always meant by it, and
+	// this change is not the place to give an existing spelling a destructive
+	// new reading. Clearing the anchor stays a form-surface operation, which
+	// says it with a present-but-empty field.
 	LastPeriodStart *string
 }
 
@@ -93,7 +95,7 @@ func (service *SettingsService) ResolveCycleSettingsPatch(current *models.User, 
 	if patch.UsageGoal != nil {
 		resolved.UsageGoal = *patch.UsageGoal
 	}
-	if patch.LastPeriodStart != nil {
+	if patch.LastPeriodStart != nil && strings.TrimSpace(*patch.LastPeriodStart) != "" {
 		resolved.LastPeriodStartRaw = *patch.LastPeriodStart
 		resolved.LastPeriodStartSet = true
 	}

--- a/internal/services/settings_cycle_policy.go
+++ b/internal/services/settings_cycle_policy.go
@@ -204,13 +204,31 @@ func (service *SettingsService) ApplyCycleSettings(user *models.User, update Cyc
 		return
 	}
 
-	user.CycleLength = update.CycleLength
-	user.PeriodLength = update.PeriodLength
-	user.AutoPeriodFill = update.AutoPeriodFill
-	user.IrregularCycle = update.IrregularCycle
-	user.UnpredictableCycle = update.UnpredictableCycle
-	user.AgeGroup = NormalizeAgeGroup(update.AgeGroup)
-	user.UsageGoal = NormalizeUsageGoal(update.UsageGoal)
+	// Applied member for member, exactly as SaveCycleSettings writes them: the
+	// in-request user has to end up carrying what the row carries. Normalizing a
+	// member this save did not write would render it as changed in the response
+	// while the stored value stayed as it was.
+	if update.Present.CycleLength {
+		user.CycleLength = update.CycleLength
+	}
+	if update.Present.PeriodLength {
+		user.PeriodLength = update.PeriodLength
+	}
+	if update.Present.AutoPeriodFill {
+		user.AutoPeriodFill = update.AutoPeriodFill
+	}
+	if update.Present.IrregularCycle {
+		user.IrregularCycle = update.IrregularCycle
+	}
+	if update.Present.UnpredictableCycle {
+		user.UnpredictableCycle = update.UnpredictableCycle
+	}
+	if update.Present.AgeGroup {
+		user.AgeGroup = NormalizeAgeGroup(update.AgeGroup)
+	}
+	if update.Present.UsageGoal {
+		user.UsageGoal = NormalizeUsageGoal(update.UsageGoal)
+	}
 
 	if !update.LastPeriodStartSet {
 		return

--- a/internal/services/settings_cycle_policy.go
+++ b/internal/services/settings_cycle_policy.go
@@ -15,6 +15,39 @@ var (
 	ErrSettingsCycleStartDateInvalid    = errors.New("settings cycle start date invalid")
 )
 
+// CycleSettingsMembers records which cycle columns a save may write. A save
+// writes the members it names and no others, so a request that never mentioned
+// the tracking mode cannot revert a mode another request set between this one's
+// authentication and its write — the omitted-member promise held across two
+// overlapping requests, not only inside one.
+//
+// last_period_start is absent here on purpose: it carries its own
+// LastPeriodStartSet, which already distinguishes "not sent" from "sent empty",
+// a distinction the other members do not have.
+type CycleSettingsMembers struct {
+	CycleLength        bool
+	PeriodLength       bool
+	AutoPeriodFill     bool
+	IrregularCycle     bool
+	UnpredictableCycle bool
+	AgeGroup           bool
+	UsageGoal          bool
+}
+
+// AllCycleSettingsMembers marks every member present: the answer for a full
+// snapshot, which is what the settings form submits.
+func AllCycleSettingsMembers() CycleSettingsMembers {
+	return CycleSettingsMembers{
+		CycleLength:        true,
+		PeriodLength:       true,
+		AutoPeriodFill:     true,
+		IrregularCycle:     true,
+		UnpredictableCycle: true,
+		AgeGroup:           true,
+		UsageGoal:          true,
+	}
+}
+
 type CycleSettingsValidationInput struct {
 	CycleLength        int
 	PeriodLength       int
@@ -25,6 +58,9 @@ type CycleSettingsValidationInput struct {
 	UsageGoal          string
 	LastPeriodStartRaw string
 	LastPeriodStartSet bool
+	// Present names the members this input actually carries. The zero value
+	// writes nothing, so a caller building this by hand states its answer.
+	Present CycleSettingsMembers
 }
 
 // CycleSettingsPatch is a cycle-settings body read member by member: a nil field
@@ -76,24 +112,31 @@ func (service *SettingsService) ResolveCycleSettingsPatch(current *models.User, 
 	}
 	if patch.CycleLength != nil {
 		resolved.CycleLength = *patch.CycleLength
+		resolved.Present.CycleLength = true
 	}
 	if patch.PeriodLength != nil {
 		resolved.PeriodLength = *patch.PeriodLength
+		resolved.Present.PeriodLength = true
 	}
 	if patch.AutoPeriodFill != nil {
 		resolved.AutoPeriodFill = *patch.AutoPeriodFill
+		resolved.Present.AutoPeriodFill = true
 	}
 	if patch.IrregularCycle != nil {
 		resolved.IrregularCycle = *patch.IrregularCycle
+		resolved.Present.IrregularCycle = true
 	}
 	if patch.UnpredictableCycle != nil {
 		resolved.UnpredictableCycle = *patch.UnpredictableCycle
+		resolved.Present.UnpredictableCycle = true
 	}
 	if patch.AgeGroup != nil {
 		resolved.AgeGroup = *patch.AgeGroup
+		resolved.Present.AgeGroup = true
 	}
 	if patch.UsageGoal != nil {
 		resolved.UsageGoal = *patch.UsageGoal
+		resolved.Present.UsageGoal = true
 	}
 	if patch.LastPeriodStart != nil && strings.TrimSpace(*patch.LastPeriodStart) != "" {
 		resolved.LastPeriodStartRaw = *patch.LastPeriodStart
@@ -115,6 +158,7 @@ func (service *SettingsService) ValidateCycleSettings(input CycleSettingsValidat
 	}
 
 	update := CycleSettingsUpdate{
+		Present:            input.Present,
 		CycleLength:        input.CycleLength,
 		PeriodLength:       input.PeriodLength,
 		AutoPeriodFill:     input.AutoPeriodFill,

--- a/internal/services/settings_service.go
+++ b/internal/services/settings_service.go
@@ -91,6 +91,11 @@ type SettingsUserRepository interface {
 }
 
 type CycleSettingsUpdate struct {
+	// Present names the columns this update may write; anything it does not
+	// name is left as the row holds it. Build it through ValidateCycleSettings,
+	// which carries the answer over from the request — a hand-built zero value
+	// writes nothing.
+	Present            CycleSettingsMembers
 	CycleLength        int
 	PeriodLength       int
 	AutoPeriodFill     bool
@@ -220,15 +225,33 @@ func (service *SettingsService) ValidateCurrentPassword(passwordHash string, raw
 	return nil
 }
 
+// SaveCycleSettings writes the columns the update names and no others. Writing
+// the full row instead would make every save carry a snapshot of the columns it
+// was not asked about, and a save that reverts a setting it never mentioned is
+// the defect this endpoint exists not to have — inside one request or across
+// two that overlap.
 func (service *SettingsService) SaveCycleSettings(ctx context.Context, userID uint, settings CycleSettingsUpdate) error {
-	updates := map[string]any{
-		"cycle_length":        settings.CycleLength,
-		"period_length":       settings.PeriodLength,
-		"auto_period_fill":    settings.AutoPeriodFill,
-		"irregular_cycle":     settings.IrregularCycle,
-		"unpredictable_cycle": settings.UnpredictableCycle,
-		"age_group":           NormalizeAgeGroup(settings.AgeGroup),
-		"usage_goal":          NormalizeUsageGoal(settings.UsageGoal),
+	updates := map[string]any{}
+	if settings.Present.CycleLength {
+		updates["cycle_length"] = settings.CycleLength
+	}
+	if settings.Present.PeriodLength {
+		updates["period_length"] = settings.PeriodLength
+	}
+	if settings.Present.AutoPeriodFill {
+		updates["auto_period_fill"] = settings.AutoPeriodFill
+	}
+	if settings.Present.IrregularCycle {
+		updates["irregular_cycle"] = settings.IrregularCycle
+	}
+	if settings.Present.UnpredictableCycle {
+		updates["unpredictable_cycle"] = settings.UnpredictableCycle
+	}
+	if settings.Present.AgeGroup {
+		updates["age_group"] = NormalizeAgeGroup(settings.AgeGroup)
+	}
+	if settings.Present.UsageGoal {
+		updates["usage_goal"] = NormalizeUsageGoal(settings.UsageGoal)
 	}
 	if settings.LastPeriodStartSet {
 		if settings.LastPeriodStart == nil {
@@ -236,6 +259,13 @@ func (service *SettingsService) SaveCycleSettings(ctx context.Context, userID ui
 		} else {
 			updates["last_period_start"] = *settings.LastPeriodStart
 		}
+	}
+	if len(updates) == 0 {
+		// A body that named no member is a save with nothing to save. It is not
+		// an error — the request asked for no change and got none — but it must
+		// not reach the repository, where an empty update is a driver-level
+		// question rather than a domain one.
+		return nil
 	}
 	return service.users.UpdateByID(ctx, userID, updates)
 }

--- a/internal/services/settings_service_cycle_test.go
+++ b/internal/services/settings_service_cycle_test.go
@@ -327,6 +327,7 @@ func TestSaveCycleSettingsPersistsNormalizedOwnerPreferences(t *testing.T) {
 	lastPeriodStart := time.Date(2026, time.February, 10, 0, 0, 0, 0, time.UTC)
 
 	err := service.SaveCycleSettings(context.Background(), 42, CycleSettingsUpdate{
+		Present:            AllCycleSettingsMembers(),
 		CycleLength:        29,
 		PeriodLength:       5,
 		AutoPeriodFill:     true,

--- a/internal/services/settings_service_cycle_test.go
+++ b/internal/services/settings_service_cycle_test.go
@@ -274,6 +274,7 @@ func TestApplyCycleSettings(t *testing.T) {
 	}
 
 	update := CycleSettingsUpdate{
+		Present:            AllCycleSettingsMembers(),
 		CycleLength:        28,
 		PeriodLength:       5,
 		AutoPeriodFill:     true,
@@ -295,6 +296,7 @@ func TestApplyCycleSettingsUpdatesOwnerPreferences(t *testing.T) {
 	user := &models.User{}
 
 	service.ApplyCycleSettings(user, CycleSettingsUpdate{
+		Present:            AllCycleSettingsMembers(),
 		CycleLength:        31,
 		PeriodLength:       6,
 		AutoPeriodFill:     false,

--- a/internal/services/settings_service_mutation_test.go
+++ b/internal/services/settings_service_mutation_test.go
@@ -12,6 +12,7 @@ func TestSaveCycleSettingsPersistsExplicitLastPeriodStart(t *testing.T) {
 	lastPeriodStart := time.Date(2026, time.February, 10, 0, 0, 0, 0, time.UTC)
 
 	err := service.SaveCycleSettings(context.Background(), 42, CycleSettingsUpdate{
+		Present:            AllCycleSettingsMembers(),
 		CycleLength:        28,
 		PeriodLength:       5,
 		LastPeriodStartSet: true,


### PR DESCRIPTION
**What.** `PATCH /api/v1/users/current/cycle` becomes the partial update its verb promises. A member
the JSON body carries is written — including one carrying `false` or `""`, which is a value, not an
absence — and a member it omits is left as the row holds it.

**Why.** A save of the cycle geometry alone was read as a full snapshot, so every member it did not
name was written back as that member's zero value: `usage_goal` fell to `health`, moving an owner
tracking to avoid pregnancy into general health tracking and reframing the fertile window on every
surface; `age_group` went to unknown; the three flags cleared. Two edges of the same defect went
with it — the goal-only shortcut admitted any body without the two lengths, dropping a flag
travelling beside the mode, and its success body echoed `usage_goal`, which `OkResponse`
(`additionalProperties: false`) forbids.

The save also writes only the columns it was given rather than the whole row. Resolving an omitted
member from the stored record and writing it back is not leaving it alone: the value is the one read
when this request authenticated, so a save of the lengths alone could put back a mode another
request had changed in between.

**Risk.** High (public interface), declared breaking in the fragment. A client that cleared a flag
or the age bracket by *omitting* it must now send it explicitly. The settings form is unaffected: it
submits every control it owns and an unchecked box submits nothing, so a form body carries no
absence to honour and is still read as the full snapshot it is. Rollback: revert the four commits.

**How verified.** Red before, green after (checked by reverting the patch):
`TestCycleSettingsPatchKeepsWhatTheBodyDidNotCarry`, `TestUsageGoalSwitchKeepsWhatRidesBesideIt`,
`TestUsageGoalOnlySaveAnswersTheDeclaredOkShape`. Counterweights so partial does not become inert:
`TestCycleSettingsPatchWritesEveryMemberItDoesCarry`, `TestCycleSettingsFormSaveStaysAFullSnapshot`,
`TestSaveCycleSettingsWritesOnlyTheMembersItWasGiven`. `TestGoalOnlyShortcutYieldsToEveryOtherMember`
is a no-allowlist sweep over the declared wire shape — a member added to it and forgotten in the
predicate fails there by name; verified by mutation. `go test ./internal/api ./internal/services`
over the affected areas, `golangci-lint`, `scripts/archcheck` — green.
