### PR TITLE
fix(api): stats overview publishes the confirmed ovulation day, not a superseded projection

### DIFF
--- a/changelog.d/fix-stats-overview-confirmed-ovulation.md
+++ b/changelog.d/fix-stats-overview-confirmed-ovulation.md
@@ -6,7 +6,14 @@
   has already happened. The calendar's solid marker, the dashboard's ovulation line, the stats chart
   marker and the two outbound surfaces (the `.ics` feed and the webhook reminder pass) already
   resolve this through the shared detector; the JSON API kept publishing the model's superseded
-  projection instead. `ovulation_date` now carries the confirmed day when one exists, and
-  `ovulation_exact` reports `true` for it — a measurement, not an approximate estimate. Suppression
-  is unaffected: a confirmed observation changes which day is named, never whether one may be named
-  at all.
+  projection instead. `ovulation_date` now carries the confirmed day when one exists.
+
+### Added
+
+- **`GET /api/v1/stats/overview` gains `ovulation_confirmed`.** It names the substitution above
+  directly, mirroring the dashboard's own confirmed/exact distinction: `ovulation_exact` keeps its
+  original meaning (an exact per-owner luteal-phase fit vs. the clamped 14-day fallback) and
+  `ovulation_confirmed` reports separately whether `ovulation_date` is a BBT-measured day rather than
+  a model projection — the two can differ, and a fallback-luteal account's confirmed cycle is exactly
+  that case. Suppression is unaffected: a confirmed observation changes which day is named, never
+  whether one may be named at all.

--- a/changelog.d/fix-stats-overview-confirmed-ovulation.md
+++ b/changelog.d/fix-stats-overview-confirmed-ovulation.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- **`GET /api/v1/stats/overview` now names the ovulation day the temperatures confirm, not the day
+  the cycle model projected before any of them arrived.** When basal body temperature is tracked and
+  a sustained thermal shift is detected in the current cycle, that shift confirms an ovulation that
+  has already happened. The calendar's solid marker, the dashboard's ovulation line, the stats chart
+  marker and the two outbound surfaces (the `.ics` feed and the webhook reminder pass) already
+  resolve this through the shared detector; the JSON API kept publishing the model's superseded
+  projection instead. `ovulation_date` now carries the confirmed day when one exists, and
+  `ovulation_exact` reports `true` for it — a measurement, not an approximate estimate. Suppression
+  is unaffected: a confirmed observation changes which day is named, never whether one may be named
+  at all.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -808,12 +808,18 @@ components:
         ovulation_date:
           type: [string, "null"]
           format: date
-          description: Projected. Null when `suppression.fertility` is true.
+          description: >-
+            Projected, unless the owner's own BBT readings have already
+            confirmed the current cycle's ovulation, in which case this is the
+            measured day the calendar and dashboard also show. Null when
+            `suppression.fertility` is true.
         ovulation_exact:
           type: boolean
           description: >-
-            The ovulation date is anchored on an observation rather than on the
-            cycle-length fallback. Always false when `ovulation_date` is null.
+            True when the ovulation date is anchored on an observation —
+            either a per-owner inferred luteal phase rather than the 14-day
+            fallback, or (see `ovulation_date`) a BBT-confirmed day for the
+            current cycle. Always false when `ovulation_date` is null.
         ovulation_impossible:
           type: boolean
           description: No ovulation can be placed in the running cycle at all.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -742,6 +742,7 @@ components:
         - next_period_start
         - ovulation_date
         - ovulation_exact
+        - ovulation_confirmed
         - ovulation_impossible
         - fertility_window_start
         - fertility_window_end
@@ -816,10 +817,20 @@ components:
         ovulation_exact:
           type: boolean
           description: >-
-            True when the ovulation date is anchored on an observation —
-            either a per-owner inferred luteal phase rather than the 14-day
-            fallback, or (see `ovulation_date`) a BBT-confirmed day for the
-            current cycle. Always false when `ovulation_date` is null.
+            The ovulation date is anchored on a per-owner inferred luteal
+            phase rather than on the 14-day fallback. Independent of
+            `ovulation_confirmed` — a fallback-luteal cycle (`false` here) can
+            still have its ovulation confirmed by a BBT shift. Always false
+            when `ovulation_date` is null.
+        ovulation_confirmed:
+          type: boolean
+          description: >-
+            `ovulation_date` is a MEASUREMENT: the owner's own BBT readings
+            already confirmed the current cycle's ovulation, and the date
+            reported is the detector's day rather than the model's
+            projection — the same day the calendar's solid marker and the
+            dashboard's ovulation line show. Always false when
+            `ovulation_date` is null.
         ovulation_impossible:
           type: boolean
           description: No ovulation can be placed in the running cycle at all.

