### PR TITLE
fix(a11y): dashboard cycle ribbon carries per-day accessible names

### DIFF
--- a/changelog.d/fix-dashboard-cycle-ribbon-a11y.md
+++ b/changelog.d/fix-dashboard-cycle-ribbon-a11y.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- **The dashboard cycle ribbon is no longer invisible to a screen reader.** It carried
+  `aria-hidden="true"` on the premise that every fact it draws is stated in the status line above
+  it, but two per-day facts — which days fall in the predicted start window and which were actually
+  logged — exist only in the ribbon, with no textual equivalent anywhere else on the page. Each day
+  cell now carries its own accessible name (`role="img"` plus a computed `aria-label`: cycle day,
+  phase, and start-window/logged when they apply) instead of the ribbon being hidden outright. Also
+  dropped `data-projected`, a ribbon-day attribute nothing ever read.

--- a/internal/api/dashboard_status_header_regression_test.go
+++ b/internal/api/dashboard_status_header_regression_test.go
@@ -51,10 +51,23 @@ func TestDashboardStatusHeaderCarriesTheSegmentedRingForStableCycleContext(t *te
 	if dashboardElementByDataAttr(header, "data-dashboard-cycle-day") == nil {
 		t.Fatal("expected the cycle day beside the ribbon")
 	}
-	if htmlFindElement(ribbon, func(node *html.Node) bool {
+	dayOne := htmlFindElement(ribbon, func(node *html.Node) bool {
 		return node.Type == html.ElementNode && htmlAttr(node, "data-cycle-ribbon-day") == "1"
-	}) == nil {
+	})
+	if dayOne == nil {
 		t.Fatal("expected the ribbon to run from cycle day 1")
+	}
+	// The ribbon used to be aria-hidden outright; per-day facts like
+	// data-logged and data-start-window have no textual equivalent
+	// elsewhere on the page, so each cell now needs its own accessible name.
+	if htmlHasAttr(ribbon, "aria-hidden") {
+		t.Fatal("expected the ribbon to be exposed to assistive tech, not aria-hidden")
+	}
+	if got := htmlAttr(dayOne, "role"); got != "img" {
+		t.Fatalf("expected the ribbon day to carry role=img, got %q", got)
+	}
+	if got := htmlAttr(dayOne, "aria-label"); got == "" {
+		t.Fatal("expected the ribbon day to carry a non-empty aria-label")
 	}
 	if dashboardElementByDataAttr(header, "data-dashboard-status-line") == nil {
 		t.Fatal("expected the single status line inside the status header")

--- a/internal/templates/dashboard.html
+++ b/internal/templates/dashboard.html
@@ -162,23 +162,26 @@
       {{/* The cycle ribbon. One cell per day of the axis, in cycle order: the
            phase colours, the fertile window, the days a period may start on and
            the days this account actually recorded, all drawn from the calendar's
-           own --cal-* source so the two screens cannot disagree. It is
-           aria-hidden because every fact it encodes is stated in the status line
-           above it — the ribbon is the picture of that sentence, not a second
-           source. */}}
+           own --cal-* source so the two screens cannot disagree. The status line
+           above states the aggregate (today's phase, the next-period window, the
+           ovulation estimate), but two per-day facts — which days fall in the
+           predicted start window and which were actually logged — exist only
+           here, so each cell carries its own accessible name instead of the
+           ribbon being aria-hidden. */}}
       <div
         class="dashboard-cycle-ribbon-wrap"
         data-dashboard-cycle-ribbon
         data-cycle-ribbon-visible="{{if .CycleHero.Visible}}true{{else}}false{{end}}">
         {{if .CycleHero.Visible}}
-        <div class="dashboard-cycle-ribbon" aria-hidden="true">
+        <div class="dashboard-cycle-ribbon">
           {{range .CycleHero.Days}}
           <span
             class="dashboard-cycle-ribbon-day"
             data-cycle-ribbon-day="{{.Day}}"
             data-phase="{{.Phase}}"
+            role="img"
+            aria-label="{{t $.Messages "dashboard.cycle_day"}} {{.Day}}: {{phaseLabel $.Messages .Phase}}{{if .IsStartWindow}}, {{t $.Messages "calendar.legend.start_window"}}{{end}}{{if .IsLogged}}, {{t $.Messages "calendar.data_logged"}}{{end}}"
             {{if .IsToday}}data-today="true"{{end}}
-            {{if .IsProjected}}data-projected="true"{{end}}
             {{if .IsPredictedFlow}}data-predicted-flow="true"{{end}}
             {{if .IsFertile}}data-fertile="true"{{end}}
             {{if .IsFertilePeak}}data-fertile-peak="true"{{end}}

--- a/internal/templates/dom_attribute_consumers_test.go
+++ b/internal/templates/dom_attribute_consumers_test.go
@@ -103,7 +103,6 @@ var domAttrConsumerResidual = map[string]string{
 	// These two are not decoration, and closing them is a change of its own.
 	"data-cycle-start-implantation": "the only unread field of the cycle-start confirm island: its siblings (conflict-date, short-gap, replace-message) are all read, so the implantation warning the server computes reaches no dialog",
 	"data-next-period-paused-key":   "the state key beside data-dashboard-next-period-paused, which is asserted while its key is not",
-	"data-projected":                "the only ribbon-day flag with no reader; data-today, data-fertile and the rest are all addressed",
 	"data-period":                   "the cycle-stack day flag beside data-fertile, data-fertile-peak and data-logged, which are all addressed while it is not (stats.html:352)",
 }
 

--- a/web/src/css/input.css
+++ b/web/src/css/input.css
@@ -4482,14 +4482,18 @@
        Measured against the white card (light) with the ribbon's own fills:
        menstrual 3.39:1, ovulation 3.61:1 — the two phases a reader actually
        looks for clear the 3:1 non-text floor — while follicular 1.71:1 and
-       luteal 2.32:1 sit under it deliberately. The band is a REDUNDANT graphic:
-       it is aria-hidden and every fact it draws is stated in the status line
-       beside it, so 1.4.11 does not bind it, and forcing all four to one
-       contrast level flattens them into a single luminance where neighbouring
-       phases stop being separable at all (measured: adjacent pairs collapse
-       from ~2:1 to ~1.05:1). What the band needs instead is a lightness ladder,
-       which is what these four are: adjacent pairs stay ≥1.46:1 in light and
-       ≥1.96:1 in dark, hue separating them further. */
+       luteal 2.32:1 sit under it deliberately. The phase fill is a REDUNDANT
+       graphic: the current phase it paints is already stated as visible text
+       in the status line beside it, so 1.4.11 does not bind it (this is
+       independent of aria-hidden — the ribbon now carries a per-day
+       aria-label of its own, for the two per-day facts that have no textual
+       equivalent elsewhere; the phase colour was never that gap). Forcing
+       all four to one contrast level flattens them into a single luminance
+       where neighbouring phases stop being separable at all (measured:
+       adjacent pairs collapse from ~2:1 to ~1.05:1). What the band needs
+       instead is a lightness ladder, which is what these four are: adjacent
+       pairs stay ≥1.46:1 in light and ≥1.96:1 in dark, hue separating them
+       further. */
     --phase-menstrual: var(--cal-period);
     --phase-follicular: 229 192 150;
     --phase-ovulation: 172 127 36;


### PR DESCRIPTION
## What
Dashboard cycle ribbon (`internal/templates/dashboard.html`): each day cell gets `role="img"` +
`aria-label`; wrapper drops `aria-hidden`. Removed the dead `data-projected` attribute and its
`dom_attribute_consumers_test.go` residual entry.

## Why
A11Y-1: the ribbon was `aria-hidden="true"` on the premise that every fact it draws is already in
the status line. Two per-day facts — `data-logged` and `data-start-window` — have no textual
equivalent anywhere else on the page, so a screen-reader user never learns which days were logged
or fall in the predicted start window. Reused existing `calendar.legend.start_window` /
`calendar.data_logged` i18n keys (already translated in all 6 locales) rather than adding new ones.

## Evidence
`TestEveryTemplateDataHookIsNamedOutsideTheTemplates` catches a dead hook left behind; ran green
after dropping `data-projected` and its residual entry together.

## Risk
Low. Markup + one Go test-fixture edit; no schema/auth/public-interface change.
