### PR TITLE
test(a11y): contrast gate measures all four ribbon phases via background-image

### DIFF
--- a/changelog.d/fix-contrast-gate-ribbon-phases.md
+++ b/changelog.d/fix-contrast-gate-ribbon-phases.md
@@ -1,0 +1,13 @@
+### Internal
+
+- **The cycle-ribbon contrast gate now measures all four phases, and sees `background-image`.**
+  `theme-dark-mode.spec.ts` checked only the `menstrual` phase, and `measureGraphicContrast` read
+  only `background-color` — the predicted-flow hatch and the start-window gradient are both painted
+  as `background-image` on top of the phase fill, so a cell carrying either flag was measured as if
+  it did not. The independently recomputed ratios were already correct (light theme: menstrual
+  3.39:1 and ovulation 3.61:1 clear the 3:1 floor by design; follicular 1.71:1 and luteal 2.32:1 sit
+  under it deliberately, per the sanctioned exception documented beside the phase colours in
+  `input.css`; dark theme clears the floor on all four) — the gap was in the tool, not the picture.
+  A new `'background'` mode on `measureGraphicContrast` resolves the graphic's own
+  `background-color` and `background-image` stops together; the spec now measures a clean (no
+  overlay) cell of each phase and keeps the same pass/exempt split the design already carries.

