### PR TITLE
The schema can say when a webhook delivery was accepted

### DIFF
--- a/changelog.d/webhook-delivery-timestamp-and-feed-key-epoch.md
+++ b/changelog.d/webhook-delivery-timestamp-and-feed-key-epoch.md
@@ -1,0 +1,7 @@
+### Added
+
+- The database now records when a webhook delivery was actually accepted, and which key
+  regime a calendar-feed link was issued under. Both are written only when the event
+  happens — a delivery mark appears after the endpoint answers, never when the send is
+  attempted — and both start empty on upgrade rather than being guessed from existing
+  data. Nothing displays them yet.

--- a/internal/db/migration_039_column_shape_test.go
+++ b/internal/db/migration_039_column_shape_test.go
@@ -1,0 +1,141 @@
+package db
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// migration039Columns are the two marks migration 039 adds, and the shape all
+// three assertions below are about: nullable, no default, no index.
+//
+// Each property is load-bearing rather than stylistic. NULLABLE and NO DEFAULT
+// are how "nothing is recorded" stays distinguishable from a recorded value on
+// every row that existed before the upgrade — a default would backfill by the
+// back door, which is precisely what the migration's prose forbids. NO INDEX
+// because both are read one row at a time by owner id, and an index on a column
+// that says when an owner's data last left the instance is a structure worth
+// nothing to this workload.
+var migration039Columns = []string{"webhook_last_delivered_at", "calendar_feed_key_epoch"}
+
+// TestMigration039AddsTwoUnbackfilledNullableColumns applies migration 039 to a
+// POPULATED users table — the state every upgrading instance is in — and pins
+// what the existing row gets: NULL, in both columns, with the rest of the row
+// untouched.
+func TestMigration039AddsTwoUnbackfilledNullableColumns(t *testing.T) {
+	databasePath := filepath.Join(t.TempDir(), "ovumcy-migration-039.db")
+	database := openSQLiteForMigrationBootstrapTest(t, databasePath)
+	repo := NewUserRepository(database)
+
+	user := createUserForTimezoneTest(t, repo, "migration-039@example.com")
+	// A populated row that also carries the watermarks, so a backfill from them —
+	// the one temptation the migration's prose is written against — would have
+	// something to draw on and would show up here as a non-NULL mark.
+	if err := database.Exec(
+		`UPDATE users SET webhook_period_last_sent_cycle_start = ?, webhook_ovulation_last_sent_cycle_start = ?, calendar_feed_selector = ? WHERE id = ?`,
+		"2026-03-01", "2026-03-15", "SELECTOR16CHARSXX", user.ID,
+	).Error; err != nil {
+		t.Fatalf("seed the pre-upgrade row: %v", err)
+	}
+
+	// Rewind to the pre-039 schema and re-boot, so the migration runs against a
+	// table that already holds data rather than against a fresh install.
+	for _, column := range migration039Columns {
+		if err := database.Exec(`ALTER TABLE users DROP COLUMN ` + column).Error; err != nil {
+			t.Fatalf("drop %s to rewind the schema: %v", column, err)
+		}
+	}
+	if err := database.Exec(`DELETE FROM schema_migrations WHERE version = ?`, "039").Error; err != nil {
+		t.Fatalf("delete the migration 039 record: %v", err)
+	}
+	sqlDB, err := database.DB()
+	if err != nil {
+		t.Fatalf("get sql db handle: %v", err)
+	}
+	if err := sqlDB.Close(); err != nil {
+		t.Fatalf("close sql db: %v", err)
+	}
+
+	reopened, err := OpenDatabase(Config{Driver: DriverSQLite, SQLitePath: databasePath})
+	if err != nil {
+		t.Fatalf("expected migration 039 to apply to a populated users table: %v", err)
+	}
+	reopenedSQLDB, err := reopened.DB()
+	if err != nil {
+		t.Fatalf("get reopened sql db handle: %v", err)
+	}
+	t.Cleanup(func() { _ = reopenedSQLDB.Close() })
+	assertAllEmbeddedMigrationsApplied(t, reopened)
+
+	upgraded, err := NewUserRepository(reopened).FindByID(context.Background(), user.ID)
+	if err != nil {
+		t.Fatalf("reload the upgraded row: %v", err)
+	}
+	if upgraded.WebhookLastDeliveredAt != nil {
+		t.Fatalf("the upgrade wrote a delivery time (%s) onto a row that never recorded one: the watermarks are claim anchors and backfilling from them makes that lie permanent", upgraded.WebhookLastDeliveredAt)
+	}
+	if upgraded.CalendarFeedKeyEpoch != "" {
+		t.Fatalf("the upgrade stamped a key epoch (%q) onto a token minted before it was recorded, asserting the one thing the column exists to deny", upgraded.CalendarFeedKeyEpoch)
+	}
+	if upgraded.WebhookPeriodLastSentCycleStart == nil || upgraded.CalendarFeedSelector == "" {
+		t.Fatal("the seeded row lost data across the upgrade, so the NULL assertions above could be reporting an empty row")
+	}
+}
+
+// TestMigration039ColumnsAreNullableUndefaultedAndUnindexed reads the migrated
+// schema back through the driver rather than trusting the DDL text, so a value
+// arriving from a rebuild or a later migration would still be caught.
+func TestMigration039ColumnsAreNullableUndefaultedAndUnindexed(t *testing.T) {
+	database := openSQLiteForMigrationBootstrapTest(t, filepath.Join(t.TempDir(), "ovumcy-039-shape.db"))
+
+	columnTypes, err := database.Migrator().ColumnTypes("users")
+	if err != nil {
+		t.Fatalf("read users column types: %v", err)
+	}
+	seen := map[string]bool{}
+	for _, columnType := range columnTypes {
+		name := strings.ToLower(strings.TrimSpace(columnType.Name()))
+		for _, wanted := range migration039Columns {
+			if name != wanted {
+				continue
+			}
+			seen[wanted] = true
+
+			nullable, reported := columnType.Nullable()
+			if !reported {
+				t.Errorf("the driver reported no nullability for users.%s, so that half of the contract went unmeasured", wanted)
+			} else if !nullable {
+				t.Errorf("users.%s is NOT NULL: an upgraded row could then never say that nothing is recorded", wanted)
+			}
+			if value, hasDefault := columnType.DefaultValue(); hasDefault && strings.TrimSpace(value) != "" {
+				t.Errorf("users.%s carries the default %q: a default is a backfill by the back door, which migration 039 exists to refuse", wanted, value)
+			}
+		}
+	}
+	for _, wanted := range migration039Columns {
+		if !seen[wanted] {
+			t.Fatalf("users.%s does not exist after migrations: this guard would otherwise pass over an absent column", wanted)
+		}
+	}
+
+	// Read the index definitions straight out of the catalogue: the driver's own
+	// GetIndexes cannot scan this schema's expression index (it returns a NULL
+	// column name), and the DDL text answers the question directly anyway.
+	var definitions []string
+	if err := database.Raw(
+		`SELECT COALESCE(sql, '') FROM sqlite_master WHERE type = 'index' AND tbl_name = 'users'`,
+	).Scan(&definitions).Error; err != nil {
+		t.Fatalf("read users index definitions: %v", err)
+	}
+	if len(definitions) == 0 {
+		t.Fatal("the users table reported no indexes at all, so this guard would pass over any index the migration might add")
+	}
+	for _, definition := range definitions {
+		for _, wanted := range migration039Columns {
+			if strings.Contains(strings.ToLower(definition), wanted) {
+				t.Errorf("users.%s is indexed by %q: neither mark is queried across owners, and an index on when an owner's data last left is a structure this workload never asked for", wanted, definition)
+			}
+		}
+	}
+}

