### PR TITLE
chore: gofmt the drifted DashboardCycleContext field block

### DIFF
--- a/changelog.d/gofmt-the-drifted-dashboard-cycle-context.md
+++ b/changelog.d/gofmt-the-drifted-dashboard-cycle-context.md
@@ -1,0 +1,7 @@
+none
+
+Formatting-only fix: `DashboardCycleContext`'s field block in
+`internal/services/dashboard_cycle.go` had drifted out of gofmt alignment, so
+`gofmt -l` over the tracked Go files named that one file on a clean `main`. No
+CI lane runs gofmt, which is why it stayed. Whitespace only — no declaration,
+type or comment changed.

--- a/internal/services/dashboard_cycle.go
+++ b/internal/services/dashboard_cycle.go
@@ -53,14 +53,14 @@ type DashboardCycleContext struct {
 	// keep gating on DisplayOvulationNeedsData: the ring is projection
 	// arithmetic, and the banner counts down to a day still ahead, neither of
 	// which a past measurement answers.
-	DisplayOvulationConfirmed   bool
-	DisplayOvulationExact       bool
-	DisplayOvulationImpossible  bool
-	NextPeriodEstimatePaused    bool
-	AwaitingFirstCycle          bool
-	FertilitySuppressed         bool
-	NextPeriodInPast            bool
-	OvulationInPast             bool
+	DisplayOvulationConfirmed  bool
+	DisplayOvulationExact      bool
+	DisplayOvulationImpossible bool
+	NextPeriodEstimatePaused   bool
+	AwaitingFirstCycle         bool
+	FertilitySuppressed        bool
+	NextPeriodInPast           bool
+	OvulationInPast            bool
 }
 
 type dashboardPredictionDisplay struct {


### PR DESCRIPTION
## What
`gofmt -w internal/services/dashboard_cycle.go`. Whitespace only — eight field
declarations in `DashboardCycleContext` re-aligned. No declaration, type or
comment changed.

## Why
`gofmt -l` over the tracked Go files named that one file on a clean `main`. It
surfaced while formatting was checked for a neighbouring PR and was left out of
that one deliberately, since it is unrelated to its subject.

## Risk
None. The drift stood because no CI lane runs gofmt — this PR does not add one,
so the same drift can return.

## Verified
`gofmt -l` over `git ls-files '*.go'` now returns empty; `go build ./...` exit 0;
`git diff` is whitespace in a single field block.
