### PR TITLE
OpenAPI: each operation declares the statuses its own handler chain can answer

### DIFF
--- a/changelog.d/pr-openapi-per-operation-reachability.md
+++ b/changelog.d/pr-openapi-per-operation-reachability.md
@@ -1,0 +1,34 @@
+### Fixed
+
+- **`docs/openapi.yaml` now declares every status each operation's own handler chain can answer
+  with.** Thirty-two declarations were missing across twenty-seven operations, all pre-existing;
+  none is a v2.0.0 breaking change, and no server behavior moved. The gap was structural: the
+  existing contract test proves `declared ⊆ emittable` over the whole server at once, so a status
+  emittable *somewhere* satisfied it even on an operation that never declared it.
+  - Fifteen operations answer `403` and did not say so — eleven behind the owner-only gate
+    (`GET /api/v1/days`, `GET /api/v1/days/{date}`, `GET /api/v1/symptoms`, `GET
+    /api/v1/stats/overview`, `GET /api/v1/users/current`, `DELETE /api/v1/users/current`, `DELETE
+    /api/v1/sessions/current`, the three onboarding steps, `POST
+    /api/v1/users/current/data-wipe/validate`), and four on the deployment gate that turns the
+    local-credential surface off in an SSO-only install (`POST /api/v1/users`, `POST
+    /api/v1/sessions`, `POST /api/v1/password-resets`, `POST /api/v1/password-resets/redeem`). The
+    `Forbidden` component's description now covers the second cause too.
+  - Ten operations answer `400` on input they parse themselves and did not declare it: the three
+    `/api/v1/exports/*` range parameters, `DELETE` and `HEAD /api/v1/days/{date}` on the path date,
+    the `interface` / `tracking` / `reminders` settings bodies, `POST /api/v1/onboarding/complete`,
+    and `POST /api/v1/sessions`.
+  - `POST /api/v1/users/current/recovery-code` and `PUT /api/v1/users/current/2fa` share the
+    per-account re-auth budget with the four endpoints that got their `429` in the previous
+    release, and answer the same `429`.
+  - The three step-up endpoints (`POST /api/v1/users/current/{password,data-wipe,deletion}/step-up`)
+    answer `503` when the identity provider they must re-authenticate through is disabled or
+    unreachable. A `ServiceUnavailable` response component carries it.
+  - Three auth endpoints documented only their browser redirect and never their JSON success
+    answer: `POST /api/v1/users` returns `201`, `POST /api/v1/password-resets/redeem` returns
+    `200`, both with the new `NextStepResponse` shape (`ok`, `next_step`, `next_path`), and `POST
+    /api/v1/password-resets` returns `200 {ok: true}`. A programmatic client had no documented
+    success status on any of the three.
+
+  A new test walks each `/api/v1` route's registered handler chain as Go AST and fails when the
+  chain can reach a `fiber.Status*` the spec does not declare for that operation, so the class
+  cannot reopen silently.

--- a/changelog.d/pr-openapi-per-operation-reachability.md
+++ b/changelog.d/pr-openapi-per-operation-reachability.md
@@ -1,7 +1,7 @@
 ### Fixed
 
 - **`docs/openapi.yaml` now declares every status each operation's own handler chain can answer
-  with.** Thirty-two declarations were missing across twenty-seven operations, all pre-existing;
+  with.** Thirty-two declarations were missing across twenty-eight operations, all pre-existing;
   none is a v2.0.0 breaking change, and no server behavior moved. The gap was structural: the
   existing contract test proves `declared ⊆ emittable` over the whole server at once, so a status
   emittable *somewhere* satisfied it even on an operation that never declared it.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -384,7 +384,10 @@ components:
         Answer of an auth step that succeeded but is not finished: the server
         sealed a one-time cookie and names where the client must go to spend it.
         `next_step` is the stable programmatic name of that stage; `next_path` is
-        the page serving it.
+        the page serving it. The enum is exactly the two stages reached this way
+        (`POST /api/v1/users` and `POST /api/v1/password-resets/redeem`) — the
+        calendar-feed reveal names a stage too and has its own schema, so a new
+        stage extends the enum only if it also answers with this shape.
       required: [ok, next_step, next_path]
       properties:
         ok:
@@ -446,6 +449,23 @@ components:
           type: boolean
           default: false
           description: When true, the issued `ovumcy_auth` cookie carries an explicit ~7-day Expires. Otherwise the cookie is browser-session-scoped.
+      additionalProperties: false
+
+    RecoveryCodeRequiredResponse:
+      type: object
+      description: >-
+        Step 1 of `POST /api/v1/password-resets`: the body named `email` alone,
+        so nothing was started and the caller must repeat the request with
+        `recovery_code` and `password`. Carries no `next_path` — the step is the
+        same endpoint again, not another one.
+      required: [ok, next_step]
+      properties:
+        ok:
+          type: boolean
+          enum: [true]
+        next_step:
+          type: string
+          enum: [recovery_code]
       additionalProperties: false
 
     LoginTOTPRequiredResponse:
@@ -1524,11 +1544,22 @@ paths:
       responses:
         '200':
           description: |
-            Reset cookie issued. Sent when `Accept: application/json` is set; the
-            browser surface gets the `303` below instead.
+            Sent when `Accept: application/json` is set; the browser surface gets
+            the `303` below instead. Two shapes, one per step of the flow — see
+            `ForgotPasswordRequest`.
           content:
             application/json:
-              schema: { $ref: '#/components/schemas/OkResponse' }
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/RecoveryCodeRequiredResponse'
+                  - $ref: '#/components/schemas/OkResponse'
+              examples:
+                recoveryCodeRequired:
+                  summary: Step 1 — email alone; nothing started yet
+                  value: { ok: true, next_step: "recovery_code" }
+                resetCookieIssued:
+                  summary: Step 2 — reset cookie issued
+                  value: { ok: true }
         '303':
           description: Redirect to `/reset-password` with a sealed reset cookie.
         '400':

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -158,11 +158,7 @@ components:
             error: "unauthorized"
             error_detail: { key: "unauthorized", category: "unauthorized", target: "global" }
     Forbidden:
-      description: |
-        The request is refused on grounds other than identity: the caller lacks
-        the required role (typically owner-only), CSRF validation failed, or the
-        deployment has the local-credential surface turned off (SSO-only), which
-        refuses sign-in, registration and password recovery alike.
+      description: Session is valid but the caller lacks the required role (typically owner-only) or CSRF validation failed.
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
@@ -1546,7 +1542,13 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/ApiError' }
         '403':
-          $ref: '#/components/responses/Forbidden'
+          description: Local password recovery is disabled on this deployment (SSO-only).
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ApiError' }
+              example:
+                error: "local recovery unavailable"
+                error_detail: { key: "local recovery unavailable", category: "forbidden", target: "auth_form" }
         '429':
           $ref: '#/components/responses/RateLimited'
 
