### PR TITLE
chore: tracked comments stop citing agent-only rule files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1236,8 +1236,8 @@ jobs:
   # reports one context per cell (`e2e-shard (1)`, ...), none of which is the
   # literal name the required check is pinned to.
   #
-  # Sharding is NOT raising parallelism inside one database, which
-  # `.claude/rules/e2e.md` rules out for the SQLite-backed stateful flows.
+  # Sharding is NOT raising parallelism inside one database — that stays ruled
+  # out for the SQLite-backed stateful flows.
   # Every shard is its own runner: its own `go run` app, its own SQLite file
   # under .tmp/e2e, and still `--workers=1` from the runner (`--mode=ci`). What
   # changes is how many app instances exist, not how many tests share one.

--- a/changelog.d/chore-tracked-sources-stop-citing-agent-paths.md
+++ b/changelog.d/chore-tracked-sources-stop-citing-agent-paths.md
@@ -1,0 +1,12 @@
+none
+
+Comment-only fix: twenty-one comments in Go, workflow and Playwright sources
+cited an agent-only rule file — some by path, some by bare filename, which is
+why a sweep for the path spelling alone had found only half of them. A tracked
+source must never name one. None of the twenty-one was a security-invariant
+claim, so none could be redirected to `docs/SECURITY_INVARIANTS.md` without
+asserting something that document does not say; each comment now restates the
+constraint it relies on, leaving the tracked source self-contained. One site is
+deliberately kept: the locale reachability test writes a fixture under an
+agent-only directory as DATA the walker under test must skip, not as a citation.
+No behaviour change.