--- a/internal/api/handlers_stats.go
+++ b/internal/api/handlers_stats.go
@@ -28,7 +28,7 @@ func (handler *Handler) GetStatsOverview(c fiber.Ctx) error {
 	// BBT shift that has superseded the model's projection is not the one thing
 	// this endpoint still names the old day for.
 	today := services.DateAtLocation(now, location)
-	published, suppression := services.PublishedOverviewStats(user, logs, stats, today, location)
+	published, suppression, confirmed := services.PublishedOverviewStats(user, logs, stats, today, location)
 
-	return c.JSON(newStatsOverviewResponse(published, suppression, handler.medicalDisclaimer(c)))
+	return c.JSON(newStatsOverviewResponse(published, suppression, confirmed, handler.medicalDisclaimer(c)))
 }

--- a/internal/api/handlers_stats.go
+++ b/internal/api/handlers_stats.go
@@ -15,7 +15,7 @@ func (handler *Handler) GetStatsOverview(c fiber.Ctx) error {
 
 	location := handler.requestLocation(c)
 	now := time.Now().In(location)
-	stats, err := handler.statsService.BuildOverviewStats(c.Context(), user, now, location)
+	stats, logs, err := handler.statsService.BuildOverviewStats(c.Context(), user, now, location)
 	if err != nil {
 		return handler.respondMappedError(c, statsFetchErrorSpec())
 	}
@@ -23,7 +23,12 @@ func (handler *Handler) GetStatsOverview(c fiber.Ctx) error {
 	// The same adapter /stats and the dashboard publish through: this endpoint
 	// used to serialize the domain struct, so every date those pages withhold
 	// left the instance as JSON (medical safety — suppression is the floor).
-	published, suppression := services.PublishedStats(user, stats)
+	// PublishedOverviewStats additionally resolves a confirmed ovulation day the
+	// way the calendar's solid marker and the dashboard's line already do, so a
+	// BBT shift that has superseded the model's projection is not the one thing
+	// this endpoint still names the old day for.
+	today := services.DateAtLocation(now, location)
+	published, suppression := services.PublishedOverviewStats(user, logs, stats, today, location)
 
 	return c.JSON(newStatsOverviewResponse(published, suppression, handler.medicalDisclaimer(c)))
 }

--- a/internal/api/stats_overview_contract_test.go
+++ b/internal/api/stats_overview_contract_test.go
@@ -399,6 +399,44 @@ func TestStatsOverviewConfirmedOvulationIsIndependentOfOvulationExact(t *testing
 	}
 }
 
+// TestStatsOverviewSuppressedOvulationIsNeverReportedConfirmed pins the floor
+// PublishedOverviewStats' own doc comment names: ovulation_confirmed is
+// derived off the CLEARED stats, never off the ConfirmedCurrentCycleOvulation
+// call alone, so a suppressed projection cannot assert a measurement even if a
+// real BBT shift exists in the account's history. The fixture is
+// TestStatsOverviewPublishesTheConfirmedOvulationDayNotTheModelsProjection's,
+// with unpredictable-cycle mode layered on top — the same temperatures that
+// confirm a day there must confirm nothing here, matching the suppression
+// gate ConfirmedCurrentCycleOvulation already reads for itself
+// (FertilityProjectionSuppressed, cycle_signals.go).
+func TestStatsOverviewSuppressedOvulationIsNeverReportedConfirmed(t *testing.T) {
+	app, database, _ := newOnboardingTestAppWithLocation(t, time.UTC)
+	user := createOnboardingTestUser(t, database, "overview-confirmed-suppressed@example.com", "StrongPass1", true)
+	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
+	today := services.DateAtLocation(time.Now().In(time.UTC), time.UTC)
+	updateStatsOverviewUser(t, database, user, map[string]any{"track_bbt": true, "unpredictable_cycle": true})
+
+	seedStatsOverviewCycleHistory(t, database, user, today, 104, 76, 48, 20)
+	for _, offset := range []int{9, 8, 7, 6, 5, 4} {
+		seedStatsOverviewLog(t, database, models.DailyLog{UserID: user.ID, Date: today.AddDate(0, 0, -offset), BBT: new(36.20)})
+	}
+	for _, offset := range []int{3, 2, 1} {
+		seedStatsOverviewLog(t, database, models.DailyLog{UserID: user.ID, Date: today.AddDate(0, 0, -offset), BBT: new(36.50)})
+	}
+
+	_, payload := fetchStatsOverview(t, app, authCookie)
+
+	if !payload.Suppression.Fertility {
+		t.Fatal("suppression.fertility = false for an unpredictable-cycle account — fixture did not build the state it claims")
+	}
+	if payload.OvulationDate != nil {
+		t.Fatalf("ovulation_date = %s while suppression.fertility is true", *payload.OvulationDate)
+	}
+	if payload.OvulationConfirmed {
+		t.Fatal("ovulation_confirmed = true beside a null ovulation_date — a suppressed projection must never assert a measurement, even with a real BBT shift on record")
+	}
+}
+
 // TestStatsOverviewCarriesTheDisclaimerWithoutTheLanguageMiddleware pins the
 // framing against its own wiring.
 //

