### PR TITLE
fix(api): a JSON-posted BBT converts by account unit, same as the form

### DIFF
--- a/changelog.d/pr17-json-bbt-fahrenheit.md
+++ b/changelog.d/pr17-json-bbt-fahrenheit.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- **A basal body temperature logged in Fahrenheit via the JSON API now converts, same as the form.**
+  `POST /api/v1/days` accepts `bbt` from both a browser form post and a JSON body; only the form path
+  converted the value into the account's preferred unit before storing it. A Fahrenheit-preference
+  owner posting JSON (`{"bbt": 98.6}`) had it validated straight against the Celsius physiological
+  range and refused — no bad data was ever stored, but every JSON write of BBT failed for her. The
+  JSON path now converts through the same unit-aware helper the form path uses. `docs/openapi.yaml`
+  also now states that a read of `bbt` is always Celsius, regardless of the account's write-side unit.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -579,7 +579,11 @@ components:
           type: number
           format: float
           nullable: true
-          description: Present only when measured; absent when not measured.
+          description: >-
+            Always Celsius regardless of the account's display unit
+            preference (write-side unit conversion happens on input; storage
+            and this response are canonical Celsius). Present only when
+            measured; absent when not measured.
         cervical_mucus:
           type: string
           enum: [none, dry, moist, creamy, eggwhite]

--- a/internal/api/input_validation_day_payload_helpers.go
+++ b/internal/api/input_validation_day_payload_helpers.go
@@ -19,6 +19,7 @@ func parseDayPayload(c fiber.Ctx, user *models.User) (dayPayload, error) {
 		if err := c.Bind().Body(&payload); err != nil {
 			return payload, err
 		}
+		payload.BBT = services.ConvertDayBBTToStorage(payload.BBT, temperatureUnit)
 	} else {
 		var err error
 		payload.IsPeriod = services.ParseBoolLike(c.FormValue("is_period"))

--- a/internal/api/input_validation_day_payload_test.go
+++ b/internal/api/input_validation_day_payload_test.go
@@ -163,6 +163,18 @@ func TestParseDayPayloadFromFormWithFahrenheitPreference(t *testing.T) {
 	}
 }
 
+func TestParseDayPayloadFromJSONWithFahrenheitPreference(t *testing.T) {
+	t.Parallel()
+
+	request := httptest.NewRequest(http.MethodPost, "/day", strings.NewReader(`{"bbt":98.6}`))
+	request.Header.Set("Content-Type", fiber.MIMEApplicationJSON)
+
+	payload := parseDayPayloadForUser(t, request, &models.User{TemperatureUnit: services.TemperatureUnitFahrenheit})
+	if payload.BBT == nil || *payload.BBT != 37.00 {
+		t.Fatalf("expected converted BBT 37.00, got %v", payload.BBT)
+	}
+}
+
 func parseDayPayloadForTest(t *testing.T, request *http.Request) dayPayload {
 	t.Helper()
 	return parseDayPayloadForUser(t, request, &models.User{TemperatureUnit: services.DefaultTemperatureUnit})

--- a/internal/services/day_tracking.go
+++ b/internal/services/day_tracking.go
@@ -145,10 +145,24 @@ func ParseDayBBTRawWithUnit(raw string, unit string) (*float64, error) {
 	if err != nil {
 		return nil, fmt.Errorf("invalid day bbt: %w", err)
 	}
-	if NormalizeTemperatureUnit(unit) == TemperatureUnitFahrenheit {
-		value = fahrenheitToCelsius(value)
+	return ConvertDayBBTToStorage(&value, unit), nil
+}
+
+// ConvertDayBBTToStorage takes a BBT value already expressed in the account's
+// chosen unit and converts it to the canonical stored Celsius form. It is the
+// unit-conversion half of ParseDayBBTRawWithUnit, factored out so the JSON
+// bind path — which parses its own float via encoding/json rather than a form
+// string — converts and rounds identically instead of writing whatever unit
+// the caller sent straight to storage.
+func ConvertDayBBTToStorage(value *float64, unit string) *float64 {
+	if value == nil {
+		return nil
 	}
-	return normalizeStoredDayBBT(&value), nil
+	converted := *value
+	if NormalizeTemperatureUnit(unit) == TemperatureUnitFahrenheit {
+		converted = fahrenheitToCelsius(converted)
+	}
+	return normalizeStoredDayBBT(&converted)
 }
 
 // normalizeStoredDayBBT collapses any non-measurement (nil or a non-positive


### PR DESCRIPTION
## What
`parseDayPayload`'s JSON branch bound `bbt` from the request body without running it through
`temperatureUnit`, unlike the form branch (`services.ParseDayBBTRawWithUnit`). The conversion is
factored out into `services.ConvertDayBBTToStorage` and now runs on both branches.

## Why
A Fahrenheit-preference owner posting `{"bbt": 98.6}` via JSON had it checked straight against the
Celsius range (`MinDayBBTCelsius`/`MaxDayBBTCelsius`) and refused — every JSON BBT write failed for
her. Pre-existing since v1.9.2 (`git show v1.9.2:internal/api/input_validation_day_payload_helpers.go`
has the same asymmetry); not a v2.0.0 breaking change.

`docs/openapi.yaml` `DailyLog.bbt` now states the read side is always Celsius, since storage and
`newDayResponse` return the canonical Celsius value regardless of the account's write-side unit.

## Verified
`TestParseDayPayloadFromJSONWithFahrenheitPreference` — JSON `{"bbt": 98.6}` from a Fahrenheit
account now stores `37.00` (red before the fix). `go test ./internal/api/... ./internal/services/...`,
`go build ./...`, `go vet` all pass.

## Risk
Low — internal helper + one write-path branch, no schema change, fail-closed behavior preserved.