--- a/e2e/dashboard-reminder-banner.spec.ts
+++ b/e2e/dashboard-reminder-banner.spec.ts
@@ -10,9 +10,9 @@ import { registerAndOnboardWithStartDaysAgo } from './support/stats-helpers';
 // pins "today" to the browser timezone, so those day counts hold whatever zone
 // the server runs in.
 test.describe('Dashboard reminder banner', () => {
-  // testing.md keeps the backend HTML regressions on the data-reminder-banner-key
-  // hook only; the rendered visible copy — including the day count interpolated
-  // into the plural variant — is owned here, addressed via that same hook.
+  // The backend HTML regressions stay on the data-reminder-banner-key hook only;
+  // the rendered visible copy — including the day count interpolated into the
+  // plural variant — is owned here, addressed via that same hook.
   test('a next period two days out renders the plural "~N days" reminder copy', async ({
     page,
   }) => {

--- a/e2e/settings-password-export-danger.spec.ts
+++ b/e2e/settings-password-export-danger.spec.ts
@@ -264,7 +264,7 @@ test.describe('Settings: password, export, clear data, delete account', () => {
 
     // GET-only route: CSRF gates state-changing methods, so no token is sent.
     // The explicit Origin keeps the call valid under the HTTPS posture, where
-    // the CSRF middleware rejects mutating requests without one (testing.md).
+    // the CSRF middleware rejects mutating requests without one.
     const csvResponse = await page.request.get('/api/v1/exports/csv', {
       headers: apiOriginHeader(page),
     });

--- a/internal/api/auth_login_invalid_credentials_regressions_test.go
+++ b/internal/api/auth_login_invalid_credentials_regressions_test.go
@@ -30,7 +30,7 @@ func TestLoginInvalidCredentialsRedirectDoesNotPersistEmail(t *testing.T) {
 		bodyStringMatch{fragment: `id="login-email"`, message: "expected login email input in page"},
 	)
 	// Assert the error via its stable data-error-key hook, not the localized copy
-	// (testing.md: never strings.Contains on a localized phrase).
+	// — never strings.Contains on a localized phrase.
 	if htmlAuthErrorByKey(mustParseHTMLDocument(t, rendered), "auth.error.invalid_credentials") == nil {
 		t.Fatalf("expected invalid-credentials auth error surfaced via data-error-key, got %q", rendered)
 	}

--- a/internal/api/auth_register_email_persistence_regressions_test.go
+++ b/internal/api/auth_register_email_persistence_regressions_test.go
@@ -35,7 +35,7 @@ func TestRegisterPageDoesNotPersistEmailAfterPasswordValidationError(t *testing.
 		bodyStringMatch{fragment: `id="register-email"`, message: "expected register email input on validation-error page"},
 	)
 	// Assert the weak-password error via its stable data-error-key hook, not the
-	// localized copy (testing.md: never strings.Contains on a localized phrase).
+	// localized copy — never strings.Contains on a localized phrase.
 	if htmlAuthErrorByKey(mustParseHTMLDocument(t, rendered), "auth.error.weak_password") == nil {
 		t.Fatalf("expected weak-password auth error surfaced via data-error-key, got %q", rendered)
 	}

--- a/internal/api/handlers_days_autofill_regressions_test.go
+++ b/internal/api/handlers_days_autofill_regressions_test.go
@@ -504,8 +504,7 @@ func TestDayAndSymptomJSONUseSnakeCaseWireKeys(t *testing.T) {
 	// snake_case DTO contract. A no-CSRF app is appropriate here: the test
 	// isolates content negotiation, while the valid-token CSRF update path is
 	// covered by the settings symptom HTMX regressions and the missing-token 403
-	// by state_mutation_csrf_missing_token_test.go (testing.md content-negotiation
-	// rule).
+	// by state_mutation_csrf_missing_token_test.go.
 	custom := models.SymptomType{
 		UserID:    user.ID,
 		Name:      "Wire custom symptom",

--- a/internal/api/oidc_link_pending_cookie_test.go
+++ b/internal/api/oidc_link_pending_cookie_test.go
@@ -11,11 +11,10 @@ import (
 
 // The OIDC link-pending cookie hands a user from a partial OIDC callback to
 // the password-confirmation page, carrying enough state to finish the link
-// without re-running the OIDC exchange. testing.md AEAD-sealed cookie rules
-// require every sealed-cookie purpose to lock the four AAD-binding invariants:
-// round-trip, cross-purpose AAD, byte tamper, key rotation. Expiry and
-// minimum-payload checks are added because validAt() also gates handler
-// behavior.
+// without re-running the OIDC exchange. Every sealed-cookie purpose locks the
+// four AAD-binding invariants: round-trip, cross-purpose AAD, byte tamper, key
+// rotation. Expiry and minimum-payload checks are added because validAt() also
+// gates handler behavior.
 
 func newOIDCLinkPendingTestPayload(t *testing.T, now time.Time) oidcLinkPendingPayload {
 	t.Helper()

--- a/internal/api/openapi_operation_reachability_test.go
+++ b/internal/api/openapi_operation_reachability_test.go
@@ -24,10 +24,9 @@ import (
 // emittable across the WHOLE server, which passes even when a status is
 // emittable only by an operation that never declared it — a 429 the spec
 // forgot is invisible to a check that only asks whether 429 appears anywhere
-// in internal/. Two real drifts of exactly that shape shipped for a release
-// (four re-auth-budget endpoints undeclaring 429; the "OpenAPI spec contract"
-// rule in .claude/rules/api.md — governance-update, 2026-09-02 — has the
-// prose).
+// in internal/. Two real drifts of exactly that shape shipped for a release:
+// four re-auth-budget endpoints undeclaring 429. The spec contract binds each
+// operation separately — every operation declares every status it can emit.
 //
 // This test is deliberately one-directional, the same way its sibling is:
 // under-declaration (emittable but not declared) is what it asserts, because
@@ -202,7 +201,7 @@ const maxReachDepth = 8
 // because they are cross-cutting rather than a decision the operation's own
 // business logic makes: 500 is the universal default arm of every domain
 // error-mapping switch (already documented centrally, not per-operation, by
-// api.md's ErrorHandler total-resolution rule and
+// the ErrorHandler's total-resolution contract and
 // TestOpenAPIDocumentsEveryTransportStatusTheEnvelopeCovers); 303 is emitted
 // by the shared JSON/HTMX content-negotiation helper any handler MAY reach
 // regardless of its own logic, and the spec's own preamble scopes documented

--- a/internal/api/stats_cycle_stack_truncation_regression_test.go
+++ b/internal/api/stats_cycle_stack_truncation_regression_test.go
@@ -140,9 +140,8 @@ func statsBodyForCycleGaps(t *testing.T, email string, gaps []int) string {
 // from input.css and rebuild and the two agree perfectly: the guard is green,
 // every Go test is green, the linter is green, and the mark is gone, so two
 // capped rows are once more the same width with nothing saying so.
-// `css-components.md` states that blind spot for the removal direction; this is
-// the dependency direction, where markup carries a hook whose only consumer is
-// a component rule.
+// That blind spot is the removal direction; this is the dependency direction,
+// where markup carries a hook whose only consumer is a component rule.
 //
 // That is exactly the failure this change exists to close, one layer down: #581
 // computed Truncated and AxisTruncated and shipped them with no consumer, and

--- a/internal/api/stats_overview_dto.go
+++ b/internal/api/stats_overview_dto.go
@@ -7,17 +7,16 @@ import (
 	"github.com/ovumcy/ovumcy-web/internal/services"
 )
 
-// statsOverviewDateLayout is the wire spelling of every date in this payload
-// (api.md: YYYY-MM-DD, never an RFC 3339 instant). A cycle date is a calendar
-// day, and serializing it as an instant published a timezone the owner never
-// chose along with it.
+// statsOverviewDateLayout is the wire spelling of every date in this payload:
+// YYYY-MM-DD, never an RFC 3339 instant. A cycle date is a calendar day, and
+// serializing it as an instant published a timezone the owner never chose along
+// with it.
 const statsOverviewDateLayout = "2006-01-02"
 
 // medicalDisclaimerMessageKey is the single catalogue entry every predictive
-// surface renders. The API sends the resolved text AND the key, per api.md's
-// stable-key-beside-localized-copy rule: a client cannot branch on translated
-// prose, and a test asserting the copy alone goes quiet the day the wording
-// changes.
+// surface renders. The API sends the resolved text AND the key, because a
+// client cannot branch on translated prose, and a test asserting the copy alone
+// goes quiet the day the wording changes.
 const medicalDisclaimerMessageKey = "medical.disclaimer"
 
 // medicalDisclaimer resolves the safety framing for this request, falling back

--- a/internal/services/calendar_day_construction_barrier_test.go
+++ b/internal/services/calendar_day_construction_barrier_test.go
@@ -359,8 +359,7 @@ func inspectCalendarDayFile(fileSet *token.FileSet, file *ast.File, relative str
 		// tie the anti-vacuity anchor to the very thing the sweep judges: every
 		// site fixed lowers it, so a fully converted tree would fail as "discovery
 		// is broken" — which is exactly what happened once this class was swept.
-		// A guard's floor must not depend on the data it judges
-		// (`.claude/rules/testing.md`).
+		// A guard's floor must not depend on the data it judges.
 		ast.Inspect(function.Body, func(inner ast.Node) bool {
 			call, isCall := inner.(*ast.CallExpr)
 			if !isCall || len(call.Args) != 3 {
@@ -639,7 +638,7 @@ func calendarDayIsPackageIdent(expr ast.Expr) bool {
 // Without it the shape's only live positive example is an allowlist entry, so the
 // day that site is converted the classifier stops being exercised and the barrier
 // passes while measuring nothing — the anti-vacuity anchor would depend on the
-// data it judges, which `.claude/rules/testing.md` forbids. The floors do not
+// data it judges, which a guard's floor must never do. The floors do not
 // cover this: they prove the parser SEES steps, not that the classifier still
 // tells a location anchor from a UTC one.
 const calendarDayBarrierShapeCFixture = `package sample

--- a/internal/services/calendar_day_construction_barrier_test.go
+++ b/internal/services/calendar_day_construction_barrier_test.go
@@ -638,7 +638,7 @@ func calendarDayIsPackageIdent(expr ast.Expr) bool {
 // Without it the shape's only live positive example is an allowlist entry, so the
 // day that site is converted the classifier stops being exercised and the barrier
 // passes while measuring nothing — the anti-vacuity anchor would depend on the
-// data it judges, which a guard's floor must never do. The floors do not
+// data it judges, which an anti-vacuity anchor must never do. The floors do not
 // cover this: they prove the parser SEES steps, not that the classifier still
 // tells a location anchor from a UTC one.
 const calendarDayBarrierShapeCFixture = `package sample

--- a/internal/services/calendar_day_step_dst_test.go
+++ b/internal/services/calendar_day_step_dst_test.go
@@ -17,8 +17,8 @@ package services
 // user-visible surfaces that were stepping by hand.
 //
 // The zone must be west of UTC — east-of-UTC zones normalize a missing midnight
-// forward and keep the date, so the same fixture there is green about nothing
-// (`.claude/rules/testing.md`). Every case carries a UTC control.
+// forward and keep the date, so the same fixture there is green about nothing.
+// Every case carries a UTC control.
 
 import (
 	"testing"

--- a/internal/services/context_rooting_guard_test.go
+++ b/internal/services/context_rooting_guard_test.go
@@ -35,8 +35,8 @@ var detachesFromTheCaller = map[string]bool{
 // stuck database would hang the boot exactly as it did before the budget
 // existed, and every test would stay green.
 //
-// The rule is not new, only unenforced here. persistence.md already requires a
-// ctx parameter over context.Background for repositories, and this package held
+// The rule is not new, only unenforced here. Repositories already take a ctx
+// parameter rather than rooting one at context.Background, and this package held
 // to it on its own — the sweep found zero occurrences when it was written, which
 // is why it can be an outright refusal rather than an allowlist. A service that
 // genuinely needs a detached context (a goroutine outliving its request) has to

--- a/internal/services/cycle_signals.go
+++ b/internal/services/cycle_signals.go
@@ -112,8 +112,9 @@ func InferUserLutealPhase(logs []models.DailyLog, location *time.Location) (int,
 // save would put the future-dated value straight back, which is precisely the
 // disagreement the paragraph above promises cannot happen. `now` is a required
 // parameter for the same reason — a writer cannot omit the bound by forgetting
-// it. Same shape as the pregnancy pause (`prediction-display.md`): the bound
-// belongs to the derivation, never to the caller's fetch.
+// it. Same shape as the pregnancy pause: the bound belongs to the derivation
+// and never to the caller's fetch, so two callers cannot reach two answers for
+// one owner.
 func deriveUserLutealPhase(logs []models.DailyLog, now time.Time, location *time.Location) int {
 	observed := filterLogsNotAfter(logs, DateAtLocation(now, location))
 	if lutealPhase, refined := InferUserLutealPhase(observed, location); refined {
@@ -146,8 +147,8 @@ func ConfirmedCurrentCycleOvulation(user *models.User, logs []models.DailyLog, s
 	// dashboard cannot gate the same signal differently. It is the same
 	// predicate the calendar already wrapped this pass in
 	// (FertilityProjectionSuppressed = unpredictable · pregnancy-paused ·
-	// overdue, plus the first-cycle floor), read once instead of restated —
-	// prediction-display.md forbids a surface recombining the signals itself.
+	// overdue, plus the first-cycle floor), read once instead of restated: a
+	// surface may not recombine the suppression signals itself.
 	if FertilityProjectionSuppressed(user, stats) {
 		return time.Time{}, false
 	}

--- a/internal/services/cycle_signals.go
+++ b/internal/services/cycle_signals.go
@@ -112,9 +112,8 @@ func InferUserLutealPhase(logs []models.DailyLog, location *time.Location) (int,
 // save would put the future-dated value straight back, which is precisely the
 // disagreement the paragraph above promises cannot happen. `now` is a required
 // parameter for the same reason — a writer cannot omit the bound by forgetting
-// it. Same shape as the pregnancy pause: the bound belongs to the derivation
-// and never to the caller's fetch, so two callers cannot reach two answers for
-// one owner.
+// it. Same shape as the pregnancy pause: the bound belongs to the derivation,
+// never to the caller's fetch.
 func deriveUserLutealPhase(logs []models.DailyLog, now time.Time, location *time.Location) int {
 	observed := filterLogsNotAfter(logs, DateAtLocation(now, location))
 	if lutealPhase, refined := InferUserLutealPhase(observed, location); refined {

--- a/internal/services/cycle_signals_dst_test.go
+++ b/internal/services/cycle_signals_dst_test.go
@@ -25,8 +25,8 @@ package services
 // start itself.
 //
 // The zone must be west of UTC: east-of-UTC zones normalize a missing midnight
-// forward and keep the date, so the same fixture there is green about nothing
-// (`.claude/rules/testing.md`). Controls: UTC over the identical fixtures.
+// forward and keep the date, so the same fixture there is green about nothing.
+// Controls: UTC over the identical fixtures.
 
 import (
 	"testing"

--- a/internal/services/dashboard_confirmed_ovulation_test.go
+++ b/internal/services/dashboard_confirmed_ovulation_test.go
@@ -13,7 +13,7 @@ package services
 //
 // Both surfaces now resolve the day through ConfirmedCurrentCycleOvulation. The
 // substitution changes only WHICH day is named: whether a day may be named at
-// all stays with the suppression gates (prediction-display.md).
+// all stays with the suppression gates.
 
 import (
 	"testing"

--- a/internal/services/dashboard_cycle.go
+++ b/internal/services/dashboard_cycle.go
@@ -497,14 +497,15 @@ func buildDashboardPredictionDisplay(user *models.User, logs []models.DailyLog, 
 	// ConfirmedCurrentCycleOvulation so they cannot disagree.
 	//
 	// This substitution deliberately sits ABOVE the suppression branches and
-	// changes only WHICH day is named, never whether a day is named at all: what
-	// may render is prediction-display.md's subject, and a confirmed observation
-	// must not become a way around a gate. dashboardOvulationInPast then reads
-	// the substituted date, so a confirmed ovulation already behind the owner is
-	// rendered as past instead of announced as upcoming — which is the whole
-	// defect: on the projected day itself the difference to today was zero, the
-	// anchor never shifted, and the line declared an ovulation the temperatures
-	// had placed several days earlier.
+	// changes only WHICH day is named, never whether a day is named at all:
+	// whether a window may render at all belongs to the suppression gates, and a
+	// confirmed observation must not become a way around one.
+	// dashboardOvulationInPast then reads the substituted date, so a confirmed
+	// ovulation already behind the owner is rendered as past instead of
+	// announced as upcoming — which is the whole defect: on the projected day
+	// itself the difference to today was zero, the anchor never shifted, and the
+	// line declared an ovulation the temperatures had placed several days
+	// earlier.
 	if confirmed, ok := ConfirmedCurrentCycleOvulation(user, logs, stats, today, location); ok {
 		display.ovulationDate = confirmed
 		display.ovulationConfirmed = true


### PR DESCRIPTION
## What
Twenty-one comments in Go, workflow and Playwright sources cited an agent-only
rule file. Comments only, no behaviour change.

## Why
A tracked source must never name one. The class was wider than the handoff
recorded: some sites spell the path, some name the file bare, so a sweep keyed
on the path spelling saw half of them.

## How
None of the twenty-one was a security-invariant claim, so redirecting them to
the public security mirror would assert something that document does not say.
Each comment now restates the constraint it relied on and drops the pointer,
leaving the tracked source self-contained.

Deliberately kept: `internal/i18n/locale_reachability_test.go` writes a fixture
under an agent-only directory as DATA the walker under test must skip — naming
the path is the point of the case, not a citation.

## Risk
None at runtime. The sweep is keyed on both axes (path spelling and bare
basename, the latter derived from the live file list), so a site spelling it a
third way would still be missed.

## Verified
Sweep over both axes returns only the kept fixture and three `.mutation/`
artifact references that are not agent-only; `go build ./...` exit 0;
`go vet ./internal/api/ ./internal/services/ ./internal/i18n/` clean; `gofmt -l`
over tracked Go files reports only `internal/services/dashboard_cycle.go`, whose
field-alignment drift predates this branch on `main` and is out of scope here.