--- a/internal/api/stats_overview_contract_test.go
+++ b/internal/api/stats_overview_contract_test.go
@@ -160,6 +160,9 @@ func TestStatsOverviewWithholdsEveryProjectionItsGatesRefuse(t *testing.T) {
 			if payload.OvulationExact {
 				t.Fatal("ovulation_exact is true beside a null ovulation_date")
 			}
+			if payload.OvulationConfirmed {
+				t.Fatal("ovulation_confirmed is true beside a null ovulation_date")
+			}
 			if (payload.NextPeriodStart != nil) != state.wantNextPeriodSet {
 				t.Fatalf("next_period_start present = %v, want %v", payload.NextPeriodStart != nil, state.wantNextPeriodSet)
 			}
@@ -288,10 +291,12 @@ func TestStatsOverviewAgreesWithTheStatsPageOnAPublishedProjection(t *testing.T)
 // made to differ deliberately, the way MED-2's trace does: a median-cycle
 // projection lands on cycle day 14, while a recorded BBT shift confirms cycle
 // day 17. Before this fix the endpoint answered the model's superseded day;
-// it must now answer the measured one, with ovulation_exact reporting true
-// for it — a confirmed day is a measurement, not an approximate estimate,
-// matching what the calendar's solid marker and the dashboard's line already
-// mean by never showing the "approximate" caption beside one.
+// it must now answer the measured one, with ovulation_confirmed reporting
+// true for it — the same "confirmed, not modeled" bit the dashboard carries
+// as DisplayOvulationConfirmed beside its own DisplayOvulationExact
+// (dashboard_cycle.go). This fixture's luteal phase is not clamped, so
+// ovulation_exact is true here too; the case that pulls the two apart is
+// TestStatsOverviewConfirmedOvulationIsIndependentOfOvulationExact below.
 func TestStatsOverviewPublishesTheConfirmedOvulationDayNotTheModelsProjection(t *testing.T) {
 	app, database, _ := newOnboardingTestAppWithLocation(t, time.UTC)
 	user := createOnboardingTestUser(t, database, "overview-confirmed-ovulation@example.com", "StrongPass1", true)
@@ -331,11 +336,66 @@ func TestStatsOverviewPublishesTheConfirmedOvulationDayNotTheModelsProjection(t 
 	if *payload.OvulationDate != wantConfirmed {
 		t.Fatalf("ovulation_date = %s, want the BBT-confirmed %s", *payload.OvulationDate, wantConfirmed)
 	}
+	if !payload.OvulationConfirmed {
+		t.Fatal("ovulation_confirmed = false beside a BBT-confirmed ovulation_date — the JSON view must name the substitution the calendar and dashboard already applied")
+	}
 	if !payload.OvulationExact {
-		t.Fatal("ovulation_exact = false beside a BBT-confirmed ovulation_date — a measurement is not an approximate estimate")
+		t.Fatal("ovulation_exact = false: this fixture's luteal phase (14, cycle length 28) is not clamped, so the model's own fit is exact independent of the confirmation")
 	}
 	if payload.Suppression.Fertility {
 		t.Fatalf("suppression.fertility = true for an owner with observed cycles and a confirmed shift: %v", payload.Suppression.Reasons)
+	}
+}
+
+// TestStatsOverviewConfirmedOvulationIsIndependentOfOvulationExact pins the
+// boundary TestStatsOverviewPublishesTheConfirmedOvulationDayNotTheModelsProjection
+// cannot: ovulation_confirmed and ovulation_exact are two different signals,
+// mirroring the dashboard's own DisplayOvulationConfirmed vs
+// DisplayOvulationExact (dashboard_cycle.go), and a single collapsed boolean
+// would hide whichever one it discarded. The fixture forces the fallback
+// 14-day luteal phase to be CLAMPED (a short 18-day median cycle: the shared
+// CalcOvulationDay caps a 14-day luteal phase at cycleLen-5=13), so
+// ovulation_exact must read false, while the current cycle's own BBT shift
+// still confirms an ovulation — a fact ovulation_confirmed must still report
+// regardless of the model's own fit.
+func TestStatsOverviewConfirmedOvulationIsIndependentOfOvulationExact(t *testing.T) {
+	app, database, _ := newOnboardingTestAppWithLocation(t, time.UTC)
+	user := createOnboardingTestUser(t, database, "overview-confirmed-not-exact@example.com", "StrongPass1", true)
+	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
+	today := services.DateAtLocation(time.Now().In(time.UTC), time.UTC)
+	updateStatsOverviewUser(t, database, user, map[string]any{"track_bbt": true})
+
+	// Three prior 18-day cycles fix the median at 18 (no BBT data recorded in
+	// them, so InferUserLutealPhase finds nothing to personalize and the
+	// 14-day fallback stays in force); the fourth start opens the CURRENT
+	// cycle at today-11 (cycle day 12 today). CalcOvulationDay(18, 14) clamps
+	// the fallback to 13 (18-5), landing the model's projection on cycle day
+	// 5 = today-7, with ovulation_exact = false.
+	seedStatsOverviewCycleHistory(t, database, user, today, 72, 54, 36, 11)
+
+	// Undisturbed temperatures fill the coverline window (cycle days 3-8 =
+	// today-9..today-4); three elevated days follow (cycle days 9-11 =
+	// today-3..today-1). The detector confirms ovulation the day BEFORE the
+	// shift: cycle day 8 = today-4.
+	for _, offset := range []int{9, 8, 7, 6, 5, 4} {
+		seedStatsOverviewLog(t, database, models.DailyLog{UserID: user.ID, Date: today.AddDate(0, 0, -offset), BBT: new(36.20)})
+	}
+	for _, offset := range []int{3, 2, 1} {
+		seedStatsOverviewLog(t, database, models.DailyLog{UserID: user.ID, Date: today.AddDate(0, 0, -offset), BBT: new(36.50)})
+	}
+
+	_, payload := fetchStatsOverview(t, app, authCookie)
+
+	wantConfirmed := today.AddDate(0, 0, -4).Format(statsOverviewDateLayout)
+
+	if payload.OvulationDate == nil || *payload.OvulationDate != wantConfirmed {
+		t.Fatalf("ovulation_date = %v, want the BBT-confirmed %s", payload.OvulationDate, wantConfirmed)
+	}
+	if !payload.OvulationConfirmed {
+		t.Fatal("ovulation_confirmed = false beside a BBT-confirmed ovulation_date")
+	}
+	if payload.OvulationExact {
+		t.Fatal("ovulation_exact = true, want false: the fixture's 18-day median clamps the 14-day fallback luteal phase, and a confirmed observation must not silently launder that into an exact model fit")
 	}
 }
 

--- a/internal/api/stats_overview_contract_test.go
+++ b/internal/api/stats_overview_contract_test.go
@@ -280,6 +280,65 @@ func TestStatsOverviewAgreesWithTheStatsPageOnAPublishedProjection(t *testing.T)
 	}
 }
 
