### PR TITLE
docs(openapi): the spec catches up to what the server already does

### DIFF
--- a/changelog.d/pr18-api-spec-fixes.md
+++ b/changelog.d/pr18-api-spec-fixes.md
@@ -1,0 +1,20 @@
+### Fixed
+
+- **`docs/openapi.yaml` now matches three places where the server's actual behavior had drifted
+  from the published contract.** All three were pre-existing since v1.9.2; none is a v2.0.0
+  breaking change.
+  - Four settings endpoints that share the per-account re-auth budget — `DELETE
+    /api/v1/users/current`, `PUT /api/v1/users/current/password`, `POST
+    /api/v1/users/current/data-wipe/validate`, `POST /api/v1/users/current/data-wipe` — can answer
+    `429` once the budget is spent, but the spec never declared it. All four now do.
+  - `ForgotPasswordRequest` (`POST /api/v1/password-resets`) required `recovery_code` and
+    `password` even though the handler is a two-step flow: step 1 sends `email` alone and gets
+    `next_step: recovery_code` back, without starting anything. Only `email` is schema-required
+    now, and the schema documents both steps. The endpoint's declared `401` was also unreachable —
+    `mapPasswordRecoveryStartError` has no arm that returns it, every step-2 rejection is a uniform
+    `400` — so the response now documents that instead.
+  - `docs/openapi.yaml` declares `openapi: 3.1.0` but used the OpenAPI-3.0-only `nullable: true`
+    keyword on nine properties (`DayPayload.bbt`, `DailyLog.bbt`, `Symptom.archived_at`, five
+    `StatsOverview` projection fields, `ExportJSONEntry.bbt`), which fails structural validation
+    under 3.1's JSON Schema base. Each now uses the 3.1 form, `type: [<type>, "null"]`.
+    `npx @redocly/cli lint docs/openapi.yaml` is green.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -438,7 +438,16 @@ components:
 
     ForgotPasswordRequest:
       type: object
-      required: [email, recovery_code, password]
+      required: [email]
+      description: >-
+        Two-step body on one endpoint. Step 1 sends `email` alone; the
+        response is `{"ok": true, "next_step": "recovery_code"}` and starts
+        nothing. Step 2 repeats `email` and adds `recovery_code` and
+        `password`, which is what actually calls `StartRecovery`. Neither of
+        the step-2 fields is schema-required, because an absent one does not
+        fail validation — it is read as an empty string and refused later, by
+        name, with the same uniform credential rejection a wrong value gets;
+        see each field's own description.
       properties:
         email:
           type: string
@@ -518,9 +527,8 @@ components:
           enum: [none, protected, unprotected]
           default: none
         bbt:
-          type: number
+          type: [number, "null"]
           format: float
-          nullable: true
           description: >-
             Basal body temperature in the unit selected per account (°C or °F).
             Omitted or null means not measured. On write, a null, an omitted
@@ -576,9 +584,8 @@ components:
           type: string
           enum: [none, protected, unprotected]
         bbt:
-          type: number
+          type: [number, "null"]
           format: float