@@ -1582,7 +1584,16 @@ paths:
         '400':
           $ref: '#/components/responses/ValidationError'
         '403':
-          $ref: '#/components/responses/Forbidden'
+          description: |
+            Local password recovery is disabled on this deployment (SSO-only).
+            A reset token minted by the OIDC flow for an account carrying
+            `must_change_password` survives this gate and can still be redeemed.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ApiError' }
+              example:
+                error: "local recovery unavailable"
+                error_detail: { key: "local recovery unavailable", category: "forbidden", target: "auth_form" }
 
   # =========================================================================
   # onboarding

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -158,7 +158,11 @@ components:
             error: "unauthorized"
             error_detail: { key: "unauthorized", category: "unauthorized", target: "global" }
     Forbidden:
-      description: Session is valid but the caller lacks the required role (typically owner-only) or CSRF validation failed.
+      description: |
+        The request is refused on grounds other than identity: the caller lacks
+        the required role (typically owner-only), CSRF validation failed, or the
+        deployment has the local-credential surface turned off (SSO-only), which
+        refuses sign-in, registration and password recovery alike.
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
@@ -213,6 +217,18 @@ components:
             error: "too many requests"
             error_detail: { key: "too many requests", category: "rate_limited", target: "global" }
             retry_after_seconds: 60
+    ServiceUnavailable:
+      description: |
+        A dependency the operation needs is not available. On the step-up
+        endpoints this is the identity provider: the account has no local
+        password, so the re-authentication can only be satisfied through SSO,
+        and SSO is disabled or unreachable. Retryable once the provider is back.
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/ApiError' }
+          example:
+            error: "sso temporarily unavailable"
+            error_detail: { key: "sso temporarily unavailable", category: "internal", target: "auth_form" }
     InternalError:
       description: Unexpected server error.
       content:
@@ -364,6 +380,26 @@ components:
         rejected:
           type: integer
           description: Malformed or duplicate day records dropped without writing.
+      additionalProperties: false
+
+    NextStepResponse:
+      type: object
+      description: |
+        Answer of an auth step that succeeded but is not finished: the server
+        sealed a one-time cookie and names where the client must go to spend it.
+        `next_step` is the stable programmatic name of that stage; `next_path` is
+        the page serving it.
+      required: [ok, next_step, next_path]
+      properties:
+        ok:
+          type: boolean
+          enum: [true]
+        next_step:
+          type: string
+          enum: [register_welcome, recovery_code]
+        next_path:
+          type: string
+          example: "/recovery-code"
       additionalProperties: false
 
     OkRedirectResponse:
@@ -1327,10 +1363,30 @@ paths:
           application/json:
             schema: { $ref: '#/components/schemas/RegisterRequest' }
       responses:
+        '201':
+          description: |
+            Pickup cookie issued. Sent when `Accept: application/json` is set; the
+            browser surface gets the `303` below instead. Identical for new and
+            duplicate emails.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/NextStepResponse' }
+              example:
+                ok: true
+                next_step: "register_welcome"
+                next_path: "/register/welcome"
         '303':
           description: Redirect to `/register/welcome` with the sealed pickup cookie. Shape is identical for new and duplicate emails.
         '400':
           $ref: '#/components/responses/ValidationError'
+        '403':
+          description: Registration is closed on this deployment (SSO-only).
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ApiError' }
+              example:
+                error: "local sign-in unavailable"
+                error_detail: { key: "local sign-in unavailable", category: "forbidden", target: "auth_form" }
         '429':
           $ref: '#/components/responses/RateLimited'
 
@@ -1376,6 +1432,16 @@ paths:
               example:
                 error: "invalid credentials"
                 error_detail: { key: "invalid credentials", category: "unauthorized", target: "auth_form" }
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '403':
+          description: Local sign-in is disabled on this deployment (SSO-only).
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ApiError' }
+              example:
+                error: "local sign-in unavailable"
+                error_detail: { key: "local sign-in unavailable", category: "forbidden", target: "auth_form" }
         '429':
           $ref: '#/components/responses/RateLimited'
 
@@ -1435,6 +1501,8 @@ paths:
           description: Browser redirect to `/login` or the OIDC logout bridge path.
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
         '429':
           $ref: '#/components/responses/RateLimited'
 
@@ -1458,6 +1526,13 @@ paths:
           application/json:
             schema: { $ref: '#/components/schemas/ForgotPasswordRequest' }
       responses:
+        '200':
+          description: |
+            Reset cookie issued. Sent when `Accept: application/json` is set; the
+            browser surface gets the `303` below instead.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/OkResponse' }
         '303':
           description: Redirect to `/reset-password` with a sealed reset cookie.
         '400':
@@ -1470,6 +1545,8 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ApiError' }
+        '403':
+          $ref: '#/components/responses/Forbidden'
         '429':
           $ref: '#/components/responses/RateLimited'
 
@@ -1488,10 +1565,24 @@ paths:
           application/json:
             schema: { $ref: '#/components/schemas/ResetPasswordRequest' }
       responses:
+        '200':
+          description: |
+            Password replaced and a session issued; the freshly minted recovery
+            code waits behind `next_path`. Sent when `Accept: application/json`
+            is set; the browser surface gets the `303` below instead.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/NextStepResponse' }
+              example:
+                ok: true
+                next_step: "recovery_code"
+                next_path: "/recovery-code"
         '303':
           description: Redirect to `/login` after success.
         '400':
           $ref: '#/components/responses/ValidationError'
+        '403':
+          $ref: '#/components/responses/Forbidden'
 
   # =========================================================================
   # onboarding