+// TestStatsOverviewPublishesTheConfirmedOvulationDayNotTheModelsProjection is
+// the JSON-API half of the confirmed-ovulation substitution the calendar's
+// solid marker, the dashboard's ovulation line and four other surfaces
+// already apply (services.ConfirmedCurrentCycleOvulation,
+// dashboard_confirmed_ovulation_test.go). The model and the measured day are
+// made to differ deliberately, the way MED-2's trace does: a median-cycle
+// projection lands on cycle day 14, while a recorded BBT shift confirms cycle
+// day 17. Before this fix the endpoint answered the model's superseded day;
+// it must now answer the measured one, with ovulation_exact reporting true
+// for it — a confirmed day is a measurement, not an approximate estimate,
+// matching what the calendar's solid marker and the dashboard's line already
+// mean by never showing the "approximate" caption beside one.
+func TestStatsOverviewPublishesTheConfirmedOvulationDayNotTheModelsProjection(t *testing.T) {
+	app, database, _ := newOnboardingTestAppWithLocation(t, time.UTC)
+	user := createOnboardingTestUser(t, database, "overview-confirmed-ovulation@example.com", "StrongPass1", true)
+	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
+	today := services.DateAtLocation(time.Now().In(time.UTC), time.UTC)
+	updateStatsOverviewUser(t, database, user, map[string]any{"track_bbt": true})
+
+	// Three prior 28-day cycles fix the median at 28 and lift the
+	// zero-completed-cycle floor; the fourth start opens the CURRENT cycle at
+	// today-20 (cycle day 21 today). The median projects ovulation on cycle
+	// day 14 (cycleLen 28 - luteal 14), i.e. today-7.
+	seedStatsOverviewCycleHistory(t, database, user, today, 104, 76, 48, 20)
+
+	// Undisturbed temperatures fill the shared 3-over-6 detector's 6-day
+	// coverline window (cycle days 12-17 = today-9..today-4); three elevated
+	// days follow (cycle days 18-20 = today-3..today-1). The detector confirms
+	// ovulation the day BEFORE the shift: cycle day 17 = today-4 — three days
+	// off the model's today-7, so the two dates cannot pass by coincidence.
+	for _, offset := range []int{9, 8, 7, 6, 5, 4} {
+		seedStatsOverviewLog(t, database, models.DailyLog{UserID: user.ID, Date: today.AddDate(0, 0, -offset), BBT: new(36.20)})
+	}
+	for _, offset := range []int{3, 2, 1} {
+		seedStatsOverviewLog(t, database, models.DailyLog{UserID: user.ID, Date: today.AddDate(0, 0, -offset), BBT: new(36.50)})
+	}
+
+	_, payload := fetchStatsOverview(t, app, authCookie)
+
+	wantConfirmed := today.AddDate(0, 0, -4).Format(statsOverviewDateLayout)
+	wantModel := today.AddDate(0, 0, -7).Format(statsOverviewDateLayout)
+
+	if payload.OvulationDate == nil {
+		t.Fatal("ovulation_date is null for an owner with a published projection")
+	}
+	if *payload.OvulationDate == wantModel {
+		t.Fatalf("ovulation_date = %s — the model's projection the owner's own temperatures already superseded; want the confirmed %s", *payload.OvulationDate, wantConfirmed)
+	}
+	if *payload.OvulationDate != wantConfirmed {
+		t.Fatalf("ovulation_date = %s, want the BBT-confirmed %s", *payload.OvulationDate, wantConfirmed)
+	}
+	if !payload.OvulationExact {
+		t.Fatal("ovulation_exact = false beside a BBT-confirmed ovulation_date — a measurement is not an approximate estimate")
+	}
+	if payload.Suppression.Fertility {
+		t.Fatalf("suppression.fertility = true for an owner with observed cycles and a confirmed shift: %v", payload.Suppression.Reasons)
+	}
+}
+
 // TestStatsOverviewCarriesTheDisclaimerWithoutTheLanguageMiddleware pins the
 // framing against its own wiring.
 //

