### PR TITLE
ci(rel-5): gate release tag and :latest publish on e2e-cross-browser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1770,6 +1770,7 @@ jobs:
       - e2e
       - e2e-postgres-smoke
       - image-smoke
+      - e2e-cross-browser
     # Never on a pull request, and never for the `release: published` event —
     # release tags publish from their own tag push, through the same workflow.
     # `workflow_dispatch` on `main` is kept as the manual re-publish path, gated
@@ -1806,7 +1807,7 @@ jobs:
     # The condition below is correct under either reading, which is why it did
     # not wait for that probe. `!cancelled()` suppresses the implicit predicate
     # whatever that predicate ranges over; on its own it would then publish off
-    # a FAILED gate, so the five results are required by name and judged here
+    # a FAILED gate, so the six results are required by name and judged here
     # rather than inferred from anything. `success` and nothing else: `skipped`
     # must not publish, because a lane that did not run is not a lane that
     # passed, and a required check reads the same either way.
@@ -1828,7 +1829,8 @@ jobs:
       && needs.race.result == 'success'
       && needs.e2e.result == 'success'
       && needs.e2e-postgres-smoke.result == 'success'
-      && needs.image-smoke.result == 'success' }}
+      && needs.image-smoke.result == 'success'
+      && needs.e2e-cross-browser.result == 'success' }}
     # A caller cannot grant a called workflow more than it holds, so this must
     # match the permissions the publish job declares — plus `actions: read` and
     # `checks: read`, for the tag gate that workflow runs ahead of the publish.

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -119,7 +119,7 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-          # The five ci.yml's `publish-image` requires before it lets `:latest`
+          # The six ci.yml's `publish-image` requires before it lets `:latest`
           # follow `main`, split by WHERE each one's verdict is real. The split
           # is not a preference about which run to trust; it is ci.yml's own
           # gating read back.
@@ -155,14 +155,15 @@ jobs:
           # queue's verdict as untrustworthy, and then accepted a push-run green
           # whose only justification WAS that the queue had already run.
           QUEUE_CHECKS: test race e2e
-          HEAVY_CHECKS: e2e-postgres-smoke image-smoke
-          # `e2e-cross-browser` is deliberately absent from both lists, not an
-          # omission: ci.yml:1512 marks it non-required and publish-image's own
-          # `needs:` excludes it for the same reason (deferred, slower
-          # cross-browser coverage, non-blocking by design). This gate mirrors
-          # exactly the five checks publish-image requires — see the comment
-          # above `QUEUE_CHECKS` — so a release tag is held to the same bar as
-          # `:latest`, no stricter. Re-verified against HEAD 2026-09-01.
+          HEAVY_CHECKS: e2e-postgres-smoke image-smoke e2e-cross-browser
+          # `e2e-cross-browser` runs only on push/release/workflow_dispatch —
+          # the same event set as `HEAVY_CHECKS` above, never merge_group — so
+          # it joins that list, not `QUEUE_CHECKS`. REL-5 (owner decision,
+          # 2026-09-03): held out until now for the reasons the prior version
+          # of this comment gave (a release tag stricter than `:latest`); the
+          # owner chose to accept that trade rather than leave the gap. This
+          # gate mirrors exactly the six checks publish-image now requires —
+          # see ci.yml's `publish-image` job `needs:`.
         run: |
           set -euo pipefail
 
@@ -256,7 +257,7 @@ jobs:
           # `success` and nothing else, in the run where the lane ran. `skipped`
           # is refused here even where the lane may legitimately have been
           # cleared for the diff: a release image is being signed off, the
-          # cleared lane is one of the five that hold `:latest` back, and this
+          # cleared lane is one of the six that hold `:latest` back, and this
           # gate cannot tell a lane cleared by `changes` from one skipped
           # because its run was cancelled. `pending` is not `skipped` either —
           # a queued or still-running check is no verdict at all.

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -159,11 +159,12 @@ jobs:
           # `e2e-cross-browser` runs only on push/release/workflow_dispatch —
           # the same event set as `HEAVY_CHECKS` above, never merge_group — so
           # it joins that list, not `QUEUE_CHECKS`. REL-5 (owner decision,
-          # 2026-09-03): held out until now for the reasons the prior version
-          # of this comment gave (a release tag stricter than `:latest`); the
-          # owner chose to accept that trade rather than leave the gap. This
-          # gate mirrors exactly the six checks publish-image now requires —
-          # see ci.yml's `publish-image` job `needs:`.
+          # 2026-09-03): the prior version of this comment held it out because
+          # adding it here alone would have made a release tag stricter than
+          # `:latest`; it is added to both gates in the same change instead, so
+          # the two stay level. This gate mirrors exactly the six checks
+          # publish-image now requires — see ci.yml's `publish-image` job
+          # `needs:`.
         run: |
           set -euo pipefail
 

