### PR TITLE
test(ci): pin REL-6..REL-10 so a revert of any one reds

### DIFF
--- a/changelog.d/rel-6-10-ci-supply-chain-pins.md
+++ b/changelog.d/rel-6-10-ci-supply-chain-pins.md
@@ -1,0 +1,6 @@
+none
+
+Test-only: pins REL-6 through REL-10 (patch-coverage in the merge queue, the three
+--ignore-unfixed removals, mutation-merge's -expect flag, the changelog gate's untrusted-ref
+splice, and the checkout persist-credentials sweep) with regression tests, so a future edit
+reverting any of them fails CI instead of shipping silently. No workflow behavior changes.

--- a/scripts/ciguards/main_test.go
+++ b/scripts/ciguards/main_test.go
@@ -50,7 +50,10 @@ func repoRoot(t *testing.T) string {
 // allWorkflowFiles lists every workflow under .github/workflows, module-root
 // relative with forward slashes — the shape workflowfile.Read expects. A
 // directory listing rather than a literal list, so a workflow added later is
-// swept in without this file needing an edit.
+// swept in without this file needing an edit. GitHub Actions loads `.yml` and
+// `.yaml` identically, so both extensions are accepted — a filter on one
+// spelling alone would make a workflow written with the other invisible to
+// every guard below that relies on this list.
 func allWorkflowFiles(t *testing.T) []string {
 	t.Helper()
 
@@ -62,7 +65,10 @@ func allWorkflowFiles(t *testing.T) []string {
 
 	var files []string
 	for _, entry := range entries {
-		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".yml") {
+		if entry.IsDir() {
+			continue
+		}
+		if !strings.HasSuffix(entry.Name(), ".yml") && !strings.HasSuffix(entry.Name(), ".yaml") {
 			continue
 		}
 		files = append(files, ".github/workflows/"+entry.Name())
@@ -153,21 +159,24 @@ func NoIgnoreUnfixedAmongVulnScans(lines []string) error {
 }
 
 func TestNoIgnoreUnfixedAmongTheThreeVulnGatingTrivyScans(t *testing.T) {
+	// Every workflow is swept, not just the two REL-7 happened to touch —
+	// otherwise a vulnerability-gating scan added to a third workflow is
+	// never even opened, and neither half of this test would notice: this
+	// loop wouldn't read it, and a count fixed at 3 would still see exactly
+	// 3 among the files it DID read.
 	var lines []string
-	for _, workflow := range []string{
-		".github/workflows/security.yml",
-		".github/workflows/docker-image.yml",
-	} {
+	for _, workflow := range allWorkflowFiles(t) {
 		lines = append(lines, vulnScanLines(t, workflow)...)
 	}
 
-	// REL-7 touched exactly three vulnerability-gating Trivy invocations
-	// (trivy-fs and trivy-image in security.yml; the pre-publish re-scan in
-	// docker-image.yml). A count that has moved means a scan site was added
-	// or removed and deserves a human decision about --ignore-unfixed, not a
-	// guard that silently widens or narrows around it.
-	if len(lines) != 3 {
-		t.Fatalf("found %d vulnerability-gating Trivy scan(s), want exactly the three REL-7 covers: %v", len(lines), lines)
+	// A hardcoded expected count has the same staleness problem the REL-10
+	// guard below refuses: it goes stale the day a workflow adds another
+	// vulnerability-gating scan. The property this guards is "no such scan
+	// carries --ignore-unfixed", checked over every one this sweep finds;
+	// this assertion only guards against the sweep itself going vacuous
+	// (finding zero scans because the pattern or the directory broke).
+	if len(lines) == 0 {
+		t.Fatal("found zero vulnerability-gating Trivy scans across every workflow — the scan itself is broken, since security.yml and docker-image.yml both gate on one")
 	}
 
 	if err := NoIgnoreUnfixedAmongVulnScans(lines); err != nil {
@@ -212,18 +221,43 @@ func stepBlock(t *testing.T, jobBlock, stepName string) string {
 	return rest
 }
 
-// runBody returns a step's `run:` key onward, deliberately excluding the
-// `env:` mapping above it: `env:` is where a GitHub Actions expression is
-// SUPPOSED to land, and only a splice that reaches `run:` itself is the
-// untrusted-expression defect this guards against.
+// runBody returns a step's `run:` key and everything more indented beneath
+// it — the block-scalar body — stopping at the first line back at or above
+// `run:`'s own indentation: a sibling key (`env:`, `with:`, `if:`, …) or the
+// end of the step. YAML mapping keys are unordered, so `env:` cannot be
+// assumed to sit above `run:` in the text; cutting at the next sibling KEY,
+// wherever it falls, is what keeps a legitimate `${{ }}` in a same-step
+// `env:` block from ever entering the text this file inspects for a splice.
 func runBody(t *testing.T, block string) string {
 	t.Helper()
 
-	idx := strings.Index(block, "\n        run:")
-	if idx < 0 {
-		t.Fatalf("step has no `run:` key at the expected 8-space indentation")
+	lines := strings.Split(block, "\n")
+
+	start, indent := -1, 0
+	for i, line := range lines {
+		trimmed := strings.TrimLeft(line, " ")
+		if strings.HasPrefix(trimmed, "run:") {
+			start = i
+			indent = len(line) - len(trimmed)
+			break
+		}
 	}
-	return block[idx:]
+	if start < 0 {
+		t.Fatalf("step has no `run:` key")
+	}
+
+	end := len(lines)
+	for i := start + 1; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) == "" {
+			continue
+		}
+		lineIndent := len(lines[i]) - len(strings.TrimLeft(lines[i], " "))
+		if lineIndent <= indent {
+			end = i
+			break
+		}
+	}
+	return strings.Join(lines[start:end], "\n")
 }
 
 // NoUntrustedRefSplicedIntoRun refuses a `run:` body that reaches a GitHub
@@ -251,6 +285,32 @@ func TestChangelogFragmentDoesNotSpliceTheBaseRefIntoRun(t *testing.T) {
 
 	if err := NoUntrustedRefSplicedIntoRun(runBody(t, step)); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// TestRunBodyStopsAtTheNextSiblingKeyRegardlessOfOrder proves runBody does not
+// rely on `env:` sitting above `run:` in the text. YAML mapping keys are
+// unordered — a step with `run:` first and `env:` after is valid and behaves
+// identically — and a reader that assumed `env:`-then-`run:` would fold a
+// same-step `env:`'s legitimate `${{ }}` straight into the body this file
+// scans for a splice, failing a correct workflow.
+func TestRunBodyStopsAtTheNextSiblingKeyRegardlessOfOrder(t *testing.T) {
+	block := strings.Join([]string{
+		"      - name: Some step",
+		"        run: |",
+		"          echo hi",
+		"        env:",
+		"          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}",
+		"",
+	}, "\n")
+
+	body := runBody(t, block)
+
+	if strings.Contains(body, "${{") {
+		t.Fatalf("runBody with env: AFTER run: leaked the env: block's expression into the body: %q", body)
+	}
+	if body != "        run: |\n          echo hi" {
+		t.Fatalf("runBody with env: AFTER run: returned %q, want just the run: block", body)
 	}
 }
 

--- a/scripts/ciguards/main_test.go
+++ b/scripts/ciguards/main_test.go
@@ -1,0 +1,377 @@
+// Package ciguards pins five CI/supply-chain fixes that shipped with no test
+// of their own: patch-coverage's absence from the merge-queue suite, Trivy
+// hiding an unfixed CVE from itself, an untrusted ref spliced into a shell
+// command, and a checkout step holding onto a git credential it never needs.
+// (The fifth, mutation-merge's `-expect` flag, is pinned in
+// scripts/mutationmerge — the check already lived in that package, not this
+// one.) Each of these is a workflow-file SHAPE a future edit could revert
+// with nothing here to catch it, until now.
+//
+// Modelled on scripts/covmerge: every fixed property is a named function,
+// proven first against a fixture this repository does not contain (so the
+// rule is shown to refuse the shape it exists to refuse), then read against
+// the real workflow.
+package ciguards
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/ovumcy/ovumcy-web/scripts/workflowfile"
+)
+
+// repoRoot walks up from the test's working directory to the module root, the
+// same way workflowfile's own (unexported) repoRoot does — needed here only
+// to list the workflow directory, which workflowfile has no reason to expose.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("go.mod not found above %s", dir)
+		}
+		dir = parent
+	}
+}
+
+// allWorkflowFiles lists every workflow under .github/workflows, module-root
+// relative with forward slashes — the shape workflowfile.Read expects. A
+// directory listing rather than a literal list, so a workflow added later is
+// swept in without this file needing an edit.
+func allWorkflowFiles(t *testing.T) []string {
+	t.Helper()
+
+	dir := filepath.Join(repoRoot(t), ".github", "workflows")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read %s: %v", dir, err)
+	}
+
+	var files []string
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".yml") {
+			continue
+		}
+		files = append(files, ".github/workflows/"+entry.Name())
+	}
+	sort.Strings(files)
+	return files
+}
+
+// ---------------------------------------------------------------------------
+// REL-6: patch-coverage runs in the merge queue.
+// ---------------------------------------------------------------------------
+
+var jobIfLine = regexp.MustCompile(`(?m)^    if: (.*)$`)
+
+// jobCondition returns a job's own single-line `if:` value, at the 4-space
+// indentation a job key sits under its 2-space job header. Conditions in this
+// repository are not folded across lines the way publishgate's is; a folded
+// condition here is refused rather than mis-parsed.
+func jobCondition(t *testing.T, block string) string {
+	t.Helper()
+
+	match := jobIfLine.FindStringSubmatch(block)
+	if match == nil {
+		t.Fatalf("job has no single-line `if:` key at 4-space indentation — it was reshaped, and this guard would judge nothing")
+	}
+	return match[1]
+}
+
+// PatchCoverageRunsInTheQueue refuses a patch-coverage `if:` that does not
+// admit merge_group. REL-6: this is a REQUIRED check, but it used to run only
+// on `pull_request` — in the merge_group suite that actually decides queue
+// admission it reported `skipped`, and a skipped required check is satisfied,
+// so a queued change could merge having never had its patch coverage judged
+// there.
+func PatchCoverageRunsInTheQueue(condition string) error {
+	if !strings.Contains(condition, "github.event_name == 'merge_group'") {
+		return fmt.Errorf("patch-coverage's `if:` (%s) does not admit merge_group — a queued change can merge without patch coverage ever being judged there", condition)
+	}
+	return nil
+}
+
+func TestPatchCoverageRunsInTheMergeQueue(t *testing.T) {
+	block := workflowfile.Job(t, ".github/workflows/ci.yml", "patch-coverage")
+
+	if err := PatchCoverageRunsInTheQueue(jobCondition(t, block)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPatchCoverageRunsInTheQueueRefusesAPullRequestOnlyCondition(t *testing.T) {
+	if err := PatchCoverageRunsInTheQueue("github.event_name == 'pull_request'"); err == nil {
+		t.Fatal("a condition admitting only pull_request was accepted")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// REL-7: --ignore-unfixed removed at the three vulnerability-gating Trivy
+// scans.
+// ---------------------------------------------------------------------------
+
+// vulnScanLine matches any Trivy invocation that gates on vulnerabilities
+// (`--scanners vuln`), across whichever files call it — a fourth site added
+// later is judged by the same rule, not only the three REL-7 touched.
+var vulnScanLine = regexp.MustCompile(`(?m)^.*--scanners vuln.*$`)
+
+func vulnScanLines(t *testing.T, workflow string) []string {
+	t.Helper()
+	return vulnScanLine.FindAllString(workflowfile.Read(t, workflow), -1)
+}
+
+// NoIgnoreUnfixedAmongVulnScans refuses any vulnerability-gating Trivy
+// invocation that carries --ignore-unfixed. REL-7: it was set on the
+// filesystem scan, the image scan, and the pre-publish re-scan — all three
+// required or gating checks, all three writing what the Security tab or the
+// publish gate reads — so a CRITICAL with no upstream fix yet, the ordinary
+// case for a fresh CVE, tripped none of them.
+func NoIgnoreUnfixedAmongVulnScans(lines []string) error {
+	var offending []string
+	for _, line := range lines {
+		if strings.Contains(line, "--ignore-unfixed") {
+			offending = append(offending, strings.TrimSpace(line))
+		}
+	}
+	if len(offending) > 0 {
+		return fmt.Errorf("%d vulnerability-gating Trivy scan(s) carry --ignore-unfixed, hiding an unfixed CRITICAL/HIGH finding from the gate and the Security tab: %v", len(offending), offending)
+	}
+	return nil
+}
+
+func TestNoIgnoreUnfixedAmongTheThreeVulnGatingTrivyScans(t *testing.T) {
+	var lines []string
+	for _, workflow := range []string{
+		".github/workflows/security.yml",
+		".github/workflows/docker-image.yml",
+	} {
+		lines = append(lines, vulnScanLines(t, workflow)...)
+	}
+
+	// REL-7 touched exactly three vulnerability-gating Trivy invocations
+	// (trivy-fs and trivy-image in security.yml; the pre-publish re-scan in
+	// docker-image.yml). A count that has moved means a scan site was added
+	// or removed and deserves a human decision about --ignore-unfixed, not a
+	// guard that silently widens or narrows around it.
+	if len(lines) != 3 {
+		t.Fatalf("found %d vulnerability-gating Trivy scan(s), want exactly the three REL-7 covers: %v", len(lines), lines)
+	}
+
+	if err := NoIgnoreUnfixedAmongVulnScans(lines); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNoIgnoreUnfixedAmongVulnScansRefusesAnOffendingLine(t *testing.T) {
+	clean := []string{`run: docker run "$TRIVY" image --scanners vuln --severity HIGH,CRITICAL --exit-code 1 x`}
+	if err := NoIgnoreUnfixedAmongVulnScans(clean); err != nil {
+		t.Fatalf("a scan without --ignore-unfixed was refused: %v", err)
+	}
+
+	dirty := []string{`run: docker run "$TRIVY" image --scanners vuln --ignore-unfixed --severity HIGH,CRITICAL --exit-code 1 x`}
+	if err := NoIgnoreUnfixedAmongVulnScans(dirty); err == nil {
+		t.Fatal("a scan carrying --ignore-unfixed was accepted")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// REL-9: the changelog-fragment gate no longer splices the PR base ref
+// straight into a shell command.
+// ---------------------------------------------------------------------------
+
+var stepHeader = regexp.MustCompile(`(?m)^      - name: `)
+
+// stepBlock cuts one step out of a job block by its `name:`, the same
+// fail-closed shape workflowfile.Job cuts a job out of a workflow with: a
+// renamed or removed step is a failure here, not a silently empty search.
+func stepBlock(t *testing.T, jobBlock, stepName string) string {
+	t.Helper()
+
+	header := "\n      - name: " + stepName + "\n"
+	start := strings.Index(jobBlock, header)
+	if start < 0 {
+		t.Fatalf("no step named %q — it was renamed or removed, and this guard would judge nothing", stepName)
+	}
+	rest := jobBlock[start+len(header):]
+	if next := stepHeader.FindStringIndex(rest); next != nil {
+		return rest[:next[0]]
+	}
+	return rest
+}
+
+// runBody returns a step's `run:` key onward, deliberately excluding the
+// `env:` mapping above it: `env:` is where a GitHub Actions expression is
+// SUPPOSED to land, and only a splice that reaches `run:` itself is the
+// untrusted-expression defect this guards against.
+func runBody(t *testing.T, block string) string {
+	t.Helper()
+
+	idx := strings.Index(block, "\n        run:")
+	if idx < 0 {
+		t.Fatalf("step has no `run:` key at the expected 8-space indentation")
+	}
+	return block[idx:]
+}
+
+// NoUntrustedRefSplicedIntoRun refuses a `run:` body that reaches a GitHub
+// Actions event expression directly, and separately requires the safe
+// replacement to actually be present — an absence-only check would pass a
+// `run:` block that dropped the base-ref fetch entirely and verified
+// nothing. REL-9: `git fetch --no-tags origin ${{
+// github.event.pull_request.base.ref }}` interpolated an unescaped
+// expression straight into `run:`; a ref name is fork-PR-controlled. Fixed by
+// routing it through env.PR_BASE_REF and quoting the shell use:
+// "$PR_BASE_REF" — the same pattern `ci.yml`'s `changes` job already used.
+func NoUntrustedRefSplicedIntoRun(body string) error {
+	if strings.Contains(body, "${{") {
+		return fmt.Errorf("a `run:` block splices an Actions expression directly rather than through a quoted env var: %q", body)
+	}
+	if !strings.Contains(body, `"$PR_BASE_REF"`) {
+		return fmt.Errorf("a `run:` block no longer reaches the base ref through the quoted $PR_BASE_REF shell variable: %q", body)
+	}
+	return nil
+}
+
+func TestChangelogFragmentDoesNotSpliceTheBaseRefIntoRun(t *testing.T) {
+	block := workflowfile.Job(t, ".github/workflows/changelog.yml", "changelog-fragment")
+	step := stepBlock(t, block, "Check changelog fragment")
+
+	if err := NoUntrustedRefSplicedIntoRun(runBody(t, step)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNoUntrustedRefSplicedIntoRunRefusesARawSplice(t *testing.T) {
+	spliced := "\n        run: |\n          git fetch --no-tags origin ${{ github.event.pull_request.base.ref }}\n"
+	if err := NoUntrustedRefSplicedIntoRun(spliced); err == nil {
+		t.Fatal("a run: block splicing the raw expression was accepted")
+	}
+
+	unquoted := "\n        run: |\n          git fetch --no-tags origin $PR_BASE_REF\n"
+	if err := NoUntrustedRefSplicedIntoRun(unquoted); err == nil {
+		t.Fatal("a run: block using the safe variable unquoted was accepted")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// REL-10: every actions/checkout step sets persist-credentials: false.
+// ---------------------------------------------------------------------------
+
+var stepMarkerLine = regexp.MustCompile(`(?m)^(\s*)- `)
+
+// CheckoutSitesMissingPersistCredentialsFalse scans one workflow's raw text
+// for every `actions/checkout` step and reports which ones do not set
+// `persist-credentials: false` anywhere in their own step mapping. `total` is
+// every checkout site FOUND by this scan, never a number carried in this
+// file — the completeness the caller asserts is "every site found", so a
+// checkout step added later is judged the same way without this file needing
+// an edit.
+func CheckoutSitesMissingPersistCredentialsFalse(content string) (missing []string, total int) {
+	lines := strings.Split(content, "\n")
+	for i, line := range lines {
+		if !strings.Contains(line, "uses: actions/checkout@") {
+			continue
+		}
+		total++
+
+		// A step's own indentation is that of its "- " marker, which may be
+		// this very line (a combined "- uses: …") or a preceding "- name:"
+		// line — walk backward to find it, so the body captured below is the
+		// whole step mapping and not just the siblings of `uses:` itself.
+		stepIndent := -1
+		for j := i; j >= 0; j-- {
+			if m := stepMarkerLine.FindStringSubmatch(lines[j]); m != nil {
+				stepIndent = len(m[1])
+				break
+			}
+		}
+		if stepIndent < 0 {
+			missing = append(missing, fmt.Sprintf("line %d: %s (no enclosing step marker found)", i+1, strings.TrimSpace(line)))
+			continue
+		}
+
+		set := false
+		for j := i + 1; j < len(lines); j++ {
+			trimmed := strings.TrimSpace(lines[j])
+			if trimmed == "" {
+				continue
+			}
+			indent := len(lines[j]) - len(strings.TrimLeft(lines[j], " "))
+			if indent <= stepIndent {
+				break
+			}
+			if trimmed == "persist-credentials: false" {
+				set = true
+				break
+			}
+		}
+		if !set {
+			missing = append(missing, fmt.Sprintf("line %d: %s", i+1, strings.TrimSpace(line)))
+		}
+	}
+	return missing, total
+}
+
+// TestEveryCheckoutSetsPersistCredentialsFalse sweeps every workflow file and
+// judges every actions/checkout site it finds — not a fixed 26, since that
+// count goes stale the day a workflow adds another checkout step. REL-10: it
+// was present at exactly 1 of 26 occurrences across 8 files; none of the
+// other 25 push or otherwise need the persisted git credential afterward.
+func TestEveryCheckoutSetsPersistCredentialsFalse(t *testing.T) {
+	var allMissing []string
+	total := 0
+	for _, workflow := range allWorkflowFiles(t) {
+		missing, count := CheckoutSitesMissingPersistCredentialsFalse(workflowfile.Read(t, workflow))
+		total += count
+		for _, m := range missing {
+			allMissing = append(allMissing, workflow+": "+m)
+		}
+	}
+
+	if total == 0 {
+		t.Fatal("found zero actions/checkout sites across every workflow — the scan itself is broken, since this repository checks out its own code in several of them")
+	}
+	if len(allMissing) > 0 {
+		t.Fatalf("%d of %d actions/checkout site(s) do not set persist-credentials: false: %v", len(allMissing), total, allMissing)
+	}
+}
+
+func TestCheckoutSitesMissingPersistCredentialsFalseCatchesAMissingFlag(t *testing.T) {
+	content := strings.Join([]string{
+		"jobs:",
+		"  build:",
+		"    steps:",
+		"      - name: Checkout",
+		"        uses: actions/checkout@deadbeef # v7.0.1",
+		"        with:",
+		"          persist-credentials: false",
+		"",
+		"      - name: Checkout again",
+		"        uses: actions/checkout@deadbeef # v7.0.1",
+		"        with:",
+		"          fetch-depth: 0",
+		"",
+	}, "\n")
+
+	missing, total := CheckoutSitesMissingPersistCredentialsFalse(content)
+
+	if total != 2 {
+		t.Fatalf("found %d checkout site(s), want 2", total)
+	}
+	if len(missing) != 1 || !strings.HasPrefix(missing[0], "line 10:") {
+		t.Fatalf("found missing site(s) %v, want exactly line 10 (the second checkout, carrying only fetch-depth)", missing)
+	}
+}

--- a/scripts/mutationmerge/main.go
+++ b/scripts/mutationmerge/main.go
@@ -58,15 +58,8 @@ func main() {
 	if len(matches) == 0 {
 		fatalf("no shard report files matched %s under %s — nothing to merge", *pattern, *inDir)
 	}
-	// A shard whose "Verify mutation output was produced" guard fails still
-	// leaves the merge free to run (mutation-merge's own `if: always()`), and
-	// its upload is `if-no-files-found: ignore` — so a missing shard is
-	// otherwise invisible here: mergeReports below only checks go_module
-	// agreement and file_name overlap, neither of which a missing FILE trips.
-	// Without this, the merge would fold N-1 shards into a report published
-	// under the same canonical name a complete run uses, reading as whole.
-	if *expect > 0 && len(matches) != *expect {
-		fatalf("found %d shard report(s) under %s, expected %d — a shard's guard likely failed and its upload was skipped; refusing to publish a partial report as if it were complete", len(matches), *inDir, *expect)
+	if err := RequireCount(matches, *expect); err != nil {
+		fatalf("under %s: %v", *inDir, err)
 	}
 
 	merged, err := mergeReports(matches)
@@ -86,6 +79,27 @@ func main() {
 	}
 
 	fmt.Printf("merged %d shard report(s), %d file(s), into %s\n", len(matches), len(merged.Files), *outPath)
+}
+
+// RequireCount refuses a set of shard reports that is not the size the caller
+// was promised. A shard whose "Verify mutation output was produced" guard
+// fails still leaves the merge free to run (mutation-merge's own
+// `if: always()`), and its upload is `if-no-files-found: ignore` — so a
+// missing shard is otherwise invisible here: mergeReports only checks
+// go_module agreement and file_name overlap, neither of which a missing FILE
+// trips. Without this, the merge would fold N-1 shards into a report
+// published under the same canonical name a complete run uses, reading as
+// whole.
+//
+// `expect` of 0 disables the check, for a caller that genuinely does not know
+// the count. CI always knows it: scripts/mutation.sh reads it from the same
+// SHARDED_PKGS registry `verify-shards` already checks the partition against.
+func RequireCount(matches []string, expect int) error {
+	if expect <= 0 || len(matches) == expect {
+		return nil
+	}
+	return fmt.Errorf("found %d shard report(s), expected %d — a shard's guard likely failed and its upload was skipped; refusing to publish a partial report as if it were complete: %v",
+		len(matches), expect, matches)
 }
 
 // findShardFiles walks dir (shard reports may land in per-artifact

--- a/scripts/mutationmerge/main_test.go
+++ b/scripts/mutationmerge/main_test.go
@@ -151,6 +151,25 @@ func TestMergeReportsPreservesMutationsRawJSON(t *testing.T) {
 	}
 }
 
+// REL-8: a shard whose upload never arrived used to leave the remaining
+// shards merging cleanly — the check lived inline in main() and nothing here
+// could reach it. RequireCount is that check lifted into a named function
+// (mirroring scripts/covmerge's RequireCount), so a partial shard set is
+// refused rather than silently published as a complete report.
+func TestACountOtherThanTheExpectedOneIsRefused(t *testing.T) {
+	two := []string{"a/internal_api_1.json", "b/internal_api_2.json"}
+
+	if err := RequireCount(two, 5); err == nil {
+		t.Fatal("two shard reports passed a check expecting five")
+	}
+	if err := RequireCount(two, 2); err != nil {
+		t.Fatalf("two shard reports failed a check expecting two: %v", err)
+	}
+	if err := RequireCount(two, 0); err != nil {
+		t.Fatalf("an expectation of 0 must disable the check, got %v", err)
+	}
+}
+
 func TestMergeReportsRejectsUnparseableJSON(t *testing.T) {
 	dir := t.TempDir()
 	shard := writeShardFile(t, dir, "shard.json", `not valid json`)


### PR DESCRIPTION
## Summary
- Pins five CI/supply-chain fixes (REL-6..REL-10) that were correct on `main` but carried no test
  of their own, so any of them could be silently reverted.
- `scripts/mutationmerge`: lifts the inline `-expect` count check into a named `RequireCount`
  function, mirroring `scripts/covmerge`'s own function and failure-message register, and adds a
  test for it.
- New `scripts/ciguards` package: reads the real workflows via `scripts/workflowfile` and pins the
  other four — patch-coverage's `if:` admitting `merge_group`, the three vulnerability-gating Trivy
  invocations carrying no `--ignore-unfixed`, the changelog-fragment gate never splicing a raw
  Actions expression into `run:`, and `persist-credentials: false` at every `actions/checkout` site
  found (counted dynamically at test time, not hardcoded).
- No workflow behavior changes — test-only.

## Test plan
- [x] `go test ./scripts/ciguards/... ./scripts/mutationmerge/... ./scripts/covmerge/...` — all pass
- [x] `go test ./scripts/...` (full scripts suite) — all pass
- [x] `golangci-lint run --max-issues-per-linter=0 --max-same-issues=0 ./scripts/...` — 0 issues
- [x] `go run ./scripts/changelogd check` — OK
- [x] Proved red-on-revert for two pins by temporarily reverting the real fix, confirming the pin
      fails and names the culprit, then restoring (`git diff` confirmed byte-identical afterward):
      REL-6 (patch-coverage's `if:` narrowed back to `pull_request`-only) and REL-10 (one
      `persist-credentials: false` removed from a checkout step in `ci.yml`).