--- a/e2e/support/contrast-helpers.ts
+++ b/e2e/support/contrast-helpers.ts
@@ -316,15 +316,47 @@ export async function measureGraphicContrast(
   graphic: Locator,
   surface: Locator,
   label: string,
-  property: 'stroke' | 'fill' | 'background-color' = 'stroke'
+  property: 'stroke' | 'fill' | 'background-color' | 'background' = 'stroke'
 ): Promise<ContrastMeasurement> {
-  const paint = await graphic.evaluate(
-    (node: Element, name: string) => window.getComputedStyle(node).getPropertyValue(name).trim(),
-    property
-  );
-  const graphicColor = parseCssColor(paint);
-  if (graphicColor === null) {
-    throw new Error(`${label}: unresolvable ${property} ${paint}`);
+  let graphicColors: Rgba[];
+  let paintDescription: string;
+
+  if (property === 'background') {
+    // Unlike 'background-color', this mode also resolves a background-image
+    // layer painted on top of it (the ribbon's predicted-flow hatch and
+    // start-window gradient are both background-image) — 'background-color'
+    // alone reads the phase's base fill and stays blind to that overlay, so a
+    // cell that also carries one of those flags is measured as if it did not.
+    const graphicPainted = await readPaintedSurface(graphic);
+    if (!graphicPainted.measurable) {
+      throw new Error(`${label}: the graphic is unmeasurable (${graphicPainted.reason})`);
+    }
+    const stops = backgroundStops(graphicPainted.backgroundColor, graphicPainted.backgroundImage);
+    graphicColors = stops.map((source) => {
+      const parsed = parseCssColor(source);
+      if (parsed === null) {
+        throw new Error(`${label}: unresolvable graphic paint stop ${source}`);
+      }
+      return parsed;
+    });
+    if (graphicColors.length === 0) {
+      throw new Error(
+        `${label}: the graphic paints no background of its own ` +
+          `(background-color: ${graphicPainted.backgroundColor}, background-image: ${graphicPainted.backgroundImage})`
+      );
+    }
+    paintDescription = `background-color: ${graphicPainted.backgroundColor}, background-image: ${graphicPainted.backgroundImage}`;
+  } else {
+    const paint = await graphic.evaluate(
+      (node: Element, name: string) => window.getComputedStyle(node).getPropertyValue(name).trim(),
+      property
+    );
+    const graphicColor = parseCssColor(paint);
+    if (graphicColor === null) {
+      throw new Error(`${label}: unresolvable ${property} ${paint}`);
+    }
+    graphicColors = [graphicColor];
+    paintDescription = paint;
   }
 
   const painted = await readPaintedSurface(surface);
@@ -340,15 +372,22 @@ export async function measureGraphicContrast(
     );
   }
 
-  const stops: ContrastStop[] = surfaceStops.map((stop) => ({
-    source: stop.source,
-    painted: formatRgb(stop.color),
-    ratio: contrastRatio(flattenOver(graphicColor, stop.color), stop.color),
-  }));
+  // Every graphic stop against every surface stop: a reader gets whichever
+  // pairing they land on, so the weakest pairing is the one that matters.
+  const stops: ContrastStop[] = [];
+  for (const graphicColor of graphicColors) {
+    for (const stop of surfaceStops) {
+      stops.push({
+        source: stop.source,
+        painted: formatRgb(stop.color),
+        ratio: contrastRatio(flattenOver(graphicColor, stop.color), stop.color),
+      });
+    }
+  }
 
   return {
     label,
-    color: paint,
+    color: paintDescription,
     backgroundColor: painted.backgroundColor,
     backgroundImage: painted.backgroundImage,
     stops,

--- a/e2e/theme-dark-mode.spec.ts
+++ b/e2e/theme-dark-mode.spec.ts
@@ -229,13 +229,14 @@ test.describe('Theme mode', () => {
 
     // The two phases a reader looks for — the period itself and the ovulation
     // day — carry the 3:1 non-text floor against the card in both themes. The
-    // recessive pair (follicular, luteal) deliberately does not: the band is a
-    // redundant aria-hidden graphic whose every fact is stated in the status
-    // line, and levelling all four collapses them into one luminance where
-    // neighbouring phases stop being separable at all (docs: input.css, the
-    // calendar phase/state colours comment). The exception is on the two
-    // recessive phases specifically, not on skipping their measurement — both
-    // are asserted below, just against different floors.
+    // recessive pair (follicular, luteal) deliberately does not: the phase
+    // fill is a redundant graphic — the current phase it paints is already
+    // stated as visible text in the status line beside it — and levelling all
+    // four collapses them into one luminance where neighbouring phases stop
+    // being separable at all (docs: input.css, the calendar phase/state
+    // colours comment). The exception is on the two recessive phases
+    // specifically, not on skipping their measurement — both are asserted
+    // below, just against different floors.
     const exemptFromTheFloor = new Set(['follicular', 'luteal']);
 
     for (const phase of phases) {

--- a/e2e/theme-dark-mode.spec.ts
+++ b/e2e/theme-dark-mode.spec.ts
@@ -212,39 +212,69 @@ test.describe('Theme mode', () => {
       'data-cycle-ribbon-visible',
       'true'
     );
+
+    // All four phases, measured with 'background' (not 'background-color') so
+    // a cell that also carries data-predicted-flow or data-start-window — both
+    // painted as background-image, layered on top of the phase's own fill —
+    // is not measured as if that overlay were absent. Restricted to a cell
+    // carrying neither flag, so this pins the phase's OWN fill, the same
+    // quantity input.css's own contrast comment documents.
+    const phases = ['menstrual', 'follicular', 'ovulation', 'luteal'] as const;
+    const cleanPhaseCell = (phase: (typeof phases)[number]) =>
+      header
+        .locator(
+          `[data-cycle-ribbon-day][data-phase="${phase}"]:not([data-predicted-flow="true"]):not([data-start-window="true"])`
+        )
+        .first();
+
     // The two phases a reader looks for — the period itself and the ovulation
     // day — carry the 3:1 non-text floor against the card in both themes. The
     // recessive pair (follicular, luteal) deliberately does not: the band is a
     // redundant aria-hidden graphic whose every fact is stated in the status
     // line, and levelling all four collapses them into one luminance where
-    // neighbouring phases stop being separable at all.
-    const menstrual = header.locator('[data-cycle-ribbon-day][data-phase="menstrual"]').first();
-    await expect(menstrual).toHaveCount(1);
+    // neighbouring phases stop being separable at all (docs: input.css, the
+    // calendar phase/state colours comment). The exception is on the two
+    // recessive phases specifically, not on skipping their measurement — both
+    // are asserted below, just against different floors.
+    const exemptFromTheFloor = new Set(['follicular', 'luteal']);
 
-    const darkContrast = await measureGraphicContrast(
-      menstrual,
-      header,
-      'cycle ribbon menstrual (dark)',
-      'background-color'
-    );
-    expect(darkContrast.worstRatio, describeContrast(darkContrast)).toBeGreaterThanOrEqual(
-      WCAG_AA_GRAPHIC_CONTRAST
-    );
+    for (const phase of phases) {
+      const cell = cleanPhaseCell(phase);
+      await expect(cell).toHaveCount(1);
 
-    // Anti-vacuity: the same reader has to resolve the light theme's cell too.
+      const darkContrast = await measureGraphicContrast(
+        cell,
+        header,
+        `cycle ribbon ${phase} (dark)`,
+        'background'
+      );
+      // Dark theme's lightness ladder clears the floor on all four phases.
+      expect(darkContrast.worstRatio, describeContrast(darkContrast)).toBeGreaterThanOrEqual(
+        WCAG_AA_GRAPHIC_CONTRAST
+      );
+    }
+
+    // Anti-vacuity: the same reader has to resolve the light theme's cells too.
     // A reader that silently stopped resolving anything would pass the dark
-    // assertion above by measuring nothing at all.
+    // assertions above by measuring nothing at all.
     await applyTheme(page, 'light');
-    const lightContrast = await measureGraphicContrast(
-      menstrual,
-      header,
-      'cycle ribbon menstrual (light)',
-      'background-color'
-    );
-    expect(lightContrast.stops.length, describeContrast(lightContrast)).toBeGreaterThan(0);
-    expect(lightContrast.worstRatio, describeContrast(lightContrast)).toBeGreaterThanOrEqual(
-      WCAG_AA_GRAPHIC_CONTRAST
-    );
+
+    for (const phase of phases) {
+      const cell = cleanPhaseCell(phase);
+      const lightContrast = await measureGraphicContrast(
+        cell,
+        header,
+        `cycle ribbon ${phase} (light)`,
+        'background'
+      );
+      expect(lightContrast.stops.length, describeContrast(lightContrast)).toBeGreaterThan(0);
+      if (exemptFromTheFloor.has(phase)) {
+        continue;
+      }
+      expect(lightContrast.worstRatio, describeContrast(lightContrast)).toBeGreaterThanOrEqual(
+        WCAG_AA_GRAPHIC_CONTRAST
+      );
+    }
 
     await logoutViaAPI(page);
   });


### PR DESCRIPTION
## What
`e2e/support/contrast-helpers.ts`: `measureGraphicContrast` gets a new `'background'` mode that
resolves the graphic's own `background-color` AND `background-image` stops together (mirrors how
the surface side already handles `background-image`). `e2e/theme-dark-mode.spec.ts`: the ribbon
contrast test now measures all four phases, using that mode, on a clean (no predicted-flow /
start-window overlay) cell of each.

## Why
A11Y-2: the gate checked only `menstrual`, reading only `background-color` — the predicted-flow
hatch and the start-window gradient both paint via `background-image` on top of the phase fill, so
a cell carrying either flag scored as if the overlay were absent.

Independently recomputed ratios confirm the picture the gate was blind to is fine: light theme
menstrual 3.39:1 and ovulation 3.61:1 clear 3:1 by design; follicular 1.71:1 and luteal 2.32:1 sit
under it deliberately (documented beside `--phase-*` in `input.css`, since the ribbon is a
redundant `aria-hidden`… — see below); dark theme clears the floor on all four. The fix is in the
tool, not the exception, so the spec keeps the same pass/exempt split, now for real.

**Depends on** [PR-24](https://github.com/ovumcy/ovumcy-web/pull/680): PR-24 removes the ribbon's
`aria-hidden`, so the second half of `input.css`'s parenthetical (the graphic is exempt from 1.4.11
*because* it's `aria-hidden`) is now stale prose, not evidence this PR relies on for its own claim —
noted here since the two share a premise, but left for whoever revisits that comment; out of scope
for this PR.

## Evidence
`e2e/theme-dark-mode.spec.ts:196` (`dark theme keeps the cycle ribbon readable in the status
header`) — ran locally, 4/4 theme-dark-mode.spec.ts tests pass; `npx eslint`/`tsc --noEmit` clean.

## Risk
Low. Test-only change, no production code touched.