--- a/changelog.d/rel-5-e2e-cross-browser-gates-publish.md
+++ b/changelog.d/rel-5-e2e-cross-browser-gates-publish.md
@@ -1,0 +1,10 @@
+none
+
+CI/tooling only, with no user-visible effect: REL-5 implemented as originally written (owner
+decision, 2026-09-03), reversing the 2026-09-01 audit note in
+`docker-image-tag-gate-documents-e2e-cross-browser-scope.md` that had left it out on scope grounds.
+`e2e-cross-browser` now joins `docker-image.yml`'s `HEAVY_CHECKS` (it runs only on
+push/release/workflow_dispatch, the same event set) and `ci.yml`'s `publish-image` job `needs:` and
+`if:` result check. A release tag and `:latest` now both hold for cross-browser coverage, not only
+Chromium; both gates run slower as a result. Branch-protection required-checks in GitHub settings
+is a separate, owner-only step, tracked outside this repo's tree.

--- a/scripts/publishgate/main_test.go
+++ b/scripts/publishgate/main_test.go
@@ -2,7 +2,7 @@
 // `if` carrying no status-check function cannot have.
 //
 // `publish-image` in .github/workflows/ci.yml is the only path by which
-// `ghcr.io/<repo>:latest` follows `main`. It lists five jobs in `needs:` and
+// `ghcr.io/<repo>:latest` follows `main`. It lists six jobs in `needs:` and
 // carried an `if` naming only the event and the ref, with no status-check
 // function in it. Six consecutive runs — 33217555948, 33213567903,
 // 33188023148, 32905532451, 32882518209, 32853636750 — show it `skipped` with
@@ -56,7 +56,7 @@ import (
 	"github.com/ovumcy/ovumcy-web/scripts/workflowfile"
 )
 
-// workflowPath is the workflow that owns both the publish job and the five
+// workflowPath is the workflow that owns both the publish job and the six
 // jobs it gates on: `needs:` cannot cross a workflow boundary, which is why the
 // gate lives there rather than beside the publish itself.
 const workflowPath = ".github/workflows/ci.yml"
@@ -69,7 +69,7 @@ const publishJob = "publish-image"
 // by this one — that is what makes an added dependency fail. This list is the
 // other direction: a dependency silently dropped from `needs:` weakens the gate
 // just as much, and would leave a check that reads the actual list green.
-var wantNeeds = []string{"e2e", "e2e-postgres-smoke", "image-smoke", "race", "test"}
+var wantNeeds = []string{"e2e", "e2e-cross-browser", "e2e-postgres-smoke", "image-smoke", "race", "test"}
 
 // eventDisjunction is the ONE `||` the gate is allowed to hold: the two events
 // that may publish. Everything else has to be a conjunction, and gateProblems
@@ -160,7 +160,7 @@ func jobNeeds(t *testing.T, block string) []string {
 // parseNeeds reads a dependency list in any of the three spellings YAML allows
 // for it. All three are the same list to GitHub, so all three have to be the
 // same list here: a reader that knew only the block sequence would report "no
-// dependencies at all" over a workflow that in fact declares five, and the
+// dependencies at all" over a workflow that in fact declares six, and the
 // per-dependency checks would never run.
 func parseNeeds(lines []string) []string {
 	var needs []string

--- a/scripts/releasegate/main_test.go
+++ b/scripts/releasegate/main_test.go
@@ -1,5 +1,5 @@
 // Package releasegate holds the release tag gate to the one thing it exists to
-// assert: that the five checks `:latest` waits for were really run on the
+// assert: that the six checks `:latest` waits for were really run on the
 // commit being tagged.
 //
 // `verify-release-tag` in .github/workflows/docker-image.yml is the only gate
@@ -116,6 +116,7 @@ func greenQueue(suite string) []checkRun {
 		{suite, "e2e", "success"},
 		{suite, "e2e-postgres-smoke", "success"},
 		{suite, "image-smoke", "skipped"},
+		{suite, "e2e-cross-browser", "skipped"},
 	}
 }
 
@@ -126,6 +127,7 @@ func greenPush(suite string) []checkRun {
 		{suite, "e2e", "success"},
 		{suite, "e2e-postgres-smoke", "success"},
 		{suite, "image-smoke", "success"},
+		{suite, "e2e-cross-browser", "success"},
 	}
 }
 


### PR DESCRIPTION
## Summary
- REL-5 as written (owner decision, 2026-09-03): `e2e-cross-browser` joins `docker-image.yml`'s `HEAVY_CHECKS` and `ci.yml`'s `publish-image` `needs:`/`if:` result check.
- Reverses the 2026-09-01 audit note that had left it out on scope grounds (`changelog.d/docker-image-tag-gate-documents-e2e-cross-browser-scope.md`).

## Risk
Both the release-tag gate and `:latest` publish now also wait on cross-browser e2e, which is slower and only runs on push/release/dispatch. Branch-protection required-checks list (GitHub ruleset 13619179) needs the owner's own separate update — not in this PR.

## Test plan
- [ ] CI green through the merge queue