### PR TITLE
build(deps): the dev lockfile drops the symlink-following copy

### DIFF
--- a/changelog.d/the-dev-lockfile-drops-the-symlink-following-copy.md
+++ b/changelog.d/the-dev-lockfile-drops-the-symlink-following-copy.md
@@ -1,3 +1,3 @@
 ### Dependencies
 
-- `@humanfs/node` 0.16.7 → 0.16.8, closing GHSA-p498-v437-472g (moderate): its recursive copy followed symlinked files and copied data from outside the source tree. The package is a dev-scope transitive dependency of `eslint` and is never built into the runtime image. `eslint`'s own range (`^0.16.6`) still admits the vulnerable version, so the floor is held by an `overrides` entry rather than by the lockfile alone.
+- `@humanfs/node` 0.16.7 → 0.16.8, closing GHSA-p498-v437-472g (moderate): its recursive copy followed symlinked files and copied data from outside the source tree. The package is a dev-scope transitive dependency of `eslint` and is never built into the runtime image. An `overrides` entry keeps the floor at `^0.16.8`, so no other dependent can reintroduce the vulnerable version under `eslint`'s wider `^0.16.6` range.

--- a/changelog.d/the-dev-lockfile-drops-the-symlink-following-copy.md
+++ b/changelog.d/the-dev-lockfile-drops-the-symlink-following-copy.md
@@ -1,3 +1,3 @@
 ### Dependencies
 
-- `@humanfs/node` 0.16.7 → 0.16.8, closing GHSA-p498-v437-472g (moderate): its recursive copy followed symlinked files and copied data from outside the source tree. The package is a dev-scope transitive dependency of `eslint` and is never built into the runtime image. An `overrides` entry keeps the floor at `^0.16.8`, so no other dependent can reintroduce the vulnerable version under `eslint`'s wider `^0.16.6` range.
+- `@humanfs/node` 0.16.7 → 0.16.8, closing GHSA-p498-v437-472g (moderate): its recursive copy followed symlinked files and copied data from outside the source tree. The package is a dev-scope transitive dependency of `eslint` and is never built into the runtime image. `eslint`'s own range already admits the patched version, so the lockfile carries the fix and no manifest pin was added.

--- a/changelog.d/the-dev-lockfile-drops-the-symlink-following-copy.md
+++ b/changelog.d/the-dev-lockfile-drops-the-symlink-following-copy.md
@@ -1,0 +1,3 @@
+### Dependencies
+
+- `@humanfs/node` 0.16.7 → 0.16.8, closing GHSA-p498-v437-472g (moderate): its recursive copy followed symlinked files and copied data from outside the source tree. The package is a dev-scope transitive dependency of `eslint` and is never built into the runtime image. `eslint`'s own range (`^0.16.6`) still admits the vulnerable version, so the floor is held by an `overrides` entry rather than by the lockfile alone.

--- a/package-lock.json
+++ b/package-lock.json
@@ -358,25 +358,39 @@
       }
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
         "@humanwhocodes/retry": "^0.4.0"
       },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "typescript-eslint": "^8.68.0"
   },
   "overrides": {
-    "@humanfs/node": "^0.16.8",
     "brace-expansion": "^5.0.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "typescript-eslint": "^8.68.0"
   },
   "overrides": {
+    "@humanfs/node": "^0.16.8",
     "brace-expansion": "^5.0.8"
   }
 }


### PR DESCRIPTION
**What was wrong.** Dependabot alert #29 (moderate, GHSA-p498-v437-472g): `@humanfs/node` 0.16.7 — its recursive copy follows symlinked files and copies data from outside the source tree. Dev scope, transitive under `eslint`, reached only by lint/e2e tooling; the runtime image is `scratch` plus the Go binary and installs no npm package. No dependabot PR exists for it: `eslint`'s range `^0.16.6` already admits the patched version, so there is no manifest edit for the bot to propose — only the lockfile was stale.

**What changed.** `package-lock.json` only: `@humanfs/node` 0.16.7 → 0.16.8, with its `@humanfs/core` 0.19.1 → 0.19.2 and the new `@humanfs/types` 0.15.0. No `overrides` entry: npm already resolves the range to the patched version, and 1.9.2 records what an override that outlives its reason costs here — the `brace-expansion` pin became the `trivy-fs` finding itself and blocked merges.

**Evidence.** `npm ci --dry-run` resolves the lockfile (171 packages); `go run ./scripts/changelogd check` passes; a relock with the manifest untouched keeps 0.16.8. The diff is the `@humanfs/*` lock block and the fragment — no runtime dependency, and no input to `npm run build`, so the committed bundles are unchanged.

**Rollback.** Revert the commits; the alert reopens and nothing else moves.