-          nullable: true
           description: >-
             Always Celsius regardless of the account's display unit
             preference (write-side unit conversion happens on input; storage
@@ -651,9 +658,8 @@ components:
         color: { type: string }
         is_builtin: { type: boolean }
         archived_at:
-          type: string
+          type: [string, "null"]
           format: date-time
-          nullable: true
 
     StatsOverview:
       type: object
@@ -740,19 +746,16 @@ components:
           type: integer
           description: Days following ovulation; per-owner when inferable, else the 14-day default.
         last_period_start:
-          type: string
+          type: [string, "null"]
           format: date
-          nullable: true
           description: Recorded anchor, not a projection. Null only when no cycle start is known.
         next_period_start:
-          type: string
+          type: [string, "null"]
           format: date
-          nullable: true
           description: Projected. Null when `suppression.predictions` is true.
         ovulation_date:
-          type: string
+          type: [string, "null"]
           format: date
-          nullable: true
           description: Projected. Null when `suppression.fertility` is true.
         ovulation_exact:
           type: boolean
@@ -763,14 +766,12 @@ components:
           type: boolean
           description: No ovulation can be placed in the running cycle at all.
         fertility_window_start:
-          type: string
+          type: [string, "null"]
           format: date
-          nullable: true
           description: Projected. Null when `suppression.fertility` is true.
         fertility_window_end:
-          type: string
+          type: [string, "null"]
           format: date
-          nullable: true
           description: Projected. Null when `suppression.fertility` is true.
         pregnancy_paused:
           type: boolean
@@ -847,9 +848,8 @@ components:
           type: string
           enum: [none, protected, unprotected]
         bbt:
-          type: number
+          type: [number, "null"]
           format: float
-          nullable: true
           description: >-
             Emitted only when measured; absent otherwise. On import, absent,
             null, or a non-positive value (legacy 0 sentinel) all mean "not
@@ -1461,9 +1461,12 @@ paths:
         '303':
           description: Redirect to `/reset-password` with a sealed reset cookie.
         '400':
-          $ref: '#/components/responses/ValidationError'
-        '401':
-          description: Recovery code does not match the supplied email.
+          description: >-
+            Every step-2 rejection lands here with the same uniform body,
+            whichever of email/recovery_code/password was wrong or missing —
+            `mapPasswordRecoveryStartError` in `internal/api/error_mapping_auth.go`
+            has no arm that answers with 401: this endpoint proves nothing to
+            an unauthenticated caller by status code.
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ApiError' }
@@ -1926,6 +1929,7 @@ paths:
               schema: { $ref: '#/components/schemas/OkResponse' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '400': { $ref: '#/components/responses/ValidationError' }
+        '429': { $ref: '#/components/responses/RateLimited' }
 
   /api/v1/users/current/profile:
     patch:
@@ -2220,6 +2224,7 @@ paths:
                 error: "oidc reauth required"
                 error_detail: { key: "oidc reauth required", category: "forbidden", target: "settings_form" }
         '400': { $ref: '#/components/responses/ValidationError' }
+        '429': { $ref: '#/components/responses/RateLimited' }
 
   /api/v1/users/current/password/step-up:
     post:
@@ -2388,6 +2393,7 @@ paths:
           description: Same as 200 for non-JSON clients.
         '401': { $ref: '#/components/responses/Unauthorized' }
         '400': { $ref: '#/components/responses/ValidationError' }
+        '429': { $ref: '#/components/responses/RateLimited' }
 
   /api/v1/users/current/data-wipe:
     post:
@@ -2413,3 +2419,4 @@ paths:
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
         '400': { $ref: '#/components/responses/ValidationError' }
+        '429': { $ref: '#/components/responses/RateLimited' }


### PR DESCRIPTION
## What
Three pre-existing (since v1.9.2) drifts between `docs/openapi.yaml` and actual server behavior.
Doc-only; no code changed.

## Why
- **API-3**: four settings endpoints sharing the per-account re-auth budget (`DELETE
  /api/v1/users/current`, `PUT .../password`, `POST .../data-wipe/validate`, `POST .../data-wipe`)
  can answer `429` (`internal/services/settings_service.go:25,32-33`) and never declared it.
- **API-4**: `ForgotPasswordRequest.required` claimed `recovery_code`/`password` always required,
  but `ForgotPassword` (`internal/api/handlers_auth_session_recovery.go`) is a two-step flow —
  step 1 is `email` alone. The declared `401` was also unreachable:
  `mapPasswordRecoveryStartError` (`internal/api/error_mapping_auth.go`) has no arm that returns
  it; every step-2 rejection is a uniform `400`.
- **API-6**: nine properties used the OpenAPI-3.0-only `nullable: true` under a spec declared
  `openapi: 3.1.0`, which fails 3.1's JSON Schema structural validation (`struct` rule). The plan
  that scoped this PR counted 4; the tree currently has 9 — re-counted against the live file
  rather than trusting the stale figure.

None of the three is a v2.0.0 breaking change (all three predate it).

## Verified
`npx @redocly/cli lint docs/openapi.yaml` — 9 errors → 0 (56 pre-existing warnings, out of scope:
missing `operationId`, one unused response component). `go test ./internal/api/...` including
`TestOpenAPIDeclaresOnlyStatusesTheServerCanEmit` and `TestOpenAPIContractMatchesRegisteredRoutes`
pass. `go build ./...` clean.

## Risk
Low — documentation only, no behavior change.