--- a/internal/db/user_repository.go
+++ b/internal/db/user_repository.go
@@ -338,15 +338,68 @@ func (repo *UserRepository) UpdateReminderLeadDays(ctx context.Context, userID u
 // retry it: a save landing inside that one pass drops that cycle's reminder.
 // Losing a reminder the owner was mid-way through reconfiguring is the
 // fail-closed direction, but it is a dropped reminder and not a delay.
+//
+// It also decides the fate of webhook_last_delivered_at, in this same statement
+// and never in a follow-up: a mark saying "a delivery to your endpoint was
+// accepted" must not survive the endpoint it was about by even one read. The
+// judgement is the caller's (settings.ClearLastDeliveredAt) because it needs the
+// plaintext — persistence sees ciphertext, and a re-encryption of the same URL
+// differs from it byte for byte. A save that leaves the destination alone leaves
+// the mark alone, which is what a toggle-only save is. Regression:
+// TestEveryWebhookURLWriterDecidesTheDeliveryMark.
 func (repo *UserRepository) SaveWebhookSettings(ctx context.Context, userID uint, settings models.WebhookSettingsColumns) error {
-	return repo.database.WithContext(ctx).Model(&models.User{}).Where("id = ?", userID).Updates(map[string]any{
+	updates := map[string]any{
 		"webhook_enabled":          settings.Enabled,
 		"webhook_url":              settings.EncryptedURL,
 		"webhook_notify_period":    settings.NotifyPeriod,
 		"webhook_notify_ovulation": settings.NotifyOvulation,
 		"reminder_lead_days":       settings.ReminderLeadDays,
 		"webhook_config_version":   gorm.Expr("webhook_config_version + 1"),
-	}).Error
+	}
+	if settings.ClearLastDeliveredAt {
+		updates["webhook_last_delivered_at"] = nil
+	}
+	return repo.database.WithContext(ctx).Model(&models.User{}).Where("id = ?", userID).Updates(updates).Error
+}
+
+// MarkWebhookDelivered records that a delivery to this owner's endpoint was
+// ACCEPTED — a 2xx already returned — scoped strictly to userID. It is the only
+// writer of webhook_last_delivered_at that sets a value, and the notify pass
+// calls it in exactly one place: after Deliver returns nil, never at the claim.
+//
+// It is a second write, and the claim is emphatically not a substitute for it.
+// The claim happens BEFORE the POST, stores a cycle anchor rather than a clock
+// reading, and stands for a send that was never accepted until the failure path
+// releases it. Reading a watermark as a delivery time is the exact misreading
+// this column was added to make impossible.
+//
+// configVersion is the revocation epoch the delivering pass's snapshot carried —
+// the same value it handed ClaimWebhookWatermark — and pinning it here means a
+// configuration revoked while the request was on the wire is not credited with a
+// delivery. The pass cannot recall that request, but it can decline to record it
+// against a configuration the owner has withdrawn.
+//
+// It does NOT advance that epoch, and that is deliberate rather than an
+// oversight of migration 038's "a later writer owes the same advance": the
+// obligation is on writers of the DELIVERY CONFIGURATION — whether, where and
+// how early delivery happens — and this write changes none of those. Advancing
+// here would also break the pass making the call, because the epoch is pinned
+// once per owner outside the reminder loop: a bump after a period delivery would
+// lose the ovulation claim of that same pass. Regression:
+// TestMarkWebhookDeliveredLeavesTheRevocationEpochAlone.
+//
+// The stamp is monotonic — the predicate refuses a value not later than the one
+// stored — so a late-returning delivery cannot walk the mark backwards over a
+// newer one. A refused write affects zero rows and is not an error: the mark is
+// already at least as current as this call would make it, or the configuration
+// moved on. It writes ONE column: not the epoch it pins, not a watermark, not
+// auth_session_version.
+func (repo *UserRepository) MarkWebhookDelivered(ctx context.Context, userID uint, deliveredAt time.Time, configVersion int) error {
+	stamp := deliveredAt.UTC()
+	return repo.database.WithContext(ctx).Model(&models.User{}).
+		Where("id = ? AND webhook_config_version = ?", userID, configVersion).
+		Where("webhook_last_delivered_at IS NULL OR webhook_last_delivered_at < ?", stamp).
+		Update("webhook_last_delivered_at", stamp).Error
 }
 
 // ListAllForNotify returns the per-owner projection a future request-free batch
@@ -519,11 +572,14 @@ func canonicalWatermarkAnchor(cycleAnchor time.Time) time.Time {
 // the statement that performs it, so a claim presenting the previous epoch
 // matches no row. That list is the complete set of writers, not an
 // illustration: SaveWebhookSettings, UpdateReminderLeadDays and
-// ClearAllDataAndResetSettings are the three, and a fourth added later owes the
-// same advance. It covers WHETHER, WHERE and HOW EARLY delivery happens and
-// deliberately not what the reminder would say — a cycle-data edit or a
-// timezone capture moves the prediction, which is the watermark
-// compare-and-set's own subject, not this column's.
+// ClearAllDataAndResetSettings are the three, and a later writer owes the same
+// advance whenever it CHANGES that configuration — never merely because it
+// touched the users row. MarkWebhookDelivered is the counter-example and must
+// stay one: it records a delivery that already happened, and advancing there
+// would lose this same pass's next claim. It covers WHETHER, WHERE and HOW
+// EARLY delivery happens and deliberately not what the reminder would say — a
+// cycle-data edit or a timezone capture moves the prediction, which is the
+// watermark compare-and-set's own subject, not this column's.
 //
 // Without the epoch the two revocation
 // shapes both survive the watermark check: a settings save deliberately leaves
@@ -651,6 +707,14 @@ func (repo *UserRepository) ReleaseWebhookWatermark(ctx context.Context, userID 
 // previous one must not outlive the token it was about. Riding the same write
 // means a mint can never leave a token armed with a stale mark that would refuse
 // its own reveal.
+//
+// calendar_feed_key_epoch (migration 039) rides it for the same reason and is
+// the only place that value is ever stamped: it names the verification regime
+// this token was minted under, so arming a token and recording what armed it are
+// one event. Revoke and both bulk disarms deliberately leave it standing — they
+// clear the token, and a stamp without a token asserts nothing. That keeps this
+// the sole writer, so the restore-fence completeness guard needs no exemption
+// for it.
 func (repo *UserRepository) SaveCalendarFeedToken(ctx context.Context, userID uint, columns models.CalendarFeedTokenColumns) error {
 	// Fence first: see advanceCalendarFeedFence. A rotation retires the previous
 	// token, so this write is a revocation as much as ClearCalendarFeedToken is.
@@ -662,6 +726,7 @@ func (repo *UserRepository) SaveCalendarFeedToken(ctx context.Context, userID ui
 		"calendar_feed_verifier_hash": columns.VerifierHash,
 		"calendar_feed_verifier_mac":  columns.VerifierMAC,
 		"calendar_feed_revealed_at":   nil,
+		"calendar_feed_key_epoch":     columns.KeyEpoch,
 	}).Error
 }
 
@@ -1063,6 +1128,13 @@ func (repo *UserRepository) LoadSettingsByID(ctx context.Context, userID uint) (
 			"webhook_url",
 			"webhook_notify_period",
 			"webhook_notify_ovulation",
+			// The two marks migration 039 added. They are here and the two
+			// *_last_sent_cycle_start watermarks are deliberately NOT: a watermark
+			// is a claim taken before a POST and would be read as a delivery time
+			// by anything that rendered it, which is the misreading these two
+			// columns exist to replace.
+			"webhook_last_delivered_at",
+			"calendar_feed_key_epoch",
 		).
 		First(&user, userID).Error; err != nil {
 		return models.User{}, err
@@ -1167,8 +1239,15 @@ func (repo *UserRepository) ClearAllDataAndResetSettings(ctx context.Context, us
 			"webhook_notify_ovulation":                true,
 			"webhook_period_last_sent_cycle_start":    nil,
 			"webhook_ovulation_last_sent_cycle_start": nil,
-			"reminder_lead_days":                      models.DefaultReminderLeadDays,
-			"webhook_config_version":                  gorm.Expr("webhook_config_version + 1"),
+			// The delivery mark (migration 039) goes with them, and
+			// unconditionally: this statement erases the endpoint, so a mark
+			// saying a delivery there was accepted would outlive the only thing
+			// that gave it meaning. Unlike the reveal marks below, NULL here is
+			// not an armed state — it is "no delivery recorded", which is exactly
+			// true of an account whose endpoint this write just cleared.
+			"webhook_last_delivered_at": nil,
+			"reminder_lead_days":        models.DefaultReminderLeadDays,
+			"webhook_config_version":    gorm.Expr("webhook_config_version + 1"),
 			// Calendar (.ics) feed token: a clear-data wipe revokes the feed by
 			// NULLing all three columns (selector plus both verifier columns —
 			// the MAC arrived with migration 032, after this comment was

--- a/internal/db/user_repository_calendar_feed_key_epoch_test.go
+++ b/internal/db/user_repository_calendar_feed_key_epoch_test.go
@@ -129,13 +129,24 @@ func TestRevokeAndDisarmLeaveTheCalendarFeedKeyEpochAlone(t *testing.T) {
 	}
 }
 
-// TestGenerateCalendarFeedTokenRefusesToMintWithoutAKeyEpoch guards the mint's
-// fail-closed direction. An empty stamp is not a neutral value: the row reads it
+// TestEveryMintedCalendarFeedTokenCarriesAKeyEpoch guards the mint's fail-closed
+// direction as an invariant over what it RETURNS, which is the form that can
+// actually be violated. An empty stamp is not a neutral value: the row reads it
 // as "issued before this was recorded", so a token minted with one would be
 // permanently unable to say it can be retired.
-func TestGenerateCalendarFeedTokenRefusesToMintWithoutAKeyEpoch(t *testing.T) {
-	if _, columns, err := services.GenerateCalendarFeedToken(nil); err == nil {
-		t.Fatalf("expected a keyless mint to fail, got columns %+v", columns)
+//
+// The keyless case is not the test: a nil key is refused a step earlier, by the
+// verifier MAC, so a mint that dropped the epoch derivation entirely would still
+// fail it. This asserts the successful path instead.
+func TestEveryMintedCalendarFeedTokenCarriesAKeyEpoch(t *testing.T) {
+	for _, key := range []string{calendarFeedRepoTestSecretKey, "another-calendar-feed-db-test-key"} {
+		_, columns, err := services.GenerateCalendarFeedToken([]byte(key))
+		if err != nil {
+			t.Fatalf("GenerateCalendarFeedToken: %v", err)
+		}
+		if columns.KeyEpoch == "" {
+			t.Fatal("a mint returned an empty key epoch, which the row reads as \"issued before this was recorded\"")
+		}
 	}
 }
 

--- a/internal/db/user_repository_calendar_feed_key_epoch_test.go
+++ b/internal/db/user_repository_calendar_feed_key_epoch_test.go
@@ -1,0 +1,160 @@
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+	"github.com/ovumcy/ovumcy-web/internal/services"
+)
+
+// calendar_feed_key_epoch (migration 039) records WHICH verification regime a
+// feed token was minted under. It is the one health question this row can answer
+// honestly — the verifier is not stored in the clear and its MAC cannot be
+// recomputed — and it is what decides whether an owner can still retire a URL
+// they handed out. Everything here defends its single-writer shape.
+
+// TestSaveCalendarFeedTokenStampsTheKeyEpochWithTheTokenItself proves the stamp
+// rides the mint: it is written in the same statement as the token triple, and
+// a rotation re-stamps it. Arming a token and recording what armed it are one
+// event or the row can disagree with itself.
+func TestSaveCalendarFeedTokenStampsTheKeyEpochWithTheTokenItself(t *testing.T) {
+	repo := openCalendarFeedRepoForTest(t)
+	user := createUserForTimezoneTest(t, repo, "feed-epoch-stamp@example.com")
+	ctx := context.Background()
+
+	if before := reloadUserForCalendarFeed(t, repo, user.ID); before.CalendarFeedKeyEpoch != "" {
+		t.Fatalf("expected a fresh row to carry no key epoch, got %q", before.CalendarFeedKeyEpoch)
+	}
+
+	_, columns, err := services.GenerateCalendarFeedToken([]byte(calendarFeedRepoTestSecretKey))
+	if err != nil {
+		t.Fatalf("GenerateCalendarFeedToken: %v", err)
+	}
+	if columns.KeyEpoch == "" {
+		t.Fatal("the generator produced no key epoch: an empty stamp reads as \"issued before this was recorded\", which a fresh mint must never claim")
+	}
+	if err := repo.SaveCalendarFeedToken(ctx, user.ID, columns); err != nil {
+		t.Fatalf("SaveCalendarFeedToken: %v", err)
+	}
+
+	minted := reloadUserForCalendarFeed(t, repo, user.ID)
+	if minted.CalendarFeedKeyEpoch != columns.KeyEpoch {
+		t.Fatalf("expected the stamp %q beside the token, got %q", columns.KeyEpoch, minted.CalendarFeedKeyEpoch)
+	}
+	if minted.CalendarFeedSelector != columns.Selector {
+		t.Fatal("the token and its stamp did not land together")
+	}
+
+	// A rotation is a second mint, and it re-stamps: under a key that has changed
+	// since, the row must stop claiming the previous regime.
+	_, rotated, err := services.GenerateCalendarFeedToken([]byte("a-different-calendar-feed-db-test-key"))
+	if err != nil {
+		t.Fatalf("GenerateCalendarFeedToken (rotation): %v", err)
+	}
+	if rotated.KeyEpoch == columns.KeyEpoch {
+		t.Fatal("the two keys derived the same epoch: this case can no longer show a re-stamp")
+	}
+	if err := repo.SaveCalendarFeedToken(ctx, user.ID, rotated); err != nil {
+		t.Fatalf("SaveCalendarFeedToken (rotation): %v", err)
+	}
+	if after := reloadUserForCalendarFeed(t, repo, user.ID); after.CalendarFeedKeyEpoch != rotated.KeyEpoch {
+		t.Fatalf("expected the rotation to re-stamp the epoch to %q, got %q", rotated.KeyEpoch, after.CalendarFeedKeyEpoch)
+	}
+}
+
+// TestRevokeAndDisarmLeaveTheCalendarFeedKeyEpochAlone pins the other half of
+// the single-writer shape. Revoke and both bulk disarms clear the token, and a
+// stamp without a token asserts nothing — so none of them may write this column.
+// Leaving it to the mint is what keeps SaveCalendarFeedToken the sole writer and
+// the restore-fence completeness guard free of a new exemption.
+func TestRevokeAndDisarmLeaveTheCalendarFeedKeyEpochAlone(t *testing.T) {
+	ctx := context.Background()
+
+	for _, testCase := range []struct {
+		name  string
+		clear func(t *testing.T, repo *UserRepository, userID uint)
+	}{
+		{
+			name: "revoke",
+			clear: func(t *testing.T, repo *UserRepository, userID uint) {
+				if err := repo.ClearCalendarFeedToken(ctx, userID); err != nil {
+					t.Fatalf("ClearCalendarFeedToken: %v", err)
+				}
+			},
+		},
+		{
+			name: "the restore fence's bulk disarm",
+			clear: func(t *testing.T, repo *UserRepository, _ uint) {
+				if _, err := repo.DisarmAllCalendarFeedTokens(ctx); err != nil {
+					t.Fatalf("DisarmAllCalendarFeedTokens: %v", err)
+				}
+			},
+		},
+		{
+			name: "the key-rotation sentinel's bulk disarm",
+			clear: func(t *testing.T, repo *UserRepository, _ uint) {
+				if _, err := repo.DisarmCalendarFeedTokensWithoutMAC(ctx); err != nil {
+					t.Fatalf("DisarmCalendarFeedTokensWithoutMAC: %v", err)
+				}
+			},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			repo := openCalendarFeedRepoForTest(t)
+			user := createUserForTimezoneTest(t, repo, "feed-epoch-revoke@example.com")
+
+			_, columns, err := services.GenerateCalendarFeedToken([]byte(calendarFeedRepoTestSecretKey))
+			if err != nil {
+				t.Fatalf("GenerateCalendarFeedToken: %v", err)
+			}
+			// The sentinel's disarm only reaches MAC-less rows, so its case seeds one.
+			if testCase.name == "the key-rotation sentinel's bulk disarm" {
+				columns.VerifierMAC = ""
+			}
+			if err := repo.SaveCalendarFeedToken(ctx, user.ID, columns); err != nil {
+				t.Fatalf("SaveCalendarFeedToken: %v", err)
+			}
+
+			testCase.clear(t, repo, user.ID)
+
+			after := reloadUserForCalendarFeed(t, repo, user.ID)
+			if after.CalendarFeedSelector != "" {
+				t.Fatalf("the fixture did not actually clear the token (selector %q), so the assertion below would be vacuous", after.CalendarFeedSelector)
+			}
+			if after.CalendarFeedKeyEpoch != columns.KeyEpoch {
+				t.Fatalf("clearing the token also wrote calendar_feed_key_epoch (%q -> %q): only a mint may stamp it", columns.KeyEpoch, after.CalendarFeedKeyEpoch)
+			}
+		})
+	}
+}
+
+// TestGenerateCalendarFeedTokenRefusesToMintWithoutAKeyEpoch guards the mint's
+// fail-closed direction. An empty stamp is not a neutral value: the row reads it
+// as "issued before this was recorded", so a token minted with one would be
+// permanently unable to say it can be retired.
+func TestGenerateCalendarFeedTokenRefusesToMintWithoutAKeyEpoch(t *testing.T) {
+	if _, columns, err := services.GenerateCalendarFeedToken(nil); err == nil {
+		t.Fatalf("expected a keyless mint to fail, got columns %+v", columns)
+	}
+}
+
+// TestSaveCalendarFeedTokenAddsNoFeedAccessWriter states in one place what the
+// restore-fence completeness guard would otherwise only imply: the epoch stamp
+// added no writer of a feed access column, so exemptCalendarFeedWriters needs no
+// new entry. An exemption added "because the guard complained" is how that guard
+// turns into an allowlist.
+func TestSaveCalendarFeedTokenAddsNoFeedAccessWriter(t *testing.T) {
+	if _, exempt := exemptCalendarFeedWriters["SaveCalendarFeedToken"]; exempt {
+		t.Fatal("SaveCalendarFeedToken is exempt from the restore fence: the epoch stamp rides an existing revocation write and must not have bought an exemption")
+	}
+	for _, column := range calendarFeedAccessColumns {
+		if column == `"calendar_feed_key_epoch"` {
+			t.Fatal("calendar_feed_key_epoch was added to the feed ACCESS columns: it records what minted a token and grants no access on its own")
+		}
+	}
+	// Anti-vacuity: the model must still carry the field this test is about.
+	if (models.CalendarFeedTokenColumns{KeyEpoch: "x"}).KeyEpoch != "x" {
+		t.Fatal("CalendarFeedTokenColumns no longer carries KeyEpoch")
+	}
+}

--- a/internal/db/user_repository_webhook_delivery_mark_test.go
+++ b/internal/db/user_repository_webhook_delivery_mark_test.go
@@ -66,6 +66,42 @@ func TestMarkWebhookDeliveredStampsUnderTheClaimedEpochOnly(t *testing.T) {
 	}
 }
 
+// TestMarkWebhookDeliveredTouchesNoOtherOwnersRow is the isolation assertion the
+// predicate's SHAPE makes necessary. The write carries a disjunction — "NULL or
+// older than this stamp" — and it is scoped to one owner only while that
+// disjunction stays parenthesised against the id and epoch conjuncts. Spelled as
+// one flat condition it would read as "(this owner, this epoch, never delivered)
+// OR (anyone whose mark is older)", and stamping one owner would walk every
+// other owner's mark forward to a delivery they never received. Nothing else in
+// the suite would notice: a single-row fixture satisfies both spellings.
+func TestMarkWebhookDeliveredTouchesNoOtherOwnersRow(t *testing.T) {
+	repo := openWebhookRepoForTest(t)
+	ctx := context.Background()
+	bystander := createUserForTimezoneTest(t, repo, "wh-mark-bystander@example.com")
+	deliveredTo := createUserForTimezoneTest(t, repo, "wh-mark-delivered-to@example.com")
+
+	earlier := time.Date(2026, 4, 1, 9, 0, 0, 0, time.UTC)
+	later := time.Date(2026, 4, 10, 9, 0, 0, 0, time.UTC)
+
+	// The bystander carries an OLDER mark, which is what the second disjunct
+	// would match, and the delivered-to owner carries none, which is what the
+	// first one matches.
+	if err := repo.MarkWebhookDelivered(ctx, bystander.ID, earlier, reloadUserForWebhook(t, repo, bystander.ID).WebhookConfigVersion); err != nil {
+		t.Fatalf("MarkWebhookDelivered (bystander): %v", err)
+	}
+	if err := repo.MarkWebhookDelivered(ctx, deliveredTo.ID, later, reloadUserForWebhook(t, repo, deliveredTo.ID).WebhookConfigVersion); err != nil {
+		t.Fatalf("MarkWebhookDelivered (delivered-to): %v", err)
+	}
+
+	untouched := markedDeliveryOf(t, repo, bystander.ID)
+	if untouched == nil || !untouched.Equal(earlier) {
+		t.Fatalf("recording a delivery for owner %d moved owner %d's mark from %s to %v", deliveredTo.ID, bystander.ID, earlier, untouched)
+	}
+	if got := markedDeliveryOf(t, repo, deliveredTo.ID); got == nil || !got.Equal(later) {
+		t.Fatalf("expected owner %d's own mark at %s, got %v", deliveredTo.ID, later, got)
+	}
+}
+
 // TestMarkWebhookDeliveredNeverMovesTheStampBackwards pins monotonicity. A
 // delivery that took longer than the next one must not walk the mark back to
 // its own start, or the ledger would report an older delivery as the latest.
@@ -201,7 +237,6 @@ func TestClearAllDataClearsTheDeliveryMarkWithBothWatermarks(t *testing.T) {
 	user := createUserForTimezoneTest(t, repo, "wh-mark-clear-data@example.com")
 	ctx := context.Background()
 
-	epoch := reloadUserForWebhook(t, repo, user.ID).WebhookConfigVersion
 	anchor := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
 	if err := repo.SaveWebhookSettings(ctx, user.ID, models.WebhookSettingsColumns{
 		Enabled:          true,
@@ -212,7 +247,8 @@ func TestClearAllDataClearsTheDeliveryMarkWithBothWatermarks(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("SaveWebhookSettings: %v", err)
 	}
-	epoch = reloadUserForWebhook(t, repo, user.ID).WebhookConfigVersion
+	// The save advanced the epoch, so the claims below must present the new one.
+	epoch := reloadUserForWebhook(t, repo, user.ID).WebhookConfigVersion
 	for _, reminderType := range []string{models.WebhookReminderTypePeriod, models.WebhookReminderTypeOvulation} {
 		claimed, err := repo.ClaimWebhookWatermark(ctx, user.ID, reminderType, anchor, nil, epoch)
 		if err != nil {

--- a/internal/db/user_repository_webhook_delivery_mark_test.go
+++ b/internal/db/user_repository_webhook_delivery_mark_test.go
@@ -1,0 +1,338 @@
+package db
+
+import (
+	"context"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+)
+
+// webhook_last_delivered_at (migration 039) is the only column in this schema
+// that records that a delivery was ACCEPTED. Everything here defends the two
+// properties that make it worth rendering: it moves only forward and only under
+// the configuration that was delivered to, and it never outlives the endpoint it
+// was about.
+
+func markedDeliveryOf(t *testing.T, repo *UserRepository, userID uint) *time.Time {
+	t.Helper()
+	return reloadUserForWebhook(t, repo, userID).WebhookLastDeliveredAt
+}
+
+// TestMarkWebhookDeliveredStampsUnderTheClaimedEpochOnly proves the second write
+// asks the same revocation question the claim did. A stamp accepted under a
+// moved epoch would credit a delivery to a configuration the owner withdrew
+// while the request was on the wire.
+func TestMarkWebhookDeliveredStampsUnderTheClaimedEpochOnly(t *testing.T) {
+	repo := openWebhookRepoForTest(t)
+	user := createUserForTimezoneTest(t, repo, "wh-mark-epoch@example.com")
+	ctx := context.Background()
+
+	claimed := reloadUserForWebhook(t, repo, user.ID).WebhookConfigVersion
+	delivered := time.Date(2026, 4, 10, 9, 30, 0, 0, time.UTC)
+
+	// The owner saves their settings while the request is on the wire, which
+	// advances the epoch the delivering pass pinned.
+	if err := repo.SaveWebhookSettings(ctx, user.ID, models.WebhookSettingsColumns{
+		Enabled:          true,
+		EncryptedURL:     "ciphertext-a",
+		ReminderLeadDays: models.DefaultReminderLeadDays,
+	}); err != nil {
+		t.Fatalf("SaveWebhookSettings: %v", err)
+	}
+
+	if err := repo.MarkWebhookDelivered(ctx, user.ID, delivered, claimed); err != nil {
+		t.Fatalf("MarkWebhookDelivered under a stale epoch: %v", err)
+	}
+	if mark := markedDeliveryOf(t, repo, user.ID); mark != nil {
+		t.Fatalf("expected a stale-epoch stamp to be discarded, got %s", mark)
+	}
+
+	current := reloadUserForWebhook(t, repo, user.ID).WebhookConfigVersion
+	if err := repo.MarkWebhookDelivered(ctx, user.ID, delivered, current); err != nil {
+		t.Fatalf("MarkWebhookDelivered under the current epoch: %v", err)
+	}
+	mark := markedDeliveryOf(t, repo, user.ID)
+	if mark == nil {
+		t.Fatal("expected the stamp to be stored under the current epoch")
+	}
+	if !mark.Equal(delivered) {
+		t.Fatalf("expected the stamp to be %s, got %s", delivered, *mark)
+	}
+}
+
+// TestMarkWebhookDeliveredNeverMovesTheStampBackwards pins monotonicity. A
+// delivery that took longer than the next one must not walk the mark back to
+// its own start, or the ledger would report an older delivery as the latest.
+func TestMarkWebhookDeliveredNeverMovesTheStampBackwards(t *testing.T) {
+	repo := openWebhookRepoForTest(t)
+	user := createUserForTimezoneTest(t, repo, "wh-mark-monotonic@example.com")
+	ctx := context.Background()
+
+	epoch := reloadUserForWebhook(t, repo, user.ID).WebhookConfigVersion
+	later := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+	earlier := later.Add(-2 * time.Hour)
+
+	if err := repo.MarkWebhookDelivered(ctx, user.ID, later, epoch); err != nil {
+		t.Fatalf("MarkWebhookDelivered (later): %v", err)
+	}
+	if err := repo.MarkWebhookDelivered(ctx, user.ID, earlier, epoch); err != nil {
+		t.Fatalf("MarkWebhookDelivered (earlier): %v", err)
+	}
+
+	mark := markedDeliveryOf(t, repo, user.ID)
+	if mark == nil {
+		t.Fatal("expected the stamp to stand")
+	}
+	if !mark.Equal(later) {
+		t.Fatalf("expected the later stamp %s to stand, got %s", later, *mark)
+	}
+}
+
+// TestMarkWebhookDeliveredLeavesTheRevocationEpochAlone is the trap migration
+// 038's own prose would have led a reader into. Its writer list is about the
+// DELIVERY CONFIGURATION, and this write is not one: advancing the epoch here
+// would make the delivering pass lose the claim of its own second reminder, so
+// an owner opted into both kinds would silently receive only the first.
+func TestMarkWebhookDeliveredLeavesTheRevocationEpochAlone(t *testing.T) {
+	repo := openWebhookRepoForTest(t)
+	user := createUserForTimezoneTest(t, repo, "wh-mark-epoch-frozen@example.com")
+	ctx := context.Background()
+
+	before := reloadUserForWebhook(t, repo, user.ID).WebhookConfigVersion
+	if err := repo.MarkWebhookDelivered(ctx, user.ID, time.Date(2026, 4, 10, 9, 0, 0, 0, time.UTC), before); err != nil {
+		t.Fatalf("MarkWebhookDelivered: %v", err)
+	}
+
+	after := reloadUserForWebhook(t, repo, user.ID)
+	if after.WebhookConfigVersion != before {
+		t.Fatalf("recording a delivery moved webhook_config_version from %d to %d: the very next claim of this pass would be lost", before, after.WebhookConfigVersion)
+	}
+	if after.WebhookPeriodLastSentCycleStart != nil || after.WebhookOvulationLastSentCycleStart != nil {
+		t.Fatal("recording a delivery moved a watermark: the mark writes exactly one column")
+	}
+}
+
+// TestSaveWebhookSettingsClearsTheDeliveryMarkOnlyWhenTheDestinationChanges is
+// the cleanup rule at the persistence layer, both directions. A toggle-only save
+// re-encrypts the same endpoint and must keep the mark standing.
+func TestSaveWebhookSettingsClearsTheDeliveryMarkOnlyWhenTheDestinationChanges(t *testing.T) {
+	stamp := time.Date(2026, 4, 10, 9, 0, 0, 0, time.UTC)
+
+	for _, testCase := range []struct {
+		name  string
+		clear bool
+	}{
+		{name: "a save that proved the destination unchanged keeps the mark", clear: false},
+		{name: "a save that could not prove it clears the mark in the same write", clear: true},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			repo := openWebhookRepoForTest(t)
+			user := createUserForTimezoneTest(t, repo, "wh-mark-cleanup@example.com")
+			ctx := context.Background()
+
+			epoch := reloadUserForWebhook(t, repo, user.ID).WebhookConfigVersion
+			if err := repo.MarkWebhookDelivered(ctx, user.ID, stamp, epoch); err != nil {
+				t.Fatalf("MarkWebhookDelivered: %v", err)
+			}
+
+			if err := repo.SaveWebhookSettings(ctx, user.ID, models.WebhookSettingsColumns{
+				Enabled:              true,
+				EncryptedURL:         "ciphertext-b",
+				ReminderLeadDays:     models.DefaultReminderLeadDays,
+				ClearLastDeliveredAt: testCase.clear,
+			}); err != nil {
+				t.Fatalf("SaveWebhookSettings: %v", err)
+			}
+
+			after := reloadUserForWebhook(t, repo, user.ID)
+			if after.WebhookURL != "ciphertext-b" {
+				t.Fatalf("expected the save to write the endpoint, got %q", after.WebhookURL)
+			}
+			switch {
+			case testCase.clear && after.WebhookLastDeliveredAt != nil:
+				t.Fatalf("expected the mark cleared alongside the endpoint, got %s", after.WebhookLastDeliveredAt)
+			case !testCase.clear && after.WebhookLastDeliveredAt == nil:
+				t.Fatal("a save that left the destination alone cleared the delivery mark")
+			}
+		})
+	}
+}
+
+// TestUpdateReminderLeadDaysLeavesTheDeliveryMarkStanding: the lead window says
+// how early a reminder goes out, not where. It moves the revocation epoch — it
+// is a delivery-configuration write — and still says nothing about whether the
+// deliveries already recorded happened.
+func TestUpdateReminderLeadDaysLeavesTheDeliveryMarkStanding(t *testing.T) {
+	repo := openWebhookRepoForTest(t)
+	user := createUserForTimezoneTest(t, repo, "wh-mark-lead-days@example.com")
+	ctx := context.Background()
+
+	epoch := reloadUserForWebhook(t, repo, user.ID).WebhookConfigVersion
+	stamp := time.Date(2026, 4, 10, 9, 0, 0, 0, time.UTC)
+	if err := repo.MarkWebhookDelivered(ctx, user.ID, stamp, epoch); err != nil {
+		t.Fatalf("MarkWebhookDelivered: %v", err)
+	}
+
+	if err := repo.UpdateReminderLeadDays(ctx, user.ID, 5); err != nil {
+		t.Fatalf("UpdateReminderLeadDays: %v", err)
+	}
+
+	after := reloadUserForWebhook(t, repo, user.ID)
+	if after.WebhookLastDeliveredAt == nil || !after.WebhookLastDeliveredAt.Equal(stamp) {
+		t.Fatalf("expected the lead-days write to leave the mark at %s, got %v", stamp, after.WebhookLastDeliveredAt)
+	}
+	if after.WebhookConfigVersion == epoch {
+		t.Fatal("the lead-days write no longer advances the revocation epoch: this test would no longer be about a write that moves the epoch without touching the mark")
+	}
+}
+
+// TestClearAllDataClearsTheDeliveryMarkWithBothWatermarks: the wipe erases the
+// endpoint, so the mark must not survive it. It goes with the watermarks because
+// it is the same fact from the other side — nothing about this account's egress
+// may outlive the account's data.
+func TestClearAllDataClearsTheDeliveryMarkWithBothWatermarks(t *testing.T) {
+	repo := openWebhookRepoForTest(t)
+	user := createUserForTimezoneTest(t, repo, "wh-mark-clear-data@example.com")
+	ctx := context.Background()
+
+	epoch := reloadUserForWebhook(t, repo, user.ID).WebhookConfigVersion
+	anchor := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	if err := repo.SaveWebhookSettings(ctx, user.ID, models.WebhookSettingsColumns{
+		Enabled:          true,
+		EncryptedURL:     "ciphertext-a",
+		NotifyPeriod:     true,
+		NotifyOvulation:  true,
+		ReminderLeadDays: models.DefaultReminderLeadDays,
+	}); err != nil {
+		t.Fatalf("SaveWebhookSettings: %v", err)
+	}
+	epoch = reloadUserForWebhook(t, repo, user.ID).WebhookConfigVersion
+	for _, reminderType := range []string{models.WebhookReminderTypePeriod, models.WebhookReminderTypeOvulation} {
+		claimed, err := repo.ClaimWebhookWatermark(ctx, user.ID, reminderType, anchor, nil, epoch)
+		if err != nil {
+			t.Fatalf("ClaimWebhookWatermark(%s): %v", reminderType, err)
+		}
+		if !claimed {
+			t.Fatalf("expected to win the %s claim", reminderType)
+		}
+	}
+	if err := repo.MarkWebhookDelivered(ctx, user.ID, time.Date(2026, 4, 10, 9, 0, 0, 0, time.UTC), epoch); err != nil {
+		t.Fatalf("MarkWebhookDelivered: %v", err)
+	}
+
+	before := reloadUserForWebhook(t, repo, user.ID)
+	if before.WebhookLastDeliveredAt == nil || before.WebhookPeriodLastSentCycleStart == nil || before.WebhookOvulationLastSentCycleStart == nil {
+		t.Fatal("the fixture did not set all three columns: the wipe assertion below would pass vacuously")
+	}
+
+	if err := repo.ClearAllDataAndResetSettings(ctx, user.ID); err != nil {
+		t.Fatalf("ClearAllDataAndResetSettings: %v", err)
+	}
+
+	after := reloadUserForWebhook(t, repo, user.ID)
+	if after.WebhookLastDeliveredAt != nil {
+		t.Fatalf("the wipe left a delivery mark for an endpoint it erased: %s", after.WebhookLastDeliveredAt)
+	}
+	if after.WebhookPeriodLastSentCycleStart != nil || after.WebhookOvulationLastSentCycleStart != nil {
+		t.Fatal("the wipe left a watermark standing")
+	}
+}
+
+// TestEveryWebhookURLWriterDecidesTheDeliveryMark is the completeness guard the
+// cleanup rule rests on, and it is derived from the file rather than restated:
+// a hand-written list of the writers would agree with itself while a new writer
+// went unguarded.
+//
+// A mark saying "a delivery to your endpoint was accepted" is a claim about ONE
+// destination. Any statement that writes webhook_url may be changing that
+// destination, so each one has to decide the mark's fate in the same statement —
+// keeping it, or clearing it. Silence is the failure mode: the write lands, the
+// mark stays, and the ledger now describes an endpoint that is gone.
+func TestEveryWebhookURLWriterDecidesTheDeliveryMark(t *testing.T) {
+	const path = "user_repository.go"
+	const urlColumn = `"webhook_url"`
+	const markColumn = `"webhook_last_delivered_at"`
+
+	source, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	fileSet := token.NewFileSet()
+	parsed, err := parser.ParseFile(fileSet, path, source, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+
+	// Only map-literal KEYS count as writes. webhook_url also appears as a plain
+	// argument in the read projections (LoadSettingsByID, ListAllForNotify), and
+	// counting those would put every reader under a rule about writes.
+	writers := map[string]bool{}
+	decides := map[string]bool{}
+	for _, declaration := range parsed.Decls {
+		function, ok := declaration.(*ast.FuncDecl)
+		if !ok || function.Body == nil {
+			continue
+		}
+		ast.Inspect(function.Body, func(node ast.Node) bool {
+			switch typed := node.(type) {
+			case *ast.KeyValueExpr:
+				key, ok := typed.Key.(*ast.BasicLit)
+				if !ok || key.Kind != token.STRING {
+					return true
+				}
+				switch key.Value {
+				case urlColumn:
+					writers[function.Name.Name] = true
+				case markColumn:
+					decides[function.Name.Name] = true
+				}
+			case *ast.IndexExpr:
+				// A conditional clear is an index assignment onto the update map
+				// rather than a map entry, so the column is named there instead.
+				index, ok := typed.Index.(*ast.BasicLit)
+				if ok && index.Kind == token.STRING && index.Value == markColumn {
+					decides[function.Name.Name] = true
+				}
+			}
+			return true
+		})
+	}
+
+	// Anti-vacuity: the two writers this rule is about must both be found, or the
+	// scan is looking at the wrong thing and would report success over an empty
+	// set.
+	for _, required := range []string{"SaveWebhookSettings", "ClearAllDataAndResetSettings"} {
+		if !writers[required] {
+			t.Fatalf("the scan did not find %s among the webhook_url writers (%v): it is not measuring what it claims", required, sortedNamesOf(writers))
+		}
+	}
+
+	var undecided []string
+	for name := range writers {
+		if !decides[name] {
+			undecided = append(undecided, name)
+		}
+	}
+	sort.Strings(undecided)
+	if len(undecided) > 0 {
+		t.Fatalf("these writes change where deliveries go but never decide the fate of webhook_last_delivered_at, so the ledger would keep describing an endpoint that is gone: %v", undecided)
+	}
+
+	// The reverse direction. Only the endpoint writers may name the mark in an
+	// update map: the one write that SETS a value goes through
+	// MarkWebhookDelivered's single-column Update, which is not an update map and
+	// carries its own tests, so anything found here is a second clearing path
+	// nobody declared.
+	for name := range decides {
+		if writers[name] {
+			continue
+		}
+		t.Fatalf("%s puts webhook_last_delivered_at in an update map without writing webhook_url: the mark is cleared only beside the endpoint it was about", name)
+	}
+}

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -142,6 +142,25 @@ type User struct {
 	// Nil until the first send. Stored as UTC-midnight DATE like LastPeriodStart.
 	WebhookPeriodLastSentCycleStart    *time.Time `gorm:"column:webhook_period_last_sent_cycle_start;type:date"`
 	WebhookOvulationLastSentCycleStart *time.Time `gorm:"column:webhook_ovulation_last_sent_cycle_start;type:date"`
+	// WebhookLastDeliveredAt is the only column in this block that records a
+	// DELIVERY (migration 039). The two watermarks above do not and cannot: each
+	// is claimed BEFORE the POST, holds a cycle anchor rather than a clock
+	// reading, and stands for a send that was never accepted until the failure
+	// path puts it back. This one is written in exactly one place — after the
+	// notify pass gets a 2xx, by MarkWebhookDelivered, pinned to the
+	// WebhookConfigVersion that pass read — so it can never be derived from, or
+	// confused with, a claim.
+	//
+	// Nil means "no delivery recorded", which is a statement about this
+	// instance's records and NOT about history: rows that predate migration 039
+	// are nil and were never backfilled, because the only values available to
+	// backfill from are the watermarks.
+	//
+	// It is cleared in the same UPDATE that writes webhook_url whenever the
+	// destination changes, is removed, or its ciphertext no longer opens, and by
+	// a clear-data wipe alongside both watermarks: a mark must never outlive the
+	// endpoint it was about.
+	WebhookLastDeliveredAt *time.Time `gorm:"column:webhook_last_delivered_at"`
 	// ReminderLeadDays is the SHARED lead window (in days) for BOTH the in-app
 	// dashboard banner (issue #123) and webhook reminders: a reminder surfaces
 	// once the predicted event is within this many days of "today". Default 3
@@ -230,6 +249,26 @@ type User struct {
 	// that may still be held). Account erasure removes them with the row.
 	RecoveryCodeRevealedAt *time.Time `gorm:"column:recovery_code_revealed_at"`
 	CalendarFeedRevealedAt *time.Time `gorm:"column:calendar_feed_revealed_at"`
+	// CalendarFeedKeyEpoch records WHICH verification regime the stored token was
+	// minted under (migration 039): the opaque security.CalendarFeedKeyEpoch value
+	// derived from the SECRET_KEY in force at the mint. It is stamped only by
+	// SaveCalendarFeedToken, in the same UPDATE as the token triple above, so
+	// arming and recording what armed it are one event and no new writer of a feed
+	// access column exists.
+	//
+	// It answers the one health question this row can answer honestly. The
+	// verifier is not stored in the clear and its MAC cannot be recomputed, so
+	// "does this token still verify" is genuinely unknown here — but "was it
+	// minted under the key this process is running" is knowable, and it is what
+	// decides whether the owner can still retire the URL they handed out.
+	//
+	// EMPTY means "issued before this was recorded" and never "minted under the
+	// current key": rows older than migration 039 were not backfilled, because
+	// the only value available to backfill from is the CURRENT epoch, which would
+	// assert exactly the thing the column exists to be able to deny. Revoke and
+	// both bulk disarms leave it alone — they clear the token, and a stamp
+	// without a token states nothing.
+	CalendarFeedKeyEpoch string `gorm:"column:calendar_feed_key_epoch"`
 }
 
 // CalendarFeedTokenColumns is the transport-free narrow view of the three stored
@@ -248,4 +287,11 @@ type CalendarFeedTokenColumns struct {
 	Selector     string
 	VerifierHash string
 	VerifierMAC  string
+	// KeyEpoch is the opaque identifier of the verification regime this token was
+	// minted under (security.CalendarFeedKeyEpoch). It is derived at mint, beside
+	// VerifierMAC and from the same key, and written in the same UPDATE as the
+	// triple above — so a token and the record of what signed it can never
+	// disagree. The verify path builds this struct too and leaves it empty: it
+	// compares the MAC, and the epoch is not part of verification.
+	KeyEpoch string
 }

--- a/internal/models/webhook.go
+++ b/internal/models/webhook.go
@@ -24,6 +24,19 @@ type WebhookSettingsColumns struct {
 	NotifyPeriod     bool
 	NotifyOvulation  bool
 	ReminderLeadDays int
+	// ClearLastDeliveredAt asks the same UPDATE that writes EncryptedURL to NULL
+	// webhook_last_delivered_at (migration 039). It is the caller's judgement
+	// because only the caller can make it: persistence stores ciphertext and
+	// cannot tell a re-encryption of the same endpoint from a different one. The
+	// service sets it whenever it cannot PROVE the destination is unchanged — a
+	// replaced URL, a removed one, or a stored ciphertext that no longer opens.
+	//
+	// False, the zero value, means "leave the mark standing", which is what a
+	// toggle-only save wants. A caller that forgets the field therefore keeps a
+	// mark that may now be about a different endpoint, and that is why the rule is
+	// pinned by enumerating the writers of webhook_url rather than by this
+	// comment: TestEveryWebhookURLWriterDecidesTheDeliveryMark.
+	ClearLastDeliveredAt bool
 }
 
 // WebhookNotifyRecord is the read projection returned by ListAllForNotify: the

--- a/internal/reminders/idempotency_layering_test.go
+++ b/internal/reminders/idempotency_layering_test.go
@@ -50,6 +50,11 @@ type statefulNotifyRepo struct {
 	mu       sync.Mutex
 	records  []models.WebhookNotifyRecord
 	snapshot *sync.WaitGroup
+	// delivered models webhook_last_delivered_at per owner. It is deliberately
+	// NOT reflected back into the notify projection: the pass never reads the
+	// delivery mark, and a stub that fed it back would hide a projection that
+	// started to.
+	delivered map[uint]time.Time
 }
 
 func (r *statefulNotifyRepo) ListAllForNotify(context.Context) ([]models.WebhookNotifyRecord, error) {
@@ -107,6 +112,27 @@ func (r *statefulNotifyRepo) ReleaseWebhookWatermark(_ context.Context, userID u
 		return nil
 	}
 	*column = previous
+	return nil
+}
+
+// MarkWebhookDelivered mirrors the repository's second write: the epoch the
+// delivering pass pinned must still be the stored one, and the stamp only moves
+// forward. It advances no epoch and touches no watermark, which is what lets the
+// overlap test below assert that recording a delivery cannot cost this same pass
+// its next claim.
+func (r *statefulNotifyRepo) MarkWebhookDelivered(_ context.Context, userID uint, deliveredAt time.Time, configVersion int) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if !r.epochMatches(userID, configVersion) {
+		return nil
+	}
+	if r.delivered == nil {
+		r.delivered = map[uint]time.Time{}
+	}
+	if existing, ok := r.delivered[userID]; ok && !deliveredAt.After(existing) {
+		return nil
+	}
+	r.delivered[userID] = deliveredAt
 	return nil
 }
 

--- a/internal/services/calendar_feed_token.go
+++ b/internal/services/calendar_feed_token.go
@@ -74,7 +74,9 @@ const (
 //
 // A missing secretKey is a hard failure, never a token with an empty MAC: an
 // empty MAC means "minted before migration 032, verify via bcrypt", so minting
-// one would silently pin a fresh subscription to the slow path forever.
+// one would silently pin a fresh subscription to the slow path forever. The same
+// applies to KeyEpoch (migration 039), which the persisted row reads as "issued
+// before this was recorded" when empty — a fresh mint must never claim that.
 func GenerateCalendarFeedToken(secretKey []byte) (fullToken string, columns models.CalendarFeedTokenColumns, err error) {
 	selector, err := security.RandomString(calendarFeedSelectorLength, calendarFeedAlphabet)
 	if err != nil {
@@ -92,10 +94,18 @@ func GenerateCalendarFeedToken(secretKey []byte) (fullToken string, columns mode
 	if err != nil {
 		return "", models.CalendarFeedTokenColumns{}, err // codecov:ignore -- bcrypt only errors on an out-of-range cost
 	}
+	// The epoch of the regime this token is minted under, derived here rather than
+	// at the write so it comes from the SAME key that just produced the MAC. A
+	// stamp taken later could name a key that no longer signs this token.
+	keyEpoch, err := security.CalendarFeedKeyEpoch(secretKey)
+	if err != nil {
+		return "", models.CalendarFeedTokenColumns{}, err
+	}
 	return selector + verifier, models.CalendarFeedTokenColumns{
 		Selector:     selector,
 		VerifierHash: string(hash),
 		VerifierMAC:  verifierMAC,
+		KeyEpoch:     keyEpoch,
 	}, nil
 }
 

--- a/internal/services/calendar_feed_token.go
+++ b/internal/services/calendar_feed_token.go
@@ -99,7 +99,7 @@ func GenerateCalendarFeedToken(secretKey []byte) (fullToken string, columns mode
 	// stamp taken later could name a key that no longer signs this token.
 	keyEpoch, err := security.CalendarFeedKeyEpoch(secretKey)
 	if err != nil {
-		return "", models.CalendarFeedTokenColumns{}, err
+		return "", models.CalendarFeedTokenColumns{}, err // codecov:ignore -- unreachable: a missing key is the only error this returns, and the MAC above already refused it
 	}
 	return selector + verifier, models.CalendarFeedTokenColumns{
 		Selector:     selector,

--- a/internal/services/webhook_notify_service.go
+++ b/internal/services/webhook_notify_service.go
@@ -97,6 +97,19 @@ type NotifyUserRepository interface {
 	// previous must be the same value handed to ClaimWebhookWatermark, which is
 	// what that claim replaced.
 	ReleaseWebhookWatermark(ctx context.Context, userID uint, reminderType string, cycleAnchor time.Time, previous *time.Time) error
+	// MarkWebhookDelivered records that a delivery to this owner's endpoint was
+	// ACCEPTED, at deliveredAt. It is called ONLY after Deliver returns nil, and
+	// it is the pass's only statement about delivery a later reader can trust:
+	// the claim above is taken before the request leaves and holds a cycle
+	// anchor, so it says a send was attempted under some configuration, never
+	// that one arrived.
+	//
+	// configVersion is the same revocation epoch the claim pinned, so a
+	// configuration the owner withdrew while the request was on the wire is not
+	// credited with a delivery. The write does not advance that epoch and moves
+	// no watermark. An error here is a lost ledger entry, never a lost delivery:
+	// the caller logs it and leaves the report alone.
+	MarkWebhookDelivered(ctx context.Context, userID uint, deliveredAt time.Time, configVersion int) error
 }
 
 // NotifyLogReader is the narrow read surface for an owner's day logs (the
@@ -371,8 +384,34 @@ func (service *WebhookNotifyService) processOwner(
 			continue
 		}
 
-		// Success: the claim stands as the watermark for this kind, so a re-run
-		// skips it. No second write is needed — the claim WAS the write.
+		// Success. Two different facts are now true and they need two different
+		// columns. The claim stands as the watermark for this kind, so a re-run
+		// skips the reminder — that is idempotency, and it was already written,
+		// before the request left, against a cycle anchor. It is NOT a record that
+		// anything arrived: the same value stands for a send that failed until the
+		// release above puts it back, and it holds an anchor rather than a clock
+		// reading. Reading it as a delivery time is the misreading the second
+		// write below exists to make unnecessary.
+		//
+		// So this is where — and the only place where — an accepted delivery is
+		// recorded, after a 2xx and never at the claim. It pins the SAME epoch the
+		// claim did, so a configuration the owner revoked while the request was on
+		// the wire is not credited with a delivery, and it deliberately does not
+		// advance that epoch: doing so would lose this very pass's ovulation claim
+		// a few lines from now (migration 039 corrects migration 038 on the point).
+		//
+		// now is the pass's injected clock, not a fresh reading — this service
+		// holds no clock on purpose. The mark is therefore "the pass that accepted
+		// this delivery began at", accurate to the length of a pass, and it is a
+		// record of acceptance rather than a latency measurement.
+		//
+		// A failed mark is not a failed delivery. The POST was accepted, so the
+		// reminder counts as sent and the report is left alone; the cost is one
+		// missing ledger entry. Counting it as failed would be the expensive
+		// mistake, because nothing would then stop the next pass re-sending it.
+		if err := service.users.MarkWebhookDelivered(ctx, record.ID, now, record.WebhookConfigVersion); err != nil {
+			log.Printf("webhook notify: delivery mark write failed after an accepted delivery, owner id=%d", record.ID)
+		}
 		report.Sent++
 	}
 }

--- a/internal/services/webhook_notify_service_delivery_timestamp_test.go
+++ b/internal/services/webhook_notify_service_delivery_timestamp_test.go
@@ -1,0 +1,217 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+)
+
+// The privacy ledger will say "last delivery accepted <T>" from
+// webhook_last_delivered_at, and the whole value of that sentence is that no
+// other column in this schema could carry it truthfully. The two watermarks are
+// claimed BEFORE the POST, hold a cycle anchor rather than a clock reading, and
+// stand for a send that was never accepted until the failure path puts them
+// back. These tests pin the difference at the only place it can be lost: the
+// notify pass.
+
+// readingDeliverer runs a hook while the outbound request is notionally in
+// flight — the one moment at which a claim and a delivery record are
+// distinguishable — and can then fail the delivery.
+type readingDeliverer struct {
+	duringDelivery func()
+	fail           bool
+}
+
+func (d readingDeliverer) Deliver(context.Context, string, WebhookPayload) error {
+	if d.duringDelivery != nil {
+		d.duringDelivery()
+	}
+	if d.fail {
+		return errors.New("stub delivery failure")
+	}
+	return nil
+}
+
+// TestWebhookDeliveryRecordsAcceptedTimestampOnlyAfterSuccess is the pass-level
+// contract of the delivery mark: it appears only for a delivery the endpoint
+// accepted, it does not exist yet while the request is in flight, and a failed
+// delivery leaves it absent while still handing the claim back.
+func TestWebhookDeliveryRecordsAcceptedTimestampOnlyAfterSuccess(t *testing.T) {
+	now := time.Date(2026, 4, 10, 9, 0, 0, 0, time.UTC)
+
+	t.Run("an accepted delivery records the mark", func(t *testing.T) {
+		repo := &stubNotifyRepo{records: []models.WebhookNotifyRecord{dueRecord(1, "url-1", now, 26)}}
+		logs := stubLogReader{byUser: map[uint][]models.DailyLog{1: completedCycleStartLogs(1, now.AddDate(0, 0, -26))}}
+		service := newTestNotifyService(repo, logs, stubDecryptor{}, readingDeliverer{})
+
+		report, err := service.RunOnce(context.Background(), now, time.UTC, false)
+		if err != nil {
+			t.Fatalf("RunOnce: %v", err)
+		}
+		if report.Sent != 1 {
+			t.Fatalf("expected one delivered reminder, got %+v", report)
+		}
+		at, marked := repo.markedAt(1)
+		if !marked {
+			t.Fatal("expected webhook_last_delivered_at to be set after an accepted delivery")
+		}
+		if !at.Equal(now) {
+			t.Fatalf("expected the mark to carry the pass clock %s, got %s", now, at)
+		}
+	})
+
+	t.Run("the mark is still NULL while the request is in flight", func(t *testing.T) {
+		repo := &stubNotifyRepo{records: []models.WebhookNotifyRecord{dueRecord(1, "url-1", now, 26)}}
+		logs := stubLogReader{byUser: map[uint][]models.DailyLog{1: completedCycleStartLogs(1, now.AddDate(0, 0, -26))}}
+
+		// The arming assertion this whole PR turns on. An implementation that
+		// stamped the mark at the claim — beside the watermark, before the POST —
+		// would pass every other test in this file and make the ledger claim a
+		// delivery for a request that never left.
+		var markedDuringDelivery bool
+		var watermarkClaimedDuringDelivery bool
+		deliverer := readingDeliverer{duringDelivery: func() {
+			_, markedDuringDelivery = repo.markedAt(1)
+			watermarkClaimedDuringDelivery = len(repo.writes()) > 0
+		}}
+		service := newTestNotifyService(repo, logs, stubDecryptor{}, deliverer)
+
+		if _, err := service.RunOnce(context.Background(), now, time.UTC, false); err != nil {
+			t.Fatalf("RunOnce: %v", err)
+		}
+		if !watermarkClaimedDuringDelivery {
+			t.Fatal("the claim is supposed to be taken before the request leaves: this test is no longer measuring the window it claims to")
+		}
+		if markedDuringDelivery {
+			t.Fatal("webhook_last_delivered_at was already set while the request was in flight: the mark is being written at the claim, not after a 2xx")
+		}
+		if _, marked := repo.markedAt(1); !marked {
+			t.Fatal("expected the mark to be set once the delivery was accepted")
+		}
+	})
+
+	t.Run("a failed delivery leaves the mark absent and still releases the claim", func(t *testing.T) {
+		repo := &stubNotifyRepo{records: []models.WebhookNotifyRecord{dueRecord(1, "url-1", now, 26)}}
+		logs := stubLogReader{byUser: map[uint][]models.DailyLog{1: completedCycleStartLogs(1, now.AddDate(0, 0, -26))}}
+		service := newTestNotifyService(repo, logs, stubDecryptor{}, readingDeliverer{fail: true})
+
+		report, err := service.RunOnce(context.Background(), now, time.UTC, false)
+		if err != nil {
+			t.Fatalf("RunOnce: %v", err)
+		}
+		if report.Sent != 0 || report.Failed != 1 {
+			t.Fatalf("expected the failed delivery to be counted as failed, got %+v", report)
+		}
+		if calls := repo.marks(); len(calls) != 0 {
+			t.Fatalf("expected no delivery mark write for a failed delivery, got %+v", calls)
+		}
+		if _, marked := repo.markedAt(1); marked {
+			t.Fatal("a failed delivery moved webhook_last_delivered_at")
+		}
+		if released := repo.released(); len(released) != 1 {
+			t.Fatalf("expected the claim to be released after a failed delivery, got %d releases", len(released))
+		}
+	})
+}
+
+// TestWebhookDeliveryMarkPinsTheClaimedConfigVersion proves the second write
+// asks the same question the claim did. Between the claim and the 2xx the owner
+// can revoke the configuration; a mark written without the pinned epoch would
+// credit a delivery to a configuration that no longer exists.
+func TestWebhookDeliveryMarkPinsTheClaimedConfigVersion(t *testing.T) {
+	now := time.Date(2026, 4, 10, 9, 0, 0, 0, time.UTC)
+	record := dueRecord(1, "url-1", now, 26)
+	record.WebhookConfigVersion = 7
+
+	repo := &stubNotifyRepo{
+		records: []models.WebhookNotifyRecord{record},
+		// The stored epoch has moved on since the snapshot: a settings save landed
+		// while the request was on the wire.
+		epochs: map[uint]int{1: 8},
+	}
+	logs := stubLogReader{byUser: map[uint][]models.DailyLog{1: completedCycleStartLogs(1, now.AddDate(0, 0, -26))}}
+	service := newTestNotifyService(repo, logs, stubDecryptor{}, readingDeliverer{})
+
+	if _, err := service.RunOnce(context.Background(), now, time.UTC, false); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	calls := repo.marks()
+	if len(calls) != 1 {
+		t.Fatalf("expected exactly one delivery mark attempt, got %d", len(calls))
+	}
+	if calls[0].configVersion != 7 {
+		t.Fatalf("expected the mark to pin the epoch the pass's own snapshot carried (7), got %d", calls[0].configVersion)
+	}
+	if _, marked := repo.markedAt(1); marked {
+		t.Fatal("the mark was stored although the owner's configuration epoch had moved since the claim")
+	}
+}
+
+// TestWebhookDeliveryMarkFailureDoesNotChangeTheReport pins the priority between
+// the delivery and its record: the POST was accepted, so the reminder is sent
+// however the mark write goes. Counting it as failed would be the expensive
+// error — nothing would stop the next pass sending the same reminder again.
+func TestWebhookDeliveryMarkFailureDoesNotChangeTheReport(t *testing.T) {
+	now := time.Date(2026, 4, 10, 9, 0, 0, 0, time.UTC)
+	repo := &stubNotifyRepo{
+		records: []models.WebhookNotifyRecord{dueRecord(1, "url-1", now, 26)},
+		markErr: errors.New("stub mark write failure"),
+	}
+	logs := stubLogReader{byUser: map[uint][]models.DailyLog{1: completedCycleStartLogs(1, now.AddDate(0, 0, -26))}}
+	service := newTestNotifyService(repo, logs, stubDecryptor{}, readingDeliverer{})
+
+	report, err := service.RunOnce(context.Background(), now, time.UTC, false)
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if report.Sent != 1 || report.Failed != 0 {
+		t.Fatalf("expected Sent=1, Failed=0 for one accepted delivery whose mark write failed, got %+v", report)
+	}
+	if writes := repo.writes(); len(writes) != 1 {
+		t.Fatalf("expected the watermark claim to stand after a failed mark write, got %d net writes", len(writes))
+	}
+	if released := repo.released(); len(released) != 0 {
+		t.Fatalf("a failed mark write released the claim, which would let the next pass re-send a delivered reminder: %+v", released)
+	}
+}
+
+// TestWebhookDeliveryMarkIsNotDerivedFromAWatermark is the ledger's first
+// constraint, asserted where it can actually be violated. The recorded value
+// must be a clock reading, never either watermark and nothing computed from
+// them: those are UTC-midnight cycle anchors, and rendering one as a delivery
+// time is the falsehood this column exists to replace.
+func TestWebhookDeliveryMarkIsNotDerivedFromAWatermark(t *testing.T) {
+	now := time.Date(2026, 4, 10, 9, 0, 0, 0, time.UTC)
+	record := dueRecord(1, "url-1", now, 26)
+	// Both watermarks carry a value, so a mark derived from max() of them would
+	// have something to be derived from.
+	periodWatermark := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	ovulationWatermark := time.Date(2026, 3, 15, 0, 0, 0, 0, time.UTC)
+	record.WebhookPeriodLastSentCycleStart = &periodWatermark
+	record.WebhookOvulationLastSentCycleStart = &ovulationWatermark
+
+	repo := &stubNotifyRepo{records: []models.WebhookNotifyRecord{record}}
+	logs := stubLogReader{byUser: map[uint][]models.DailyLog{1: completedCycleStartLogs(1, now.AddDate(0, 0, -26))}}
+	service := newTestNotifyService(repo, logs, stubDecryptor{}, readingDeliverer{})
+
+	if _, err := service.RunOnce(context.Background(), now, time.UTC, false); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	at, marked := repo.markedAt(1)
+	if !marked {
+		t.Fatal("expected a delivery mark for the accepted delivery")
+	}
+	for _, watermark := range []time.Time{periodWatermark, ovulationWatermark} {
+		if at.Equal(watermark) {
+			t.Fatalf("the delivery mark was written as a watermark value (%s): a claim anchor is not a delivery time", watermark)
+		}
+	}
+	if at.Hour() == 0 && at.Minute() == 0 && at.Second() == 0 {
+		t.Fatalf("the delivery mark landed on UTC midnight (%s), the shape of a cycle anchor rather than of a clock reading", at)
+	}
+}

--- a/internal/services/webhook_notify_service_test.go
+++ b/internal/services/webhook_notify_service_test.go
@@ -108,18 +108,38 @@ type watermarkWrite struct {
 // assert the pass pins the epoch its OWN snapshot carried — the value the
 // repository compares a revocation against — rather than a constant or a fresher
 // re-read that would agree with whatever the revocation just wrote.
+//
+// marked models the webhook_last_delivered_at COLUMN (migration 039) rather than
+// just recording calls, so a test can read the row mid-pass and see NULL where
+// the real column would be NULL. deliveryMarks records every call including the
+// ones the modelled compare-and-set refuses, which is how a test tells "not
+// called" apart from "called and correctly discarded". epochs, when set, is the
+// stored revocation epoch per owner: a mark whose configVersion no longer
+// matches it is discarded exactly as the repository would discard it. markErr
+// makes the mark write fail after the delivery already succeeded.
 type stubNotifyRepo struct {
 	records         []models.WebhookNotifyRecord
 	listErr         error
 	claimErr        error
 	claimLost       bool
 	releaseErr      error
+	markErr         error
+	epochs          map[uint]int
 	mu              sync.Mutex
 	watermarks      []watermarkWrite
 	releases        []watermarkWrite
 	claimExpected   []*time.Time
 	claimEpochs     []int
 	releaseRestored []*time.Time
+	deliveryMarks   []deliveryMark
+	marked          map[uint]time.Time
+}
+
+// deliveryMark records one MarkWebhookDelivered call, refused or not.
+type deliveryMark struct {
+	userID        uint
+	at            time.Time
+	configVersion int
 }
 
 func (stub *stubNotifyRepo) ListAllForNotify(context.Context) ([]models.WebhookNotifyRecord, error) {
@@ -157,6 +177,47 @@ func (stub *stubNotifyRepo) ReleaseWebhookWatermark(_ context.Context, userID ui
 		}
 	}
 	return stub.releaseErr
+}
+
+func (stub *stubNotifyRepo) MarkWebhookDelivered(_ context.Context, userID uint, deliveredAt time.Time, configVersion int) error {
+	stub.mu.Lock()
+	defer stub.mu.Unlock()
+	stub.deliveryMarks = append(stub.deliveryMarks, deliveryMark{userID: userID, at: deliveredAt, configVersion: configVersion})
+	if stub.markErr != nil {
+		return stub.markErr
+	}
+	// The modelled column carries the repository's own compare-and-set: the
+	// pinned epoch must still be the stored one, and the stamp must move forward.
+	if stub.epochs != nil {
+		if stored, known := stub.epochs[userID]; known && stored != configVersion {
+			return nil
+		}
+	}
+	if stub.marked == nil {
+		stub.marked = map[uint]time.Time{}
+	}
+	if existing, ok := stub.marked[userID]; ok && !deliveredAt.After(existing) {
+		return nil
+	}
+	stub.marked[userID] = deliveredAt
+	return nil
+}
+
+// markedAt reports the modelled webhook_last_delivered_at of one owner; the
+// second return is false while the column would still be NULL.
+func (stub *stubNotifyRepo) markedAt(userID uint) (time.Time, bool) {
+	stub.mu.Lock()
+	defer stub.mu.Unlock()
+	at, ok := stub.marked[userID]
+	return at, ok
+}
+
+func (stub *stubNotifyRepo) marks() []deliveryMark {
+	stub.mu.Lock()
+	defer stub.mu.Unlock()
+	out := make([]deliveryMark, len(stub.deliveryMarks))
+	copy(out, stub.deliveryMarks)
+	return out
 }
 
 func (stub *stubNotifyRepo) writes() []watermarkWrite {

--- a/internal/services/webhook_settings_delivery_mark_test.go
+++ b/internal/services/webhook_settings_delivery_mark_test.go
@@ -1,0 +1,149 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+	"github.com/ovumcy/ovumcy-web/internal/security"
+)
+
+// The delivery mark says "a delivery to your endpoint was accepted". It is a
+// claim about ONE destination, so it may only survive a save that can be shown
+// to have kept that destination. Persistence cannot make the call — every save
+// re-encrypts under a fresh nonce, so the stored bytes always differ — which is
+// why the verdict is computed here and travels with the write.
+
+// storedWebhookURL encrypts a plaintext endpoint the way a previous save would
+// have, so a test can seed a row whose ciphertext really opens.
+func storedWebhookURL(t *testing.T, userID uint, plaintext string) string {
+	t.Helper()
+	ciphertext, err := security.EncryptField(plaintext, []byte(webhookTestSecretKey), aadForWebhookURL(userID))
+	if err != nil {
+		t.Fatalf("encrypt stored webhook url: %v", err)
+	}
+	return ciphertext
+}
+
+// TestWebhookSaveKeepsTheDeliveryMarkOnlyForAProvablyUnchangedDestination walks
+// every shape of save the settings surfaces can produce and pins which of them
+// may keep the mark. The keep cases are the point: a blanket clear on every
+// write of webhook_url would pass a test that only checked the clear cases, and
+// would erase the ledger entry every time an owner touched a checkbox.
+func TestWebhookSaveKeepsTheDeliveryMarkOnlyForAProvablyUnchangedDestination(t *testing.T) {
+	const userID = uint(7)
+	const endpoint = "https://hooks.example.com/abc"
+
+	for _, testCase := range []struct {
+		name       string
+		storedURL  func(t *testing.T) string
+		loadErr    error
+		update     WebhookSettingsUpdate
+		wantClear  bool
+		wantReason string
+	}{
+		{
+			name:       "the same endpoint re-saved with toggles changed",
+			storedURL:  func(t *testing.T) string { return storedWebhookURL(t, userID, endpoint) },
+			update:     WebhookSettingsUpdate{Enabled: true, URL: endpoint, NotifyPeriod: false, NotifyOvulation: true, ReminderLeadDays: 3},
+			wantClear:  false,
+			wantReason: "the destination is provably the same one the mark was about",
+		},
+		{
+			name:       "the same endpoint re-saved with delivery disabled",
+			storedURL:  func(t *testing.T) string { return storedWebhookURL(t, userID, endpoint) },
+			update:     WebhookSettingsUpdate{Enabled: false, URL: endpoint, ReminderLeadDays: 3},
+			wantClear:  false,
+			wantReason: "turning delivery off does not change where past deliveries went",
+		},
+		{
+			name:       "a different endpoint",
+			storedURL:  func(t *testing.T) string { return storedWebhookURL(t, userID, endpoint) },
+			update:     WebhookSettingsUpdate{Enabled: true, URL: "https://hooks.example.com/other", ReminderLeadDays: 3},
+			wantClear:  true,
+			wantReason: "the mark would describe an endpoint this row no longer holds",
+		},
+		{
+			name:       "the endpoint removed",
+			storedURL:  func(t *testing.T) string { return storedWebhookURL(t, userID, endpoint) },
+			update:     WebhookSettingsUpdate{Enabled: false, URL: "", ReminderLeadDays: 3},
+			wantClear:  true,
+			wantReason: "nothing is left for the mark to be about",
+		},
+		{
+			name:       "a stored ciphertext that no longer opens",
+			storedURL:  func(*testing.T) string { return "not-a-ciphertext-this-key-can-open" },
+			update:     WebhookSettingsUpdate{Enabled: true, URL: endpoint, ReminderLeadDays: 3},
+			wantClear:  true,
+			wantReason: "after a key rotation the previous destination is unknowable, not merely different",
+		},
+		{
+			name:       "a row that could not be read",
+			storedURL:  func(*testing.T) string { return "" },
+			loadErr:    errors.New("stub load failure"),
+			update:     WebhookSettingsUpdate{Enabled: true, URL: endpoint, ReminderLeadDays: 3},
+			wantClear:  true,
+			wantReason: "an unprovable destination clears rather than fails the save",
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			svc, repo := newWebhookServiceForTest()
+			repo.loadUser = models.User{WebhookURL: testCase.storedURL(t)}
+			repo.loadErr = testCase.loadErr
+
+			if err := svc.SaveWebhookSettings(context.Background(), userID, testCase.update); err != nil {
+				t.Fatalf("SaveWebhookSettings: %v", err)
+			}
+			if repo.saveCalls != 1 {
+				t.Fatalf("expected the save to reach persistence once, got %d calls", repo.saveCalls)
+			}
+			if repo.savedColumns.ClearLastDeliveredAt != testCase.wantClear {
+				t.Fatalf("expected ClearLastDeliveredAt=%t (%s), got %t", testCase.wantClear, testCase.wantReason, repo.savedColumns.ClearLastDeliveredAt)
+			}
+		})
+	}
+}
+
+// TestWebhookFormSaveKeepsTheDeliveryMarkWhenTheURLFieldIsLeftBlank covers the
+// shape the settings page actually submits. The URL field is write-only and
+// renders blank, so the overwhelmingly common save carries no URL at all and
+// means "leave the endpoint alone" — the one save that must never cost the
+// owner their ledger entry.
+func TestWebhookFormSaveKeepsTheDeliveryMarkWhenTheURLFieldIsLeftBlank(t *testing.T) {
+	const userID = uint(7)
+	const endpoint = "https://hooks.example.com/abc"
+
+	svc, repo := newWebhookServiceForTest()
+	repo.loadUser = models.User{WebhookURL: storedWebhookURL(t, userID, endpoint), ReminderLeadDays: 3}
+
+	if err := svc.SaveWebhookSettingsFromForm(context.Background(), userID, WebhookSettingsFormUpdate{
+		Enabled:      true,
+		NotifyPeriod: true,
+	}); err != nil {
+		t.Fatalf("SaveWebhookSettingsFromForm: %v", err)
+	}
+	if repo.savedColumns.ClearLastDeliveredAt {
+		t.Fatal("a blank-URL form save cleared the delivery mark: the endpoint it was about is unchanged")
+	}
+}
+
+// TestWebhookFormRemoveClearsTheDeliveryMark is the same surface's other
+// affordance. Removing the endpoint must take the mark with it, in the write
+// that removes it.
+func TestWebhookFormRemoveClearsTheDeliveryMark(t *testing.T) {
+	const userID = uint(7)
+
+	svc, repo := newWebhookServiceForTest()
+	repo.loadUser = models.User{WebhookURL: storedWebhookURL(t, userID, "https://hooks.example.com/abc"), ReminderLeadDays: 3}
+
+	if err := svc.SaveWebhookSettingsFromForm(context.Background(), userID, WebhookSettingsFormUpdate{RemoveURL: true}); err != nil {
+		t.Fatalf("SaveWebhookSettingsFromForm: %v", err)
+	}
+	if repo.savedColumns.EncryptedURL != "" {
+		t.Fatalf("expected the remove to clear the endpoint, got %q", repo.savedColumns.EncryptedURL)
+	}
+	if !repo.savedColumns.ClearLastDeliveredAt {
+		t.Fatal("removing the endpoint left the delivery mark standing")
+	}
+}

--- a/internal/services/webhook_settings_service.go
+++ b/internal/services/webhook_settings_service.go
@@ -184,6 +184,9 @@ func validateWebhookAuthority(parsed *url.URL) error {
 //   - The URL is encrypted with security.EncryptField, aad-bound to userID, and
 //     only the ciphertext is handed to persistence. An empty URL (disabled with
 //     no endpoint) is stored as an empty string, not encrypted.
+//   - The delivery mark's fate travels with the write: unless this save can
+//     prove the destination is unchanged, it asks the same UPDATE to NULL
+//     webhook_last_delivered_at. See destinationNotProvablyUnchanged.
 //
 // It does not bump auth_session_version: a notification-preference change is not
 // a security-posture change.
@@ -196,6 +199,9 @@ func (service *WebhookSettingsService) SaveWebhookSettings(ctx context.Context, 
 	}
 
 	trimmedURL := strings.TrimSpace(update.URL)
+	// destination is the PLAINTEXT this save will store, in the same validated
+	// form the previous save stored its own, so the two are comparable below.
+	destination := ""
 	switch {
 	case update.Enabled:
 		validated, err := ValidateWebhookURL(trimmedURL)
@@ -207,6 +213,7 @@ func (service *WebhookSettingsService) SaveWebhookSettings(ctx context.Context, 
 			return fmt.Errorf("webhook url encrypt failed: %w", err)
 		}
 		columns.EncryptedURL = ciphertext
+		destination = validated
 	case trimmedURL == "":
 		// Disabled and no endpoint supplied: clear any stored ciphertext.
 		columns.EncryptedURL = ""
@@ -224,9 +231,46 @@ func (service *WebhookSettingsService) SaveWebhookSettings(ctx context.Context, 
 			return fmt.Errorf("webhook url encrypt failed: %w", err)
 		}
 		columns.EncryptedURL = ciphertext
+		destination = validated
 	}
+	columns.ClearLastDeliveredAt = service.destinationNotProvablyUnchanged(ctx, userID, destination)
 
 	return service.users.SaveWebhookSettings(ctx, userID, columns)
+}
+
+// destinationNotProvablyUnchanged decides the fate of the delivery mark for the
+// save about to run: true asks persistence to NULL webhook_last_delivered_at in
+// the same UPDATE that writes the new webhook_url.
+//
+// The question is deliberately asked in the negative. The mark says "a delivery
+// to your endpoint was accepted", so keeping it is a claim about one specific
+// destination and may only survive where this instance can PROVE the destination
+// is the one the mark was about. Everything else clears it: a replaced URL, a
+// removed one, a row that could not be read, and a stored ciphertext that no
+// longer opens — after a SECRET_KEY rotation the previous destination is not
+// merely different, it is unknowable, and the ledger must not assert about it.
+//
+// The comparison is on PLAINTEXT because ciphertext cannot answer it: every save
+// re-encrypts under a fresh nonce, so a toggle-only save that re-stores the very
+// same endpoint yields bytes that differ from the stored ones. Keeping the mark
+// across exactly that save is the whole reason this comparison exists instead of
+// a blanket clear on every write of the column.
+//
+// It reads the row itself rather than taking the verdict from its callers: this
+// is the one choke point every webhook save passes through, and a rule placed in
+// the callers would hold at the two that exist today and be missed by the third.
+// A read error clears rather than fails the save — an owner's save is not
+// refused over the fate of a display mark.
+func (service *WebhookSettingsService) destinationNotProvablyUnchanged(ctx context.Context, userID uint, destination string) bool {
+	current, err := service.users.LoadSettingsByID(ctx, userID)
+	if err != nil {
+		return true
+	}
+	stored, err := service.DecryptWebhookURL(userID, current.WebhookURL)
+	if err != nil {
+		return true
+	}
+	return stored != destination
 }
 
 // SaveWebhookSettingsFromForm applies a write-only-field save from the settings

--- a/migrations/038_webhook_config_version.sql
+++ b/migrations/038_webhook_config_version.sql
@@ -15,13 +15,22 @@
 --
 -- webhook_config_version closes that window. Three writers advance it, each in
 -- the same statement that performs its own write, and that is the COMPLETE set
--- rather than an illustration -- a fourth added later owes the same advance:
+-- of DELIVERY CONFIGURATION writers rather than an illustration -- a later one
+-- owes the same advance:
 --
 --   * SaveWebhookSettings -- a save, a disable, an endpoint replacement, a
 --     removal.
 --   * UpdateReminderLeadDays -- the shared banner-and-webhook lead window, which
 --     ListAllForNotify projects and the notify decision places the reminder from.
 --   * ClearAllDataAndResetSettings.
+--
+-- What obliges a writer is what it CHANGES, never that it touched the users row.
+-- MarkWebhookDelivered (migration 039) writes that row after a 2xx and must NOT
+-- advance this column: it records that delivery happened, changing neither
+-- WHETHER, WHERE nor HOW EARLY it happens. Advancing there would also break the
+-- pass doing the delivering -- the epoch is pinned once per owner OUTSIDE the
+-- reminder loop, so a bump after a period delivery loses the ovulation claim of
+-- that same pass.
 --
 -- The claim pins the value the claiming pass's snapshot carried. Monotonic on
 -- purpose: clear-data ADVANCES the counter rather than resetting it, because a

--- a/migrations/039_delivery_mark_and_feed_key_epoch.sql
+++ b/migrations/039_delivery_mark_and_feed_key_epoch.sql
@@ -1,0 +1,57 @@
+-- Two marks the privacy ledger (item 23) needs before it can say anything true
+-- about what has left this instance. Both are nullable, both start NULL on every
+-- existing row, and NO BACKFILL is performed or owed.
+--
+-- NO BACKFILL, webhook_last_delivered_at. The only per-owner data this schema
+-- already holds about sending is the pair of watermarks
+-- webhook_period_last_sent_cycle_start and webhook_ovulation_last_sent_cycle_start,
+-- and they are not delivery times. Each is a compare-and-set value written
+-- BEFORE the POST, holding a CYCLE ANCHOR rather than a clock reading, and it
+-- stands unchanged for a send that was never accepted until the failure path
+-- puts it back. A migration seeding this column from max() of the two would
+-- write a claim time as a delivery time on every upgraded row and make that lie
+-- permanent -- exactly the constraint the ledger exists to respect. An upgraded
+-- instance says "no delivery recorded" until one is, which is the true
+-- statement.
+--
+-- The column is written in exactly one place: after the notify pass gets a 2xx
+-- from the endpoint, through MarkWebhookDelivered, pinned to the
+-- webhook_config_version the delivering pass read. It is cleared in the same
+-- UPDATE that writes webhook_url whenever the destination changes, is removed,
+-- or its stored ciphertext no longer opens, and by the clear-data wipe alongside
+-- both watermarks -- a mark must never outlive the endpoint it was about.
+--
+-- NO BACKFILL, calendar_feed_key_epoch. It holds the opaque identifier of the
+-- verification regime a feed token was minted under (security.CalendarFeedKeyEpoch,
+-- derived from SECRET_KEY). No value can be recomputed for a token minted before
+-- this migration: the epoch of the key that signed it is recorded nowhere, and
+-- deriving it from the CURRENT key would assert that every legacy row was minted
+-- under the running regime -- the one claim the column exists to be able to
+-- deny. NULL means "issued before this was recorded", which is what the instance
+-- actually knows. It is stamped only by SaveCalendarFeedToken, in the same
+-- UPDATE as the token triple, so no new writer of a feed access column appears.
+-- Revoke and both bulk disarms leave it alone.
+--
+-- CORRECTION to migration 038. That file names SaveWebhookSettings,
+-- UpdateReminderLeadDays and ClearAllDataAndResetSettings as the COMPLETE set of
+-- webhook_config_version writers and says a fourth added later owes the same
+-- advance. The rule is about writers of the DELIVERY CONFIGURATION, not about
+-- writers of the users row. MarkWebhookDelivered is the second kind and must NOT
+-- advance the epoch: the epoch is pinned once per owner OUTSIDE the reminder
+-- loop, and advancing it after a period delivery would make that same pass lose
+-- the ovulation claim it is about to take. A later writer owes the advance if
+-- and only if it changes WHETHER, WHERE or HOW EARLY delivery happens.
+--
+-- Neither column is indexed: both are read one row at a time, by owner id, on
+-- the settings path.
+--
+-- The migration runner skips any ADD COLUMN whose column already exists, so this
+-- file is idempotent across clean installs and rolling deploys. Rollback
+-- (forward-only repo) is documented in the commit body, not here.
+--
+-- NOTE: keep prose in this file free of semicolons -- the migration runner
+-- splits statements on the semicolon character without stripping SQL comments,
+-- so a semicolon inside a comment is mis-parsed as a statement boundary.
+
+ALTER TABLE users ADD COLUMN webhook_last_delivered_at DATETIME;
+ALTER TABLE users ADD COLUMN calendar_feed_key_epoch TEXT;

--- a/migrations/postgres/038_webhook_config_version.sql
+++ b/migrations/postgres/038_webhook_config_version.sql
@@ -4,11 +4,20 @@
 --
 -- webhook_config_version is the monotonic revocation epoch of an owner's
 -- delivery configuration. Three writers advance it, each in the same statement
--- that performs its own write, and that is the COMPLETE set rather than an
--- illustration -- a fourth added later owes the same advance:
--- SaveWebhookSettings (a save, a disable, an endpoint replacement, a removal),
--- UpdateReminderLeadDays (the shared banner-and-webhook lead window, which the
--- notify pass places its reminder from), and ClearAllDataAndResetSettings.
+-- that performs its own write, and that is the COMPLETE set of DELIVERY
+-- CONFIGURATION writers rather than an illustration -- a later one owes the same
+-- advance: SaveWebhookSettings (a save, a disable, an endpoint replacement, a
+-- removal), UpdateReminderLeadDays (the shared banner-and-webhook lead window,
+-- which the notify pass places its reminder from), and
+-- ClearAllDataAndResetSettings.
+--
+-- What obliges a writer is what it CHANGES, never that it touched the users row.
+-- MarkWebhookDelivered (migration 039) writes that row after a 2xx and must NOT
+-- advance this column: it records that delivery happened, changing neither
+-- WHETHER, WHERE nor HOW EARLY it happens. Advancing there would also break the
+-- pass doing the delivering -- the epoch is pinned once per owner OUTSIDE the
+-- reminder loop, so a bump after a period delivery loses the ovulation claim of
+-- that same pass.
 --
 -- The pre-delivery watermark claim pins the value the claiming pass's snapshot
 -- carried, so a pass that read the configuration before a revocation can no

--- a/migrations/postgres/039_delivery_mark_and_feed_key_epoch.sql
+++ b/migrations/postgres/039_delivery_mark_and_feed_key_epoch.sql
@@ -1,0 +1,57 @@
+-- Postgres mirror of migrations/039_delivery_mark_and_feed_key_epoch.sql (item
+-- 23, privacy ledger). Same version number and basename so schema history stays
+-- aligned across engines.
+--
+-- NO BACKFILL, both columns, and the reason is the same one that makes them
+-- worth adding.
+--
+-- webhook_last_delivered_at is the only honest record that a delivery was
+-- ACCEPTED. The two watermarks this schema already carries
+-- (webhook_period_last_sent_cycle_start, webhook_ovulation_last_sent_cycle_start)
+-- are not that: each is a compare-and-set value written BEFORE the POST, holding
+-- a CYCLE ANCHOR rather than a clock reading, and it stands unchanged for a send
+-- that was never accepted until the failure path puts it back. Seeding this
+-- column from max() of the two would write a claim time as a delivery time on
+-- every upgraded row and make that lie permanent. An upgraded instance says "no
+-- delivery recorded" until one is, which is the true statement.
+--
+-- It is written in exactly one place -- MarkWebhookDelivered, after a 2xx,
+-- pinned to the webhook_config_version the delivering pass read -- cleared in
+-- the same UPDATE that writes webhook_url whenever the destination changes, is
+-- removed, or its stored ciphertext no longer opens, and cleared by the
+-- clear-data wipe alongside both watermarks.
+--
+-- calendar_feed_key_epoch holds the opaque identifier of the verification regime
+-- a feed token was minted under (security.CalendarFeedKeyEpoch, derived from
+-- SECRET_KEY). No value can be recomputed for a token minted before this
+-- migration: the epoch of the key that signed it is recorded nowhere, and
+-- deriving it from the CURRENT key would assert that every legacy row was minted
+-- under the running regime -- the one claim the column exists to be able to
+-- deny. NULL means "issued before this was recorded". It is stamped only by
+-- SaveCalendarFeedToken, in the same UPDATE as the token triple, so no new
+-- writer of a feed access column appears. Revoke and both bulk disarms leave it
+-- alone.
+--
+-- CORRECTION to migration 038. That file names SaveWebhookSettings,
+-- UpdateReminderLeadDays and ClearAllDataAndResetSettings as the COMPLETE set of
+-- webhook_config_version writers and says a fourth added later owes the same
+-- advance. The rule is about writers of the DELIVERY CONFIGURATION, not about
+-- writers of the users row. MarkWebhookDelivered is the second kind and must NOT
+-- advance the epoch: the epoch is pinned once per owner OUTSIDE the reminder
+-- loop, and advancing it after a period delivery would make that same pass lose
+-- the ovulation claim it is about to take. A later writer owes the advance if
+-- and only if it changes WHETHER, WHERE or HOW EARLY delivery happens.
+--
+-- Neither column is indexed: both are read one row at a time, by owner id, on
+-- the settings path.
+--
+-- ALTER TABLE ADD COLUMN IF NOT EXISTS keeps the migration idempotent across the
+-- postgres test bootstrap and rolling deploys (in addition to the runner's own
+-- already-exists skip). Rollback (forward-only repo) is documented in the commit
+-- body, not here.
+--
+-- NOTE: keep prose in this file free of semicolons -- the migration runner
+-- splits statements on the semicolon character without stripping SQL comments.
+
+ALTER TABLE users ADD COLUMN IF NOT EXISTS webhook_last_delivered_at TIMESTAMPTZ;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS calendar_feed_key_epoch TEXT;


### PR DESCRIPTION
## What
Migration 039 adds two nullable, unbackfilled columns and the single writer of each.
`webhook_last_delivered_at` is stamped only after `Deliver` returns nil, through
`MarkWebhookDelivered`, CAS-pinned to the `webhook_config_version` the pass claimed
under and monotonic. `calendar_feed_key_epoch` is stamped inside the existing
`SaveCalendarFeedToken`, in the same UPDATE as the token triple.

## Why
The ledger (item 23) must not render a watermark as a delivery time: a watermark is
claimed before the POST, holds a cycle anchor, and stands for a send that was never
accepted. No column could say "a delivery was accepted" until now — hence NO BACKFILL,
stated in the prose of both dialects.

## Risk
High: schema, forward-only, no `down.sql`. Newly reachable: one DB write inside the
notify pass's success branch, per accepted delivery per owner, in the scheduler
process — where previously only a pre-POST CAS ran. A failing stamp is logged and
leaves `report.Sent` alone.

`MarkWebhookDelivered` deliberately does **not** advance `webhook_config_version`;
038's prose said a fourth writer owes the advance, and is corrected in both dialects.

## How verified
Full suite green (`-timeout 20m`, TESTING.md package set); `gofmt`, `go vet`, archcheck
clean; patch-coverage gate OK. Red before the fix:
`TestWebhookDeliveryRecordsAcceptedTimestampOnlyAfterSuccess` (the symbols do not exist
on main). `git grep` for both fields in `internal/templates` and `internal/api` is empty.

## Rollback
Reverting this commit restores HEAD behaviour exactly; both columns become unread and
always NULL. The migration is forward-only and both columns are nullable without a
default, so an older binary ignores them. A true schema rollback is a restore from the
pre-upgrade backup.