@@ -1513,6 +1604,7 @@ paths:
               schema: { $ref: '#/components/schemas/OkResponse' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '400': { $ref: '#/components/responses/ValidationError' }
+        '403': { $ref: '#/components/responses/Forbidden' }
 
   /api/v1/onboarding/steps/2:
     post:
@@ -1531,6 +1623,7 @@ paths:
               schema: { $ref: '#/components/schemas/OkResponse' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '400': { $ref: '#/components/responses/ValidationError' }
+        '403': { $ref: '#/components/responses/Forbidden' }
 
   /api/v1/onboarding/complete:
     post:
@@ -1543,6 +1636,8 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/OkResponse' }
         '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '400': { $ref: '#/components/responses/ValidationError' }
 
   # =========================================================================
   # days
@@ -1564,6 +1659,7 @@ paths:
                 items: { $ref: '#/components/schemas/DailyLog' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '400': { $ref: '#/components/responses/ValidationError' }
+        '403': { $ref: '#/components/responses/Forbidden' }
 
   /api/v1/days/{date}:
     parameters:
@@ -1579,6 +1675,7 @@ paths:
               schema: { $ref: '#/components/schemas/DailyLog' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '400': { $ref: '#/components/responses/ValidationError' }
+        '403': { $ref: '#/components/responses/Forbidden' }
     head:
       tags: [days]
       summary: Check whether the day has any persisted data (owner only).
@@ -1593,6 +1690,7 @@ paths:
           description: Day has no persisted data.
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
+        '400': { $ref: '#/components/responses/ValidationError' }
     put:
       tags: [days]
       summary: Upsert a day's entry (owner only).
@@ -1637,6 +1735,7 @@ paths:
               schema: { $ref: '#/components/schemas/OkResponse' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
+        '400': { $ref: '#/components/responses/ValidationError' }
 
   /api/v1/days/{date}/cycle-start:
     post:
@@ -1693,6 +1792,7 @@ paths:
                 type: array
                 items: { $ref: '#/components/schemas/Symptom' }
         '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
     post:
       tags: [symptoms]
       summary: Create a custom symptom (owner only).
@@ -1785,6 +1885,7 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/StatsOverview' }
         '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
 
   # =========================================================================
   # exports
@@ -1804,6 +1905,7 @@ paths:
               schema: { $ref: '#/components/schemas/ExportSummary' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
+        '400': { $ref: '#/components/responses/ValidationError' }
 
   /api/v1/exports/csv:
     get:
@@ -1824,6 +1926,7 @@ paths:
               schema: { type: string }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
+        '400': { $ref: '#/components/responses/ValidationError' }
 
   /api/v1/exports/json:
     get:
@@ -1844,6 +1947,7 @@ paths:
               schema: { $ref: '#/components/schemas/ExportJSON' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
+        '400': { $ref: '#/components/responses/ValidationError' }
 
   /api/v1/imports/json:
     post:
@@ -1909,6 +2013,7 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/CurrentUser' }
         '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
     delete:
       tags: [settings]
       summary: Delete the current account and all related data (owner only).
@@ -1930,6 +2035,7 @@ paths:
         '401': { $ref: '#/components/responses/Unauthorized' }
         '400': { $ref: '#/components/responses/ValidationError' }
         '429': { $ref: '#/components/responses/RateLimited' }
+        '403': { $ref: '#/components/responses/Forbidden' }
 
   /api/v1/users/current/profile:
     patch:
@@ -1967,6 +2073,7 @@ paths:
               schema: { $ref: '#/components/schemas/OkResponse' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
+        '400': { $ref: '#/components/responses/ValidationError' }
 
   /api/v1/users/current/tracking:
     patch:
@@ -1985,6 +2092,7 @@ paths:
               schema: { $ref: '#/components/schemas/OkResponse' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
+        '400': { $ref: '#/components/responses/ValidationError' }
 
   /api/v1/users/current/timezone:
     post:
@@ -2193,6 +2301,7 @@ paths:
               schema: { $ref: '#/components/schemas/OkResponse' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
+        '400': { $ref: '#/components/responses/ValidationError' }
 
   /api/v1/users/current/password:
     put:
@@ -2252,6 +2361,7 @@ paths:
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
         '400': { $ref: '#/components/responses/ValidationError' }
+        '503': { $ref: '#/components/responses/ServiceUnavailable' }
 
   /api/v1/users/current/data-wipe/step-up:
     post:
@@ -2286,6 +2396,7 @@ paths:
               example:
                 error: "invalid settings input"
                 error_detail: { key: "invalid settings input", category: "validation", target: "settings_form" }
+        '503': { $ref: '#/components/responses/ServiceUnavailable' }
 
   /api/v1/users/current/deletion/step-up:
     post:
@@ -2314,6 +2425,7 @@ paths:
               example:
                 error: "invalid settings input"
                 error_detail: { key: "invalid settings input", category: "validation", target: "settings_form" }
+        '503': { $ref: '#/components/responses/ServiceUnavailable' }
 
   /api/v1/users/current/recovery-code:
     post:
@@ -2335,6 +2447,7 @@ paths:
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
         '400': { $ref: '#/components/responses/ValidationError' }
+        '429': { $ref: '#/components/responses/RateLimited' }
 
   /api/v1/users/current/2fa:
     put:
@@ -2355,6 +2468,7 @@ paths:
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
         '400': { $ref: '#/components/responses/ValidationError' }
+        '429': { $ref: '#/components/responses/RateLimited' }
     delete:
       tags: [settings]
       summary: Disable TOTP 2FA (owner only).
@@ -2394,6 +2508,7 @@ paths:
         '401': { $ref: '#/components/responses/Unauthorized' }
         '400': { $ref: '#/components/responses/ValidationError' }
         '429': { $ref: '#/components/responses/RateLimited' }
+        '403': { $ref: '#/components/responses/Forbidden' }
 
   /api/v1/users/current/data-wipe:
     post:

--- a/internal/api/openapi_operation_reachability_test.go
+++ b/internal/api/openapi_operation_reachability_test.go
@@ -1,0 +1,240 @@
+package api
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"net/http"
+	"os"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/gofiber/fiber/v3"
+)
+
+// TestOpenAPIOperationsDeclareEveryStatusTheirOwnHandlerChainCanEmit closes the
+// direction TestOpenAPIDeclaresOnlyStatusesTheServerCanEmit's own doc comment
+// names as underivable "from a source scan": that test proves declared ⊆
+// emittable across the WHOLE server, which passes even when a status is
+// emittable only by an operation that never declared it — a 429 the spec
+// forgot is invisible to a check that only asks whether 429 appears anywhere
+// in internal/. Two real drifts of exactly that shape shipped for a release
+// (four re-auth-budget endpoints undeclaring 429; the "OpenAPI spec contract"
+// rule in .claude/rules/api.md — governance-update, 2026-09-02 — has the
+// prose).
+//
+// This test is deliberately one-directional, the same way its sibling is:
+// under-declaration (emittable but not declared) is what it asserts, because
+// over-declaration (declared but never reachable) needs proving a NEGATIVE —
+// that no path through the handler chain reaches a status — which a call-graph
+// approximation cannot soundly claim. Missing a declaration is provable by
+// finding the one call site that emits it; the reverse is not provable by not
+// finding one.
+//
+// "Emittable" is read from the registered handler chain for that exact route
+// (Fiber's own Route.Handlers, not routes.go text), walked as Go AST rather
+// than grepped: every fiber.Status* selector reached by a breadth-first walk
+// from each handler function, following calls to functions/methods defined in
+// internal/api (excluding _test.go) to a bounded depth. A handler that never
+// calls a status-bearing function reachable within that depth is undercounted
+// rather than over-claimed — the same conservative-on-false-positives choice
+// the removed rule-of-thumb in governance-update's own admission test asks
+// for: a check that can go red on nothing is worse than one that occasionally
+// stays quiet.
+func TestOpenAPIOperationsDeclareEveryStatusTheirOwnHandlerChainCanEmit(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+	app, _ := newOnboardingTestApp(t)
+
+	declared := openAPIDeclaredStatuses(t, filepath.Join(repoRoot, "docs", "openapi.yaml"))
+	declaredByOperation := make(map[string]map[int]bool)
+	for status, operations := range declared {
+		for _, operation := range operations {
+			if declaredByOperation[operation] == nil {
+				declaredByOperation[operation] = make(map[int]bool)
+			}
+			declaredByOperation[operation][status] = true
+		}
+	}
+
+	statusByIdentifier := knownFiberStatusIdentifiers(t)
+	funcs := parseAPIPackageFuncs(t, filepath.Join(repoRoot, "internal", "api"))
+
+	valid := map[string]bool{
+		fiber.MethodGet: true, fiber.MethodPost: true, fiber.MethodPut: true,
+		fiber.MethodPatch: true, fiber.MethodDelete: true, fiber.MethodHead: true,
+	}
+
+	var offenders []string
+	seen := make(map[string]bool)
+	for _, route := range app.GetRoutes(true) {
+		if !valid[route.Method] || !strings.HasPrefix(route.Path, "/api/v1") {
+			continue
+		}
+		operation := route.Method + " " + fiberPathToOpenAPI(route.Path)
+		if seen[operation] {
+			continue // duplicate registration (e.g. HEAD mirroring GET); one check is enough
+		}
+		seen[operation] = true
+
+		emittable := make(map[int]bool)
+		for _, h := range route.Handlers {
+			name := handlerFuncName(h)
+			if decl, ok := funcs[name]; ok {
+				collectReachableStatuses(decl, funcs, statusByIdentifier, emittable, make(map[string]bool), 0)
+			}
+		}
+
+		var missing []int
+		for status := range emittable {
+			if crossCuttingStatus[status] {
+				continue
+			}
+			if !declaredByOperation[operation][status] {
+				missing = append(missing, status)
+			}
+		}
+		if len(missing) == 0 {
+			continue
+		}
+		sort.Ints(missing)
+		labels := make([]string, len(missing))
+		for i, s := range missing {
+			labels[i] = http.StatusText(s)
+		}
+		offenders = append(offenders, operation+": emits "+strings.Join(labels, ", ")+" but docs/openapi.yaml does not declare it there")
+	}
+
+	if len(offenders) == 0 {
+		return
+	}
+	sort.Strings(offenders)
+	t.Errorf("operations whose handler chain can emit a status docs/openapi.yaml never declares for that operation:\n  %s",
+		strings.Join(offenders, "\n  "))
+}
+
+// handlerFuncName extracts the bare Go function/method name a fiber.Handler
+// value was built from — "ChangePassword" out of the runtime symbol
+// ".../internal/api.(*Handler).ChangePassword-fm" a bound method value carries,
+// or the same bare name for a plain function. Handlers that are not simple
+// named funcs/methods (an inline closure, a wrapped middleware factory) yield
+// "" and are silently skipped: the walk is already one-directional, and a
+// wrapper this cannot name is an underclaim, not a false one.
+func handlerFuncName(h fiber.Handler) string {
+	symbol := runtime.FuncForPC(reflect.ValueOf(h).Pointer()).Name()
+	match := regexp.MustCompile(`\.(\w+)(?:-fm)?$`).FindStringSubmatch(symbol)
+	if match == nil {
+		return ""
+	}
+	return match[1]
+}
+
+// parseAPIPackageFuncs parses every non-test .go file directly under dir and
+// indexes each top-level func and each method on *Handler by its bare name.
+// Two distinct functions sharing a name (none do today) would merge into one
+// entry — an over-approximation, which is the safe direction for a
+// missing-declaration check.
+func parseAPIPackageFuncs(t *testing.T, dir string) map[string]*ast.FuncDecl {
+	t.Helper()
+	fset := token.NewFileSet()
+	funcs := make(map[string]*ast.FuncDecl)
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read %s: %v", dir, err)
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, filepath.Join(dir, name), nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+			funcs[fn.Name.Name] = fn
+		}
+	}
+	if len(funcs) == 0 {
+		t.Fatalf("no functions parsed from %s; test setup is wrong", dir)
+	}
+	return funcs
+}
+
+// collectReachableStatuses walks decl's body, recording every fiber.Status*
+// selector it finds directly and recursing into every call to another
+// function/method this package defines, up to maxReachDepth hops. visited
+// guards both infinite recursion (mutual calls) and repeated work across the
+// route's handler chain.
+const maxReachDepth = 8
+
+// crossCuttingStatus lists statuses excluded from the per-operation check
+// because they are cross-cutting rather than a decision the operation's own
+// business logic makes: 500 is the universal default arm of every domain
+// error-mapping switch (already documented centrally, not per-operation, by
+// api.md's ErrorHandler total-resolution rule and
+// TestOpenAPIDocumentsEveryTransportStatusTheEnvelopeCovers); 303 is emitted
+// by the shared JSON/HTMX content-negotiation helper any handler MAY reach
+// regardless of its own logic, and the spec's own preamble scopes documented
+// responses to the JSON surface. An operation that documents 303 as an actual
+// primary outcome (the two-step password-reset flow) is unaffected — this
+// exclusion only suppresses it as a MISSING-declaration finding, it does not
+// forbid declaring it.
+var crossCuttingStatus = map[int]bool{
+	http.StatusInternalServerError: true,
+	http.StatusSeeOther:            true,
+}
+
+func collectReachableStatuses(decl *ast.FuncDecl, funcs map[string]*ast.FuncDecl, statusByIdentifier map[string]int, out map[int]bool, visited map[string]bool, depth int) {
+	if decl == nil || decl.Body == nil || visited[decl.Name.Name] || depth > maxReachDepth {
+		return
+	}
+	visited[decl.Name.Name] = true
+
+	ast.Inspect(decl.Body, func(n ast.Node) bool {
+		switch node := n.(type) {
+		case *ast.SelectorExpr:
+			if pkg, ok := node.X.(*ast.Ident); ok && pkg.Name == "fiber" {
+				if status, ok := statusByIdentifier["fiber."+node.Sel.Name]; ok {
+					out[status] = true
+				}
+			}
+		case *ast.CallExpr:
+			switch fn := node.Fun.(type) {
+			case *ast.Ident:
+				if callee, ok := funcs[fn.Name]; ok {
+					collectReachableStatuses(callee, funcs, statusByIdentifier, out, visited, depth+1)
+				}
+			case *ast.SelectorExpr:
+				if callee, ok := funcs[fn.Sel.Name]; ok {
+					collectReachableStatuses(callee, funcs, statusByIdentifier, out, visited, depth+1)
+				}
+			}
+		}
+		return true
+	})
+}
+
+// knownFiberStatusIdentifiers inverts fiberStatusIdentifier over every
+// registered HTTP status, so a selector found in source resolves back to its
+// numeric code without a hand-maintained table that could drift from it.
+func knownFiberStatusIdentifiers(t *testing.T) map[string]int {
+	t.Helper()
+	out := make(map[string]int)
+	for status := 100; status < 600; status++ {
+		if http.StatusText(status) == "" {
+			continue
+		}
+		out[fiberStatusIdentifier(t, status)] = status
+	}
+	return out
+}

--- a/internal/api/openapi_operation_reachability_test.go
+++ b/internal/api/openapi_operation_reachability_test.go
@@ -82,10 +82,11 @@ func TestOpenAPIOperationsDeclareEveryStatusTheirOwnHandlerChainCanEmit(t *testi
 		seen[operation] = true
 
 		emittable := make(map[int]bool)
+		visited := make(map[*ast.FuncDecl]bool)
 		for _, h := range route.Handlers {
 			name := handlerFuncName(h)
-			if decl, ok := funcs[name]; ok {
-				collectReachableStatuses(decl, funcs, statusByIdentifier, emittable, make(map[string]bool), 0)
+			for _, decl := range funcs[name] {
+				collectReachableStatuses(decl, funcs, statusByIdentifier, emittable, visited, 0)
 			}
 		}
 
@@ -134,14 +135,18 @@ func handlerFuncName(h fiber.Handler) string {
 }
 
 // parseAPIPackageFuncs parses every non-test .go file directly under dir and
-// indexes each top-level func and each method on *Handler by its bare name.
-// Two distinct functions sharing a name (none do today) would merge into one
-// entry — an over-approximation, which is the safe direction for a
-// missing-declaration check.
-func parseAPIPackageFuncs(t *testing.T, dir string) map[string]*ast.FuncDecl {
+// indexes each top-level func and each method by its bare name. A name is
+// keyed to a SLICE, not a single decl: this package has real same-name
+// collisions across distinct receivers (validAt on five different sealed-
+// cookie payload types, matchesState on two), and a bare-map index that
+// overwrote on collision would silently drop whichever declaration parsed
+// last — the wrong direction for a check whose whole point is not
+// under-claiming what a name can reach. collectReachableStatuses walks every
+// decl a name resolves to.
+func parseAPIPackageFuncs(t *testing.T, dir string) map[string][]*ast.FuncDecl {
 	t.Helper()
 	fset := token.NewFileSet()
-	funcs := make(map[string]*ast.FuncDecl)
+	funcs := make(map[string][]*ast.FuncDecl)
 
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -161,7 +166,7 @@ func parseAPIPackageFuncs(t *testing.T, dir string) map[string]*ast.FuncDecl {
 			if !ok || fn.Body == nil {
 				continue
 			}
-			funcs[fn.Name.Name] = fn
+			funcs[fn.Name.Name] = append(funcs[fn.Name.Name], fn)
 		}
 	}
 	if len(funcs) == 0 {
@@ -172,9 +177,13 @@ func parseAPIPackageFuncs(t *testing.T, dir string) map[string]*ast.FuncDecl {
 
 // collectReachableStatuses walks decl's body, recording every fiber.Status*
 // selector it finds directly and recursing into every call to another
-// function/method this package defines, up to maxReachDepth hops. visited
-// guards both infinite recursion (mutual calls) and repeated work across the
-// route's handler chain.
+// function/method this package defines, up to maxReachDepth hops. visited is
+// keyed by *ast.FuncDecl, not by name: two distinct declarations can share a
+// bare name (parseAPIPackageFuncs' own doc comment has the confirmed
+// collisions), and a name-keyed visited set would mark the whole name walked
+// after the first same-named decl, silently skipping every other body that
+// name resolves to. Keying by decl guards infinite recursion (mutual calls)
+// and repeated work across the route's handler chain without that loss.
 const maxReachDepth = 8
 
 // crossCuttingStatus lists statuses excluded from the per-operation check
@@ -194,11 +203,11 @@ var crossCuttingStatus = map[int]bool{
 	http.StatusSeeOther:            true,
 }
 
-func collectReachableStatuses(decl *ast.FuncDecl, funcs map[string]*ast.FuncDecl, statusByIdentifier map[string]int, out map[int]bool, visited map[string]bool, depth int) {
-	if decl == nil || decl.Body == nil || visited[decl.Name.Name] || depth > maxReachDepth {
+func collectReachableStatuses(decl *ast.FuncDecl, funcs map[string][]*ast.FuncDecl, statusByIdentifier map[string]int, out map[int]bool, visited map[*ast.FuncDecl]bool, depth int) {
+	if decl == nil || decl.Body == nil || visited[decl] || depth > maxReachDepth {
 		return
 	}
-	visited[decl.Name.Name] = true
+	visited[decl] = true
 
 	ast.Inspect(decl.Body, func(n ast.Node) bool {
 		switch node := n.(type) {
@@ -209,15 +218,15 @@ func collectReachableStatuses(decl *ast.FuncDecl, funcs map[string]*ast.FuncDecl
 				}
 			}
 		case *ast.CallExpr:
+			var calleeName string
 			switch fn := node.Fun.(type) {
 			case *ast.Ident:
-				if callee, ok := funcs[fn.Name]; ok {
-					collectReachableStatuses(callee, funcs, statusByIdentifier, out, visited, depth+1)
-				}
+				calleeName = fn.Name
 			case *ast.SelectorExpr:
-				if callee, ok := funcs[fn.Sel.Name]; ok {
-					collectReachableStatuses(callee, funcs, statusByIdentifier, out, visited, depth+1)
-				}
+				calleeName = fn.Sel.Name
+			}
+			for _, callee := range funcs[calleeName] {
+				collectReachableStatuses(callee, funcs, statusByIdentifier, out, visited, depth+1)
 			}
 		}
 		return true

--- a/internal/api/openapi_operation_reachability_test.go
+++ b/internal/api/openapi_operation_reachability_test.go
@@ -290,6 +290,14 @@ func (reach *statusReach) walk(node ast.Node, emitsStatuses bool, depth int, gua
 			if !nonJSONSurfaceGuard(typed.Cond) {
 				return true
 			}
+			// Only the BODY is the HTML arm. The guard itself still runs on
+			// every request, so its init and condition are walked like any
+			// other code — skipping them would drop a status, or a sentinel a
+			// later mapper arm depends on, that the JSON surface does reach.
+			if typed.Init != nil {
+				reach.walk(typed.Init, emitsStatuses, depth, guards)
+			}
+			reach.walk(typed.Cond, emitsStatuses, depth, guards)
 			if typed.Else != nil {
 				reach.walk(typed.Else, emitsStatuses, depth, guards)
 			}

--- a/internal/api/openapi_operation_reachability_test.go
+++ b/internal/api/openapi_operation_reachability_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"fmt"
 	"go/ast"
 	"go/parser"
 	"go/token"
@@ -40,12 +41,12 @@ import (
 // (Fiber's own Route.Handlers, not routes.go text), walked as Go AST rather
 // than grepped: every fiber.Status* selector reached by a breadth-first walk
 // from each handler function, following calls to functions/methods defined in
-// internal/api (excluding _test.go) to a bounded depth. A handler that never
-// calls a status-bearing function reachable within that depth is undercounted
-// rather than over-claimed — the same conservative-on-false-positives choice
-// the removed rule-of-thumb in governance-update's own admission test asks
-// for: a check that can go red on nothing is worse than one that occasionally
-// stays quiet.
+// internal/api or internal/services (excluding _test.go) to a bounded depth. A
+// handler that never calls a status-bearing function reachable within that
+// depth is undercounted rather than over-claimed — the same conservative-on-
+// false-positives choice the removed rule-of-thumb in governance-update's own
+// admission test asks for: a check that can go red on nothing is worse than one
+// that occasionally stays quiet.
 func TestOpenAPIOperationsDeclareEveryStatusTheirOwnHandlerChainCanEmit(t *testing.T) {
 	repoRoot := filepath.Join("..", "..")
 	app, _ := newOnboardingTestApp(t)
@@ -62,7 +63,9 @@ func TestOpenAPIOperationsDeclareEveryStatusTheirOwnHandlerChainCanEmit(t *testi
 	}
 
 	statusByIdentifier := knownFiberStatusIdentifiers(t)
-	funcs := parseAPIPackageFuncs(t, filepath.Join(repoRoot, "internal", "api"))
+	funcs, transport := parseReachableFuncs(t,
+		filepath.Join(repoRoot, "internal", "api"),
+		filepath.Join(repoRoot, "internal", "services"))
 
 	valid := map[string]bool{
 		fiber.MethodGet: true, fiber.MethodPost: true, fiber.MethodPut: true,
@@ -81,17 +84,21 @@ func TestOpenAPIOperationsDeclareEveryStatusTheirOwnHandlerChainCanEmit(t *testi
 		}
 		seen[operation] = true
 
-		emittable := make(map[int]bool)
-		visited := make(map[*ast.FuncDecl]bool)
+		reach := newStatusReach(funcs, transport, statusByIdentifier)
 		for _, h := range route.Handlers {
 			name := handlerFuncName(h)
 			for _, decl := range funcs[name] {
-				collectReachableStatuses(decl, funcs, statusByIdentifier, emittable, visited, 0)
+				// A handler value is always a transport function; resolving the
+				// bare name against the domain package too would let a
+				// same-named service method stand in for the real handler.
+				if transport[decl] {
+					reach.walkFunc(decl, 0, nil)
+				}
 			}
 		}
 
 		var missing []int
-		for status := range emittable {
+		for status := range reach.emittable() {
 			if crossCuttingStatus[status] {
 				continue
 			}
@@ -134,56 +141,61 @@ func handlerFuncName(h fiber.Handler) string {
 	return match[1]
 }
 
-// parseAPIPackageFuncs parses every non-test .go file directly under dir and
-// indexes each top-level func and each method by its bare name. A name is
-// keyed to a SLICE, not a single decl: this package has real same-name
-// collisions across distinct receivers (validAt on five different sealed-
-// cookie payload types, matchesState on two), and a bare-map index that
+// parseReachableFuncs parses every non-test .go file directly under
+// transportDir and domainDir, indexes each top-level func and each method by
+// its bare name, and reports which declarations came from transportDir.
+//
+// A name is keyed to a SLICE, not a single decl: these packages have real
+// same-name collisions across distinct receivers (validAt on five different
+// sealed-cookie payload types, matchesState on two), and a bare-map index that
 // overwrote on collision would silently drop whichever declaration parsed
 // last — the wrong direction for a check whose whole point is not
-// under-claiming what a name can reach. collectReachableStatuses walks every
-// decl a name resolves to.
-func parseAPIPackageFuncs(t *testing.T, dir string) map[string][]*ast.FuncDecl {
+// under-claiming what a name can reach. statusReach walks every decl a name
+// resolves to.
+//
+// domainDir is walked for one purpose only: deciding which arm of a shared
+// error mapper a given handler can actually reach (see statusReach). It
+// contributes no statuses of its own — the transport set gates that, and the
+// architecture contract already keeps internal/services free of any HTTP
+// framework.
+func parseReachableFuncs(t *testing.T, transportDir string, domainDir string) (map[string][]*ast.FuncDecl, map[*ast.FuncDecl]bool) {
 	t.Helper()
 	fset := token.NewFileSet()
 	funcs := make(map[string][]*ast.FuncDecl)
+	transport := make(map[*ast.FuncDecl]bool)
 
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		t.Fatalf("read %s: %v", dir, err)
-	}
-	for _, entry := range entries {
-		name := entry.Name()
-		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
-			continue
-		}
-		file, err := parser.ParseFile(fset, filepath.Join(dir, name), nil, 0)
+	for _, dir := range []string{transportDir, domainDir} {
+		entries, err := os.ReadDir(dir)
 		if err != nil {
-			t.Fatalf("parse %s: %v", name, err)
+			t.Fatalf("read %s: %v", dir, err)
 		}
-		for _, decl := range file.Decls {
-			fn, ok := decl.(*ast.FuncDecl)
-			if !ok || fn.Body == nil {
+		for _, entry := range entries {
+			name := entry.Name()
+			if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
 				continue
 			}
-			funcs[fn.Name.Name] = append(funcs[fn.Name.Name], fn)
+			file, err := parser.ParseFile(fset, filepath.Join(dir, name), nil, 0)
+			if err != nil {
+				t.Fatalf("parse %s: %v", name, err)
+			}
+			for _, decl := range file.Decls {
+				fn, ok := decl.(*ast.FuncDecl)
+				if !ok || fn.Body == nil {
+					continue
+				}
+				funcs[fn.Name.Name] = append(funcs[fn.Name.Name], fn)
+				if dir == transportDir {
+					transport[fn] = true
+				}
+			}
 		}
 	}
-	if len(funcs) == 0 {
-		t.Fatalf("no functions parsed from %s; test setup is wrong", dir)
+	if len(transport) == 0 {
+		t.Fatalf("no functions parsed from %s; test setup is wrong", transportDir)
 	}
-	return funcs
+	return funcs, transport
 }
 
-// collectReachableStatuses walks decl's body, recording every fiber.Status*
-// selector it finds directly and recursing into every call to another
-// function/method this package defines, up to maxReachDepth hops. visited is
-// keyed by *ast.FuncDecl, not by name: two distinct declarations can share a
-// bare name (parseAPIPackageFuncs' own doc comment has the confirmed
-// collisions), and a name-keyed visited set would mark the whole name walked
-// after the first same-named decl, silently skipping every other body that
-// name resolves to. Keying by decl guards infinite recursion (mutual calls)
-// and repeated work across the route's handler chain without that loss.
 const maxReachDepth = 8
 
 // crossCuttingStatus lists statuses excluded from the per-operation check
@@ -203,34 +215,264 @@ var crossCuttingStatus = map[int]bool{
 	http.StatusSeeOther:            true,
 }
 
-func collectReachableStatuses(decl *ast.FuncDecl, funcs map[string][]*ast.FuncDecl, statusByIdentifier map[string]int, out map[int]bool, visited map[*ast.FuncDecl]bool, depth int) {
-	if decl == nil || decl.Body == nil || visited[decl] || depth > maxReachDepth {
+// guardSet is one case clause's sentinel errors, read as a disjunction: the arm
+// runs if the mapped error matches ANY of them. A status carries a conjunction
+// of those sets — one per clause it sits inside.
+type guardSet []string
+
+// statusReach walks one route's handler chain and answers which fiber.Status*
+// values that chain can emit.
+//
+// Two narrowings keep it from claiming statuses the JSON contract can never
+// show. Both drop statuses rather than add them, so they can only make the
+// check quieter, never falsely red:
+//
+//   - Content negotiation. A status emitted only inside an isHTMX(c) or
+//     !acceptsJSON(c) arm belongs to the HTML surface, which the spec's own
+//     preamble puts outside this contract — the same argument crossCuttingStatus
+//     makes for 303, applied where it lives instead of per status code. The
+//     shared error responder answers HTMX with 200 and error markup, and four
+//     handlers answer it with 204; neither is a JSON outcome.
+//   - Shared error mappers. A status inside `case errors.Is(err, ErrX):` is
+//     credited only when ErrX is producible somewhere in the same chain. Two
+//     handlers share mapDayUpsertError but only the cycle-start one can raise
+//     the conflict its 409 arm maps, and PrepareLocalPasswordHash cannot raise
+//     the re-auth rate limit its mapper's 429 arm maps — call-graph reachability
+//     of the MAPPER is not reachability of the ARM. Deciding that needs the
+//     sentinel's producer, which is why the walk reads internal/services too.
+//
+// An `if errors.Is(...)` guard is deliberately NOT read as a narrowing, only a
+// case clause is: the same reasoning would apply, but the one-directional design
+// prefers keeping a status it cannot rule out over dropping one it can.
+type statusReach struct {
+	funcs              map[string][]*ast.FuncDecl
+	transport          map[*ast.FuncDecl]bool
+	statusByIdentifier map[string]int
+	// visited is keyed by declaration pointer AND the guards in force, not by
+	// name: two distinct declarations can share a bare name (parseReachableFuncs'
+	// own doc comment has the confirmed collisions), and a name-keyed set would
+	// mark the whole name walked after the first same-named decl. The guards
+	// belong in the key because the same helper is reached both inside a
+	// sentinel-guarded arm and outside one, and the unguarded sighting must not
+	// be lost to a guarded visit that happened to come first.
+	visited   map[string]bool
+	sightings map[int]map[string][]guardSet
+	sentinels map[string]bool
+}
+
+func newStatusReach(funcs map[string][]*ast.FuncDecl, transport map[*ast.FuncDecl]bool, statusByIdentifier map[string]int) *statusReach {
+	return &statusReach{
+		funcs:              funcs,
+		transport:          transport,
+		statusByIdentifier: statusByIdentifier,
+		visited:            make(map[string]bool),
+		sightings:          make(map[int]map[string][]guardSet),
+		sentinels:          make(map[string]bool),
+	}
+}
+
+func (reach *statusReach) walkFunc(decl *ast.FuncDecl, depth int, guards []guardSet) {
+	if decl == nil || decl.Body == nil || depth > maxReachDepth {
 		return
 	}
-	visited[decl] = true
+	key := fmt.Sprintf("%p|%s", decl, guardKey(guards))
+	if reach.visited[key] {
+		return
+	}
+	reach.visited[key] = true
+	reach.walk(decl.Body, reach.transport[decl], depth, guards)
+}
 
-	ast.Inspect(decl.Body, func(n ast.Node) bool {
-		switch node := n.(type) {
+func (reach *statusReach) walk(node ast.Node, emitsStatuses bool, depth int, guards []guardSet) {
+	ast.Inspect(node, func(n ast.Node) bool {
+		switch typed := n.(type) {
+		case *ast.IfStmt:
+			if !nonJSONSurfaceGuard(typed.Cond) {
+				return true
+			}
+			if typed.Else != nil {
+				reach.walk(typed.Else, emitsStatuses, depth, guards)
+			}
+			return false
+		case *ast.CaseClause:
+			sentinels := caseGuardSentinels(typed.List)
+			if len(sentinels) == 0 {
+				return true
+			}
+			inner := append(append([]guardSet{}, guards...), sentinels)
+			for _, stmt := range typed.Body {
+				reach.walk(stmt, emitsStatuses, depth, inner)
+			}
+			return false
 		case *ast.SelectorExpr:
-			if pkg, ok := node.X.(*ast.Ident); ok && pkg.Name == "fiber" {
-				if status, ok := statusByIdentifier["fiber."+node.Sel.Name]; ok {
-					out[status] = true
+			if pkg, ok := typed.X.(*ast.Ident); ok && pkg.Name == "fiber" && emitsStatuses {
+				if status, ok := reach.statusByIdentifier["fiber."+typed.Sel.Name]; ok {
+					reach.record(status, guards)
 				}
 			}
+			return true
+		case *ast.Ident:
+			if name := sentinelName(typed); name != "" {
+				reach.sentinels[name] = true
+			}
+			return true
 		case *ast.CallExpr:
-			var calleeName string
-			switch fn := node.Fun.(type) {
-			case *ast.Ident:
-				calleeName = fn.Name
-			case *ast.SelectorExpr:
-				calleeName = fn.Sel.Name
+			// The sentinel named in a guard is being TESTED, not produced;
+			// harvesting it here would make every mapper arm self-satisfying.
+			if isSentinelComparison(typed) {
+				return false
 			}
-			for _, callee := range funcs[calleeName] {
-				collectReachableStatuses(callee, funcs, statusByIdentifier, out, visited, depth+1)
+			for _, callee := range reach.funcs[calleeName(typed)] {
+				reach.walkFunc(callee, depth+1, guards)
 			}
+			return true
 		}
 		return true
 	})
+}
+
+func (reach *statusReach) record(status int, guards []guardSet) {
+	if reach.sightings[status] == nil {
+		reach.sightings[status] = make(map[string][]guardSet)
+	}
+	reach.sightings[status][guardKey(guards)] = guards
+}
+
+// emittable keeps a status when at least one of its sightings sits under guards
+// the chain can satisfy. An unguarded sighting always counts.
+func (reach *statusReach) emittable() map[int]bool {
+	out := make(map[int]bool)
+	for status, byGuard := range reach.sightings {
+		for _, guards := range byGuard {
+			if reach.satisfiable(guards) {
+				out[status] = true
+				break
+			}
+		}
+	}
+	return out
+}
+
+func (reach *statusReach) satisfiable(guards []guardSet) bool {
+	for _, set := range guards {
+		matched := false
+		for _, name := range set {
+			if reach.sentinels[name] {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+	return true
+}
+
+func guardKey(guards []guardSet) string {
+	if len(guards) == 0 {
+		return ""
+	}
+	parts := make([]string, len(guards))
+	for i, set := range guards {
+		parts[i] = strings.Join(set, "|")
+	}
+	return strings.Join(parts, "&")
+}
+
+// nonJSONSurfaceGuard reports whether an if-condition selects the HTML surface.
+// Only top-level conjuncts are read: `acceptsJSON(c) || isHTMX(c)` names the
+// union of both surfaces and must not be taken for HTML-only.
+func nonJSONSurfaceGuard(cond ast.Expr) bool {
+	for _, term := range conjuncts(cond) {
+		switch typed := term.(type) {
+		case *ast.CallExpr:
+			if calleeName(typed) == "isHTMX" {
+				return true
+			}
+		case *ast.UnaryExpr:
+			if typed.Op != token.NOT {
+				continue
+			}
+			if call, ok := unparen(typed.X).(*ast.CallExpr); ok && calleeName(call) == "acceptsJSON" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// caseGuardSentinels returns the sentinel errors a case clause tests, or nil
+// when the clause is anything other than a list of errors.Is/errors.As calls
+// naming Err* values — a `default:` arm, a tagged switch, or a mixed condition
+// stays unguarded, which is the direction that keeps statuses.
+func caseGuardSentinels(list []ast.Expr) guardSet {
+	if len(list) == 0 {
+		return nil
+	}
+	var names guardSet
+	for _, expr := range list {
+		call, ok := unparen(expr).(*ast.CallExpr)
+		if !ok || !isSentinelComparison(call) {
+			return nil
+		}
+		for _, arg := range call.Args {
+			if name := sentinelName(arg); name != "" {
+				names = append(names, name)
+			}
+		}
+	}
+	return names
+}
+
+func isSentinelComparison(call *ast.CallExpr) bool {
+	selector, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	pkg, ok := selector.X.(*ast.Ident)
+	return ok && pkg.Name == "errors" && (selector.Sel.Name == "Is" || selector.Sel.Name == "As")
+}
+
+func sentinelName(expr ast.Expr) string {
+	switch typed := unparen(expr).(type) {
+	case *ast.Ident:
+		if strings.HasPrefix(typed.Name, "Err") {
+			return typed.Name
+		}
+	case *ast.SelectorExpr:
+		if strings.HasPrefix(typed.Sel.Name, "Err") {
+			return typed.Sel.Name
+		}
+	}
+	return ""
+}
+
+func calleeName(call *ast.CallExpr) string {
+	switch fn := unparen(call.Fun).(type) {
+	case *ast.Ident:
+		return fn.Name
+	case *ast.SelectorExpr:
+		return fn.Sel.Name
+	}
+	return ""
+}
+
+func conjuncts(expr ast.Expr) []ast.Expr {
+	if binary, ok := unparen(expr).(*ast.BinaryExpr); ok && binary.Op == token.LAND {
+		return append(conjuncts(binary.X), conjuncts(binary.Y)...)
+	}
+	return []ast.Expr{unparen(expr)}
+}
+
+func unparen(expr ast.Expr) ast.Expr {
+	for {
+		paren, ok := expr.(*ast.ParenExpr)
+		if !ok {
+			return expr
+		}
+		expr = paren.X
+	}
 }
 
 // knownFiberStatusIdentifiers inverts fiberStatusIdentifier over every


### PR DESCRIPTION
## What

`docs/openapi.yaml` declares 32 statuses it was missing across 28 `/api/v1` operations, and a new
test keeps the class from reopening. No server code changed.

## Why

`TestOpenAPIDeclaresOnlyStatusesTheServerCanEmit` proves `declared ⊆ emittable` over the whole
server at once, so a status emittable *anywhere* satisfies it even on an operation that never
declared it. The new test walks each route's registered `Route.Handlers` chain as Go AST and asks
the per-operation question instead. It found 41 gaps; 32 were real.

The nine that were not exposed two holes in the walk, both now fixed rather than papered over in
the spec:

- Statuses emitted only under `isHTMX(c)` / `!acceptsJSON(c)` belong to the HTML surface the
  spec's preamble excludes — the shared error responder answers HTMX with `200` and error markup,
  four handlers answer it with `204`.
- A status inside `case errors.Is(err, ErrX):` of a *shared* error mapper is not reachable just
  because the mapper is. `PUT /api/v1/days/{date}` cannot raise the conflict `mapDayUpsertError`'s
  `409` arm maps (only `MarkCycleStartManually` calls the validator that returns it), and
  `PrepareLocalPasswordHash` cannot raise the re-auth rate limit its mapper's `429` arm maps.
  Deciding this reads `internal/services`, which is transport-free and so contributes no statuses.

## Risk

Medium — a published contract changes, without a code change. Every addition documents a status
the server already answers, so no client that handled the previous set breaks. `POST
/api/v1/users` gains `201` and the two password-reset endpoints gain `200`: those are the JSON
success answers, which the spec did not document at all.

One gap this approach cannot see, left as-is: `c.JSON(...)` with no explicit status is an
undetectable `200`. `POST /api/v1/password-resets` is the only operation it hid, found by reading
the handler, and it is fixed here.

## How verified

- `go test ./internal/api/ -run TestOpenAPI` green (the new test and its three siblings).
- `npx @redocly/cli lint docs/openapi.yaml` valid; warnings 56 -> 53.
- All 49 `$ref`s resolve.
