### PR TITLE
fix(db): an operator can repair the data that refuses migration 037

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,6 +450,7 @@ go run ./cmd/ovumcy users list
 go run ./cmd/ovumcy users delete owner@example.com
 go run ./cmd/ovumcy users delete owner@example.com --yes
 go run ./cmd/ovumcy reset-password owner@example.com
+go run ./cmd/ovumcy repair symptom-names
 ```
 
 Notes:
@@ -464,6 +465,7 @@ Notes:
 - `reset-password <email>` prompts for a new password interactively, validates it against the password policy, writes its bcrypt hash to the account, and atomically bumps `auth_session_version` so every existing session is invalidated. Use this when an owner has lost both their password and their recovery code.
 - `notify` runs one webhook reminder pass — decides due period/ovulation reminders per owner and delivers them to each owner's configured webhook. It is meant to be scheduled (cron, systemd timer, a Docker one-shot, or Task Scheduler), not run continuously; an optional built-in daily scheduler (`REMINDER_SCHEDULER_ENABLED`) can run the same pass in-process instead. See [docs/notifications.md](docs/notifications.md) for all three reminder channels (in-app banner, webhook, calendar feed), scheduling recipes, and the idempotency/security contract.
 - `webhook show|set <email>` inspects or configures an owner's webhook notification settings (endpoint, enabled state, notify-period/notify-ovulation toggles) from the shell — the same settings the Settings-page form writes. See [docs/notifications.md](docs/notifications.md) for the full flag reference.
+- `repair` lists the offline data repairs the binary carries; each inspects and reports by default and changes nothing until `--apply`. Unlike every other subcommand it opens the database *without* applying migrations, because it exists for the case where a migration is refusing to run against data it cannot cover — which also stops the server, so there is no application to fix the data in. Today it carries one repair, `symptom-names`, for an account holding two symptoms under the same name. Runbook: [docs/self-hosted.md](docs/self-hosted.md#duplicate-rows-that-refuse-a-migration).
 - Treat CLI usage as operator-only access. It is intended for local shell access on the instance, not for browser or remote public administration.
 
 ## Development

--- a/changelog.d/fix-symptom-name-uniqueness.md
+++ b/changelog.d/fix-symptom-name-uniqueness.md
@@ -47,8 +47,9 @@
   conflicting group — the key value and how many rows share it — instead of creating the index.
   It never deletes, merges or rewrites a row: this instance stores one person's health history,
   and a schema change is not consent to lose part of it. Nothing is executed, the migration's
-  transaction is rolled back, and the message says what to resolve through the application
-  before starting it again. The check reads the key expressions out of the `CREATE UNIQUE INDEX`
+  transaction is rolled back, and the message says how to resolve it with the instance down —
+  the refusal is also what stops the server, so there is no running application to resolve it
+  in. The check reads the key expressions out of the `CREATE UNIQUE INDEX`
   statement itself, so it covers the next unique index as well as this one, and it excludes
   `NULL` keys because both engines treat those as distinct in a unique index. A statement it
   cannot read — a partial index, or anything trailing the key list — is left to the engine,

--- a/changelog.d/repair-duplicate-symptom-names-offline.md
+++ b/changelog.d/repair-duplicate-symptom-names-offline.md
@@ -33,6 +33,13 @@
   is on. Both engines are covered by a test that takes a database holding duplicates through the
   documented steps to a completed start.
 
+  Being the only entry point that opens a database of unknown schema version, it is also the only
+  one that can be pointed at the wrong database and not notice — a SQLite path that does not exist
+  is created empty rather than refused. So it checks for the symptom catalogue before any query
+  assumes it, and answers a mistyped `DB_PATH` by naming the path it actually reached, instead of
+  with the engine's `no such table` about the very table the operator was told to repair. A
+  PostgreSQL target is named by `DATABASE_URL` and never by its value, which carries credentials.
+
   The refusal message now names this route and the runbook instead of the application.
 
 - **`docs/self-hosted.md` says what a rollback past the last six migrations costs.** Downgrade

--- a/changelog.d/repair-duplicate-symptom-names-offline.md
+++ b/changelog.d/repair-duplicate-symptom-names-offline.md
@@ -35,10 +35,16 @@
 
   Being the only entry point that opens a database of unknown schema version, it is also the only
   one that can be pointed at the wrong database and not notice — a SQLite path that does not exist
-  is created empty rather than refused. So it checks for the symptom catalogue before any query
-  assumes it, and answers a mistyped `DB_PATH` by naming the path it actually reached, instead of
-  with the engine's `no such table` about the very table the operator was told to repair. A
-  PostgreSQL target is named by `DATABASE_URL` and never by its value, which carries credentials.
+  is created empty rather than refused. So it checks the schema it needs before any query assumes
+  it, and answers a mistyped `DB_PATH` by naming the database it actually reached, instead of with
+  the engine's `no such table` about the very table the operator was told to repair. A PostgreSQL
+  target is named by `DATABASE_URL` and never by its value, which carries credentials.
+
+  The check covers the columns and not only the table, and the two failures get different answers
+  because they are different mistakes. A schema that predates the column deciding which row of a
+  group survives is not a wrong database, and is told so: start the instance to carry the schema
+  forward, and if it stops on migration 037, run the repair again — by then with the column it
+  needs.
 
   The refusal message now names this route and the runbook instead of the application.
 

--- a/changelog.d/repair-duplicate-symptom-names-offline.md
+++ b/changelog.d/repair-duplicate-symptom-names-offline.md
@@ -1,0 +1,49 @@
+### Fixed
+
+- **An upgrade that a duplicate symptom name stops can now be finished.** Adding the per-account
+  unique index on symptom names refuses when the database already holds two symptoms one account
+  had under the same name, and that refusal is correct — it deletes nothing and names every
+  conflicting group. What it did not have was a way out: the refusal is also what stops the
+  server, so the instruction to resolve the groups "through the application" pointed at an
+  application the refusal had already stopped, and every other operator subcommand applies
+  migrations on the way in and met the same refusal.
+
+  `ovumcy repair symptom-names` is that way out. It opens the database **without applying
+  migrations**, which is what lets it reach the state that is stuck at all. Run on its own it
+  inspects: it prints which symptom each account keeps and which rows would fold into it, changes
+  nothing, and exits non-zero while duplicates remain, so an upgrade script can gate on it. Run
+  with `--apply` it merges each group — every day log that named an absorbed symptom is
+  re-pointed at the kept one **first, in the transaction that removes the rows**, so no day loses
+  what the owner recorded, and a day that named both ends up naming one. A second run finds
+  nothing and says so, which is also what a failed run leaves behind: the merge is one
+  transaction, so a failure changes nothing and can simply be repeated.
+
+  Which row is kept follows what the owner can still reach: an active row before an archived one,
+  a built-in before a custom one, and the oldest of what remains. The built-in rule is not a
+  preference — the reachable half of this class is the built-in seeding race, and a built-in
+  symptom can be neither renamed, hidden nor removed from Settings, so leaving a second built-in
+  behind would leave a duplicate in the day-entry picker with no surface anywhere that can clear
+  it.
+
+  The repair reads its groups through the database's own `lower(name)`, the same expression the
+  index is built on, rather than folding names in Go. That is what makes one command correct on
+  both engines where they disagree: PostgreSQL folds by locale and SQLite folds ASCII only, so a
+  case-only variant of a non-ASCII name is a conflict on one and not the other — and the repair
+  reports exactly what that engine's index would refuse, without needing to know which engine it
+  is on. Both engines are covered by a test that takes a database holding duplicates through the
+  documented steps to a completed start.
+
+  The refusal message now names this route and the runbook instead of the application.
+
+- **`docs/self-hosted.md` says what a rollback past the last six migrations costs.** Downgrade
+  Caveats stopped at migration 022, so everything added since was undocumented in both
+  directions. It now covers 032 through 038: which are plain additive changes an older binary
+  ignores, which one deletes rows and why that is not a loss, and the two whose protection is
+  simply off while you are downgraded — the "shown exactly once" marks on the recovery code and
+  the calendar-feed URL, and the webhook configuration counter. Migration 037 is called out as
+  the opposite shape: safe to roll back, and the one that can refuse to roll forward.
+
+- **A new operator runbook covers a migration refused by existing data.** It gives the whole
+  sequence — stop the service, back up, inspect, apply, start — including the detail that the
+  command is reached with `docker compose run` rather than `docker exec`, because the container
+  `docker exec` would attach to is not up.

--- a/cmd/ovumcy/commands.go
+++ b/cmd/ovumcy/commands.go
@@ -18,6 +18,7 @@ func tryRunCLICommand() (bool, error) {
 		runReadycheck:    cli.RunReadycheckCommand,
 		runNotify:        cli.RunNotifyCommand,  // codecov:ignore -- main() composition-root wiring; this os.Args dispatch wrapper runs only in the binary (the handler is unit-tested via tryRunCLICommandWithHandlers with a stub)
 		runWebhook:       cli.RunWebhookCommand, // codecov:ignore -- main() composition-root wiring; this os.Args dispatch wrapper runs only in the binary (the handler is unit-tested via tryRunCLICommandWithHandlers with a stub)
+		runRepair:        cli.RunRepairCommand,  // codecov:ignore -- main() composition-root wiring; this os.Args dispatch wrapper runs only in the binary (the handler is unit-tested via tryRunCLICommandWithHandlers with a stub)
 	})
 }
 
@@ -28,6 +29,7 @@ type cliCommandHandlers struct {
 	runReadycheck    func(port string, timeout time.Duration) error
 	runNotify        func(databaseConfig db.Config, secretKey string, defaultLanguage string, location *time.Location, blockPrivateAddresses bool, args []string) error
 	runWebhook       func(databaseConfig db.Config, secretKey string, args []string) error
+	runRepair        func(databaseConfig db.Config, args []string) error
 }
 
 func tryRunCLICommandWithHandlers(args []string, handlers cliCommandHandlers) (bool, error) {
@@ -48,6 +50,8 @@ func tryRunCLICommandWithHandlers(args []string, handlers cliCommandHandlers) (b
 		return handleNotifyCommand(args, handlers)
 	case "webhook":
 		return handleWebhookCommand(args, handlers)
+	case "repair":
+		return handleRepairCommand(args, handlers)
 	default:
 		return false, nil
 	}
@@ -132,6 +136,22 @@ func handleNotifyCommand(args []string, handlers cliCommandHandlers) (bool, erro
 		return true, err
 	}
 	return true, handlers.runNotify(databaseConfig, secretKey, defaultLanguage, location, blockPrivateAddresses, args[1:])
+}
+
+// handleRepairCommand is deliberately the only subcommand that takes no secret
+// and reaches the database with migrations left unapplied: it runs when a
+// migration has stopped every other path into this instance, so anything it
+// needed from a healthy boot would make it unreachable exactly when it is
+// wanted.
+func handleRepairCommand(args []string, handlers cliCommandHandlers) (bool, error) {
+	if handlers.runRepair == nil {
+		return true, fmt.Errorf("repair handler is required")
+	}
+	databaseConfig, err := resolveDatabaseConfig()
+	if err != nil {
+		return true, fmt.Errorf("invalid database config: %w", err)
+	}
+	return true, handlers.runRepair(databaseConfig, args[1:])
 }
 
 func handleWebhookCommand(args []string, handlers cliCommandHandlers) (bool, error) {

--- a/cmd/ovumcy/main_test.go
+++ b/cmd/ovumcy/main_test.go
@@ -2003,6 +2003,80 @@ func TestTryRunCLICommandWithHandlersDispatchesWebhook(t *testing.T) {
 	}
 }
 
+func TestTryRunCLICommandWithHandlersDispatchesRepair(t *testing.T) {
+	// No SECRET_KEY is set, deliberately. This subcommand runs on an instance a
+	// migration has stopped, so a prerequisite beyond the database location
+	// would be one the operator meets least easily exactly when they need it.
+	t.Setenv("DB_DRIVER", "sqlite")
+	t.Setenv("SECRET_KEY", "")
+	t.Setenv("SECRET_KEY_FILE", "")
+
+	var receivedArgs []string
+	handled, err := tryRunCLICommandWithHandlers([]string{"repair", "symptom-names", "--apply"}, cliCommandHandlers{
+		runRepair: func(_ db.Config, args []string) error {
+			receivedArgs = args
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !handled {
+		t.Fatal("expected repair command to be handled")
+	}
+	if len(receivedArgs) != 2 || receivedArgs[0] != "symptom-names" || receivedArgs[1] != "--apply" {
+		t.Fatalf("expected the repair name and its flag forwarded as args, got %v", receivedArgs)
+	}
+}
+
+func TestTryRunCLICommandWithHandlersRepairWithNoArgumentsReachesItsHandler(t *testing.T) {
+	// `ovumcy repair` alone is what the migration refusal tells the operator to
+	// run, and it has to reach the handler that lists the repairs rather than be
+	// rejected here as a missing subcommand.
+	t.Setenv("DB_DRIVER", "sqlite")
+
+	called := false
+	handled, err := tryRunCLICommandWithHandlers([]string{"repair"}, cliCommandHandlers{
+		runRepair: func(_ db.Config, args []string) error {
+			called = true
+			if len(args) != 0 {
+				t.Fatalf("expected no args, got %v", args)
+			}
+			return nil
+		},
+	})
+	if err != nil || !handled || !called {
+		t.Fatalf("expected the repair handler to be reached, got handled=%t called=%t err=%v", handled, called, err)
+	}
+}
+
+func TestTryRunCLICommandWithHandlersRepairRequiresHandler(t *testing.T) {
+	handled, err := tryRunCLICommandWithHandlers([]string{"repair", "symptom-names"}, cliCommandHandlers{})
+	if !handled {
+		t.Fatal("expected repair command to be handled")
+	}
+	if err == nil || !strings.Contains(err.Error(), "repair handler is required") {
+		t.Fatalf("expected repair-handler-required error, got %v", err)
+	}
+}
+
+func TestTryRunCLICommandWithHandlersRepairReportsInvalidDatabaseConfig(t *testing.T) {
+	t.Setenv("DB_DRIVER", "mysql")
+
+	handled, err := tryRunCLICommandWithHandlers([]string{"repair", "symptom-names"}, cliCommandHandlers{
+		runRepair: func(db.Config, []string) error {
+			t.Fatal("did not expect the repair handler to be called with an invalid DB config")
+			return nil
+		},
+	})
+	if !handled {
+		t.Fatal("expected repair command to be handled")
+	}
+	if err == nil || !strings.Contains(err.Error(), "invalid database config") {
+		t.Fatalf("expected an invalid-database-config error, got %v", err)
+	}
+}
+
 func TestTryRunCLICommandWithHandlersRejectsMissingWebhookSubcommand(t *testing.T) {
 	handled, err := tryRunCLICommandWithHandlers([]string{"webhook"}, cliCommandHandlers{})
 	if !handled {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,7 +37,7 @@ flowchart TB
     subgraph app["Ovumcy server — single Go binary"]
         direction TB
         api["internal/api — transport only<br/>routing · auth · role · CSRF · HTMX / JSON / HTML"]
-        cli["internal/cli — operator commands<br/>users · reset-password · notify · webhook · healthcheck"]
+        cli["internal/cli — operator commands<br/>users · reset-password · notify · webhook · healthcheck · repair"]
         reminders["internal/reminders — background scheduler<br/>trigger for the request-free webhook notify pass"]
         services["internal/services — domain logic<br/>cycle · stats · dashboard · settings · export · onboarding · webhook delivery"]
         db["internal/db — persistence<br/>repositories · forward-only migrations"]
@@ -92,10 +92,14 @@ flowchart TB
   outside a request it has no session and no CSRF token: its owner scoping comes
   from the same per-`user_id` repository calls the request path uses.
 - **`internal/cli` (operator commands).** The second entry point of the binary
-  (`ovumcy users`, `reset-password`, `notify`, `webhook`, `healthcheck`). It is
-  not transport and does not pass through the authorization boundary below —
-  it reaches `internal/services` and `internal/db` directly, and is gated by
-  shell or container access to the host instead. Operator use is documented in
+  (`ovumcy users`, `reset-password`, `notify`, `webhook`, `healthcheck`,
+  `repair`). It is not transport and does not pass through the authorization
+  boundary below — it reaches `internal/services` and `internal/db` directly, and
+  is gated by shell or container access to the host instead. All of them but
+  `repair` open the database the way the server does, migrations included;
+  `repair` is the one that must reach a database a migration is refusing, so it
+  opens without applying any and is the only entry point that does. Operator use
+  is documented in
   the [README](../README.md#architecture) and
   [`docs/self-hosted.md`](self-hosted.md).
 

--- a/docs/self-hosted.md
+++ b/docs/self-hosted.md
@@ -586,7 +586,7 @@ One caveat if you ever move a SQLite instance to Postgres. The index folds names
 
 For the Postgres stacks, run the same commands from the example stack's directory; `docker compose run` starts the database container the app depends on.
 
-If you run the binary outside compose, the command is the same with the same `DB_DRIVER`/`DB_PATH` (or `DATABASE_URL`) environment the server uses. It needs no `SECRET_KEY` and does not touch the calendar-feed fence.
+If you run the binary outside compose, the command is the same with the same `DB_DRIVER`/`DB_PATH` (or `DATABASE_URL`) environment the server uses. It needs no `SECRET_KEY` and does not touch the calendar-feed fence. Get the path wrong and it says so, naming the database it actually opened — worth knowing because SQLite does not refuse a path that is not there, it creates an empty database at it.
 
 ## Troubleshooting Baseline
 

--- a/docs/self-hosted.md
+++ b/docs/self-hosted.md
@@ -17,7 +17,7 @@ Ovumcy's supported self-hosted baseline is a single application instance with a 
 - [Health Checks by Deployment Mode](#health-checks-by-deployment-mode) — [operator CLI](#running-the-operator-cli-against-the-container) · [Concurrency on the SQLite Baseline](#concurrency-on-the-sqlite-baseline) · [Secret Handling and Rotation](#secret-handling-and-rotation)
 - [Backup and Restore Contract](#backup-and-restore-contract) — [volume backup](#docker-named-volume-backup), [volume restore](#docker-named-volume-restore), [post-restore verification](#post-restore-verification)
 - [Calendar Feed Restore Fence](#calendar-feed-restore-fence)
-- [Safe Upgrade Procedure](#safe-upgrade-procedure) · [Downgrade Caveats](#downgrade-caveats)
+- [Safe Upgrade Procedure](#safe-upgrade-procedure) · [Downgrade Caveats](#downgrade-caveats) · [Duplicate rows that refuse a migration](#duplicate-rows-that-refuse-a-migration)
 
 **When something breaks**
 - [Troubleshooting Baseline](#troubleshooting-baseline) · [Common Operator Scenarios](#common-operator-scenarios) · [Advanced Deployment Path](#advanced-deployment-path)
@@ -284,6 +284,8 @@ printf '%s\n' "$NEW_PASSWORD" | docker exec -i ovumcy /app/ovumcy reset-password
 
 Use the scripted form when you need to recover several accounts at once — for example after a `SECRET_KEY` rotation, where every 2FA-enabled owner needs a way back in.
 
+Every subcommand above applies any pending migrations first, exactly as the server does, so none of them runs on a database a migration is refusing. The one that does is `ovumcy repair`, which exists for that case and opens the database without applying anything; it is also the only one you reach with `docker compose run` rather than `docker exec`, because the container it would attach to is not up. See [Duplicate rows that refuse a migration](#duplicate-rows-that-refuse-a-migration).
+
 For the public reverse-proxy stacks, do not treat a missing host-level `127.0.0.1:8080` listener as a problem. In the preferred deployment model, that port is intentionally not published to the host at all.
 
 ## Concurrency on the SQLite Baseline
@@ -517,7 +519,74 @@ Migrations are forward-only. There is no `down.sql` and no automated rollback pa
 
 - **The one-shot luteal-phase recompute** is not a migration but changes stored data on the same boot, so it belongs in the same list. The personalized luteal-phase estimate in `users.luteal_phase` used to be measured one day too long, which moved the predicted ovulation date and both fertile-window edges a day earlier for owners who had logged enough BBT or cervical-mucus signal to earn one. The first boot of the corrected version recomputes that column from each owner's own logs and records a marker in `app_state` once it has been through every account without a failure, so it normally runs exactly once; an account it could not read or write is skipped and picked up by the next boot, and the startup line reports how many. Nothing an owner typed is touched: the column has no input surface and is derived from the day logs alone. A downgrade does not restore the previous values and does not need to — the older binary re-derives the column under its own convention the next time the owner saves a day or restores an export, and until then the only difference is a prediction one day apart. Restore from a pre-upgrade backup only if you need the previous values back immediately.
 
+- **Migrations `032`, `034` and `035` are plain additive schema changes** — a nullable calendar-feed verifier column beside the one it replaces, an interface-language column defaulting to "never chosen", and a column DEFAULT restated on PostgreSQL only. An older binary ignores all three and keeps working; `032` in particular leaves the previous `calendar_feed_verifier_hash` column in place and still written, precisely so a rollback keeps verifying every existing feed token. Nothing to do in either direction.
+
+- **Migration `033_purge_unattributed_oidc_logout_states.sql` deletes rows**, the only migration in this range that does. They are pre-031 OIDC logout states with a NULL `user_id`, which account deletion could never reach and which expire on their own within 7 days. A downgrade does not bring them back and does not need them: nothing reads a logout state after its TTL, and their absence is the point of the migration. No owner data is involved.
+
+- **Migration `036_secret_reveal_consumption_marks.sql` is additive, but a downgrade turns off what it enforces.** The columns record that the recovery code and the calendar-feed subscribe URL have been shown once. A binary that predates 036 does not write them, so while you are downgraded a client that kept the sealed reveal cookie can be shown either secret again. Re-upgrading resumes recording from that moment; it cannot know about a reveal that happened while the older binary was running. Treat a downgrade past 036 as a window in which "shown exactly once" is not enforced, and rotate the calendar feed afterwards if that matters to the owners on the instance.
+
+- **Migration `038_webhook_config_version.sql` is additive with the same shape of gap.** The counter lets a reminder pass tell a stale delivery snapshot from the current one. An older binary does not bump it, so while you are downgraded a notify pass can still deliver against a configuration the owner changed mid-pass. The column keeps its value across the downgrade and the protection resumes on re-upgrade.
+
+- **Migration `037_symptom_name_uniqueness.sql` is downgrade-safe and upgrade-fragile, which is the reverse of the entries above.** The index it adds is simply ignored by an older binary — except that the index is still enforced by the database, so a duplicate name an older binary would have answered with "symptom name already exists" comes back to it as an unrecognized constraint error instead. Going the other way is where it bites: if the database already held two symptoms one account had under the same name, the upgrade refuses this migration and the instance does not start. That is deliberate and loses nothing, and it has its own runbook — [Duplicate rows that refuse a migration](#duplicate-rows-that-refuse-a-migration).
+
 If you need to downgrade through a migration above, restore the database from a backup taken before that migration was applied. An entry that is a one-shot pass rather than a migration states its own remedy, which is weaker — its bullet says whether a restore is needed at all. Keep an "upgrade-paired" backup file alongside the image-tag bump in your runbook so a rollback in either direction is a single restore-from-backup step.
+
+## Duplicate rows that refuse a migration
+
+A migration that adds a **unique** index checks first, and refuses if the database already holds rows the index cannot cover. It names every conflicting group, writes nothing, rolls its transaction back, and ends the start. That refusal is the safe outcome — the only ways to make room would be to delete or merge somebody's rows, and a schema change is not consent to do either — but it does mean the instance stays down until you resolve it.
+
+The startup log line looks like this:
+
+```
+refusing migration 037_symptom_name_uniqueness.sql: table symptom_types already
+holds rows that unique index idx_symptom_types_user_name_unique on (user_id,
+lower(name)) cannot cover ...
+```
+
+Resolve it **offline**. There is no running application to fix the data in — this refusal is what stopped it — and every other operator subcommand opens the database the same way and meets the same refusal. The `repair` subcommand is the exception: it opens the database without applying migrations, so it can reach exactly the state that is stuck.
+
+`ovumcy repair` on its own lists the repairs the binary carries. Each one inspects and reports by default and changes nothing until `--apply`.
+
+### Repairing duplicate symptom names
+
+1. **Stop the service.** The container restarts on its own otherwise, and a repair must not run beside a boot attempt.
+
+```bash
+docker compose stop ovumcy
+```
+
+2. **Back up the database.** Follow [Docker Named Volume Backup](#docker-named-volume-backup). This step is not optional: the repair removes rows, and there is no undo other than this archive.
+
+3. **Inspect.** This changes nothing and prints the plan — which symptom each account keeps and which rows fold into it:
+
+```bash
+docker compose run --rm ovumcy /app/ovumcy repair symptom-names
+```
+
+It exits non-zero while duplicates remain, so an upgrade script can gate on it. Read the plan before the next step.
+
+4. **Apply.** For each group the kept symptom absorbs the others: every day log that named an absorbed symptom is re-pointed at the kept one first, in the same transaction that removes the rows, so no day loses what the owner recorded and a day that named both ends up naming one:
+
+```bash
+docker compose run --rm ovumcy /app/ovumcy repair symptom-names --apply
+```
+
+5. **Start the service** and confirm the migration applied:
+
+```bash
+docker compose up -d
+docker compose logs ovumcy | tail -n 40
+```
+
+Running the repair a second time finds nothing and reports so, which is also what a partly-failed run leaves behind — the merge is one transaction, so a failure changes nothing and can simply be repeated.
+
+What the repair does **not** do: it never edits a name, and it never chooses between two different symptoms. It only collapses rows an account holds under the *same* name, which is a state a normal request could never have produced. The kept row is the one still reachable by the owner — an active row before an archived one, a built-in before a custom one, and the oldest of what remains. That order matters because a built-in symptom cannot be renamed, hidden or removed from Settings, so leaving a second built-in behind would leave the owner a duplicate in the day-entry picker with no way to clear it.
+
+One caveat if you ever move a SQLite instance to Postgres. The index folds names with the database's own `lower()`, and so does this repair — which is what makes one command correct on either engine. But the two engines do not fold alike: PostgreSQL folds by locale, SQLite folds ASCII only. Two symptom names differing only in the case of a non-ASCII letter are therefore one name to PostgreSQL and two to SQLite, so a database this repair reports clean on SQLite can still refuse the migration once its rows are in PostgreSQL. Run the inspection again after the import, before you conclude the move went through.
+
+For the Postgres stacks, run the same commands from the example stack's directory; `docker compose run` starts the database container the app depends on.
+
+If you run the binary outside compose, the command is the same with the same `DB_DRIVER`/`DB_PATH` (or `DATABASE_URL`) environment the server uses. It needs no `SECRET_KEY` and does not touch the calendar-feed fence.
 
 ## Troubleshooting Baseline
 
@@ -619,6 +688,8 @@ Two cases are left untouched, counted in the same log line, and cannot sign in u
 - the stored value cannot be reduced to a plain address at all (for example a quoted local part).
 
 ### The server exits during startup instead of coming up
+
+Read the last line first: a start that ends with `refusing migration ...` is not one of the cases below. That is a migration declining to run against data it cannot cover, before any of these passes exists, and it is resolved with the instance down — [Duplicate rows that refuse a migration](#duplicate-rows-that-refuse-a-migration).
 
 Three passes run on every start, after the migrations and before the server begins serving: the calendar-feed key-rotation check, the auth-email repair described above, and the luteal-phase recompute. Each pass is allowed **five minutes** end to end — not per query, so a pass making many individually fast queries can still reach it — after which a database that accepts the connection and then stops responding ends the start with an error naming the pass, instead of leaving the process alive, silent and not listening — which is what it used to do, and which a container healthcheck can only ever report as "starting".
 

--- a/internal/cli/repair.go
+++ b/internal/cli/repair.go
@@ -66,11 +66,35 @@ func runRepairCommand(databaseConfig db.Config, args []string, output io.Writer)
 		_ = sqlDB.Close()
 	}()
 
-	service := services.NewSymptomDuplicateRepairService(db.NewSymptomDuplicateRepository(database))
+	repository := db.NewSymptomDuplicateRepository(database)
+	// Before anything queries the catalogue, and once for both modes: this is
+	// the only command that opens a database of unknown schema version, so "not
+	// an Ovumcy database" is a mistake only it can make and only it can name.
+	if err := repository.RequireSymptomCatalogue(context.Background()); err != nil {
+		return fmt.Errorf(
+			"%s: %w. Point DB_DRIVER and DB_PATH (or DATABASE_URL) at the instance's own database — a SQLite path that does not exist is not refused, the driver creates an empty database there",
+			describeRepairTarget(databaseConfig), err,
+		)
+	}
+
+	service := services.NewSymptomDuplicateRepairService(repository)
 	if apply {
 		return runSymptomNamesRepairApply(service, output)
 	}
 	return runSymptomNamesRepairInspect(service, output)
+}
+
+// describeRepairTarget names the database the operator actually reached, so a
+// mistyped path is visible in the refusal rather than inferred.
+//
+// A Postgres URL carries credentials, so it is named by its variable and never
+// by its value. The SQLite path is the whole point of the message and is not a
+// secret.
+func describeRepairTarget(databaseConfig db.Config) string {
+	if databaseConfig.Driver == db.DriverPostgres {
+		return "the postgres database DATABASE_URL points at"
+	}
+	return "sqlite database " + strings.TrimSpace(databaseConfig.SQLitePath)
 }
 
 func parseRepairApplyFlag(args []string) (bool, error) {

--- a/internal/cli/repair.go
+++ b/internal/cli/repair.go
@@ -1,0 +1,161 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/ovumcy/ovumcy-web/internal/db"
+	"github.com/ovumcy/ovumcy-web/internal/models"
+	"github.com/ovumcy/ovumcy-web/internal/services"
+)
+
+// repairUsage lists the repairs this binary knows. It is what an operator
+// reaches from a refused migration, so every line has to name a command that
+// runs on a STOPPED instance — the refusal is why there is no running one.
+const repairUsage = `usage: ovumcy repair <repair> [--apply]
+
+Repairs run against the database directly and do not need the server. Each one
+inspects and reports by default, and changes nothing until --apply is passed.
+Take a backup before --apply.
+
+  symptom-names   Merge symptoms one account holds twice under the same name,
+                  which is what stops migration 037 from creating its index`
+
+// RunRepairCommand is the operator entry point for offline data repairs.
+func RunRepairCommand(databaseConfig db.Config, args []string) error {
+	return runRepairCommand(databaseConfig, args, os.Stdout)
+}
+
+func runRepairCommand(databaseConfig db.Config, args []string, output io.Writer) error {
+	if output == nil {
+		output = os.Stdout
+	}
+	if len(args) == 0 {
+		return errors.New(repairUsage)
+	}
+
+	repair := strings.ToLower(strings.TrimSpace(args[0]))
+	if repair != "symptom-names" {
+		return errors.New(repairUsage)
+	}
+
+	apply, err := parseRepairApplyFlag(args[1:])
+	if err != nil {
+		return err
+	}
+
+	// Without migrations, deliberately: this repair exists for a database a
+	// migration refuses, so opening it the ordinary way would meet that refusal
+	// and fail exactly where the boot already fails. symptom_types and
+	// daily_logs have both been there since migration 001/003, far below
+	// anything that can still be pending.
+	database, err := db.OpenDatabaseWithoutMigrations(databaseConfig)
+	if err != nil {
+		return fmt.Errorf("database init failed: %w", err)
+	}
+	sqlDB, err := database.DB()
+	if err != nil {
+		return fmt.Errorf("database init failed: %w", err) // codecov:ignore -- defensive: (*gorm.DB).DB() only errors when the pool is unavailable, which cannot happen on the handle the open just returned
+	}
+	defer func() {
+		_ = sqlDB.Close()
+	}()
+
+	service := services.NewSymptomDuplicateRepairService(db.NewSymptomDuplicateRepository(database))
+	if apply {
+		return runSymptomNamesRepairApply(service, output)
+	}
+	return runSymptomNamesRepairInspect(service, output)
+}
+
+func parseRepairApplyFlag(args []string) (bool, error) {
+	apply := false
+	for _, arg := range args {
+		switch strings.TrimSpace(arg) {
+		case "--apply":
+			apply = true
+		default:
+			return false, errors.New(repairUsage)
+		}
+	}
+	return apply, nil
+}
+
+// errSymptomNameDuplicatesRemain is what the inspection answers with when the
+// database is not ready for the migration. It is an error rather than a plain
+// report so the command can gate an upgrade script: a zero exit means this
+// instance will boot, a non-zero one means it will not.
+var errSymptomNameDuplicatesRemain = errors.New("this database is not ready for migration 037: run `ovumcy repair symptom-names --apply` to merge the groups above, after taking a backup")
+
+func runSymptomNamesRepairInspect(service *services.SymptomDuplicateRepairService, output io.Writer) error {
+	groups, err := service.Inspect(context.Background())
+	if err != nil {
+		return err
+	}
+	if len(groups) == 0 {
+		_, _ = fmt.Fprintln(output, "No account holds two symptoms under one name. Migration 037 has nothing to refuse.")
+		return nil
+	}
+
+	writeSymptomDuplicatePlan(output, services.PlanSymptomDuplicateMerges(groups))
+	return errSymptomNameDuplicatesRemain
+}
+
+func runSymptomNamesRepairApply(service *services.SymptomDuplicateRepairService, output io.Writer) error {
+	merges, outcome, err := service.Repair(context.Background())
+	if err != nil {
+		return err
+	}
+	if len(merges) == 0 {
+		_, _ = fmt.Fprintln(output, "No account holds two symptoms under one name. Nothing to merge.")
+		return nil
+	}
+
+	writeSymptomDuplicatePlan(output, merges)
+	_, _ = fmt.Fprintf(
+		output,
+		"\nMerged %d group(s): %d symptom row(s) removed, %d day log(s) re-pointed at the kept symptom.\n"+
+			"Start the instance to apply migration 037.\n",
+		outcome.GroupsMerged, outcome.SymptomsRemoved, outcome.DailyLogsRewritten,
+	)
+	return nil
+}
+
+// writeSymptomDuplicatePlan prints what will be kept and what will be absorbed,
+// per account. The same table serves the inspection and the applied run on
+// purpose: the operator reads the plan before consenting, and then reads that
+// the run carried out the plan they read.
+func writeSymptomDuplicatePlan(output io.Writer, merges []models.SymptomMerge) {
+	_, _ = fmt.Fprintf(
+		output,
+		"%d account/name group(s) hold more than one symptom, as this database's own lower() folds names:\n\n",
+		len(merges),
+	)
+
+	writer := tabwriter.NewWriter(output, 0, 4, 2, ' ', 0)
+	_, _ = fmt.Fprintln(writer, "ACCOUNT\tACTION\tSYMPTOM ID\tNAME\tKIND\tSTATE")
+	for _, merge := range merges {
+		writeSymptomDuplicateRow(writer, merge.UserID, "keep", merge.Survivor)
+		for _, absorbed := range merge.Absorbed {
+			writeSymptomDuplicateRow(writer, merge.UserID, "merge into kept", absorbed)
+		}
+	}
+	_ = writer.Flush()
+}
+
+func writeSymptomDuplicateRow(writer io.Writer, userID uint, action string, symptom models.SymptomType) {
+	kind := "custom"
+	if symptom.IsBuiltin {
+		kind = "built-in"
+	}
+	state := "active"
+	if !symptom.IsActive() {
+		state = "archived"
+	}
+	_, _ = fmt.Fprintf(writer, "%d\t%s\t%d\t%s\t%s\t%s\n", userID, action, symptom.ID, symptom.Name, kind, state)
+}

--- a/internal/cli/repair.go
+++ b/internal/cli/repair.go
@@ -71,10 +71,7 @@ func runRepairCommand(databaseConfig db.Config, args []string, output io.Writer)
 	// the only command that opens a database of unknown schema version, so "not
 	// an Ovumcy database" is a mistake only it can make and only it can name.
 	if err := repository.RequireSymptomCatalogue(context.Background()); err != nil {
-		return fmt.Errorf(
-			"%s: %w. Point DB_DRIVER and DB_PATH (or DATABASE_URL) at the instance's own database — a SQLite path that does not exist is not refused, the driver creates an empty database there",
-			describeRepairTarget(databaseConfig), err,
-		)
+		return fmt.Errorf("%s: %w%s", describeRepairTarget(databaseConfig), err, repairPreconditionRemedy(err))
 	}
 
 	service := services.NewSymptomDuplicateRepairService(repository)
@@ -82,6 +79,32 @@ func runRepairCommand(databaseConfig db.Config, args []string, output io.Writer)
 		return runSymptomNamesRepairApply(service, output)
 	}
 	return runSymptomNamesRepairInspect(service, output)
+}
+
+// repairPreconditionRemedy is what to do about each way the precondition can
+// fail, which are different mistakes and take different answers.
+//
+// It advises only on the two verdicts it actually recognises, and says nothing
+// otherwise. A default arm here would attach one of them to every failure the
+// precondition can ever grow — starting with the one it already has: a database
+// that stopped answering carries its own cause, and appending "check your
+// DB_PATH" to it would send the operator to audit a connection setting that was
+// correct, which is what the schema probe was taught to stop doing.
+//
+// A schema older than migration 004 is likewise not a wrong database. The way
+// forward there is to start the instance, which carries the schema up; that may
+// stop again on migration 037, and this command is then the answer, now with
+// the column it needs, so the loop closes rather than sending the operator in a
+// circle.
+func repairPreconditionRemedy(err error) string {
+	switch {
+	case errors.Is(err, db.ErrSymptomCatalogueTooOld):
+		return ". Start the instance once to carry the schema forward; if it stops on migration 037, run this repair again"
+	case errors.Is(err, db.ErrSymptomCatalogueAbsent):
+		return ". Point DB_DRIVER and DB_PATH (or DATABASE_URL) at the instance's own database — a SQLite path that does not exist is not refused, the driver creates an empty database there"
+	default:
+		return ""
+	}
 }
 
 // describeRepairTarget names the database the operator actually reached, so a

--- a/internal/cli/repair_test.go
+++ b/internal/cli/repair_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -215,6 +216,60 @@ func TestRepairInspectionNamesWhatEachRowIsBeforeTheOperatorConsents(t *testing.
 		if !strings.Contains(report, fragment) {
 			t.Fatalf("the report must name %q, got:\n%s", fragment, report)
 		}
+	}
+}
+
+// TestRepairNamesAWrongDatabaseRatherThanTheMissingTable covers the mistake
+// only this command can make.
+//
+// It is the one entry point that opens a database without applying migrations,
+// so it cannot tell a schema older than the binary — what it exists for — from
+// a database that is not this application's at all. On SQLite the second is
+// silent: a path that is not there is created empty rather than refused, so a
+// mistyped DB_PATH arrives looking like a real instance and the catalogue query
+// answers with the engine's `no such table`, over a dump of the SQL, naming the
+// very table the operator was told to repair.
+func TestRepairNamesAWrongDatabaseRatherThanTheMissingTable(t *testing.T) {
+	t.Parallel()
+
+	mistyped := filepath.Join(t.TempDir(), "ovumcy-typo.db")
+	err := runRepairCommand(db.Config{Driver: db.DriverSQLite, SQLitePath: mistyped}, []string{"symptom-names"}, nil)
+	if err == nil {
+		t.Fatal("expected a database with no symptom catalogue to be refused")
+	}
+	if !errors.Is(err, db.ErrSymptomCatalogueAbsent) {
+		t.Fatalf("expected the absent-catalogue sentinel, got %v", err)
+	}
+
+	message := err.Error()
+	if !strings.Contains(message, mistyped) {
+		t.Fatalf("the refusal must name the path actually reached, got: %s", message)
+	}
+	if !strings.Contains(message, "DB_PATH") {
+		t.Fatalf("the refusal must say which setting to correct, got: %s", message)
+	}
+	for _, leak := range []string{"no such table", "SELECT", "SQL logic error"} {
+		if strings.Contains(message, leak) {
+			t.Fatalf("the refusal must not read as a schema fault, %q is in: %s", leak, message)
+		}
+	}
+}
+
+// TestRepairNamesThePostgresTargetWithoutItsCredentials is the same refusal on
+// the other engine, where naming the target verbatim would print a password.
+func TestRepairNamesThePostgresTargetWithoutItsCredentials(t *testing.T) {
+	t.Parallel()
+
+	const secret = "hunter2-do-not-print"
+	described := describeRepairTarget(db.Config{
+		Driver:      db.DriverPostgres,
+		PostgresURL: "postgres://ovumcy:" + secret + "@db.example:5432/ovumcy",
+	})
+	if strings.Contains(described, secret) || strings.Contains(described, "postgres://") {
+		t.Fatalf("a connection string must never reach the output, got: %s", described)
+	}
+	if !strings.Contains(described, "DATABASE_URL") {
+		t.Fatalf("the operator still needs to know which setting to correct, got: %s", described)
 	}
 }
 

--- a/internal/cli/repair_test.go
+++ b/internal/cli/repair_test.go
@@ -255,6 +255,103 @@ func TestRepairNamesAWrongDatabaseRatherThanTheMissingTable(t *testing.T) {
 	}
 }
 
+// TestRepairRefusesASchemaOlderThanTheColumnsItReads is the half a table check
+// alone does not cover.
+//
+// This is the one command that opens a database at an UNKNOWN schema version,
+// so "symptom_types exists" does not mean "the schema this repair reads
+// exists": archived_at arrives three migrations later and is what decides which
+// row of a group survives. Left to the query, a schema that old answers with
+// the engine's own `no such column` — the same unreadable refusal the table
+// check was added to prevent, one level down.
+func TestRepairRefusesASchemaOlderThanTheColumnsItReads(t *testing.T) {
+	t.Parallel()
+
+	config := db.Config{Driver: db.DriverSQLite, SQLitePath: filepath.Join(t.TempDir(), "schema-001.db")}
+	seedSymptomCatalogueAsMigration001Created(t, config)
+
+	err := runRepairCommand(config, []string{"symptom-names"}, nil)
+	if err == nil {
+		t.Fatal("expected a pre-004 schema to be refused")
+	}
+	if !errors.Is(err, db.ErrSymptomCatalogueTooOld) {
+		t.Fatalf("expected the too-old sentinel, got %v", err)
+	}
+
+	message := err.Error()
+	if !strings.Contains(message, "archived_at") {
+		t.Fatalf("the refusal must name the column it is short of, got: %s", message)
+	}
+	if !strings.Contains(message, "Start the instance") {
+		t.Fatalf("an old schema is carried forward by a start, not by fixing a path, got: %s", message)
+	}
+	if strings.Contains(message, "DB_PATH") {
+		t.Fatalf("an old schema is not a wrong path and must not be reported as one, got: %s", message)
+	}
+	for _, leak := range []string{"no such column", "SELECT"} {
+		if strings.Contains(message, leak) {
+			t.Fatalf("the refusal must not read as a schema fault, %q is in: %s", leak, message)
+		}
+	}
+}
+
+// seedSymptomCatalogueAsMigration001Created builds symptom_types with exactly
+// the columns migration 001 gave it, through the non-migrating open so nothing
+// carries the schema forward behind the test's back.
+func seedSymptomCatalogueAsMigration001Created(t *testing.T, config db.Config) {
+	t.Helper()
+
+	database, err := db.OpenDatabaseWithoutMigrations(config)
+	if err != nil {
+		t.Fatalf("open without migrations: %v", err)
+	}
+	defer closeDatabase(t, database)
+
+	if err := database.Exec(`
+CREATE TABLE symptom_types (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id INTEGER NOT NULL,
+  name TEXT NOT NULL,
+  icon TEXT NOT NULL,
+  color TEXT NOT NULL,
+  is_builtin BOOLEAN NOT NULL DEFAULT 0
+)`).Error; err != nil {
+		t.Fatalf("create the migration 001 catalogue: %v", err)
+	}
+}
+
+// TestRepairAdvisesOnlyOnTheVerdictsItRecognises keeps the two schema answers
+// from leaking onto a failure that is neither.
+//
+// A database that stopped answering carries its own cause; appending "check
+// your DB_PATH" to it would send the operator to audit a connection setting
+// that was correct, which is exactly what the schema probe below the CLI was
+// taught to stop doing.
+func TestRepairAdvisesOnlyOnTheVerdictsItRecognises(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range []struct {
+		Name   string
+		Err    error
+		Advice string
+	}{
+		{Name: "a wrong database is sent to its path", Err: db.ErrSymptomCatalogueAbsent, Advice: "DB_PATH"},
+		{Name: "an old schema is sent to a start", Err: db.ErrSymptomCatalogueTooOld, Advice: "Start the instance"},
+	} {
+		t.Run(testCase.Name, func(t *testing.T) {
+			t.Parallel()
+
+			if remedy := repairPreconditionRemedy(fmt.Errorf("wrapped: %w", testCase.Err)); !strings.Contains(remedy, testCase.Advice) {
+				t.Fatalf("expected advice naming %q, got %q", testCase.Advice, remedy)
+			}
+		})
+	}
+
+	if remedy := repairPreconditionRemedy(errors.New("cannot read the schema of this database: connection refused")); remedy != "" {
+		t.Fatalf("a failure that is neither verdict must carry no advice, got %q", remedy)
+	}
+}
+
 // TestRepairNamesThePostgresTargetWithoutItsCredentials is the same refusal on
 // the other engine, where naming the target verbatim would print a password.
 func TestRepairNamesThePostgresTargetWithoutItsCredentials(t *testing.T) {

--- a/internal/cli/repair_test.go
+++ b/internal/cli/repair_test.go
@@ -1,0 +1,390 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/db"
+	"github.com/ovumcy/ovumcy-web/internal/models"
+	"github.com/ovumcy/ovumcy-web/internal/testdb"
+	"golang.org/x/crypto/bcrypt"
+	"gorm.io/gorm"
+)
+
+// symptomNameUniqueIndexName is migration 037's index, named here so the
+// fixture that removes it and the migration that creates it can only drift
+// apart loudly.
+const symptomNameUniqueIndexName = "idx_symptom_types_user_name_unique"
+
+// refusedUpgradeFixture is the database an operator actually meets: one that
+// held duplicate symptom names before migration 037 existed, so the boot that
+// would add the index refuses instead.
+type refusedUpgradeFixture struct {
+	Config     db.Config
+	UserID     uint
+	SurvivorID uint
+	DuplicateD uint
+	DayLogID   uint
+}
+
+// TestARefusedSymptomNameUpgradeBootsAfterTheDocumentedRepairOnSQLite is the
+// finding's own case, end to end and in the order the runbook gives.
+//
+// Before the repair existed this could not be written at all: the refusal ends
+// the boot, and the message sent the operator to the application, which is the
+// thing the refusal has stopped. Every step below therefore runs with the
+// instance down.
+func TestARefusedSymptomNameUpgradeBootsAfterTheDocumentedRepairOnSQLite(t *testing.T) {
+	t.Parallel()
+
+	fixture := seedRefusedSymptomNameUpgrade(t, db.Config{
+		Driver:     db.DriverSQLite,
+		SQLitePath: filepath.Join(t.TempDir(), "refused-upgrade.db"),
+	})
+	assertTheDocumentedRepairUnblocksTheBoot(t, fixture)
+}
+
+// TestARefusedSymptomNameUpgradeBootsAfterTheDocumentedRepairOnPostgres is the
+// same case on the other engine.
+//
+// It is not redundant with the SQLite one. The repair reads its groups through
+// the engine's own lower(), which is the expression the two engines disagree
+// about — Postgres folds by locale, SQLite folds ASCII only — so "the repair
+// finds exactly what the index would refuse" is a claim about each engine
+// separately, and a green run on one says nothing about the other.
+func TestARefusedSymptomNameUpgradeBootsAfterTheDocumentedRepairOnPostgres(t *testing.T) {
+	t.Parallel()
+
+	fixture := seedRefusedSymptomNameUpgrade(t, db.Config{
+		Driver:      db.DriverPostgres,
+		PostgresURL: testdb.StartPostgresDSN(t, "ovumcy_repair_test"),
+	})
+	assertTheDocumentedRepairUnblocksTheBoot(t, fixture)
+}
+
+func assertTheDocumentedRepairUnblocksTheBoot(t *testing.T, fixture refusedUpgradeFixture) {
+	t.Helper()
+
+	// 1. The instance does not start, and says so in terms an operator with a
+	//    stopped instance can act on.
+	bootErr := bootAndClose(fixture.Config)
+	if bootErr == nil {
+		t.Fatal("the fixture must reproduce the refused migration: the boot succeeded")
+	}
+	message := bootErr.Error()
+	if !strings.Contains(message, "ovumcy repair") {
+		t.Fatalf("the refusal must name the offline repair, got: %s", message)
+	}
+	if strings.Contains(strings.ToLower(message), "through the application") {
+		t.Fatalf("the refusal must not send the operator to an application it has stopped, got: %s", message)
+	}
+
+	// 2. The inspection reports the group and changes nothing, exiting non-zero
+	//    so an upgrade script can gate on it.
+	var inspected bytes.Buffer
+	inspectErr := runRepairCommand(fixture.Config, []string{"symptom-names"}, &inspected)
+	if inspectErr == nil {
+		t.Fatal("an inspection that found duplicates must report a non-zero outcome")
+	}
+	report := inspected.String()
+	for _, fragment := range []string{"keep", "merge into kept", fmt.Sprintf("%d", fixture.SurvivorID), fmt.Sprintf("%d", fixture.DuplicateD)} {
+		if !strings.Contains(report, fragment) {
+			t.Fatalf("the inspection must name %q, got:\n%s", fragment, report)
+		}
+	}
+	if bootAndClose(fixture.Config) == nil {
+		t.Fatal("an inspection must change nothing: the boot succeeded after it")
+	}
+
+	// 3. The repair merges the group.
+	var applied bytes.Buffer
+	if err := runRepairCommand(fixture.Config, []string{"symptom-names", "--apply"}, &applied); err != nil {
+		t.Fatalf("the documented repair must succeed, got: %v", err)
+	}
+
+	// 4. The full boot now runs every migration, this one included.
+	if err := bootAndClose(fixture.Config); err != nil {
+		t.Fatalf("the instance must start after the documented repair, got: %v", err)
+	}
+
+	// 5. Nothing the owner recorded was dropped on the way: the day that named
+	//    both rows names the surviving one, exactly once, and it resolves.
+	assertDayLogKeepsItsSymptom(t, fixture)
+
+	// 6. Running it again is a clean no-op, and the instance still starts.
+	var repeated bytes.Buffer
+	if err := runRepairCommand(fixture.Config, []string{"symptom-names", "--apply"}, &repeated); err != nil {
+		t.Fatalf("the repair must be repeatable, got: %v", err)
+	}
+	if !strings.Contains(repeated.String(), "Nothing to merge") {
+		t.Fatalf("a second run must report that it found nothing, got:\n%s", repeated.String())
+	}
+	if err := bootAndClose(fixture.Config); err != nil {
+		t.Fatalf("the instance must still start after a repeated repair, got: %v", err)
+	}
+}
+
+// TestRepairInspectionIsSilentAndCleanOnADatabaseWithNoDuplicates is the
+// anti-vacuity half: the same command on a healthy database must report clean
+// and exit zero, or the case above would pass on a command that always fails.
+func TestRepairInspectionIsSilentAndCleanOnADatabaseWithNoDuplicates(t *testing.T) {
+	t.Parallel()
+
+	config := db.Config{Driver: db.DriverSQLite, SQLitePath: filepath.Join(t.TempDir(), "clean.db")}
+	closeDatabase(t, openMigratedDatabase(t, config))
+
+	var output bytes.Buffer
+	if err := runRepairCommand(config, []string{"symptom-names"}, &output); err != nil {
+		t.Fatalf("a clean database must inspect clean, got: %v", err)
+	}
+	if !strings.Contains(output.String(), "nothing to refuse") {
+		t.Fatalf("expected a clean report, got: %s", output.String())
+	}
+}
+
+// TestRepairUsageNamesOnlyCommandsAStoppedInstanceCanRun pins the usage text
+// itself, because it is what the migration refusal points at: a repair listed
+// here that needed a running server would close the loop the finding opened.
+func TestRepairUsageNamesOnlyCommandsAStoppedInstanceCanRun(t *testing.T) {
+	t.Parallel()
+
+	config := db.Config{Driver: db.DriverSQLite, SQLitePath: filepath.Join(t.TempDir(), "usage.db")}
+	for _, args := range [][]string{nil, {"symptom-nmaes"}, {"symptom-names", "--force"}} {
+		var output bytes.Buffer
+		err := runRepairCommand(config, args, &output)
+		if err == nil {
+			t.Fatalf("expected usage for args %v", args)
+		}
+		if !strings.Contains(err.Error(), "symptom-names") || !strings.Contains(err.Error(), "--apply") {
+			t.Fatalf("usage must name the repair and its apply flag, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "do not need the server") {
+			t.Fatalf("usage must say a repair runs without the server, got: %v", err)
+		}
+	}
+}
+
+// TestRepairInspectionNamesWhatEachRowIsBeforeTheOperatorConsents covers the
+// custom half of the catalogue, which the built-in fixture above never reaches.
+//
+// The kind and the state are the two facts that decide the plan — an active row
+// is kept over an archived one, a built-in over a custom one — so an operator
+// reading the report has to be able to see both for every row, not infer them
+// from which line says "keep".
+func TestRepairInspectionNamesWhatEachRowIsBeforeTheOperatorConsents(t *testing.T) {
+	t.Parallel()
+
+	config := db.Config{Driver: db.DriverSQLite, SQLitePath: filepath.Join(t.TempDir(), "custom-pair.db")}
+	database := openMigratedDatabase(t, config)
+
+	user := models.User{
+		Email:        "custom-owner@example.com",
+		PasswordHash: "hash",
+		Role:         models.RoleOwner,
+		CycleLength:  models.DefaultCycleLength,
+		PeriodLength: models.DefaultPeriodLength,
+	}
+	if err := database.Create(&user).Error; err != nil {
+		t.Fatalf("create owner: %v", err)
+	}
+	if err := database.Exec(`DROP INDEX IF EXISTS ` + symptomNameUniqueIndexName).Error; err != nil {
+		t.Fatalf("drop the per-owner name index: %v", err)
+	}
+	archived := time.Date(2026, time.February, 1, 0, 0, 0, 0, time.UTC)
+	for _, symptom := range []models.SymptomType{
+		{UserID: user.ID, Name: "Jaw ache", Icon: "x", Color: "#FF0000", ArchivedAt: &archived},
+		{UserID: user.ID, Name: "jaw ache", Icon: "x", Color: "#FF0000"},
+	} {
+		if err := database.Create(&symptom).Error; err != nil {
+			t.Fatalf("seed %q: %v", symptom.Name, err)
+		}
+	}
+	closeDatabase(t, database)
+
+	var output bytes.Buffer
+	if err := runRepairCommand(config, []string{"symptom-names"}, &output); err == nil {
+		t.Fatal("expected the inspection to report duplicates")
+	}
+	report := output.String()
+	for _, fragment := range []string{"custom", "archived", "active", "KIND", "STATE"} {
+		if !strings.Contains(report, fragment) {
+			t.Fatalf("the report must name %q, got:\n%s", fragment, report)
+		}
+	}
+}
+
+// TestRepairReportsAnUnusableDatabaseConfigRatherThanPanicking keeps the one
+// prerequisite this subcommand does have diagnosable: it is run from a shell an
+// operator assembled by hand, not from the compose environment the server gets.
+func TestRepairReportsAnUnusableDatabaseConfigRatherThanPanicking(t *testing.T) {
+	t.Parallel()
+
+	err := runRepairCommand(db.Config{Driver: db.DriverSQLite, SQLitePath: ""}, []string{"symptom-names"}, nil)
+	if err == nil || !strings.Contains(err.Error(), "database init failed") {
+		t.Fatalf("expected a database-init failure, got %v", err)
+	}
+}
+
+// seedRefusedSymptomNameUpgrade builds the database as an upgrade meets it: the
+// duplicate pair was written by the version before the index existed, and the
+// day log points at both rows.
+//
+// It bootstraps at the current schema and then walks 037 back — drop the index,
+// forget its ledger row — because that is the only way to reach the pre-037
+// state with a binary that carries 037. The rows it then writes are exactly
+// what the built-in seeding race left behind: two identical built-in rows for
+// one account, differing only in case.
+func seedRefusedSymptomNameUpgrade(t *testing.T, config db.Config) refusedUpgradeFixture {
+	t.Helper()
+
+	database := openMigratedDatabase(t, config)
+	defer closeDatabase(t, database)
+
+	passwordHash, err := bcrypt.GenerateFromPassword([]byte("StrongPass1"), bcrypt.DefaultCost)
+	if err != nil {
+		t.Fatalf("hash password: %v", err)
+	}
+	user := models.User{
+		Email:               "repair-owner@example.com",
+		PasswordHash:        string(passwordHash),
+		Role:                models.RoleOwner,
+		OnboardingCompleted: true,
+		CycleLength:         models.DefaultCycleLength,
+		PeriodLength:        models.DefaultPeriodLength,
+		CreatedAt:           time.Now().UTC(),
+	}
+	if err := database.Create(&user).Error; err != nil {
+		t.Fatalf("create owner: %v", err)
+	}
+
+	survivor := models.SymptomType{UserID: user.ID, Name: "Cramps", Icon: "🩸", Color: "#FF4444", IsBuiltin: true}
+	if err := database.Create(&survivor).Error; err != nil {
+		t.Fatalf("create symptom: %v", err)
+	}
+
+	dayLog := models.DailyLog{
+		UserID:     user.ID,
+		Date:       time.Date(2026, time.March, 3, 0, 0, 0, 0, time.UTC),
+		SymptomIDs: []uint{survivor.ID},
+	}
+	if err := database.Create(&dayLog).Error; err != nil {
+		t.Fatalf("create day log: %v", err)
+	}
+
+	if err := database.Exec(`DROP INDEX IF EXISTS ` + symptomNameUniqueIndexName).Error; err != nil {
+		t.Fatalf("drop index for the pre-037 fixture: %v", err)
+	}
+	if err := database.Exec(`DELETE FROM schema_migrations WHERE version = '037'`).Error; err != nil {
+		t.Fatalf("forget migration 037: %v", err)
+	}
+
+	duplicate := models.SymptomType{UserID: user.ID, Name: "cramps", Icon: "🩸", Color: "#FF4444", IsBuiltin: true}
+	if err := database.Create(&duplicate).Error; err != nil {
+		t.Fatalf("seed the duplicate the index would refuse: %v", err)
+	}
+
+	// The owner's day names both rows, which is what the merge has to carry:
+	// the picker showed two symptoms a normal request would never have created.
+	references, err := json.Marshal([]uint{survivor.ID, duplicate.ID})
+	if err != nil {
+		t.Fatalf("encode symptom references: %v", err)
+	}
+	if err := database.Exec(
+		`UPDATE daily_logs SET symptom_ids = ? WHERE id = ? AND user_id = ?`,
+		string(references), dayLog.ID, user.ID,
+	).Error; err != nil {
+		t.Fatalf("point the day log at both rows: %v", err)
+	}
+
+	return refusedUpgradeFixture{
+		Config:     config,
+		UserID:     user.ID,
+		SurvivorID: survivor.ID,
+		DuplicateD: duplicate.ID,
+		DayLogID:   dayLog.ID,
+	}
+}
+
+// assertDayLogKeepsItsSymptom is the half a green boot cannot prove. Dropping
+// both symptom rows would also let the migration through, so the boot alone is
+// not evidence that the owner's day survived the repair.
+func assertDayLogKeepsItsSymptom(t *testing.T, fixture refusedUpgradeFixture) {
+	t.Helper()
+
+	database := openMigratedDatabase(t, fixture.Config)
+	defer closeDatabase(t, database)
+
+	var stored struct {
+		SymptomIDs *string `gorm:"column:symptom_ids"`
+	}
+	if err := database.Raw(
+		`SELECT symptom_ids FROM daily_logs WHERE id = ? AND user_id = ?`,
+		fixture.DayLogID, fixture.UserID,
+	).Scan(&stored).Error; err != nil {
+		t.Fatalf("read the day log back: %v", err)
+	}
+	if stored.SymptomIDs == nil {
+		t.Fatal("the repair must not clear a day's symptom references")
+	}
+
+	ids := make([]uint, 0)
+	if err := json.Unmarshal([]byte(*stored.SymptomIDs), &ids); err != nil {
+		t.Fatalf("decode the day's symptom references %q: %v", *stored.SymptomIDs, err)
+	}
+	if len(ids) != 1 || ids[0] != fixture.SurvivorID {
+		t.Fatalf("expected the day to name symptom %d exactly once, got %v", fixture.SurvivorID, ids)
+	}
+
+	var remaining int64
+	if err := database.Raw(
+		`SELECT COUNT(*) FROM symptom_types WHERE id = ? AND user_id = ?`,
+		fixture.SurvivorID, fixture.UserID,
+	).Scan(&remaining).Error; err != nil {
+		t.Fatalf("count the surviving symptom: %v", err)
+	}
+	if remaining != 1 {
+		t.Fatalf("the day must still resolve to a symptom row, found %d", remaining)
+	}
+}
+
+func openMigratedDatabase(t *testing.T, config db.Config) *gorm.DB {
+	t.Helper()
+
+	database, err := db.OpenDatabase(config)
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	return database
+}
+
+// bootAndClose is the boot this finding is about: OpenDatabase applies every
+// pending migration, so its error is the one an operator reads in the startup
+// log. The handle is released either way, which on Windows is what keeps a
+// failed case from turning into a TempDir cleanup failure.
+func bootAndClose(config db.Config) error {
+	database, err := db.OpenDatabase(config)
+	if err != nil {
+		return err
+	}
+	if sqlDB, handleErr := database.DB(); handleErr == nil {
+		_ = sqlDB.Close()
+	}
+	return nil
+}
+
+func closeDatabase(t *testing.T, database *gorm.DB) {
+	t.Helper()
+
+	sqlDB, err := database.DB()
+	if err != nil {
+		t.Fatalf("get sql handle: %v", err)
+	}
+	if err := sqlDB.Close(); err != nil {
+		t.Fatalf("close sql handle: %v", err)
+	}
+}

--- a/internal/cli/repair_test.go
+++ b/internal/cli/repair_test.go
@@ -2,9 +2,11 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -12,6 +14,7 @@ import (
 
 	"github.com/ovumcy/ovumcy-web/internal/db"
 	"github.com/ovumcy/ovumcy-web/internal/models"
+	"github.com/ovumcy/ovumcy-web/internal/services"
 	"github.com/ovumcy/ovumcy-web/internal/testdb"
 	"golang.org/x/crypto/bcrypt"
 	"gorm.io/gorm"
@@ -367,6 +370,73 @@ func TestRepairNamesThePostgresTargetWithoutItsCredentials(t *testing.T) {
 	}
 	if !strings.Contains(described, "DATABASE_URL") {
 		t.Fatalf("the operator still needs to know which setting to correct, got: %s", described)
+	}
+}
+
+// failingDuplicateRepository is a catalogue that cannot be read.
+//
+// It exists because the two report paths sit BEHIND the schema precondition: a
+// database broken enough to fail the queries fails the precondition first and
+// never reaches them, so the only way to exercise what they do with a storage
+// failure is to hand them a service over this.
+type failingDuplicateRepository struct {
+	err error
+}
+
+func (repository failingDuplicateRepository) ListDuplicateSymptomNameGroups(context.Context) ([]models.SymptomDuplicateGroup, error) {
+	return nil, repository.err
+}
+
+func (repository failingDuplicateRepository) MergeDuplicateSymptoms(context.Context, []models.SymptomMerge) (models.SymptomMergeOutcome, error) {
+	return models.SymptomMergeOutcome{}, repository.err
+}
+
+// TestBothReportPathsCarryAStorageFailureOutward pins that neither mode
+// swallows a read it could not make. Reporting "no duplicates" over a failed
+// read would tell the operator the instance is ready to start when nothing was
+// checked at all.
+func TestBothReportPathsCarryAStorageFailureOutward(t *testing.T) {
+	t.Parallel()
+
+	storageErr := errors.New("disk went away")
+	service := services.NewSymptomDuplicateRepairService(failingDuplicateRepository{err: storageErr})
+
+	for _, testCase := range []struct {
+		Name string
+		Run  func(*services.SymptomDuplicateRepairService, io.Writer) error
+	}{
+		{Name: "inspect", Run: runSymptomNamesRepairInspect},
+		{Name: "apply", Run: runSymptomNamesRepairApply},
+	} {
+		t.Run(testCase.Name, func(t *testing.T) {
+			t.Parallel()
+
+			var output bytes.Buffer
+			err := testCase.Run(service, &output)
+			if err == nil {
+				t.Fatal("a failed read must not be reported as a clean database")
+			}
+			if !strings.Contains(err.Error(), storageErr.Error()) {
+				t.Fatalf("the storage failure must reach the operator, got %v", err)
+			}
+			if strings.Contains(output.String(), "No account holds") {
+				t.Fatalf("a failed read must print no verdict, got: %s", output.String())
+			}
+		})
+	}
+}
+
+// TestRunRepairCommandIsTheEntryPointTheBinaryActuallyCalls covers the exported
+// wrapper. `main` reaches only this, so a wrapper wired to the wrong writer or
+// the wrong inner function would ship untested behind a fully tested body.
+func TestRunRepairCommandIsTheEntryPointTheBinaryActuallyCalls(t *testing.T) {
+	t.Parallel()
+
+	// An empty SQLite path fails config validation before anything opens or
+	// prints, so this exercises the wiring without writing to os.Stdout.
+	err := RunRepairCommand(db.Config{Driver: db.DriverSQLite}, []string{"symptom-names"})
+	if err == nil || !strings.Contains(err.Error(), "database init failed") {
+		t.Fatalf("expected the wrapper to reach the command body, got %v", err)
 	}
 }
 

--- a/internal/db/database.go
+++ b/internal/db/database.go
@@ -51,6 +51,29 @@ func (config Config) Validate() error {
 }
 
 func OpenDatabase(config Config) (*gorm.DB, error) {
+	return openDatabase(config, true)
+}
+
+// OpenDatabaseWithoutMigrations opens the same pool and applies nothing.
+//
+// It exists for the offline repair path, and only for it. A migration that
+// refuses — the per-owner symptom-name index meeting rows it cannot cover — ends
+// every boot AND every other operator subcommand, because all of them reach the
+// database through OpenDatabase and therefore through the same refusal. An
+// operator told to fix the data "through the application" would have no
+// application to fix it with, so the one subcommand whose job is to make the
+// migration applicable has to be able to open a database the migration has not
+// been applied to.
+//
+// What it returns is a database of UNKNOWN schema version, older than the binary
+// by however many migrations are pending. A caller may touch only tables and
+// columns that predate the migration that is stuck, and must never assume a
+// column a pending migration adds. Everything else keeps using OpenDatabase.
+func OpenDatabaseWithoutMigrations(config Config) (*gorm.DB, error) {
+	return openDatabase(config, false)
+}
+
+func openDatabase(config Config, applyMigrations bool) (*gorm.DB, error) {
 	normalized := config.normalized()
 	if err := normalized.Validate(); err != nil {
 		return nil, err
@@ -73,7 +96,7 @@ func OpenDatabase(config Config) (*gorm.DB, error) {
 		return nil, err
 	}
 
-	// The caller owns the handle only when OpenDatabase returns one: every caller
+	// The caller owns the handle only when this function returns one: every caller
 	// (cmd/ovumcy, internal/cli) closes the pool it received and has nothing to
 	// close when it gets an error back. So a failure AFTER the connection is open
 	// has to release the pool here, or the sql.DB — and on SQLite the open
@@ -88,8 +111,10 @@ func OpenDatabase(config Config) (*gorm.DB, error) {
 		}
 	}()
 
-	if err := applyEmbeddedMigrations(database, normalized.Driver); err != nil {
-		return nil, fmt.Errorf("apply embedded migrations: %w", err)
+	if applyMigrations {
+		if err := applyEmbeddedMigrations(database, normalized.Driver); err != nil {
+			return nil, fmt.Errorf("apply embedded migrations: %w", err)
+		}
 	}
 
 	handedToCaller = true

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -319,6 +319,13 @@ type duplicateGroup struct {
 // consent to lose part of it. So the migration refuses, prints the groups, and
 // leaves every row exactly where it was for the owner to resolve.
 //
+// What it must not do is send the operator somewhere this refusal has already
+// closed. The refusal ends the boot, so there is no running application to
+// resolve the groups in — and every other operator subcommand opens the database
+// through OpenDatabase and meets the same refusal. The message therefore names
+// the offline route (`ovumcy repair`, on OpenDatabaseWithoutMigrations) and the
+// runbook, and nothing that needs a started instance.
+//
 // The check derives its query from the statement rather than from a list of
 // migrations, so it covers the next unique index as well as this one, and it
 // runs only for a statement that actually asks for one. NULL keys are excluded
@@ -355,7 +362,7 @@ func refuseUniqueIndexOverExistingDuplicates(database *gorm.DB, migration embedd
 	}
 
 	return fmt.Errorf(
-		"refusing migration %s: table %s already holds rows that unique index %s on (%s) cannot cover, and this migration never deletes, merges or rewrites a row to make room for it. Conflicting group(s), keyed as (%s): %s. Nothing was written: the migration was rolled back and the database is unchanged. Resolve each group by renaming or removing the extra rows through the application, then start it again",
+		"refusing migration %s: table %s already holds rows that unique index %s on (%s) cannot cover, and this migration never deletes, merges or rewrites a row to make room for it. Conflicting group(s), keyed as (%s): %s. Nothing was written: the migration was rolled back and the database is unchanged. This refusal is also what stops the server, so it has to be resolved with the instance down, never through the running application: back up the database, then run `ovumcy repair`, which lists the repairs this binary carries and reports what it would change before changing anything. Runbook: docs/self-hosted.md, \"Duplicate rows that refuse a migration\"",
 		migration.Name,
 		intent.Table,
 		intent.IndexName,

--- a/internal/db/symptom_duplicate_repository.go
+++ b/internal/db/symptom_duplicate_repository.go
@@ -1,0 +1,259 @@
+package db
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+	"gorm.io/gorm"
+)
+
+// SymptomDuplicateRepository is the offline half of migration 037: it reads the
+// duplicate symptom names that stop the migration, and merges them when the
+// operator asks.
+//
+// It is deliberately NOT part of Repositories. Every set built by
+// bootstrap.BuildRepositories serves a running instance, and this repository
+// exists for the case where there is none: the migration refuses, the server
+// never reaches its listener, and the database can only be reached by a process
+// that opened it WITHOUT applying migrations. Handing it out beside the serving
+// repositories would invite a request path to merge somebody's symptoms.
+type SymptomDuplicateRepository struct {
+	database *gorm.DB
+}
+
+func NewSymptomDuplicateRepository(database *gorm.DB) *SymptomDuplicateRepository {
+	return &SymptomDuplicateRepository{database: database}
+}
+
+// duplicateSymptomNameKey is one conflicting (user_id, lower(name)) pair as the
+// engine groups it.
+type duplicateSymptomNameKey struct {
+	UserID      uint   `gorm:"column:user_id"`
+	ConflictKey string `gorm:"column:conflict_key"`
+}
+
+// ListDuplicateSymptomNameGroups names every group migration 037's index would
+// refuse, in the engine's own reading of lower(name).
+//
+// The grouping expression is the index's, character for character, so the two
+// agree by construction rather than by a fold this layer reimplements — which
+// is the only way one reader can serve both engines when they disagree about
+// what lower() means for a non-ASCII name.
+func (repo *SymptomDuplicateRepository) ListDuplicateSymptomNameGroups(ctx context.Context) ([]models.SymptomDuplicateGroup, error) {
+	database := repo.database.WithContext(ctx)
+
+	keys := make([]duplicateSymptomNameKey, 0)
+	if err := database.Raw(`
+SELECT user_id, lower(name) AS conflict_key
+FROM symptom_types
+GROUP BY user_id, lower(name)
+HAVING COUNT(*) > 1
+ORDER BY user_id, lower(name)`).Scan(&keys).Error; err != nil {
+		return nil, fmt.Errorf("list duplicate symptom name groups: %w", err)
+	}
+
+	groups := make([]models.SymptomDuplicateGroup, 0, len(keys))
+	for _, key := range keys {
+		symptoms := make([]models.SymptomType, 0, 2)
+		if err := database.Raw(`
+SELECT id, user_id, name, icon, color, is_builtin, archived_at
+FROM symptom_types
+WHERE user_id = ? AND lower(name) = ?
+ORDER BY id`, key.UserID, key.ConflictKey).Scan(&symptoms).Error; err != nil {
+			return nil, fmt.Errorf("load duplicate symptom name group %q: %w", key.ConflictKey, err)
+		}
+		groups = append(groups, models.SymptomDuplicateGroup{
+			UserID:      key.UserID,
+			ConflictKey: key.ConflictKey,
+			Symptoms:    symptoms,
+		})
+	}
+	return groups, nil
+}
+
+// MergeDuplicateSymptoms applies a plan: for each merge, every day log naming an
+// absorbed symptom names the survivor instead, and the absorbed rows are then
+// removed.
+//
+// The whole plan is one transaction. The two halves cannot be separated: a
+// removal that outran its rewrite would leave a day log pointing at a row that
+// is gone, which is the one outcome a repair of a health record must not
+// produce. A failure anywhere rolls the plan back whole, and the database is
+// left exactly as the inspection found it.
+func (repo *SymptomDuplicateRepository) MergeDuplicateSymptoms(ctx context.Context, merges []models.SymptomMerge) (models.SymptomMergeOutcome, error) {
+	outcome := models.SymptomMergeOutcome{}
+	if len(merges) == 0 {
+		return outcome, nil
+	}
+
+	err := repo.database.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		// The day-log rewrite is one pass per OWNER, not one per merge. An owner
+		// normally arrives here with many groups at once — the built-in seeding
+		// race duplicates the whole built-in set in one go — and a pass per
+		// merge would walk the same day once per group it names, rewriting it
+		// repeatedly and reporting a count several times the number of days it
+		// actually touched. That number is the operator's evidence that nothing
+		// was lost, so it has to count days rather than passes.
+		absorbedByOwner, owners := absorbedSymptomsByOwner(merges)
+		for _, owner := range owners {
+			rewritten, err := repointDailyLogSymptomIDs(tx, owner, absorbedByOwner[owner])
+			if err != nil {
+				return err
+			}
+			outcome.DailyLogsRewritten += rewritten
+		}
+
+		// Every reference has moved before any row goes, so no day can point at
+		// a row that is already gone even midway through the transaction.
+		for _, merge := range merges {
+			if len(merge.Absorbed) == 0 {
+				continue
+			}
+			for _, absorbed := range merge.Absorbed {
+				// Scoped by user_id as well as by id: a repair is a write on
+				// somebody's health record, and no write here may be able to
+				// reach a row that belongs to another owner.
+				result := tx.Exec(
+					`DELETE FROM symptom_types WHERE id = ? AND user_id = ?`,
+					absorbed.ID, merge.UserID,
+				)
+				if result.Error != nil {
+					return fmt.Errorf("remove duplicate symptom %d: %w", absorbed.ID, result.Error)
+				}
+				outcome.SymptomsRemoved += int(result.RowsAffected)
+			}
+			outcome.GroupsMerged++
+		}
+		return nil
+	})
+	if err != nil {
+		return models.SymptomMergeOutcome{}, err
+	}
+	return outcome, nil
+}
+
+// absorbedSymptomsByOwner folds a plan into one absorbed-to-survivor map per
+// owner, alongside the owners in the order the plan first names them so a run
+// is reproducible rather than following map iteration.
+func absorbedSymptomsByOwner(merges []models.SymptomMerge) (map[uint]map[uint]uint, []uint) {
+	absorbedByOwner := make(map[uint]map[uint]uint, len(merges))
+	owners := make([]uint, 0, len(merges))
+	for _, merge := range merges {
+		if len(merge.Absorbed) == 0 {
+			continue
+		}
+		remap, known := absorbedByOwner[merge.UserID]
+		if !known {
+			remap = make(map[uint]uint, len(merge.Absorbed))
+			absorbedByOwner[merge.UserID] = remap
+			owners = append(owners, merge.UserID)
+		}
+		for _, absorbed := range merge.Absorbed {
+			remap[absorbed.ID] = merge.Survivor.ID
+		}
+	}
+	return absorbedByOwner, owners
+}
+
+// dailyLogSymptomIDsRow is one day's symptom references as the column stores
+// them: a JSON array in TEXT on both engines, nullable since migration 003.
+type dailyLogSymptomIDsRow struct {
+	ID         uint    `gorm:"column:id"`
+	SymptomIDs *string `gorm:"column:symptom_ids"`
+}
+
+// repointDailyLogSymptomIDs moves one owner's day-log references off the
+// absorbed symptoms and onto their survivors.
+//
+// It reads and rewrites the raw column rather than going through the DailyLog
+// model on purpose: the model's BeforeSave hook re-derives the date, and a
+// repair has no business rewriting a day's date. For the same reason the UPDATE
+// names only symptom_ids — updated_at stays where the owner's last real edit
+// left it.
+func repointDailyLogSymptomIDs(tx *gorm.DB, userID uint, absorbedIntoSurvivor map[uint]uint) (int, error) {
+	rows := make([]dailyLogSymptomIDsRow, 0)
+	if err := tx.Raw(
+		`SELECT id, symptom_ids FROM daily_logs WHERE user_id = ? ORDER BY id`,
+		userID,
+	).Scan(&rows).Error; err != nil {
+		return 0, fmt.Errorf("load day logs for owner %d: %w", userID, err)
+	}
+
+	rewritten := 0
+	for _, row := range rows {
+		if row.SymptomIDs == nil {
+			continue
+		}
+		repointed, changed, err := repointSymptomIDList(*row.SymptomIDs, absorbedIntoSurvivor)
+		if err != nil {
+			return 0, fmt.Errorf("read symptom references of day log %d: %w", row.ID, err)
+		}
+		if !changed {
+			continue
+		}
+		if err := tx.Exec(
+			`UPDATE daily_logs SET symptom_ids = ? WHERE id = ? AND user_id = ?`,
+			repointed, row.ID, userID,
+		).Error; err != nil {
+			return 0, fmt.Errorf("rewrite symptom references of day log %d: %w", row.ID, err)
+		}
+		rewritten++
+	}
+	return rewritten, nil
+}
+
+// repointSymptomIDList rewrites one day's JSON array, keeping the order the
+// owner's list already had and collapsing the pair that a merge turns into one
+// id. A value it cannot read is an error rather than an empty list: the column
+// holds which symptoms somebody recorded that day, and silently replacing an
+// unreadable one with [] would delete exactly the data this repair exists to
+// keep.
+func repointSymptomIDList(stored string, absorbedIntoSurvivor map[uint]uint) (string, bool, error) {
+	if stored == "" {
+		return stored, false, nil
+	}
+
+	ids := make([]uint, 0)
+	if err := json.Unmarshal([]byte(stored), &ids); err != nil {
+		return "", false, fmt.Errorf("symptom_ids is not a JSON array of ids (%q): %w", stored, err)
+	}
+
+	// The remap alone decides whether this day is written at all. A day the
+	// merge does not name is left byte for byte as the owner left it, including
+	// a repeated id this repair was never asked about: the operator consented to
+	// a plan naming specific symptom rows, and tidying a row outside that plan
+	// would be a write on a health record nobody requested.
+	moved := make([]uint, len(ids))
+	remapped := false
+	for index, id := range ids {
+		if survivor, absorbed := absorbedIntoSurvivor[id]; absorbed {
+			id = survivor
+			remapped = true
+		}
+		moved[index] = id
+	}
+	if !remapped {
+		return stored, false, nil
+	}
+
+	// Only now does the pair the remap just created collapse. The survivor keeps
+	// the absorbed row's position, because that is where the owner's own order
+	// put it, and the later mention of the same symptom is what goes.
+	repointed := make([]uint, 0, len(moved))
+	seen := make(map[uint]struct{}, len(moved))
+	for _, id := range moved {
+		if _, duplicate := seen[id]; duplicate {
+			continue
+		}
+		seen[id] = struct{}{}
+		repointed = append(repointed, id)
+	}
+
+	encoded, err := json.Marshal(repointed)
+	if err != nil {
+		return "", false, fmt.Errorf("encode symptom references: %w", err) // codecov:ignore -- defensive: []uint always marshals
+	}
+	return string(encoded), true, nil
+}

--- a/internal/db/symptom_duplicate_repository.go
+++ b/internal/db/symptom_duplicate_repository.go
@@ -37,6 +37,22 @@ const symptomCatalogueTable = "symptom_types"
 // pointed at holds no symptom catalogue at all.
 var ErrSymptomCatalogueAbsent = errors.New("no symptom catalogue (table " + symptomCatalogueTable + ") in this database")
 
+// ErrSymptomCatalogueTooOld is what it answers when the table is there but the
+// schema predates a column this repair reads.
+var ErrSymptomCatalogueTooOld = errors.New("the symptom catalogue in this database predates the schema this repair reads")
+
+// symptomCatalogueColumnsAfterInit are the columns the repair reads that are NOT
+// part of symptom_types as migration 001 created it.
+//
+// The presence check has to cover them and not only the table. This repair opens
+// a database at an UNKNOWN schema version, so "the table is there" does not mean
+// "the schema this repair reads is there", and a column missing under a table
+// that is present comes back as the engine's own `no such column` — the same
+// unreadable answer the table check exists to prevent, one level down.
+// archived_at arrives in migration 004 and is what decides which row of a group
+// survives, so the repair cannot plan without it.
+var symptomCatalogueColumnsAfterInit = []string{"archived_at"}
+
 // RequireSymptomCatalogue answers whether this is an Ovumcy database before any
 // query assumes it.
 //
@@ -50,10 +66,39 @@ var ErrSymptomCatalogueAbsent = errors.New("no symptom catalogue (table " + symp
 // because opening a path that is not there creates an empty database rather than
 // refusing, so a mistyped DB_PATH reaches this point looking like a real one.
 func (repo *SymptomDuplicateRepository) RequireSymptomCatalogue(ctx context.Context) error {
-	if repo.database.WithContext(ctx).Migrator().HasTable(symptomCatalogueTable) {
-		return nil
+	database := repo.database.WithContext(ctx)
+	migrator := database.Migrator()
+
+	if !migrator.HasTable(symptomCatalogueTable) {
+		return absentUnlessTheDatabaseIsGone(database, ErrSymptomCatalogueAbsent)
 	}
-	return ErrSymptomCatalogueAbsent
+	for _, column := range symptomCatalogueColumnsAfterInit {
+		if !migrator.HasColumn(&models.SymptomType{}, column) {
+			return absentUnlessTheDatabaseIsGone(
+				database,
+				fmt.Errorf("%w: %s.%s is missing", ErrSymptomCatalogueTooOld, symptomCatalogueTable, column),
+			)
+		}
+	}
+	return nil
+}
+
+// absentUnlessTheDatabaseIsGone decides what a negative answer from the schema
+// probe actually means.
+//
+// gorm's Migrator answers HasTable and HasColumn with a bare bool and discards
+// the cause, so "the catalogue is not there" and "the database stopped
+// answering" arrive identically — and the two verdicts send the operator to
+// opposite places. Reporting the first when the truth is the second would have
+// them auditing a connection setting that was correct, on an instance that is
+// already down. One engine-neutral query settles it: if the database still
+// answers, the schema really is what the probe said.
+func absentUnlessTheDatabaseIsGone(database *gorm.DB, verdict error) error {
+	var reachable int
+	if err := database.Raw(`SELECT 1`).Scan(&reachable).Error; err != nil {
+		return fmt.Errorf("cannot read the schema of this database: %w", err)
+	}
+	return verdict
 }
 
 // duplicateSymptomNameKey is one conflicting (user_id, lower(name)) pair as the

--- a/internal/db/symptom_duplicate_repository.go
+++ b/internal/db/symptom_duplicate_repository.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/ovumcy/ovumcy-web/internal/models"
@@ -25,6 +26,34 @@ type SymptomDuplicateRepository struct {
 
 func NewSymptomDuplicateRepository(database *gorm.DB) *SymptomDuplicateRepository {
 	return &SymptomDuplicateRepository{database: database}
+}
+
+// symptomCatalogueTable is the table every query below reads. It is named once
+// so the presence check and the queries cannot come to disagree about which
+// table decides whether this is an Ovumcy database.
+const symptomCatalogueTable = "symptom_types"
+
+// ErrSymptomCatalogueAbsent is what the repair answers when the database it was
+// pointed at holds no symptom catalogue at all.
+var ErrSymptomCatalogueAbsent = errors.New("no symptom catalogue (table " + symptomCatalogueTable + ") in this database")
+
+// RequireSymptomCatalogue answers whether this is an Ovumcy database before any
+// query assumes it.
+//
+// This repair is the one entry point that opens a database WITHOUT applying
+// migrations, which is also the one thing that stops it telling "a schema older
+// than this binary" — exactly what it exists for — from "not this application's
+// database at all". Left to the query, the second case comes back as the
+// engine's own `no such table`, printed under a dump of the SQL, naming the very
+// table the operator was told to repair: the natural reading is that the repair
+// is broken or the data is gone. On SQLite the mistake is both easy and silent,
+// because opening a path that is not there creates an empty database rather than
+// refusing, so a mistyped DB_PATH reaches this point looking like a real one.
+func (repo *SymptomDuplicateRepository) RequireSymptomCatalogue(ctx context.Context) error {
+	if repo.database.WithContext(ctx).Migrator().HasTable(symptomCatalogueTable) {
+		return nil
+	}
+	return ErrSymptomCatalogueAbsent
 }
 
 // duplicateSymptomNameKey is one conflicting (user_id, lower(name)) pair as the

--- a/internal/db/symptom_duplicate_repository_test.go
+++ b/internal/db/symptom_duplicate_repository_test.go
@@ -292,6 +292,236 @@ func openRepairFixtureDatabase(t *testing.T, name string) *gorm.DB {
 	return database
 }
 
+// TestTheRepairReportsWhatItCouldNotReadInsteadOfGuessing covers the storage
+// failures on both halves of the read.
+//
+// They matter more here than in a request path: this repair runs on a stopped
+// instance, where the operator has no logs to compare against and no UI to
+// re-try in, so a failure that does not say which read failed leaves them with
+// a database they cannot judge.
+func TestTheRepairReportsWhatItCouldNotReadInsteadOfGuessing(t *testing.T) {
+	t.Run("the catalogue cannot be listed at all", func(t *testing.T) {
+		database := openRepairFixtureDatabase(t, "list-fails.db")
+		if err := database.Exec(`DROP TABLE symptom_types`).Error; err != nil {
+			t.Fatalf("drop the catalogue: %v", err)
+		}
+
+		_, err := NewSymptomDuplicateRepository(database).ListDuplicateSymptomNameGroups(context.Background())
+		if err == nil || !strings.Contains(err.Error(), "list duplicate symptom name groups") {
+			t.Fatalf("expected the outer read to be named, got %v", err)
+		}
+	})
+
+	// The outer query groups on lower(name) and the inner one also reads
+	// archived_at, so a catalogue predating migration 004 is exactly the shape
+	// where the first read succeeds and the second cannot.
+	t.Run("a group cannot be loaded once it is known to exist", func(t *testing.T) {
+		database := openRepairFixtureDatabase(t, "group-load-fails.db")
+		owner := createDailyLogTestUser(t, database, "group-load@example.com")
+		if err := database.Exec(`DROP TABLE symptom_types`).Error; err != nil {
+			t.Fatalf("drop the catalogue: %v", err)
+		}
+		if err := database.Exec(`
+CREATE TABLE symptom_types (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id INTEGER NOT NULL,
+  name TEXT NOT NULL,
+  icon TEXT NOT NULL,
+  color TEXT NOT NULL,
+  is_builtin BOOLEAN NOT NULL DEFAULT 0
+)`).Error; err != nil {
+			t.Fatalf("recreate the migration 001 catalogue: %v", err)
+		}
+		insertRepairSymptom(t, database, owner, "Cramps")
+		insertRepairSymptom(t, database, owner, "cramps")
+
+		_, err := NewSymptomDuplicateRepository(database).ListDuplicateSymptomNameGroups(context.Background())
+		if err == nil || !strings.Contains(err.Error(), "load duplicate symptom name group") {
+			t.Fatalf("expected the group read to be named, got %v", err)
+		}
+		if !strings.Contains(err.Error(), "cramps") {
+			t.Fatalf("the failure must name the group it was reading, got %v", err)
+		}
+	})
+}
+
+// TestAPlanWithNothingToAbsorbChangesNothing pins the two shapes that must cost
+// no write: an empty plan, and a plan whose entry absorbs nothing. Both arrive
+// from a repeated run, which the runbook tells the operator is safe.
+//
+// Named for what it verifies and no wider: only the EMPTY plan returns before
+// the transaction: a merge with an empty Absorbed enters it and is skipped
+// inside, so this says nothing about how many transactions were opened.
+func TestAPlanWithNothingToAbsorbChangesNothing(t *testing.T) {
+	database := openRepairFixtureDatabase(t, "merge-nothing.db")
+	owner := createDailyLogTestUser(t, database, "merge-nothing@example.com")
+	survivor := insertRepairSymptom(t, database, owner, "Cramps")
+	day := insertRepairDayLog(t, database, owner, "2026-03-08", "["+uintText(survivor)+"]")
+
+	repository := NewSymptomDuplicateRepository(database)
+
+	empty, err := repository.MergeDuplicateSymptoms(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("an empty plan must succeed, got %v", err)
+	}
+	if empty != (models.SymptomMergeOutcome{}) {
+		t.Fatalf("an empty plan must change nothing, got %+v", empty)
+	}
+
+	absorbingNothing, err := repository.MergeDuplicateSymptoms(context.Background(), []models.SymptomMerge{{
+		UserID:   owner,
+		Survivor: models.SymptomType{ID: survivor, UserID: owner},
+	}})
+	if err != nil {
+		t.Fatalf("a merge with nothing to absorb must succeed, got %v", err)
+	}
+	if absorbingNothing != (models.SymptomMergeOutcome{}) {
+		t.Fatalf("a merge with nothing to absorb must change nothing, got %+v", absorbingNothing)
+	}
+
+	if got := readRepairSymptomIDs(t, database, day); got != "["+uintText(survivor)+"]" {
+		t.Fatalf("no day may be rewritten by a plan that absorbs nothing, got %s", got)
+	}
+}
+
+// TestAMergeNamesTheWriteThatFailedAndKeepsNothing covers the failures inside
+// the transaction, which are the ones that decide whether a half-done repair
+// can exist. Each case leaves the plan rolled back whole.
+func TestAMergeNamesTheWriteThatFailedAndKeepsNothing(t *testing.T) {
+	t.Run("the day logs cannot be read", func(t *testing.T) {
+		database := openRepairFixtureDatabase(t, "daylogs-unreadable.db")
+		owner := createDailyLogTestUser(t, database, "daylogs-unreadable@example.com")
+		survivor := insertRepairSymptom(t, database, owner, "Cramps")
+		absorbed := insertRepairSymptom(t, database, owner, "cramps")
+		if err := database.Exec(`DROP TABLE daily_logs`).Error; err != nil {
+			t.Fatalf("drop the day logs: %v", err)
+		}
+
+		_, err := NewSymptomDuplicateRepository(database).MergeDuplicateSymptoms(context.Background(), []models.SymptomMerge{{
+			UserID:   owner,
+			Survivor: models.SymptomType{ID: survivor, UserID: owner},
+			Absorbed: []models.SymptomType{{ID: absorbed, UserID: owner}},
+		}})
+		if err == nil || !strings.Contains(err.Error(), "load day logs for owner") {
+			t.Fatalf("expected the day-log read to be named, got %v", err)
+		}
+
+		var remaining int64
+		if err := database.Raw(`SELECT COUNT(*) FROM symptom_types WHERE user_id = ?`, owner).Scan(&remaining).Error; err != nil {
+			t.Fatalf("count symptoms after the failure: %v", err)
+		}
+		if remaining != 2 {
+			t.Fatalf("a failed merge must remove nothing, found %d rows instead of 2", remaining)
+		}
+	})
+
+	// A view answers a SELECT and refuses an UPDATE, which is the one shape
+	// where the read this rewrite depends on succeeds and its paired write does
+	// not.
+	t.Run("a day log cannot be rewritten", func(t *testing.T) {
+		database := openRepairFixtureDatabase(t, "daylog-unwritable.db")
+		owner := createDailyLogTestUser(t, database, "daylog-unwritable@example.com")
+		survivor := insertRepairSymptom(t, database, owner, "Cramps")
+		absorbed := insertRepairSymptom(t, database, owner, "cramps")
+		day := insertRepairDayLog(t, database, owner, "2026-03-09", "["+uintText(absorbed)+"]")
+
+		if err := database.Exec(`ALTER TABLE daily_logs RENAME TO daily_logs_stored`).Error; err != nil {
+			t.Fatalf("rename the day logs: %v", err)
+		}
+		if err := database.Exec(`CREATE VIEW daily_logs AS SELECT * FROM daily_logs_stored`).Error; err != nil {
+			t.Fatalf("put a read-only view in front of the day logs: %v", err)
+		}
+
+		_, err := NewSymptomDuplicateRepository(database).MergeDuplicateSymptoms(context.Background(), []models.SymptomMerge{{
+			UserID:   owner,
+			Survivor: models.SymptomType{ID: survivor, UserID: owner},
+			Absorbed: []models.SymptomType{{ID: absorbed, UserID: owner}},
+		}})
+		if err == nil || !strings.Contains(err.Error(), "rewrite symptom references of day log") {
+			t.Fatalf("expected the day-log write to be named, got %v", err)
+		}
+
+		// Two assertions, because each catches what the other cannot. The day —
+		// read through the table the view hides — proves no partial write
+		// landed. The symptom count proves the failure STOPPED the plan: swallow
+		// the rewrite error and the merge walks on into the removal, leaving a
+		// day that names a row no longer there, which is the one outcome this
+		// merge may never produce.
+		var stored struct {
+			SymptomIDs *string `gorm:"column:symptom_ids"`
+		}
+		if err := database.Raw(`SELECT symptom_ids FROM daily_logs_stored WHERE id = ?`, day).Scan(&stored).Error; err != nil {
+			t.Fatalf("read the day back: %v", err)
+		}
+		if stored.SymptomIDs == nil || *stored.SymptomIDs != "["+uintText(absorbed)+"]" {
+			t.Fatalf("a failed write must leave the day exactly as it was, got %v", stored.SymptomIDs)
+		}
+
+		var remaining int64
+		if err := database.Raw(`SELECT COUNT(*) FROM symptom_types WHERE user_id = ?`, owner).Scan(&remaining).Error; err != nil {
+			t.Fatalf("count symptoms after the failure: %v", err)
+		}
+		if remaining != 2 {
+			t.Fatalf("a failed rewrite must stop the plan before any removal, found %d rows instead of 2", remaining)
+		}
+	})
+
+	t.Run("the duplicate row cannot be removed", func(t *testing.T) {
+		database := openRepairFixtureDatabase(t, "delete-fails.db")
+		owner := createDailyLogTestUser(t, database, "delete-fails@example.com")
+		survivor := insertRepairSymptom(t, database, owner, "Cramps")
+		absorbed := insertRepairSymptom(t, database, owner, "cramps")
+		day := insertRepairDayLog(t, database, owner, "2026-03-10", "["+uintText(absorbed)+"]")
+		if err := database.Exec(`DROP TABLE symptom_types`).Error; err != nil {
+			t.Fatalf("drop the catalogue: %v", err)
+		}
+
+		_, err := NewSymptomDuplicateRepository(database).MergeDuplicateSymptoms(context.Background(), []models.SymptomMerge{{
+			UserID:   owner,
+			Survivor: models.SymptomType{ID: survivor, UserID: owner},
+			Absorbed: []models.SymptomType{{ID: absorbed, UserID: owner}},
+		}})
+		if err == nil || !strings.Contains(err.Error(), "remove duplicate symptom") {
+			t.Fatalf("expected the removal to be named, got %v", err)
+		}
+
+		// The rewrite ran before the removal failed, and the rollback is what
+		// puts the day back on the row that still exists.
+		if got := readRepairSymptomIDs(t, database, day); got != "["+uintText(absorbed)+"]" {
+			t.Fatalf("a failed merge must leave the day exactly as it was, got %s", got)
+		}
+	})
+}
+
+// TestADayThatStoresAnEmptySymptomListIsLeftAlone covers the legacy shape the
+// column can hold beside NULL: the empty string, which is not a JSON array and
+// carries no reference to move.
+func TestADayThatStoresAnEmptySymptomListIsLeftAlone(t *testing.T) {
+	database := openRepairFixtureDatabase(t, "empty-symptom-list.db")
+	owner := createDailyLogTestUser(t, database, "empty-list@example.com")
+	survivor := insertRepairSymptom(t, database, owner, "Cramps")
+	absorbed := insertRepairSymptom(t, database, owner, "cramps")
+	empty := insertRepairDayLog(t, database, owner, "2026-03-11", "")
+	// The anchor: a day the merge MUST rewrite, so the count below can tell an
+	// empty list that was skipped from a pass that reached no day at all.
+	named := insertRepairDayLog(t, database, owner, "2026-03-12", "["+uintText(absorbed)+"]")
+
+	outcome := mergeRepairGroups(t, database, models.SymptomMerge{
+		UserID:   owner,
+		Survivor: models.SymptomType{ID: survivor, UserID: owner},
+		Absorbed: []models.SymptomType{{ID: absorbed, UserID: owner}},
+	})
+	if outcome.DailyLogsRewritten != 1 {
+		t.Fatalf("the pass must reach the named day and skip the empty one, got %d", outcome.DailyLogsRewritten)
+	}
+	if got := readRepairSymptomIDs(t, database, named); got != "["+uintText(survivor)+"]" {
+		t.Fatalf("the named day must move onto the survivor, got %s", got)
+	}
+	if got := readRepairSymptomIDs(t, database, empty); got != "" {
+		t.Fatalf("an empty list must be left exactly as it was, got %q", got)
+	}
+}
+
 func mergeRepairGroups(t *testing.T, database *gorm.DB, merges ...models.SymptomMerge) models.SymptomMergeOutcome {
 	t.Helper()
 

--- a/internal/db/symptom_duplicate_repository_test.go
+++ b/internal/db/symptom_duplicate_repository_test.go
@@ -1,0 +1,340 @@
+package db
+
+import (
+	"context"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+	"gorm.io/gorm"
+)
+
+// TestMergingDuplicateSymptomsRewritesOnlyTheOwnersOwnDayLogs is the privacy
+// half of the repair. Symptom ids are global, so a stale id in ANOTHER
+// account's day log looks exactly like one in the owner's, and a rewrite keyed
+// on the id alone would edit a row belonging to somebody who was never part of
+// this merge.
+func TestMergingDuplicateSymptomsRewritesOnlyTheOwnersOwnDayLogs(t *testing.T) {
+	database := openRepairFixtureDatabase(t, "merge-scope.db")
+
+	owner := createDailyLogTestUser(t, database, "merge-owner@example.com")
+	stranger := createDailyLogTestUser(t, database, "merge-stranger@example.com")
+
+	survivor := insertRepairSymptom(t, database, owner, "Cramps")
+	absorbed := insertRepairSymptom(t, database, owner, "cramps")
+
+	ownerDay := insertRepairDayLog(t, database, owner, "2026-03-01", "["+uintText(absorbed)+"]")
+	strangerDay := insertRepairDayLog(t, database, stranger, "2026-03-01", "["+uintText(absorbed)+"]")
+
+	outcome := mergeRepairGroups(t, database, models.SymptomMerge{
+		UserID:   owner,
+		Survivor: models.SymptomType{ID: survivor, UserID: owner},
+		Absorbed: []models.SymptomType{{ID: absorbed, UserID: owner}},
+	})
+	if outcome.DailyLogsRewritten != 1 {
+		t.Fatalf("expected exactly the owner's day to be rewritten, got %d", outcome.DailyLogsRewritten)
+	}
+
+	if got := readRepairSymptomIDs(t, database, ownerDay); got != "["+uintText(survivor)+"]" {
+		t.Fatalf("the owner's day must name the survivor, got %s", got)
+	}
+	if got := readRepairSymptomIDs(t, database, strangerDay); got != "["+uintText(absorbed)+"]" {
+		t.Fatalf("another owner's day must be left exactly as it was, got %s", got)
+	}
+}
+
+// TestMergingDuplicateSymptomsCollapsesADayThatNamedBothRows covers the day the
+// duplicate is most visible on: the picker offered two entries for one name and
+// the owner ticked both, so the merged day would otherwise name one symptom
+// twice.
+func TestMergingDuplicateSymptomsCollapsesADayThatNamedBothRows(t *testing.T) {
+	database := openRepairFixtureDatabase(t, "merge-collapse.db")
+
+	owner := createDailyLogTestUser(t, database, "collapse-owner@example.com")
+	survivor := insertRepairSymptom(t, database, owner, "Cramps")
+	absorbed := insertRepairSymptom(t, database, owner, "cramps")
+	other := insertRepairSymptom(t, database, owner, "Headache")
+
+	day := insertRepairDayLog(t, database, owner, "2026-03-02",
+		"["+uintText(absorbed)+","+uintText(other)+","+uintText(survivor)+"]")
+	// symptom_ids is nullable (migration 003) and a legacy row can still hold
+	// NULL; it carries no reference, so the repair must pass over it rather than
+	// fail on it or write [] into it.
+	untouched := insertRepairDayLogWithoutSymptoms(t, database, owner, "2026-03-04")
+
+	outcome := mergeRepairGroups(t, database, models.SymptomMerge{
+		UserID:   owner,
+		Survivor: models.SymptomType{ID: survivor, UserID: owner},
+		Absorbed: []models.SymptomType{{ID: absorbed, UserID: owner}},
+	})
+
+	// The survivor takes the absorbed row's position, because that is where the
+	// owner's own order put the pair, and the later mention of the same symptom
+	// is what collapses.
+	expected := "[" + uintText(survivor) + "," + uintText(other) + "]"
+	if got := readRepairSymptomIDs(t, database, day); got != expected {
+		t.Fatalf("expected %s, got %s", expected, got)
+	}
+	if got := readRepairSymptomIDs(t, database, untouched); got != "<null>" {
+		t.Fatalf("a day that names no symptom must stay untouched, got %s", got)
+	}
+	if outcome.DailyLogsRewritten != 1 {
+		t.Fatalf("only the day that named the absorbed row is a rewrite, got %d", outcome.DailyLogsRewritten)
+	}
+}
+
+// TestMergingSeveralOfOneOwnersGroupsCountsDaysRatherThanPasses is the shape
+// the built-in seeding race actually leaves behind: one account arrives with
+// the whole built-in set duplicated, so the plan carries many groups for one
+// owner and a single day names several of them.
+//
+// The count is the operator's evidence that nothing was lost, so it has to be
+// the number of days touched. A rewrite pass per group walks the same day once
+// per group it names and reports a multiple of the truth.
+func TestMergingSeveralOfOneOwnersGroupsCountsDaysRatherThanPasses(t *testing.T) {
+	database := openRepairFixtureDatabase(t, "merge-many-groups.db")
+
+	owner := createDailyLogTestUser(t, database, "many-groups-owner@example.com")
+	crampsKept := insertRepairSymptom(t, database, owner, "Cramps")
+	crampsGone := insertRepairSymptom(t, database, owner, "cramps")
+	acheKept := insertRepairSymptom(t, database, owner, "Headache")
+	acheGone := insertRepairSymptom(t, database, owner, "headache")
+
+	day := insertRepairDayLog(t, database, owner, "2026-03-05",
+		"["+uintText(crampsGone)+","+uintText(acheGone)+"]")
+
+	outcome := mergeRepairGroups(t, database,
+		models.SymptomMerge{
+			UserID:   owner,
+			Survivor: models.SymptomType{ID: crampsKept, UserID: owner},
+			Absorbed: []models.SymptomType{{ID: crampsGone, UserID: owner}},
+		},
+		models.SymptomMerge{
+			UserID:   owner,
+			Survivor: models.SymptomType{ID: acheKept, UserID: owner},
+			Absorbed: []models.SymptomType{{ID: acheGone, UserID: owner}},
+		},
+	)
+
+	if outcome.DailyLogsRewritten != 1 {
+		t.Fatalf("one day was touched, so the count must be 1, got %d", outcome.DailyLogsRewritten)
+	}
+	if outcome.GroupsMerged != 2 || outcome.SymptomsRemoved != 2 {
+		t.Fatalf("expected 2 groups and 2 removed rows, got %d / %d", outcome.GroupsMerged, outcome.SymptomsRemoved)
+	}
+
+	expected := "[" + uintText(crampsKept) + "," + uintText(acheKept) + "]"
+	if got := readRepairSymptomIDs(t, database, day); got != expected {
+		t.Fatalf("both references must land on their survivors: expected %s, got %s", expected, got)
+	}
+}
+
+// TestMergingDuplicateSymptomsLeavesADayTheMergeDoesNotName pins the scope of
+// the write. The operator consents to a plan naming specific symptom rows, so a
+// day outside that plan must come out byte for byte as they left it — including
+// a repeated id this repair was never asked about.
+func TestMergingDuplicateSymptomsLeavesADayTheMergeDoesNotName(t *testing.T) {
+	database := openRepairFixtureDatabase(t, "merge-out-of-scope.db")
+
+	owner := createDailyLogTestUser(t, database, "out-of-scope-owner@example.com")
+	survivor := insertRepairSymptom(t, database, owner, "Cramps")
+	absorbed := insertRepairSymptom(t, database, owner, "cramps")
+	unrelated := insertRepairSymptom(t, database, owner, "Headache")
+
+	named := insertRepairDayLog(t, database, owner, "2026-03-06", "["+uintText(absorbed)+"]")
+	untouched := insertRepairDayLog(t, database, owner, "2026-03-07",
+		"["+uintText(unrelated)+","+uintText(unrelated)+"]")
+
+	outcome := mergeRepairGroups(t, database, models.SymptomMerge{
+		UserID:   owner,
+		Survivor: models.SymptomType{ID: survivor, UserID: owner},
+		Absorbed: []models.SymptomType{{ID: absorbed, UserID: owner}},
+	})
+
+	if outcome.DailyLogsRewritten != 1 {
+		t.Fatalf("only the day the merge names is a rewrite, got %d", outcome.DailyLogsRewritten)
+	}
+	if got := readRepairSymptomIDs(t, database, named); got != "["+uintText(survivor)+"]" {
+		t.Fatalf("the named day must move onto the survivor, got %s", got)
+	}
+	stored := "[" + uintText(unrelated) + "," + uintText(unrelated) + "]"
+	if got := readRepairSymptomIDs(t, database, untouched); got != stored {
+		t.Fatalf("a day outside the plan must be left exactly as it was, expected %s, got %s", stored, got)
+	}
+}
+
+// TestMergingDuplicateSymptomsRefusesADayItCannotRead is the fail-loud half.
+// A column this repair cannot decode holds symptoms somebody recorded, and
+// treating it as an empty list would silently erase the very data the merge
+// exists to carry — so the whole plan rolls back and both rows stay.
+func TestMergingDuplicateSymptomsRefusesADayItCannotRead(t *testing.T) {
+	database := openRepairFixtureDatabase(t, "merge-unreadable.db")
+
+	owner := createDailyLogTestUser(t, database, "unreadable-owner@example.com")
+	survivor := insertRepairSymptom(t, database, owner, "Cramps")
+	absorbed := insertRepairSymptom(t, database, owner, "cramps")
+	day := insertRepairDayLog(t, database, owner, "2026-03-03", `{"cramps":true}`)
+
+	_, err := NewSymptomDuplicateRepository(database).MergeDuplicateSymptoms(context.Background(), []models.SymptomMerge{{
+		UserID:   owner,
+		Survivor: models.SymptomType{ID: survivor, UserID: owner},
+		Absorbed: []models.SymptomType{{ID: absorbed, UserID: owner}},
+	}})
+	if err == nil {
+		t.Fatal("expected a day log the repair cannot read to refuse the merge")
+	}
+	if !strings.Contains(err.Error(), "symptom_ids") {
+		t.Fatalf("the refusal must name what it could not read, got: %v", err)
+	}
+
+	var remaining int64
+	if err := database.Raw(`SELECT COUNT(*) FROM symptom_types WHERE user_id = ?`, owner).Scan(&remaining).Error; err != nil {
+		t.Fatalf("count symptoms after the refusal: %v", err)
+	}
+	if remaining != 2 {
+		t.Fatalf("a refused merge must remove nothing, found %d rows instead of 2", remaining)
+	}
+	if got := readRepairSymptomIDs(t, database, day); got != `{"cramps":true}` {
+		t.Fatalf("a refused merge must leave the day exactly as it was, got %s", got)
+	}
+}
+
+// TestListingDuplicateSymptomNameGroupsSeesWhatTheIndexWouldRefuse ties the two
+// readings together on one engine: every group reported here is one the unique
+// index refuses, and a name that differs by more than case is not a group.
+func TestListingDuplicateSymptomNameGroupsSeesWhatTheIndexWouldRefuse(t *testing.T) {
+	database := openRepairFixtureDatabase(t, "merge-groups.db")
+
+	owner := createDailyLogTestUser(t, database, "groups-owner@example.com")
+	other := createDailyLogTestUser(t, database, "groups-other@example.com")
+
+	insertRepairSymptom(t, database, owner, "Cramps")
+	insertRepairSymptom(t, database, owner, "cramps")
+	insertRepairSymptom(t, database, owner, "Headache")
+	// The same name under a different account is not a conflict: the index is
+	// keyed per owner.
+	insertRepairSymptom(t, database, other, "Cramps")
+
+	groups, err := NewSymptomDuplicateRepository(database).ListDuplicateSymptomNameGroups(context.Background())
+	if err != nil {
+		t.Fatalf("list duplicate groups: %v", err)
+	}
+	if len(groups) != 1 {
+		t.Fatalf("expected exactly one group, got %d: %+v", len(groups), groups)
+	}
+	if groups[0].UserID != owner || groups[0].ConflictKey != "cramps" {
+		t.Fatalf("expected owner %d / \"cramps\", got %d / %q", owner, groups[0].UserID, groups[0].ConflictKey)
+	}
+	if len(groups[0].Symptoms) != 2 {
+		t.Fatalf("expected both rows in the group, got %d", len(groups[0].Symptoms))
+	}
+	for _, symptom := range groups[0].Symptoms {
+		if symptom.UserID != owner {
+			t.Fatalf("a group may only carry its own owner's rows, got %d", symptom.UserID)
+		}
+		if strings.ToLower(symptom.Name) != "cramps" {
+			t.Fatalf("unexpected row in the group: %q", symptom.Name)
+		}
+	}
+}
+
+// openRepairFixtureDatabase is the database this repair actually meets: the
+// per-owner name index is gone, exactly as it was on the version that wrote the
+// duplicates, so the rows below can be written at all.
+func openRepairFixtureDatabase(t *testing.T, name string) *gorm.DB {
+	t.Helper()
+
+	database := openSQLiteForMigrationBootstrapTest(t, filepath.Join(t.TempDir(), name))
+	if err := database.Exec(`DROP INDEX IF EXISTS ` + symptomNameUniqueIndexName).Error; err != nil {
+		t.Fatalf("drop the per-owner name index for the pre-037 fixture: %v", err)
+	}
+	return database
+}
+
+func mergeRepairGroups(t *testing.T, database *gorm.DB, merges ...models.SymptomMerge) models.SymptomMergeOutcome {
+	t.Helper()
+
+	outcome, err := NewSymptomDuplicateRepository(database).MergeDuplicateSymptoms(context.Background(), merges)
+	if err != nil {
+		t.Fatalf("merge duplicate symptoms: %v", err)
+	}
+	return outcome
+}
+
+func insertRepairSymptom(t *testing.T, database *gorm.DB, userID uint, name string) uint {
+	t.Helper()
+
+	if err := database.Exec(
+		`INSERT INTO symptom_types (user_id, name, icon, color, is_builtin) VALUES (?, ?, 'x', '#FF0000', 0)`,
+		userID, name,
+	).Error; err != nil {
+		t.Fatalf("insert symptom %q: %v", name, err)
+	}
+
+	var id uint
+	if err := database.Raw(
+		`SELECT id FROM symptom_types WHERE user_id = ? AND name = ?`, userID, name,
+	).Scan(&id).Error; err != nil {
+		t.Fatalf("read back symptom %q: %v", name, err)
+	}
+	return id
+}
+
+func insertRepairDayLog(t *testing.T, database *gorm.DB, userID uint, day string, symptomIDs string) uint {
+	t.Helper()
+
+	if err := database.Exec(
+		`INSERT INTO daily_logs (user_id, date, symptom_ids, created_at, updated_at) VALUES (?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+		userID, day, symptomIDs,
+	).Error; err != nil {
+		t.Fatalf("insert day log for %s: %v", day, err)
+	}
+
+	var id uint
+	if err := database.Raw(
+		`SELECT id FROM daily_logs WHERE user_id = ? AND date = ?`, userID, day,
+	).Scan(&id).Error; err != nil {
+		t.Fatalf("read back day log for %s: %v", day, err)
+	}
+	return id
+}
+
+func insertRepairDayLogWithoutSymptoms(t *testing.T, database *gorm.DB, userID uint, day string) uint {
+	t.Helper()
+
+	if err := database.Exec(
+		`INSERT INTO daily_logs (user_id, date, created_at, updated_at) VALUES (?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+		userID, day,
+	).Error; err != nil {
+		t.Fatalf("insert day log without symptoms for %s: %v", day, err)
+	}
+
+	var id uint
+	if err := database.Raw(
+		`SELECT id FROM daily_logs WHERE user_id = ? AND date = ?`, userID, day,
+	).Scan(&id).Error; err != nil {
+		t.Fatalf("read back day log for %s: %v", day, err)
+	}
+	return id
+}
+
+func readRepairSymptomIDs(t *testing.T, database *gorm.DB, dayLogID uint) string {
+	t.Helper()
+
+	var stored struct {
+		SymptomIDs *string `gorm:"column:symptom_ids"`
+	}
+	if err := database.Raw(`SELECT symptom_ids FROM daily_logs WHERE id = ?`, dayLogID).Scan(&stored).Error; err != nil {
+		t.Fatalf("read symptom references of day log %d: %v", dayLogID, err)
+	}
+	if stored.SymptomIDs == nil {
+		return "<null>"
+	}
+	return *stored.SymptomIDs
+}
+
+func uintText(value uint) string {
+	return strconv.FormatUint(uint64(value), 10)
+}

--- a/internal/db/symptom_duplicate_repository_test.go
+++ b/internal/db/symptom_duplicate_repository_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -82,6 +83,44 @@ func TestMergingDuplicateSymptomsCollapsesADayThatNamedBothRows(t *testing.T) {
 	}
 	if outcome.DailyLogsRewritten != 1 {
 		t.Fatalf("only the day that named the absorbed row is a rewrite, got %d", outcome.DailyLogsRewritten)
+	}
+}
+
+// TestTheSchemaProbeTellsAnAbsentCatalogueFromAnUnreachableDatabase covers the
+// answer that decides where the operator is sent.
+//
+// gorm's Migrator reports HasTable/HasColumn as a bare bool and drops the
+// cause, so a database that stopped answering looks exactly like one with no
+// catalogue — and the two verdicts point in opposite directions: check your
+// connection setting, versus your connection setting was right and the database
+// went away.
+func TestTheSchemaProbeTellsAnAbsentCatalogueFromAnUnreachableDatabase(t *testing.T) {
+	database := openRepairFixtureDatabase(t, "unreachable.db")
+
+	// The catalogue IS there, so a verdict of "absent" here could only come from
+	// the probe failing to notice that nothing can be read at all.
+	repository := NewSymptomDuplicateRepository(database)
+	if err := repository.RequireSymptomCatalogue(context.Background()); err != nil {
+		t.Fatalf("a migrated database must satisfy the precondition, got: %v", err)
+	}
+
+	sqlDB, err := database.DB()
+	if err != nil {
+		t.Fatalf("get sql handle: %v", err)
+	}
+	if err := sqlDB.Close(); err != nil {
+		t.Fatalf("close the pool: %v", err)
+	}
+
+	err = repository.RequireSymptomCatalogue(context.Background())
+	if err == nil {
+		t.Fatal("a database that cannot be read must not pass the precondition")
+	}
+	if errors.Is(err, ErrSymptomCatalogueAbsent) || errors.Is(err, ErrSymptomCatalogueTooOld) {
+		t.Fatalf("an unreachable database must not be reported as a schema verdict, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "cannot read the schema") {
+		t.Fatalf("the refusal must say the database could not be read, got: %v", err)
 	}
 }
 

--- a/internal/models/symptom.go
+++ b/internal/models/symptom.go
@@ -48,3 +48,36 @@ func DefaultBuiltinSymptoms() []BuiltinSymptom {
 func (symptom SymptomType) IsActive() bool {
 	return symptom.ArchivedAt == nil
 }
+
+// SymptomDuplicateGroup is one (owner, folded name) collision that migration
+// 037's per-owner unique index cannot cover.
+//
+// ConflictKey is the DATABASE's own lower(name), never a fold recomputed in Go.
+// SQLite folds ASCII only and Postgres folds by locale, so the two engines
+// disagree about a case-only variant of a non-ASCII name — and a report built
+// from the engine's own expression names exactly the groups that engine's index
+// would refuse, on either one, without this layer knowing which.
+type SymptomDuplicateGroup struct {
+	UserID      uint
+	ConflictKey string
+	Symptoms    []SymptomType
+}
+
+// SymptomMerge is one group's resolution: every row in Absorbed folds into
+// Survivor, and every daily log that named an absorbed symptom names Survivor
+// instead. The day-log rewrite and the row removal are one transaction, so a
+// reference can never outlive the row it pointed at.
+type SymptomMerge struct {
+	UserID   uint
+	Survivor SymptomType
+	Absorbed []SymptomType
+}
+
+// SymptomMergeOutcome is what a merge actually changed, counted rather than
+// assumed: an operator reading it can tell a run that did nothing from one that
+// moved day-log references.
+type SymptomMergeOutcome struct {
+	GroupsMerged       int
+	SymptomsRemoved    int
+	DailyLogsRewritten int
+}

--- a/internal/services/symptom_duplicate_repair_service.go
+++ b/internal/services/symptom_duplicate_repair_service.go
@@ -1,0 +1,129 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+)
+
+var (
+	ErrSymptomDuplicateInspectFailed = errors.New("symptom duplicate inspection failed")
+	ErrSymptomDuplicateMergeFailed   = errors.New("symptom duplicate merge failed")
+)
+
+// SymptomDuplicateRepository is the offline view of the symptom catalogue: the
+// groups migration 037's per-owner name index cannot cover, and the one write
+// that resolves them.
+type SymptomDuplicateRepository interface {
+	ListDuplicateSymptomNameGroups(ctx context.Context) ([]models.SymptomDuplicateGroup, error)
+	MergeDuplicateSymptoms(ctx context.Context, merges []models.SymptomMerge) (models.SymptomMergeOutcome, error)
+}
+
+// SymptomDuplicateRepairService is the operator's way out of a refused
+// migration 037.
+//
+// The refusal itself is correct and stays: a migration may not delete, merge or
+// rewrite a row to make room for its own index, because nobody asked the owner.
+// This service is where that consent arrives — an operator running a named
+// subcommand, on a stopped instance, after a backup — and it does the one thing
+// the migration would not: it collapses each colliding group into a single
+// symptom and moves every day-log reference onto it.
+//
+// Merging rather than renaming is forced by the product, not chosen for
+// convenience. The reachable half of this class is the built-in seeding race,
+// so a group is typically two identical BUILT-IN rows — and a built-in symptom
+// can be neither renamed, archived nor removed through the application, and
+// does not appear on the settings page at all. A rename would therefore leave
+// the owner a permanent second "Cramps" in the day-entry picker with no surface
+// anywhere that can clear it, which is a worse outcome than one row carrying
+// both days.
+type SymptomDuplicateRepairService struct {
+	duplicates SymptomDuplicateRepository
+}
+
+func NewSymptomDuplicateRepairService(duplicates SymptomDuplicateRepository) *SymptomDuplicateRepairService {
+	return &SymptomDuplicateRepairService{duplicates: duplicates}
+}
+
+// Inspect reports every group that would refuse the migration, changing
+// nothing.
+func (service *SymptomDuplicateRepairService) Inspect(ctx context.Context) ([]models.SymptomDuplicateGroup, error) {
+	groups, err := service.duplicates.ListDuplicateSymptomNameGroups(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrSymptomDuplicateInspectFailed, err)
+	}
+	return groups, nil
+}
+
+// Repair inspects and then merges, returning the plan it carried out alongside
+// what changed. Running it a second time finds no groups, plans nothing and
+// reports a zero outcome — the repair is the operator's to repeat safely,
+// including after a partial run that failed and rolled back.
+func (service *SymptomDuplicateRepairService) Repair(ctx context.Context) ([]models.SymptomMerge, models.SymptomMergeOutcome, error) {
+	groups, err := service.Inspect(ctx)
+	if err != nil {
+		return nil, models.SymptomMergeOutcome{}, err
+	}
+
+	merges := PlanSymptomDuplicateMerges(groups)
+	if len(merges) == 0 {
+		return nil, models.SymptomMergeOutcome{}, nil
+	}
+
+	outcome, err := service.duplicates.MergeDuplicateSymptoms(ctx, merges)
+	if err != nil {
+		return nil, models.SymptomMergeOutcome{}, fmt.Errorf("%w: %v", ErrSymptomDuplicateMergeFailed, err)
+	}
+	return merges, outcome, nil
+}
+
+// PlanSymptomDuplicateMerges chooses, for each group, the row that survives.
+//
+// The order is active before archived, then built-in before custom, then oldest
+// id. Active comes first because a merge must never bury a symptom the owner is
+// still using under an archived row — the archived one would keep the days and
+// disappear from the picker. Built-in comes next so the catalogue keeps the
+// identity the picker's built-in handling is keyed on; it can only decide a
+// group whose rows agree on being active, since a built-in is unarchivable
+// through the application. The oldest id last, so the row the owner has had
+// longest is the one that stays and the choice is deterministic.
+//
+// A group of fewer than two rows plans nothing: it is not a conflict, and a
+// merge with no absorbed row would be a write with no reason.
+func PlanSymptomDuplicateMerges(groups []models.SymptomDuplicateGroup) []models.SymptomMerge {
+	merges := make([]models.SymptomMerge, 0, len(groups))
+	for _, group := range groups {
+		if len(group.Symptoms) < 2 {
+			continue
+		}
+
+		ordered := make([]models.SymptomType, len(group.Symptoms))
+		copy(ordered, group.Symptoms)
+		sort.SliceStable(ordered, func(first, second int) bool {
+			return symptomSurvivesOver(ordered[first], ordered[second])
+		})
+
+		merges = append(merges, models.SymptomMerge{
+			UserID:   group.UserID,
+			Survivor: ordered[0],
+			Absorbed: ordered[1:],
+		})
+	}
+	return merges
+}
+
+// symptomSurvivesOver is that order as one comparison. The id decides last and
+// is unique within a group, so no two rows compare equal and the survivor never
+// depends on the order the rows were read in.
+func symptomSurvivesOver(candidate models.SymptomType, other models.SymptomType) bool {
+	if candidate.IsActive() != other.IsActive() {
+		return candidate.IsActive()
+	}
+	if candidate.IsBuiltin != other.IsBuiltin {
+		return candidate.IsBuiltin
+	}
+	return candidate.ID < other.ID
+}

--- a/internal/services/symptom_duplicate_repair_service_test.go
+++ b/internal/services/symptom_duplicate_repair_service_test.go
@@ -1,0 +1,181 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+)
+
+type stubSymptomDuplicateRepository struct {
+	groups     []models.SymptomDuplicateGroup
+	listErr    error
+	mergeErr   error
+	outcome    models.SymptomMergeOutcome
+	seenMerges []models.SymptomMerge
+	mergeCalls int
+}
+
+func (stub *stubSymptomDuplicateRepository) ListDuplicateSymptomNameGroups(context.Context) ([]models.SymptomDuplicateGroup, error) {
+	if stub.listErr != nil {
+		return nil, stub.listErr
+	}
+	return stub.groups, nil
+}
+
+func (stub *stubSymptomDuplicateRepository) MergeDuplicateSymptoms(_ context.Context, merges []models.SymptomMerge) (models.SymptomMergeOutcome, error) {
+	stub.mergeCalls++
+	stub.seenMerges = merges
+	if stub.mergeErr != nil {
+		return models.SymptomMergeOutcome{}, stub.mergeErr
+	}
+	return stub.outcome, nil
+}
+
+func archivedAt() *time.Time {
+	moment := time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC)
+	return &moment
+}
+
+// TestPlanSymptomDuplicateMergesKeepsTheRowTheOwnerCanStillReach walks the
+// survivor order one rule at a time, each case reaching exactly one of them.
+//
+// The order is not cosmetic. Keeping an archived row would take the symptom out
+// of the day-entry picker while it kept every day that named it, and keeping a
+// custom row over a built-in would change what the catalogue calls a built-in
+// for that account.
+func TestPlanSymptomDuplicateMergesKeepsTheRowTheOwnerCanStillReach(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range []struct {
+		Name             string
+		Symptoms         []models.SymptomType
+		ExpectedSurvivor uint
+	}{
+		{
+			Name: "an active row outranks an archived one, whatever their ids",
+			Symptoms: []models.SymptomType{
+				{ID: 4, Name: "Cramps", ArchivedAt: archivedAt()},
+				{ID: 9, Name: "cramps"},
+			},
+			ExpectedSurvivor: 9,
+		},
+		{
+			Name: "among active rows the built-in outranks the custom one",
+			Symptoms: []models.SymptomType{
+				{ID: 3, Name: "cramps"},
+				{ID: 8, Name: "Cramps", IsBuiltin: true},
+			},
+			ExpectedSurvivor: 8,
+		},
+		{
+			Name: "otherwise the oldest row stays",
+			Symptoms: []models.SymptomType{
+				{ID: 12, Name: "Cramps", IsBuiltin: true},
+				{ID: 5, Name: "cramps", IsBuiltin: true},
+			},
+			ExpectedSurvivor: 5,
+		},
+		{
+			Name: "an archived pair still resolves, oldest first",
+			Symptoms: []models.SymptomType{
+				{ID: 7, Name: "Cramps", ArchivedAt: archivedAt()},
+				{ID: 2, Name: "cramps", ArchivedAt: archivedAt()},
+			},
+			ExpectedSurvivor: 2,
+		},
+	} {
+		t.Run(testCase.Name, func(t *testing.T) {
+			t.Parallel()
+
+			merges := PlanSymptomDuplicateMerges([]models.SymptomDuplicateGroup{
+				{UserID: 41, ConflictKey: "cramps", Symptoms: testCase.Symptoms},
+			})
+			if len(merges) != 1 {
+				t.Fatalf("expected one merge, got %d", len(merges))
+			}
+			if merges[0].Survivor.ID != testCase.ExpectedSurvivor {
+				t.Fatalf("expected symptom %d to survive, got %d", testCase.ExpectedSurvivor, merges[0].Survivor.ID)
+			}
+			if len(merges[0].Absorbed) != len(testCase.Symptoms)-1 {
+				t.Fatalf("every other row must be absorbed, got %d", len(merges[0].Absorbed))
+			}
+			for _, absorbed := range merges[0].Absorbed {
+				if absorbed.ID == testCase.ExpectedSurvivor {
+					t.Fatal("the survivor must not also be absorbed")
+				}
+			}
+			if merges[0].UserID != 41 {
+				t.Fatalf("a merge stays with its owner, got %d", merges[0].UserID)
+			}
+		})
+	}
+}
+
+// TestPlanSymptomDuplicateMergesPlansNothingForAGroupThatIsNotOne keeps the
+// planner from turning a report into a write. A group of one row is what an
+// engine returns for a name nothing collides on, and a merge with no absorbed
+// row would delete nothing while still opening a transaction over somebody's
+// health record.
+func TestPlanSymptomDuplicateMergesPlansNothingForAGroupThatIsNotOne(t *testing.T) {
+	t.Parallel()
+
+	merges := PlanSymptomDuplicateMerges([]models.SymptomDuplicateGroup{
+		{UserID: 1, ConflictKey: "cramps", Symptoms: []models.SymptomType{{ID: 1, Name: "Cramps"}}},
+		{UserID: 2, ConflictKey: "headache", Symptoms: nil},
+	})
+	if len(merges) != 0 {
+		t.Fatalf("expected no merges, got %d", len(merges))
+	}
+}
+
+// TestRepairMergesNothingWhenThereIsNothingToMerge pins that a clean database
+// costs no write at all: the repair is documented as repeatable, and a second
+// run that still opened a merge transaction would make that claim weaker than
+// it reads.
+func TestRepairMergesNothingWhenThereIsNothingToMerge(t *testing.T) {
+	t.Parallel()
+
+	repository := &stubSymptomDuplicateRepository{}
+	merges, outcome, err := NewSymptomDuplicateRepairService(repository).Repair(context.Background())
+	if err != nil {
+		t.Fatalf("repair on a clean database returned error: %v", err)
+	}
+	if len(merges) != 0 || outcome != (models.SymptomMergeOutcome{}) {
+		t.Fatalf("expected an empty result, got %v / %+v", merges, outcome)
+	}
+	if repository.mergeCalls != 0 {
+		t.Fatalf("expected no merge call, got %d", repository.mergeCalls)
+	}
+}
+
+// TestRepairCarriesTheStorageFailureUnderItsOwnSentinel keeps a failure
+// diagnosable on both halves: an operator reading it has to be able to tell an
+// inspection that could not read the catalogue from a merge that could not
+// write it, because only one of the two leaves the database possibly touched.
+func TestRepairCarriesTheStorageFailureUnderItsOwnSentinel(t *testing.T) {
+	t.Parallel()
+
+	storageErr := errors.New("connection refused")
+
+	if _, err := NewSymptomDuplicateRepairService(&stubSymptomDuplicateRepository{listErr: storageErr}).Inspect(context.Background()); !errors.Is(err, ErrSymptomDuplicateInspectFailed) {
+		t.Fatalf("expected the inspection sentinel, got %v", err)
+	}
+
+	_, _, err := NewSymptomDuplicateRepairService(&stubSymptomDuplicateRepository{
+		groups: []models.SymptomDuplicateGroup{{
+			UserID:   3,
+			Symptoms: []models.SymptomType{{ID: 1, Name: "Cramps"}, {ID: 2, Name: "cramps"}},
+		}},
+		mergeErr: storageErr,
+	}).Repair(context.Background())
+	if !errors.Is(err, ErrSymptomDuplicateMergeFailed) {
+		t.Fatalf("expected the merge sentinel, got %v", err)
+	}
+	if !strings.Contains(err.Error(), storageErr.Error()) {
+		t.Fatalf("the storage error must survive into the message, got %v", err)
+	}
+}

--- a/internal/services/symptom_duplicate_repair_service_test.go
+++ b/internal/services/symptom_duplicate_repair_service_test.go
@@ -165,6 +165,17 @@ func TestRepairCarriesTheStorageFailureUnderItsOwnSentinel(t *testing.T) {
 		t.Fatalf("expected the inspection sentinel, got %v", err)
 	}
 
+	// Repair inspects before it merges, so a catalogue it cannot read has to
+	// stop it there — merging against a plan built from a failed read would act
+	// on a set of groups nothing established.
+	repository := &stubSymptomDuplicateRepository{listErr: storageErr}
+	if _, _, err := NewSymptomDuplicateRepairService(repository).Repair(context.Background()); !errors.Is(err, ErrSymptomDuplicateInspectFailed) {
+		t.Fatalf("expected Repair to stop on the inspection sentinel, got %v", err)
+	}
+	if repository.mergeCalls != 0 {
+		t.Fatalf("a failed inspection must not reach the merge, got %d call(s)", repository.mergeCalls)
+	}
+
 	_, _, err := NewSymptomDuplicateRepairService(&stubSymptomDuplicateRepository{
 		groups: []models.SymptomDuplicateGroup{{
 			UserID:   3,


### PR DESCRIPTION
## What

`ovumcy repair symptom-names` — an offline data repair for the case where migration 037 refuses to
create its per-owner symptom-name index. Inspects and reports by default (non-zero exit while
duplicates remain, so an upgrade script can gate on it); `--apply` merges each group.

## Why

The refusal itself is correct and stays. What it had no way out of: the refusal is *also* what stops
the server, so the instruction to resolve the groups "through the application" named a path the
refusal had already closed — and every other operator subcommand reaches the database through
`db.OpenDatabase`, which applies migrations and met the same refusal. `repair` opens through the new
`db.OpenDatabaseWithoutMigrations`, the only entry point that does.

Merging rather than renaming is forced by the product: the reachable half of this class is the
built-in seeding race, and a built-in symptom can be neither renamed, hidden nor removed from
Settings, so a rename would leave a permanent duplicate in the day-entry picker with no surface that
can clear it.

Also closes the documentation half — Downgrade Caveats stopped at migration 022, so 032–038 were
undocumented in both directions.

## Risk

**High (migrations).** `--apply` is the only write: one transaction, all day-log references moved
before any row is removed, so no reference can outlive its row. The runbook requires a backup first.
`OpenDatabase` is unchanged for every existing caller. Rollback: revert — a merge an operator already
applied is undone only by restoring that backup.

## How verified

`TestARefusedSymptomNameUpgradeBootsAfterTheDocumentedRepairOnSQLite` / `...OnPostgres`: a fixture
holding case-insensitive duplicates and a day log naming both rows completes a FULL boot after the
documented remediation, on both engines. Red-checked by removing the day-log rewrite (`got [1 2]`),
by opening with migrations (empty inspection), by one rewrite pass per merge (`count must be 1, got
2`), and by letting any repeat decide the write (`got 2`).

Groups are read through the database's own `lower(name)` — the index's own expression — so one
command is correct on both engines where they disagree; the SQLite→Postgres consequence is in the
runbook.
