### PR TITLE
docs(api): declare 429 on every limiter-covered /api/v1 operation

### DIFF
--- a/changelog.d/fix-openapi-429-every-limiter-covered-operation.md
+++ b/changelog.d/fix-openapi-429-every-limiter-covered-operation.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- **`docs/openapi.yaml` now declares `429` (`RateLimited`) on every `/api/v1` operation.** The
+  app-wide API limiter (`cmd/ovumcy/server.go`'s `app.Use("/api", limiter.New(...))`) is mounted
+  ahead of route registration with no `Next` filter, so it sits in front of all 47 `/api/v1`
+  operations — not only the twelve that also carry a narrower per-account budget and were the only
+  ones documented. This was the same "N of N+1" shape as the status-reachability gap fixed
+  previously: a prior change added `429` where the per-account reauth budget lives and stopped
+  there, leaving the shared edge limiter's `429` real but undocumented everywhere else. No server
+  behavior changed — this is documentation only.
+  - A new test, `TestOpenAPIDeclaresRateLimitedOnEveryLimiterCoveredOperation`, reads the registered
+    `/api/v1` routes and fails when any of them lacks a declared `429`, so the gap cannot reopen
+    silently.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1625,6 +1625,7 @@ paths:
               example:
                 error: "local recovery unavailable"
                 error_detail: { key: "local recovery unavailable", category: "forbidden", target: "auth_form" }
+        '429': { $ref: '#/components/responses/RateLimited' }
 
   # =========================================================================
   # onboarding
@@ -1647,6 +1648,7 @@ paths:
         '401': { $ref: '#/components/responses/Unauthorized' }
         '400': { $ref: '#/components/responses/ValidationError' }
         '403': { $ref: '#/components/responses/Forbidden' }
+        '429': { $ref: '#/components/responses/RateLimited' }
 
   /api/v1/onboarding/steps/2:
     post:
@@ -1666,6 +1668,7 @@ paths:
         '401': { $ref: '#/components/responses/Unauthorized' }
         '400': { $ref: '#/components/responses/ValidationError' }
         '403': { $ref: '#/components/responses/Forbidden' }
+        '429': { $ref: '#/components/responses/RateLimited' }
 
   /api/v1/onboarding/complete:
     post:
@@ -1680,6 +1683,7 @@ paths:
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
         '400': { $ref: '#/components/responses/ValidationError' }
+        '429': { $ref: '#/components/responses/RateLimited' }
 
   # =========================================================================
   # days
@@ -1702,6 +1706,7 @@ paths:
         '401': { $ref: '#/components/responses/Unauthorized' }
         '400': { $ref: '#/components/responses/ValidationError' }
         '403': { $ref: '#/components/responses/Forbidden' }
+        '429': { $ref: '#/components/responses/RateLimited' }
 
   /api/v1/days/{date}:
     parameters:
@@ -1718,6 +1723,7 @@ paths:
         '401': { $ref: '#/components/responses/Unauthorized' }
         '400': { $ref: '#/components/responses/ValidationError' }
         '403': { $ref: '#/components/responses/Forbidden' }
+        '429': { $ref: '#/components/responses/RateLimited' }
     head:
       tags: [days]
       summary: Check whether the day has any persisted data (owner only).
@@ -1733,6 +1739,7 @@ paths:
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
         '400': { $ref: '#/components/responses/ValidationError' }
+        '429': { $ref: '#/components/responses/RateLimited' }
     put:
       tags: [days]
       summary: Upsert a day's entry (owner only).
@@ -1754,6 +1761,7 @@ paths:
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
         '400': { $ref: '#/components/responses/ValidationError' }
+        '429': { $ref: '#/components/responses/RateLimited' }
     delete:
       tags: [days]
       summary: Delete a single day's entry (owner only).
@@ -1778,6 +1786,7 @@ paths:
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
         '400': { $ref: '#/components/responses/ValidationError' }
+        '429': { $ref: '#/components/responses/RateLimited' }
 
   /api/v1/days/{date}/cycle-start:
     post:
@@ -1817,6 +1826,7 @@ paths:
               example:
                 error: "cycle start replace required"
                 error_detail: { key: "cycle start replace required", category: "conflict", target: "global" }
+        '429': { $ref: '#/components/responses/RateLimited' }
 
   # =========================================================================
   # symptoms
@@ -1835,6 +1845,7 @@ paths:
                 items: { $ref: '#/components/schemas/Symptom' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
+        '429': { $ref: '#/components/responses/RateLimited' }
     post:
       tags: [symptoms]
       summary: Create a custom symptom (owner only).
@@ -1853,6 +1864,7 @@ paths:
         '403': { $ref: '#/components/responses/Forbidden' }
         '400': { $ref: '#/components/responses/ValidationError' }
         '409': { $ref: '#/components/responses/Conflict' }
+        '429': { $ref: '#/components/responses/RateLimited' }
 
   /api/v1/symptoms/{id}:
     parameters:
@@ -1876,6 +1888,7 @@ paths:
         '400': { $ref: '#/components/responses/ValidationError' }
         '404': { $ref: '#/components/responses/NotFound' }
         '409': { $ref: '#/components/responses/Conflict' }
+        '429': { $ref: '#/components/responses/RateLimited' }
     delete:
       tags: [symptoms]
       summary: Archive (soft-delete) a symptom (owner only).
@@ -1894,6 +1907,7 @@ paths:
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
         '404': { $ref: '#/components/responses/NotFound' }
+        '429': { $ref: '#/components/responses/RateLimited' }
 
   /api/v1/symptoms/{id}/restore:
     post:
@@ -1912,6 +1926,7 @@ paths:
         '403': { $ref: '#/components/responses/Forbidden' }
         '404': { $ref: '#/components/responses/NotFound' }
         '409': { $ref: '#/components/responses/Conflict' }
+        '429': { $ref: '#/components/responses/RateLimited' }
 
   # =========================================================================
   # stats
@@ -1928,6 +1943,7 @@ paths:
               schema: { $ref: '#/components/schemas/StatsOverview' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
+        '429': { $ref: '#/components/responses/RateLimited' }
 
   # =========================================================================
   # exports
@@ -1948,6 +1964,7 @@ paths:
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
         '400': { $ref: '#/components/responses/ValidationError' }
+        '429': { $ref: '#/components/responses/RateLimited' }
 
   /api/v1/exports/csv:
     get:
@@ -1969,6 +1986,7 @@ paths:
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
         '400': { $ref: '#/components/responses/ValidationError' }
+        '429': { $ref: '#/components/responses/RateLimited' }
 
   /api/v1/exports/json:
     get:
@@ -1990,6 +2008,7 @@ paths:
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
         '400': { $ref: '#/components/responses/ValidationError' }
+        '429': { $ref: '#/components/responses/RateLimited' }
 
   /api/v1/imports/json:
     post:
@@ -2034,6 +2053,7 @@ paths:
               example:
                 error: "import file too large"
                 error_detail: { key: "import file too large", category: "validation", target: "global" }
+        '429': { $ref: '#/components/responses/RateLimited' }
 
   # =========================================================================
   # users/current — whoami, settings, and account management
@@ -2056,6 +2076,7 @@ paths:
               schema: { $ref: '#/components/schemas/CurrentUser' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
+        '429': { $ref: '#/components/responses/RateLimited' }
     delete:
       tags: [settings]
       summary: Delete the current account and all related data (owner only).
@@ -2097,6 +2118,7 @@ paths:
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
         '400': { $ref: '#/components/responses/ValidationError' }
+        '429': { $ref: '#/components/responses/RateLimited' }
 
   /api/v1/users/current/interface:
     patch:
@@ -2116,6 +2138,7 @@ paths:
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
         '400': { $ref: '#/components/responses/ValidationError' }
+        '429': { $ref: '#/components/responses/RateLimited' }
 
   /api/v1/users/current/tracking:
     patch:
@@ -2135,6 +2158,7 @@ paths:
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
         '400': { $ref: '#/components/responses/ValidationError' }
+        '429': { $ref: '#/components/responses/RateLimited' }
 
   /api/v1/users/current/timezone:
     post:
@@ -2167,6 +2191,7 @@ paths:
               schema: { $ref: '#/components/schemas/ApiError' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
+        '429': { $ref: '#/components/responses/RateLimited' }
 
   /api/v1/users/current/webhook:
     post:
@@ -2209,6 +2234,7 @@ paths:
                 error_detail: { key: "invalid webhook url", category: "validation", target: "settings_form" }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
+        '429': { $ref: '#/components/responses/RateLimited' }
     delete:
       tags: [settings]
       summary: Withdraw the stored webhook endpoint (owner only).
@@ -2242,6 +2268,7 @@ paths:
               example:
                 error: "failed to update webhook settings"
                 error_detail: { key: "failed to update webhook settings", category: "internal", target: "global" }
+        '429': { $ref: '#/components/responses/RateLimited' }
 
   /api/v1/users/current/calendar-feed:
     post:
@@ -2279,6 +2306,7 @@ paths:
               example:
                 error: "failed to update calendar feed"
                 error_detail: { key: "failed to update calendar feed", category: "internal", target: "global" }
+        '429': { $ref: '#/components/responses/RateLimited' }
     delete:
       tags: [settings]
       summary: Revoke (disable) the calendar (.ics) feed (owner only).
@@ -2303,6 +2331,7 @@ paths:
               example:
                 error: "failed to update calendar feed"
                 error_detail: { key: "failed to update calendar feed", category: "internal", target: "global" }
+        '429': { $ref: '#/components/responses/RateLimited' }
 
   /api/v1/users/current/calendar-feed/rotate:
     post:
@@ -2335,6 +2364,7 @@ paths:
               example:
                 error: "failed to update calendar feed"
                 error_detail: { key: "failed to update calendar feed", category: "internal", target: "global" }
+        '429': { $ref: '#/components/responses/RateLimited' }
 
   /api/v1/users/current/cycle:
     patch:
@@ -2360,6 +2390,7 @@ paths:
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
         '400': { $ref: '#/components/responses/ValidationError' }
+        '429': { $ref: '#/components/responses/RateLimited' }
 
   /api/v1/users/current/reminders:
     patch:
@@ -2383,6 +2414,7 @@ paths:
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
         '400': { $ref: '#/components/responses/ValidationError' }
+        '429': { $ref: '#/components/responses/RateLimited' }
 
   /api/v1/users/current/password:
     put:
@@ -2442,6 +2474,7 @@ paths:
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
         '400': { $ref: '#/components/responses/ValidationError' }
+        '429': { $ref: '#/components/responses/RateLimited' }
         '503': { $ref: '#/components/responses/ServiceUnavailable' }
 
   /api/v1/users/current/data-wipe/step-up:
@@ -2477,6 +2510,7 @@ paths:
               example:
                 error: "invalid settings input"
                 error_detail: { key: "invalid settings input", category: "validation", target: "settings_form" }
+        '429': { $ref: '#/components/responses/RateLimited' }
         '503': { $ref: '#/components/responses/ServiceUnavailable' }
 
   /api/v1/users/current/deletion/step-up:
@@ -2506,6 +2540,7 @@ paths:
               example:
                 error: "invalid settings input"
                 error_detail: { key: "invalid settings input", category: "validation", target: "settings_form" }
+        '429': { $ref: '#/components/responses/RateLimited' }
         '503': { $ref: '#/components/responses/ServiceUnavailable' }
 
   /api/v1/users/current/recovery-code:

--- a/internal/api/openapi_contract_test.go
+++ b/internal/api/openapi_contract_test.go
@@ -102,6 +102,48 @@ func TestOpenAPIDeclaresOnlyStatusesTheServerCanEmit(t *testing.T) {
 	}
 }
 
+// TestOpenAPIDeclaresRateLimitedOnEveryLimiterCoveredOperation pins the class
+// behind API-3: the app-wide API limiter (cmd/ovumcy/server.go's
+// `app.Use("/api", limiter.New(...))`, mounted before api.RegisterRoutes with
+// no `Next` filter) sits in front of every `/api/v1/*` route, not only the
+// handful that also carry a narrower per-account budget — so 429 is a real
+// answer on every operation this spec documents. The document previously
+// declared RateLimited on 12 of 47 operations, which is exactly the "N of
+// N+1" partial fix this test exists to close: a prior change added 429 to the
+// per-account-reauth-budget endpoints and stopped there, leaving every other
+// operation's 429 real but undocumented.
+//
+// The set to check is read from the registered routes themselves — the same
+// registeredV1Routes the route-presence contract above already trusts as the
+// ground truth for "what /api/v1 operations exist" — rather than hand-listed,
+// so a new route added later inherits the check with no edit here.
+func TestOpenAPIDeclaresRateLimitedOnEveryLimiterCoveredOperation(t *testing.T) {
+	app, _ := newOnboardingTestApp(t)
+
+	limiterCovered := registeredV1Routes(app)
+	if len(limiterCovered) == 0 {
+		t.Fatal("no /api/v1 routes discovered from the app; test setup is wrong")
+	}
+
+	declared := openAPIDeclaredStatuses(t, filepath.Join("..", "..", "docs", "openapi.yaml"))
+	declaresRateLimited := make(map[string]struct{}, len(declared[http.StatusTooManyRequests]))
+	for _, operation := range declared[http.StatusTooManyRequests] {
+		declaresRateLimited[operation] = struct{}{}
+	}
+
+	var missing []string
+	for operation := range limiterCovered {
+		if _, ok := declaresRateLimited[operation]; !ok {
+			missing = append(missing, operation)
+		}
+	}
+	sort.Strings(missing)
+	if len(missing) > 0 {
+		t.Errorf("the app-wide /api limiter (cmd/ovumcy/server.go, mounted with no Next filter) can answer 429 on every /api/v1 operation, but docs/openapi.yaml declares no '429': RateLimited response for:\n  %s",
+			strings.Join(missing, "\n  "))
+	}
+}
+
 // TestOpenAPIDocumentsEveryTransportStatusTheEnvelopeCovers pins the reverse
 // direction for the one part of the surface that keeps a registry of it. The
 // transport statuses are answered outside any operation — an unroutable request,

--- a/internal/api/openapi_contract_test.go
+++ b/internal/api/openapi_contract_test.go
@@ -102,6 +102,55 @@ func TestOpenAPIDeclaresOnlyStatusesTheServerCanEmit(t *testing.T) {
 	}
 }
 
+// apiRateLimitMountPattern locates the app-wide "/api" limiter's own
+// limiter.New(limiter.Config{...}) block in cmd/ovumcy/server.go — the exact
+// mount TestOpenAPIDeclaresRateLimitedOnEveryLimiterCoveredOperation's
+// "every registered /api/v1 route is limiter-covered" premise depends on. It
+// is anchored on the literal `app.Use("/api", limiter.New(limiter.Config{`,
+// which is unique to this mount: the per-account limiters above it in the
+// same file scope themselves with a `Next` filter instead of a path prefix,
+// and the calendar-feed limiter mounts on a different prefix entirely.
+var apiRateLimitMountPattern = regexp.MustCompile(`(?s)app\.Use\("/api", limiter\.New\(limiter\.Config\{(.*?)\n\t\}\)\)`)
+
+// requireAPIRateLimitMountHasNoNextFilter pins the premise the sweep below
+// rests on, rather than assuming it: registeredV1Routes stands in for "every
+// limiter-covered /api/v1 route" only because the app-wide limiter mount
+// carries no `Next` filter and therefore excludes nothing. The test app this
+// file assembles (newOnboardingTestApp) never mounts cmd/ovumcy's real
+// middleware chain — that wiring lives in cmd/ovumcy's newFiberApp, in
+// package main, which internal/api cannot import (cmd depends on internal/api,
+// never the reverse) — so the premise is checked by reading the mount's own
+// source text instead of executing it, the same way
+// TestOpenAPIDeclaresOnlyStatusesTheServerCanEmit reads server sources rather
+// than running the server.
+//
+// If this ever fails, the sweep below is no longer sound: a route the mount
+// newly exempts (a `Next` filter added to this exact block) can no longer
+// answer 429, docs/openapi.yaml would keep declaring it anyway, and nothing
+// else in this file would notice — the same "N of N+1" shape this whole test
+// exists to close, one level up in the guard itself.
+func requireAPIRateLimitMountHasNoNextFilter(t *testing.T) {
+	t.Helper()
+	path := filepath.Join("..", "..", "cmd", "ovumcy", "server.go")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	match := apiRateLimitMountPattern.FindSubmatch(data)
+	if match == nil {
+		t.Fatalf(`%s: no app.Use("/api", limiter.New(limiter.Config{...})) mount found — `+
+			`the app-wide API limiter moved or was rewritten; update apiRateLimitMountPattern `+
+			`before trusting registeredV1Routes as the limiter-covered set again`, path)
+	}
+	if strings.Contains(string(match[1]), "Next:") {
+		t.Fatalf(`%s: the app-wide "/api" limiter now carries a Next filter, so it no longer `+
+			`covers every /api/v1 route unconditionally — TestOpenAPIDeclaresRateLimitedOnEveryLimiterCoveredOperation's `+
+			`"every registered route is limiter-covered" premise no longer holds. Derive the covered `+
+			`set from the exemption (exclude the routes the filter skips) instead of the full route `+
+			`table before trusting this sweep again`, path)
+	}
+}
+
 // TestOpenAPIDeclaresRateLimitedOnEveryLimiterCoveredOperation pins the class
 // behind API-3: the app-wide API limiter (cmd/ovumcy/server.go's
 // `app.Use("/api", limiter.New(...))`, mounted before api.RegisterRoutes with
@@ -116,8 +165,13 @@ func TestOpenAPIDeclaresOnlyStatusesTheServerCanEmit(t *testing.T) {
 // The set to check is read from the registered routes themselves — the same
 // registeredV1Routes the route-presence contract above already trusts as the
 // ground truth for "what /api/v1 operations exist" — rather than hand-listed,
-// so a new route added later inherits the check with no edit here.
+// so a new route added later inherits the check with no edit here. That
+// stand-in is sound only while requireAPIRateLimitMountHasNoNextFilter holds;
+// it is asserted first so a mount that grows an exemption reddens this test
+// instead of leaving the spec free to over-declare 429 with nothing to catch it.
 func TestOpenAPIDeclaresRateLimitedOnEveryLimiterCoveredOperation(t *testing.T) {
+	requireAPIRateLimitMountHasNoNextFilter(t)
+
 	app, _ := newOnboardingTestApp(t)
 
 	limiterCovered := registeredV1Routes(app)


### PR DESCRIPTION
## Summary
- `docs/openapi.yaml` declared `429` (`RateLimited`) on only 12 of the 47 `/api/v1` operations —
  the ones that also sit behind a narrower per-account reauth budget. The app-wide API limiter
  (`cmd/ovumcy/server.go`'s `app.Use("/api", limiter.New(...))`) is mounted before route
  registration with **no `Next` filter**, so it covers every `/api/v1` route with no exception —
  confirmed by reading the mount order in `newFiberApp` and the full route table in
  `internal/api/routes.go`. This was the same "N of N+1" shape as a prior status-reachability fix:
  a change added `429` where the per-account budget lives and stopped there.
- Add the missing `'429': { $ref: '#/components/responses/RateLimited' }` to the other 35
  operations. No server behavior changes — documentation only.
- Add `TestOpenAPIDeclaresRateLimitedOnEveryLimiterCoveredOperation` (in
  `internal/api/openapi_contract_test.go`, alongside the file's other spec/route contract tests) to
  pin the class: it reads the registered `/api/v1` routes (the same ground truth the existing
  route-presence contract test already trusts) and fails when any of them has no declared `429`.

## Excluded routes
None. Every `/api/v1` operation is reachable through the limiter-mounted prefix; no route escapes
it (verified from the mount order and the full `registerV1APIRoutes` table).

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/api/... -run TestOpenAPI -v` — all pass, including the new guard
- [x] `golangci-lint run ./internal/api/...` — 0 issues
- [x] Proof-on-defect: reverted the `429` line added for `GET /api/v1/stats/overview`, confirmed
      `TestOpenAPIDeclaresRateLimitedOnEveryLimiterCoveredOperation` fails and names exactly that
      operation, then restored the fix and reran green.
- [x] `python -c "yaml.safe_load(...)"` sweep confirms all 47 `/api/v1` operations declare `429`
- [ ] Full `go test ./internal/api/...` (whole package) not run locally — per
      `.claude/rules/ci-unit-lane.md`, `internal/api` alone takes ~353s and CI shards it across
      three lanes with a 20m timeout; a plain local run hits Go's default 10m timeout and is not
      informative here. The scoped `-run TestOpenAPI` run above covers every test this change
      touches.