--- a/internal/api/stats_overview_dto.go
+++ b/internal/api/stats_overview_dto.go
@@ -65,6 +65,14 @@ type StatsOverviewSuppression struct {
 // domain struct's field list: a field added to CycleStats reaches no client
 // until someone names it here.
 //
+// ovulation_date carries the same additional resolution the calendar's solid
+// marker and the dashboard's ovulation line already apply, through
+// services.PublishedOverviewStats: once the owner's own BBT readings confirm
+// the current cycle's ovulation, the measured day outranks the model's
+// projection here too, and ovulation_exact reports true for it — this was the
+// one surface still naming the superseded projection after the other six
+// had moved on to the measured day.
+//
 // Every projected date is a pointer and is null when suppressed. Null rather
 // than omitted, and never a zero date: the field set stays constant across
 // states, so a client parses one shape and reads suppression from the

--- a/internal/api/stats_overview_dto.go
+++ b/internal/api/stats_overview_dto.go
@@ -69,9 +69,15 @@ type StatsOverviewSuppression struct {
 // marker and the dashboard's ovulation line already apply, through
 // services.PublishedOverviewStats: once the owner's own BBT readings confirm
 // the current cycle's ovulation, the measured day outranks the model's
-// projection here too, and ovulation_exact reports true for it — this was the
-// one surface still naming the superseded projection after the other six
-// had moved on to the measured day.
+// projection here too — this was the one surface still naming the superseded
+// projection after the other six had moved on to the measured day.
+//
+// ovulation_confirmed names that substitution rather than folding it into
+// ovulation_exact. The two are independent on the dashboard
+// (DisplayOvulationExact vs DisplayOvulationConfirmed, dashboard_cycle.go): a
+// fallback-luteal account (ovulation_exact=false) can still have its current
+// cycle's ovulation CONFIRMED by a BBT shift, and a client that cannot see
+// both loses the "measured, not modeled" distinction the domain keeps.
 //
 // Every projected date is a pointer and is null when suppressed. Null rather
 // than omitted, and never a zero date: the field set stays constant across
@@ -98,6 +104,7 @@ type StatsOverviewResponse struct {
 	NextPeriodStart      *string                  `json:"next_period_start"`
 	OvulationDate        *string                  `json:"ovulation_date"`
 	OvulationExact       bool                     `json:"ovulation_exact"`
+	OvulationConfirmed   bool                     `json:"ovulation_confirmed"`
 	OvulationImpossible  bool                     `json:"ovulation_impossible"`
 	FertilityWindowStart *string                  `json:"fertility_window_start"`
 	FertilityWindowEnd   *string                  `json:"fertility_window_end"`
@@ -114,7 +121,7 @@ type StatsOverviewResponse struct {
 // adapter exists to prevent. Handed the raw stats it would faithfully publish
 // them, so the clearing stays the caller's obligation and the verdict travels
 // with the data.
-func newStatsOverviewResponse(stats services.CycleStats, suppression services.PredictionSuppression, disclaimer string) StatsOverviewResponse {
+func newStatsOverviewResponse(stats services.CycleStats, suppression services.PredictionSuppression, confirmed bool, disclaimer string) StatsOverviewResponse {
 	return StatsOverviewResponse{
 		CurrentCycleDay:      stats.CurrentCycleDay,
 		CurrentPhase:         stats.CurrentPhase,
@@ -133,6 +140,7 @@ func newStatsOverviewResponse(stats services.CycleStats, suppression services.Pr
 		NextPeriodStart:      statsOverviewDate(stats.NextPeriodStart),
 		OvulationDate:        statsOverviewDate(stats.OvulationDate),
 		OvulationExact:       stats.OvulationExact,
+		OvulationConfirmed:   confirmed,
 		OvulationImpossible:  stats.OvulationImpossible,
 		FertilityWindowStart: statsOverviewDate(stats.FertilityWindowStart),
 		FertilityWindowEnd:   statsOverviewDate(stats.FertilityWindowEnd),

--- a/internal/services/prediction_published_stats.go
+++ b/internal/services/prediction_published_stats.go
@@ -70,3 +70,34 @@ func PublishedStats(user *models.User, stats CycleStats) (CycleStats, Prediction
 	}
 	return stats, suppression
 }
+
+// PublishedOverviewStats is PublishedStats plus the confirmed-ovulation
+// substitution the on-screen surfaces already apply: the calendar's solid
+// marker (calendar_days.go), the dashboard's ovulation line
+// (dashboard_cycle.go) and the stats chart marker all resolve the CURRENT
+// cycle's ovulation day through ConfirmedCurrentCycleOvulation, so a shift
+// the owner's own temperatures already confirm outranks the model's
+// projection everywhere an owner reads it.
+//
+// The JSON API was the one surface that skipped this: it read stats.
+// OvulationDate straight off the model and published it even after a BBT
+// shift had superseded it, while the grid, the dashboard and the chart had
+// already moved on to the measured day. The substitution runs on the RAW
+// stats, ahead of PublishedStats' own clearing, for the same reason the
+// dashboard's runs ahead of its suppression branches: ConfirmedCurrentCycleOvulation
+// already reads FertilityProjectionSuppressed itself, so a confirmed day
+// never overrides a projection the gate would have withheld anyway, and
+// running it first means PublishedStats sees the same OvulationDate every
+// other surface renders.
+//
+// A confirmed day is a MEASUREMENT, not a less-certain reading of the model:
+// OvulationExact is set true along with it, matching what the calendar's
+// solid marker and the dashboard's line already mean by never showing the
+// "approximate" caption beside a confirmed date (dashboard.html).
+func PublishedOverviewStats(user *models.User, logs []models.DailyLog, stats CycleStats, today time.Time, location *time.Location) (CycleStats, PredictionSuppression) {
+	if confirmed, ok := ConfirmedCurrentCycleOvulation(user, logs, stats, today, location); ok {
+		stats.OvulationDate = confirmed
+		stats.OvulationExact = true
+	}
+	return PublishedStats(user, stats)
+}

--- a/internal/services/prediction_published_stats.go
+++ b/internal/services/prediction_published_stats.go
@@ -90,14 +90,22 @@ func PublishedStats(user *models.User, stats CycleStats) (CycleStats, Prediction
 // running it first means PublishedStats sees the same OvulationDate every
 // other surface renders.
 //
-// A confirmed day is a MEASUREMENT, not a less-certain reading of the model:
-// OvulationExact is set true along with it, matching what the calendar's
-// solid marker and the dashboard's line already mean by never showing the
-// "approximate" caption beside a confirmed date (dashboard.html).
-func PublishedOverviewStats(user *models.User, logs []models.DailyLog, stats CycleStats, today time.Time, location *time.Location) (CycleStats, PredictionSuppression) {
+// The returned bool is the SAME "confirmed" bit the dashboard carries beside
+// its own OvulationExact (dashboard_cycle.go's DisplayOvulationConfirmed) —
+// deliberately a second signal, not a rewrite of the first. OvulationExact
+// keeps its own meaning (an exact luteal-phase fit vs a clamped estimate,
+// CalcOvulationDay); a BBT-confirmed day on a fallback-luteal account is
+// "confirmed" and still arithmetically "not exact" until it feeds back into
+// InferUserLutealPhase on a LATER cycle, and collapsing the two into one
+// boolean would make the JSON view unable to say which is true — exactly the
+// class of divergence PublishedStats itself exists to prevent, just one field
+// over.
+func PublishedOverviewStats(user *models.User, logs []models.DailyLog, stats CycleStats, today time.Time, location *time.Location) (CycleStats, PredictionSuppression, bool) {
+	confirmedOvulation := false
 	if confirmed, ok := ConfirmedCurrentCycleOvulation(user, logs, stats, today, location); ok {
 		stats.OvulationDate = confirmed
-		stats.OvulationExact = true
+		confirmedOvulation = true
 	}
-	return PublishedStats(user, stats)
+	published, suppression := PublishedStats(user, stats)
+	return published, suppression, confirmedOvulation
 }

--- a/internal/services/prediction_published_stats.go
+++ b/internal/services/prediction_published_stats.go
@@ -100,12 +100,25 @@ func PublishedStats(user *models.User, stats CycleStats) (CycleStats, Prediction
 // boolean would make the JSON view unable to say which is true — exactly the
 // class of divergence PublishedStats itself exists to prevent, just one field
 // over.
+//
+// The bool is READ BACK off `published.OvulationDate` after PublishedStats has
+// run, rather than kept from the ConfirmedCurrentCycleOvulation call above:
+// today the two calls agree by construction (both read
+// FertilityProjectionSuppressed against the same user and stats, and the only
+// field this function mutates before the second call, OvulationDate, is not an
+// input to that predicate), but a bool decided before the clearing and never
+// revisited would depend on that agreement holding forever across two files. A
+// suppressed projection reporting a measurement is exactly the medical-safety
+// floor this adapter exists to hold, so the field is derived from the
+// CLEARED stats it is published beside: it cannot outlive the date it
+// describes even if a future suppression signal reaches one predicate and not
+// the other.
 func PublishedOverviewStats(user *models.User, logs []models.DailyLog, stats CycleStats, today time.Time, location *time.Location) (CycleStats, PredictionSuppression, bool) {
-	confirmedOvulation := false
-	if confirmed, ok := ConfirmedCurrentCycleOvulation(user, logs, stats, today, location); ok {
-		stats.OvulationDate = confirmed
-		confirmedOvulation = true
+	confirmedDay, wasConfirmed := ConfirmedCurrentCycleOvulation(user, logs, stats, today, location)
+	if wasConfirmed {
+		stats.OvulationDate = confirmedDay
 	}
 	published, suppression := PublishedStats(user, stats)
+	confirmedOvulation := wasConfirmed && !published.OvulationDate.IsZero()
 	return published, suppression, confirmedOvulation
 }

--- a/internal/services/stats_service.go
+++ b/internal/services/stats_service.go
@@ -117,13 +117,17 @@ func StatsOverviewRange(now time.Time) (time.Time, time.Time) {
 	return now.AddDate(-statsOverviewWindowYears, 0, 0), now
 }
 
-func (service *StatsService) BuildOverviewStats(ctx context.Context, user *models.User, now time.Time, location *time.Location) (CycleStats, error) {
+// BuildOverviewStats also returns the logs it fetched, alongside the derived
+// stats: PublishedOverviewStats needs them to resolve a confirmed ovulation
+// day through the shared BBT detector, and a second fetch here would be a
+// second read of the same range this call already bounded.
+func (service *StatsService) BuildOverviewStats(ctx context.Context, user *models.User, now time.Time, location *time.Location) (CycleStats, []models.DailyLog, error) {
 	from, to := StatsOverviewRange(now)
-	stats, _, err := service.BuildCycleStatsForRange(ctx, user, from, to, now, location)
+	stats, logs, err := service.BuildCycleStatsForRange(ctx, user, from, to, now, location)
 	if err != nil {
-		return CycleStats{}, err
+		return CycleStats{}, nil, err
 	}
-	return stats, nil
+	return stats, logs, nil
 }
 
 func TrimTrailingCycleTrendLengths(lengths []int, maxPoints int) []int {

--- a/internal/services/stats_service_coverage_test.go
+++ b/internal/services/stats_service_coverage_test.go
@@ -37,7 +37,7 @@ func TestStatsServiceBuildOverviewStatsPropagatesToStorage(t *testing.T) {
 	user := &models.User{ID: 1, Role: models.RoleOwner, CycleLength: 28}
 	now := mustParseStatsServiceDay(t, "2026-05-01")
 
-	_, err := svc.BuildOverviewStats(context.Background(), user, now, time.UTC)
+	_, _, err := svc.BuildOverviewStats(context.Background(), user, now, time.UTC)
 	if err == nil {
 		t.Fatal("BuildOverviewStats() expected error, got nil")
 	}

--- a/internal/services/stats_service_test.go
+++ b/internal/services/stats_service_test.go
@@ -197,7 +197,7 @@ func TestBuildOverviewStatsUsesOverviewRange(t *testing.T) {
 	user := &models.User{ID: 3, Role: models.RoleOwner, CycleLength: 28}
 	now := mustParseStatsServiceDay(t, "2026-03-02")
 
-	if _, err := service.BuildOverviewStats(context.Background(), user, now, time.UTC); err != nil {
+	if _, _, err := service.BuildOverviewStats(context.Background(), user, now, time.UTC); err != nil {
 		t.Fatalf("BuildOverviewStats() unexpected error: %v", err)
 	}
 


### PR DESCRIPTION
## Summary
- `GET /api/v1/stats/overview` published the model's projected ovulation day even after the owner's
  own BBT readings had already confirmed a different day for the current cycle — the calendar's
  solid marker, the dashboard's ovulation line, the stats chart marker and both egress passes
  (`.ics` feed, webhook reminder) already resolve this through the shared
  `ConfirmedCurrentCycleOvulation` detector; the JSON API was the seventh, untranslated surface.
- Adds `services.PublishedOverviewStats`, which applies that same substitution ahead of
  `PublishedStats`' own suppression clearing, then delegates to it — no new detection logic, the
  existing resolver is reused as-is.
- The DTO gains one additive field, `ovulation_confirmed`, rather than folding confirmation into
  `ovulation_exact`. The dashboard keeps these as two independent signals
  (`DisplayOvulationConfirmed` vs `DisplayOvulationExact`, `dashboard_cycle.go:56,367,489,509-512`):
  `ovulation_exact` is untouched pass-through, still meaning "an exact per-owner luteal-phase fit vs.
  the clamped 14-day fallback"; `ovulation_confirmed` separately reports whether `ovulation_date` is
  the BBT-measured day rather than the model's projection. A fallback-luteal account whose current
  cycle gets BBT-confirmed reads `(ovulation_exact: false, ovulation_confirmed: true)` — collapsing
  the two into one boolean would have reopened the same API-vs-page divergence class MED-2 is an
  instance of, just on a different field. (An earlier revision of this branch did collapse them;
  fixed after review before merge.)
- `StatsService.BuildOverviewStats` now also returns the logs it fetched (mirroring
  `BuildCycleStatsForRange`), since the resolver needs them and a second fetch would duplicate the
  read the endpoint already bounded.
- `docs/openapi.yaml` and the DTO docstring updated to describe the new fields truthfully instead of
  naming the defect; `ovulation_confirmed` added to the schema (additive, non-breaking).

## Design note
`ovulation_confirmed` is derived off the CLEARED stats (`wasConfirmed && !published.OvulationDate.IsZero()`),
not carried from the raw `ConfirmedCurrentCycleOvulation` check alone, so a suppressed projection can
never assert a measurement even if a future change lets the two suppression reads (inside
`ConfirmedCurrentCycleOvulation` and inside `PublishedStats`) diverge. Today they can't — both call
the same `FertilityProjectionSuppressed(user, stats)` — but the field is now true by construction
instead of by an argument spanning two files.

## Test plan
- `TestStatsOverviewPublishesTheConfirmedOvulationDayNotTheModelsProjection`
  (`internal/api/stats_overview_contract_test.go`): seeds three completed 28-day cycles plus a
  current cycle whose BBT readings deliberately confirm a different day than the model projects,
  asserts the JSON payload names the confirmed day with `ovulation_confirmed: true` (this fixture's
  luteal phase is unclamped, so `ovulation_exact` is also true here).
- `TestStatsOverviewConfirmedOvulationIsIndependentOfOvulationExact`: same shape but with a short
  18-day median cycle that clamps the 14-day fallback luteal phase (`ovulation_exact: false`), and a
  current-cycle BBT shift confirming a day anyway — asserts `(ovulation_exact: false,
  ovulation_confirmed: true)`, pinning that the two flags are independent.
- `TestStatsOverviewSuppressedOvulationIsNeverReportedConfirmed`: the first fixture's cycle history
  and BBT shift, with unpredictable-cycle mode layered on top — asserts `ovulation_date` null and
  `ovulation_confirmed` false together, i.e. suppression stays the floor even with a real confirming
  shift on record.
- All three verified red against a gutted `PublishedOverviewStats` (temporarily reverted to plain
  `PublishedStats`, confirmed the failures name the exact defect, then restored) before landing.
- `go test ./internal/api/... ./internal/services/...` (targeted, including postgres-backed
  integration tests) and `go test ./cmd/... ./internal/... ./migrations/... ./scripts/... ./web/...
  -timeout 20m` (TESTING.md's sanctioned full command) — green. `internal/api` alone re-verified at
  `-timeout 25m` after one contention-driven 20m timeout with no test failures reported (shared
  machine load, not a regression — internal/api normally runs in ~600-700s per TESTING.md).
- `golangci-lint run ./internal/api/... ./internal/services/...` — 0 issues.

## Before / after (the trace from the task)
Cycle start 1 March, median 28, luteal 14 → model projects ovulation 14 March. BBT rise 18–20 March
confirms ovulation 17 March via the 3-over-6 detector. Today 21 March, next start 29 March, no
suppression active.

- Before: `"ovulation_date": "2026-03-14", "ovulation_exact": true` (no `ovulation_confirmed` field)
- After: `"ovulation_date": "2026-03-17", "ovulation_exact": true, "ovulation_confirmed": true`
