### PR TITLE
fix(api): onboarding age-group refusal now sees every request shape

### DIFF
--- a/changelog.d/onboarding-age-group-presence-covers-every-shape.md
+++ b/changelog.d/onboarding-age-group-presence-covers-every-shape.md
@@ -10,4 +10,9 @@
   removed-field-reads-as-success outcome the original refusal exists to prevent, one spelling over.
   Presence is now decided from the raw request the same way for every shape: the parsed JSON object's
   own keys for a JSON body, and the URL query string, the urlencoded body, and the multipart form in
-  that order otherwise — the same three sources `FormValue` itself reads from.
+  that order otherwise — the same three sources `FormValue` itself reads from. Two narrower routes
+  around the same guard are closed alongside it: the query-string check now runs unconditionally
+  before branching on Content-Type, so a JSON request carrying `age_group` only in its URL (not its
+  body) is caught too; and the JSON-key match is now case-insensitive, matching the fallback
+  `Bind().Body` itself uses, so a body naming `Age_Group` or `AGE_GROUP` — exactly the off-spec
+  casing a client still on the old contract might send — is refused rather than silently dropped.

--- a/changelog.d/onboarding-age-group-presence-covers-every-shape.md
+++ b/changelog.d/onboarding-age-group-presence-covers-every-shape.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- **Onboarding step 2's refusal of the removed `age_group` field now covers every shape the
+  endpoint accepts, not only a form body and a JSON string.** The presence check told "the field is
+  not there" apart from "the field is there but malformed" by inspecting the outcome of a typed
+  decode, which reads a JSON number or `null` for `age_group` as absent (the typed probe fails with
+  a type error, not a missing-field error), and only ever inspected `PostArgs`, which fasthttp never
+  populates for a multipart body or for a value the client put in the URL's own query string. A
+  client using any of those four shapes was told `200` with the field silently dropped — the exact
+  removed-field-reads-as-success outcome the original refusal exists to prevent, one spelling over.
+  Presence is now decided from the raw request the same way for every shape: the parsed JSON object's
+  own keys for a JSON body, and the URL query string, the urlencoded body, and the multipart form in
+  that order otherwise — the same three sources `FormValue` itself reads from.

--- a/internal/api/handlers_onboarding_input_helpers.go
+++ b/internal/api/handlers_onboarding_input_helpers.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"errors"
 	"net/url"
 	"strconv"
@@ -78,18 +79,58 @@ func (handler *Handler) parseOnboardingStep1Values(c fiber.Ctx, today time.Time,
 // only. Without this refusal a client written against the old contract is
 // answered 200 while the value it submitted is dropped — the removal reads as a
 // successful save, which is the one answer a removed field must never give.
-// Both transports are asked, in their own spelling, so the two cannot diverge.
+//
+// Presence is decided from the raw request, never from whether a typed decode
+// of the value succeeded: a JSON number or `null` for `age_group` fails to
+// bind into a `*string` probe with a TYPE error, which reads identically to
+// the key being absent unless the two are told apart deliberately. Both
+// transports are asked, in their own spelling, so the two cannot diverge.
 func onboardingStep2CarriesRemovedAgeGroup(c fiber.Ctx) bool {
 	if hasJSONBody(c) {
-		probe := struct {
-			AgeGroup *string `json:"age_group"`
-		}{}
-		if err := c.Bind().Body(&probe); err != nil {
-			return false
-		}
-		return probe.AgeGroup != nil
+		return jsonBodyNamesKey(c.Body(), "age_group")
 	}
-	return c.Request().PostArgs().Has("age_group")
+	return onboardingNonJSONBodyHasField(c, "age_group")
+}
+
+// jsonBodyNamesKey reports whether the given key is present in a JSON object
+// body, independent of the value's own type — a present `null` or a present
+// number both count, since the question is "did the client name this field",
+// not "did it parse into the type we expect". A body that is not a JSON
+// object (including one too malformed to decode at all) reports the key
+// absent; the subsequent `Bind().Body` call answers the generic "invalid
+// input" for that case, so presence detection never needs to duplicate it.
+func jsonBodyNamesKey(body []byte, key string) bool {
+	fields := map[string]json.RawMessage{}
+	if err := json.Unmarshal(body, &fields); err != nil {
+		return false
+	}
+	_, present := fields[key]
+	return present
+}
+
+// onboardingNonJSONBodyHasField reports whether a non-JSON request carries the
+// given field in any of the three places fiber's own `FormValue` reads from —
+// the URL's own query string, an `application/x-www-form-urlencoded` body, and
+// a multipart form field — in that same search order. Checking `PostArgs`
+// alone (fasthttp only populates it for an exact
+// `application/x-www-form-urlencoded` Content-Type) misses a value the client
+// put in the query string, and misses every multipart submission outright, so
+// both routes around the refusal above stay silent.
+func onboardingNonJSONBodyHasField(c fiber.Ctx, key string) bool {
+	if c.Request().URI().QueryArgs().Has(key) {
+		return true
+	}
+	if c.Request().PostArgs().Has(key) {
+		return true
+	}
+	if c.IsMultipart() {
+		if form, err := c.MultipartForm(); err == nil {
+			if _, present := form.Value[key]; present {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (handler *Handler) parseOnboardingStep2Input(c fiber.Ctx) (onboardingStep2Input, string) {

--- a/internal/api/handlers_onboarding_input_helpers.go
+++ b/internal/api/handlers_onboarding_input_helpers.go
@@ -73,19 +73,29 @@ func (handler *Handler) parseOnboardingStep1Values(c fiber.Ctx, today time.Time,
 	}, ""
 }
 
-// onboardingStep2CarriesRemovedAgeGroup reports whether the step-2 body still
-// names `age_group`, which v1.9.2 collected here. Onboarding stopped asking for
-// the age bracket; the field is written by PATCH /api/v1/users/current/cycle
-// only. Without this refusal a client written against the old contract is
-// answered 200 while the value it submitted is dropped — the removal reads as a
-// successful save, which is the one answer a removed field must never give.
+// onboardingStep2CarriesRemovedAgeGroup reports whether the step-2 request
+// still names `age_group`, which v1.9.2 collected here. Onboarding stopped
+// asking for the age bracket; the field is written by
+// PATCH /api/v1/users/current/cycle only. Without this refusal a client
+// written against the old contract is answered 200 while the value it
+// submitted is dropped — the removal reads as a successful save, which is the
+// one answer a removed field must never give.
 //
 // Presence is decided from the raw request, never from whether a typed decode
 // of the value succeeded: a JSON number or `null` for `age_group` fails to
 // bind into a `*string` probe with a TYPE error, which reads identically to
-// the key being absent unless the two are told apart deliberately. Both
-// transports are asked, in their own spelling, so the two cannot diverge.
+// the key being absent unless the two are told apart deliberately. The URL's
+// own query string belongs to neither transport — fiber's `FormValue` reads
+// it ahead of a form body, and nothing stops a client from attaching it to a
+// JSON request either — so it is checked once, unconditionally, before
+// branching on Content-Type; checking it only on the non-JSON arm left a JSON
+// request with the field in its query string free to drop it silently. Both
+// transports are then asked for the body itself, in their own spelling, so
+// the two cannot diverge.
 func onboardingStep2CarriesRemovedAgeGroup(c fiber.Ctx) bool {
+	if c.Request().URI().QueryArgs().Has("age_group") {
+		return true
+	}
 	if hasJSONBody(c) {
 		return jsonBodyNamesKey(c.Body(), "age_group")
 	}
@@ -95,31 +105,39 @@ func onboardingStep2CarriesRemovedAgeGroup(c fiber.Ctx) bool {
 // jsonBodyNamesKey reports whether the given key is present in a JSON object
 // body, independent of the value's own type — a present `null` or a present
 // number both count, since the question is "did the client name this field",
-// not "did it parse into the type we expect". A body that is not a JSON
-// object (including one too malformed to decode at all) reports the key
-// absent; the subsequent `Bind().Body` call answers the generic "invalid
-// input" for that case, so presence detection never needs to duplicate it.
+// not "did it parse into the type we expect". The comparison is
+// case-insensitive because that is what it is standing in for: `Bind().Body`
+// matches a JSON object key to a struct field with a case-insensitive
+// fallback when no exact match exists, so a body naming `Age_Group` or
+// `AGE_GROUP` used to bind into the removed field, refused, exactly as
+// `age_group` was — the population this guard exists for is clients still on
+// the pre-v2.0.0 contract, precisely where off-spec casing lives. A body that
+// is not a JSON object (including one too malformed to decode at all) reports
+// the key absent; the subsequent `Bind().Body` call answers the generic
+// "invalid input" for that case, so presence detection never needs to
+// duplicate it.
 func jsonBodyNamesKey(body []byte, key string) bool {
 	fields := map[string]json.RawMessage{}
 	if err := json.Unmarshal(body, &fields); err != nil {
 		return false
 	}
-	_, present := fields[key]
-	return present
+	for fieldName := range fields {
+		if strings.EqualFold(fieldName, key) {
+			return true
+		}
+	}
+	return false
 }
 
-// onboardingNonJSONBodyHasField reports whether a non-JSON request carries the
-// given field in any of the three places fiber's own `FormValue` reads from —
-// the URL's own query string, an `application/x-www-form-urlencoded` body, and
-// a multipart form field — in that same search order. Checking `PostArgs`
-// alone (fasthttp only populates it for an exact
-// `application/x-www-form-urlencoded` Content-Type) misses a value the client
-// put in the query string, and misses every multipart submission outright, so
-// both routes around the refusal above stay silent.
+// onboardingNonJSONBodyHasField reports whether a non-JSON request's BODY
+// carries the given field, in either of the two places fiber's own
+// `FormValue` reads from besides the query string (already checked by the
+// caller, ahead of the Content-Type branch): an
+// `application/x-www-form-urlencoded` body, and a multipart form field.
+// Checking `PostArgs` alone (fasthttp only populates it for an exact
+// `application/x-www-form-urlencoded` Content-Type) misses every multipart
+// submission outright.
 func onboardingNonJSONBodyHasField(c fiber.Ctx, key string) bool {
-	if c.Request().URI().QueryArgs().Has(key) {
-		return true
-	}
 	if c.Request().PostArgs().Has(key) {
 		return true
 	}

--- a/internal/api/onboarding_step2_age_group_shapes_test.go
+++ b/internal/api/onboarding_step2_age_group_shapes_test.go
@@ -13,26 +13,33 @@ import (
 	"github.com/ovumcy/ovumcy-web/internal/models"
 )
 
-// TestOnboardingStep2AgeGroupPresenceAcrossRequestShapes closes the remaining
-// three leaks in API-2 (handlers_onboarding_input_helpers.go): the presence
-// guard for the removed `age_group` field used to answer "absent" for any
-// shape it did not know how to probe, which meant a client using that shape
-// was told 200 while the field it sent was silently discarded — the exact
+// TestOnboardingStep2AgeGroupPresenceAcrossRequestShapes closes the leaks in
+// API-2 (handlers_onboarding_input_helpers.go): the presence guard for the
+// removed `age_group` field used to answer "absent" for any shape it did not
+// know how to probe, which meant a client using that shape was told 200
+// while the field it sent was silently discarded — the exact
 // removed-field-reads-as-success failure
 // TestOnboardingStep2NamesTheAgeGroupItNoLongerAccepts (in
 // api_v1_declared_breaks_contract_test.go) already closed for a form body and
-// a JSON body carrying a string. Three shapes still slipped past the
-// pre-fix guard:
-//   - the URL's own query string (`onboardingStep2CarriesRemovedAgeGroup`
-//     only inspected `PostArgs`, never `QueryArgs`, though the fields this
+// a JSON body carrying a string. Shapes that slipped past an earlier guard:
+//   - the URL's own query string on a non-JSON request (the guard only
+//     inspected `PostArgs`, never `QueryArgs`, though the fields this
 //     endpoint DOES accept are read via `FormValue`, which searches
 //     `QueryArgs` first);
 //   - multipart/form-data (fasthttp only populates `PostArgs` for an exact
 //     `application/x-www-form-urlencoded` Content-Type; a multipart field
 //     never reaches it);
 //   - a non-string JSON value (`3`, `null`): binding `age_group` into a
-//     `*string` probe fails with a TYPE error, which the pre-fix guard read
-//     identically to the key being absent.
+//     `*string` probe fails with a TYPE error, which an earlier guard read
+//     identically to the key being absent;
+//   - the URL's own query string on a JSON request: the query-string check
+//     lived only in the non-JSON branch, so `?age_group=x` with
+//     `Content-Type: application/json` and a body that never names the key
+//     was still answered 200;
+//   - a JSON key differing only in case (`Age_Group`, `AGE_GROUP`):
+//     `Bind().Body` matches an object key to a struct field with a
+//     case-insensitive fallback, so a body shaped like that used to bind and
+//     get refused; a bare map lookup by the exact key does not.
 //
 // Each row below submits a normal, otherwise-valid step-2 body and either
 // carries `age_group` in the row's shape or omits it entirely. A present
@@ -146,6 +153,29 @@ func TestOnboardingStep2AgeGroupPresenceAcrossRequestShapes(t *testing.T) {
 			present: true,
 			buildRequest: func(t *testing.T, path string) *http.Request {
 				return jsonRequest(t, path, fmt.Sprintf(`{"cycle_length":%d,"period_length":%d,"age_group":null}`, cycleLength, periodLength))
+			},
+		},
+		{
+			// The query string belongs to neither transport: a JSON request
+			// whose BODY never names age_group can still carry it in the URL.
+			// A guard that only checks QueryArgs on the non-JSON branch misses
+			// this entirely.
+			name:    "json-body/query-string-present",
+			present: true,
+			buildRequest: func(t *testing.T, path string) *http.Request {
+				queried := path + "?age_group=40-45"
+				return jsonRequest(t, queried, fmt.Sprintf(`{"cycle_length":%d,"period_length":%d}`, cycleLength, periodLength))
+			},
+		},
+		{
+			// A struct-tag JSON probe would have matched this via
+			// encoding/json's case-insensitive fallback; a bare map lookup by
+			// the exact key does not, unless it compares case-insensitively
+			// itself.
+			name:    "json-string/mixed-case-key-present",
+			present: true,
+			buildRequest: func(t *testing.T, path string) *http.Request {
+				return jsonRequest(t, path, fmt.Sprintf(`{"cycle_length":%d,"period_length":%d,"Age_Group":"40-45"}`, cycleLength, periodLength))
 			},
 		},
 	}

--- a/internal/api/onboarding_step2_age_group_shapes_test.go
+++ b/internal/api/onboarding_step2_age_group_shapes_test.go
@@ -1,0 +1,235 @@
+package api
+
+import (
+	"bytes"
+	"fmt"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+)
+
+// TestOnboardingStep2AgeGroupPresenceAcrossRequestShapes closes the remaining
+// three leaks in API-2 (handlers_onboarding_input_helpers.go): the presence
+// guard for the removed `age_group` field used to answer "absent" for any
+// shape it did not know how to probe, which meant a client using that shape
+// was told 200 while the field it sent was silently discarded — the exact
+// removed-field-reads-as-success failure
+// TestOnboardingStep2NamesTheAgeGroupItNoLongerAccepts (in
+// api_v1_declared_breaks_contract_test.go) already closed for a form body and
+// a JSON body carrying a string. Three shapes still slipped past the
+// pre-fix guard:
+//   - the URL's own query string (`onboardingStep2CarriesRemovedAgeGroup`
+//     only inspected `PostArgs`, never `QueryArgs`, though the fields this
+//     endpoint DOES accept are read via `FormValue`, which searches
+//     `QueryArgs` first);
+//   - multipart/form-data (fasthttp only populates `PostArgs` for an exact
+//     `application/x-www-form-urlencoded` Content-Type; a multipart field
+//     never reaches it);
+//   - a non-string JSON value (`3`, `null`): binding `age_group` into a
+//     `*string` probe fails with a TYPE error, which the pre-fix guard read
+//     identically to the key being absent.
+//
+// Each row below submits a normal, otherwise-valid step-2 body and either
+// carries `age_group` in the row's shape or omits it entirely. A present
+// field must always be refused by name (400, "onboarding does not accept an
+// age group") with nothing written; an absent field must always succeed
+// (200) and persist the submitted cycle/period — proving the fix does not
+// turn into a false positive that refuses ordinary submissions in that shape.
+func TestOnboardingStep2AgeGroupPresenceAcrossRequestShapes(t *testing.T) {
+	const cycleLength = 27
+	const periodLength = 4
+
+	type testCase struct {
+		name         string
+		present      bool
+		buildRequest func(t *testing.T, path string) *http.Request
+	}
+
+	cases := []testCase{
+		{
+			name:    "query-string/absent",
+			present: false,
+			buildRequest: func(t *testing.T, path string) *http.Request {
+				return formEncodedRequest(t, path, url.Values{
+					"cycle_length":  {fmt.Sprint(cycleLength)},
+					"period_length": {fmt.Sprint(periodLength)},
+				})
+			},
+		},
+		{
+			name:    "query-string/present",
+			present: true,
+			buildRequest: func(t *testing.T, path string) *http.Request {
+				// age_group rides the URL query string; the body itself never
+				// names it, which is exactly the shape PostArgs cannot see.
+				queried := path + "?age_group=40-45"
+				return formEncodedRequest(t, queried, url.Values{
+					"cycle_length":  {fmt.Sprint(cycleLength)},
+					"period_length": {fmt.Sprint(periodLength)},
+				})
+			},
+		},
+		{
+			name:    "multipart/absent",
+			present: false,
+			buildRequest: func(t *testing.T, path string) *http.Request {
+				return multipartRequest(t, path, map[string]string{
+					"cycle_length":  fmt.Sprint(cycleLength),
+					"period_length": fmt.Sprint(periodLength),
+				})
+			},
+		},
+		{
+			name:    "multipart/present",
+			present: true,
+			buildRequest: func(t *testing.T, path string) *http.Request {
+				return multipartRequest(t, path, map[string]string{
+					"cycle_length":  fmt.Sprint(cycleLength),
+					"period_length": fmt.Sprint(periodLength),
+					"age_group":     "40-45",
+				})
+			},
+		},
+		{
+			name:    "form/absent",
+			present: false,
+			buildRequest: func(t *testing.T, path string) *http.Request {
+				return formEncodedRequest(t, path, url.Values{
+					"cycle_length":  {fmt.Sprint(cycleLength)},
+					"period_length": {fmt.Sprint(periodLength)},
+				})
+			},
+		},
+		{
+			name:    "form/present",
+			present: true,
+			buildRequest: func(t *testing.T, path string) *http.Request {
+				return formEncodedRequest(t, path, url.Values{
+					"cycle_length":  {fmt.Sprint(cycleLength)},
+					"period_length": {fmt.Sprint(periodLength)},
+					"age_group":     {"40-45"},
+				})
+			},
+		},
+		{
+			name:    "json-string/absent",
+			present: false,
+			buildRequest: func(t *testing.T, path string) *http.Request {
+				return jsonRequest(t, path, fmt.Sprintf(`{"cycle_length":%d,"period_length":%d}`, cycleLength, periodLength))
+			},
+		},
+		{
+			name:    "json-string/present",
+			present: true,
+			buildRequest: func(t *testing.T, path string) *http.Request {
+				return jsonRequest(t, path, fmt.Sprintf(`{"cycle_length":%d,"period_length":%d,"age_group":"40-45"}`, cycleLength, periodLength))
+			},
+		},
+		{
+			// The core of the bug: a JSON number fails to bind into the
+			// *string probe with a type error, which the pre-fix guard
+			// mistook for the key being absent.
+			name:    "json-number/present",
+			present: true,
+			buildRequest: func(t *testing.T, path string) *http.Request {
+				return jsonRequest(t, path, fmt.Sprintf(`{"cycle_length":%d,"period_length":%d,"age_group":3}`, cycleLength, periodLength))
+			},
+		},
+		{
+			// Same failure mode as json-number: `null` still names the key.
+			name:    "json-null/present",
+			present: true,
+			buildRequest: func(t *testing.T, path string) *http.Request {
+				return jsonRequest(t, path, fmt.Sprintf(`{"cycle_length":%d,"period_length":%d,"age_group":null}`, cycleLength, periodLength))
+			},
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			app, database := newOnboardingTestApp(t)
+			user := createOnboardingTestUser(t, database, "step2-shape-"+sanitizeSubtestEmail(testCase.name)+"@example.com", "StrongPass1", false)
+			authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
+
+			request := testCase.buildRequest(t, "/api/v1/onboarding/steps/2")
+			request.Header.Set("Accept", "application/json")
+			request.Header.Set("Cookie", authCookie)
+
+			response, err := app.Test(request, testConfigNoTimeout)
+			if err != nil {
+				t.Fatalf("step2 request failed: %v", err)
+			}
+			defer func() { _ = response.Body.Close() }()
+
+			var stored models.User
+			if err := database.First(&stored, user.ID).Error; err != nil {
+				t.Fatalf("load user: %v", err)
+			}
+
+			if testCase.present {
+				if response.StatusCode != http.StatusBadRequest {
+					t.Fatalf("age_group present (%s): status = %d, want 400 (body %q)", testCase.name, response.StatusCode, mustReadBodyString(t, response.Body))
+				}
+				if key := errorKeyFromEnvelope(t, response.Body); key != "onboarding does not accept an age group" {
+					t.Fatalf("age_group present (%s): error key = %q, want the named refusal", testCase.name, key)
+				}
+				if stored.CycleLength == cycleLength || stored.PeriodLength == periodLength {
+					t.Fatalf("age_group present (%s): refused body still saved cycle=%d period=%d", testCase.name, stored.CycleLength, stored.PeriodLength)
+				}
+				return
+			}
+
+			if response.StatusCode != http.StatusOK {
+				t.Fatalf("age_group absent (%s): status = %d, want 200 (body %q)", testCase.name, response.StatusCode, mustReadBodyString(t, response.Body))
+			}
+			if stored.CycleLength != cycleLength || stored.PeriodLength != periodLength {
+				t.Fatalf("age_group absent (%s): expected cycle=%d period=%d to persist, got cycle=%d period=%d", testCase.name, cycleLength, periodLength, stored.CycleLength, stored.PeriodLength)
+			}
+		})
+	}
+}
+
+func formEncodedRequest(t *testing.T, path string, values url.Values) *http.Request {
+	t.Helper()
+	request := httptest.NewRequest(http.MethodPost, path, strings.NewReader(values.Encode()))
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	return request
+}
+
+func jsonRequest(t *testing.T, path string, body string) *http.Request {
+	t.Helper()
+	request := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
+	request.Header.Set("Content-Type", "application/json")
+	return request
+}
+
+// multipartRequest encodes the given fields as a multipart/form-data body —
+// the shape fasthttp never mirrors into PostArgs, so a presence guard reading
+// only PostArgs is structurally blind to it.
+func multipartRequest(t *testing.T, path string, fields map[string]string) *http.Request {
+	t.Helper()
+	var buffer bytes.Buffer
+	writer := multipart.NewWriter(&buffer)
+	for key, value := range fields {
+		if err := writer.WriteField(key, value); err != nil {
+			t.Fatalf("write multipart field %s: %v", key, err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close multipart writer: %v", err)
+	}
+	request := httptest.NewRequest(http.MethodPost, path, &buffer)
+	request.Header.Set("Content-Type", writer.FormDataContentType())
+	return request
+}
+
+// sanitizeSubtestEmail turns a subtest name (which contains '/') into a
+// address-local-part-safe fragment so each row seeds its own user.
+func sanitizeSubtestEmail(name string) string {
+	return strings.NewReplacer("/", "-").Replace(name)
+}


### PR DESCRIPTION
## Summary
- API-2's onboarding step-2 `age_group` refusal (`onboardingStep2CarriesRemovedAgeGroup`) decided
  "field absent" vs. "field present but malformed" from a typed decode's outcome; a JSON number or
  `null` fails that decode with a TYPE error, indistinguishable from the key not being there, and
  the non-JSON path only ever checked `PostArgs`, which fasthttp never populates for a multipart
  body or for a value carried in the URL's own query string. Those four shapes were answered `200`
  with the field silently dropped.
- Presence is now decided from the raw request for every shape: the parsed JSON object's own keys
  for a JSON body, and the URL query string → urlencoded body → multipart form (in that order,
  mirroring fiber's own `FormValue` search) otherwise.
- Review follow-up, same PR: two narrower routes around the same guard were still open.
  - The query-string check lived only in the non-JSON branch, so a JSON request whose *body* never
    named `age_group` but whose *URL* did (`POST .../steps/2?age_group=25-34` with
    `Content-Type: application/json`) still answered 200 and dropped it. Fixed by checking the query
    string once, unconditionally, before branching on Content-Type — it belongs to neither transport.
  - The JSON presence check became an exact map-key lookup, which is narrower than the struct-tag
    probe it replaced: `encoding/json` matches an object key to a struct field with a
    case-insensitive fallback, so a body naming `Age_Group` or `AGE_GROUP` used to bind and get
    refused; the map lookup did not. Fixed by comparing keys with `strings.EqualFold` — exactly the
    population this guard exists for (clients on the pre-v2.0.0 contract) is where off-spec casing
    lives.

## Test plan
- [x] `go test ./internal/api/... -run TestOnboardingStep2AgeGroupPresenceAcrossRequestShapes -v` —
  12 subtests (absent/present × query-string, multipart, form, json-string; json-number/present;
  json-null/present; json-body query-string-present; json mixed-case-key-present).
  - The original 4: confirmed to fail on exactly `query-string/present`, `multipart/present`,
    `json-number/present`, `json-null/present` against the pre-fix code, pass against the fix.
  - The 2 added for this review round (`json-body/query-string-present`,
    `json-string/mixed-case-key-present`): confirmed to fail against the code at the previous push
    (only those two — the original four stayed green), pass after this round's fix.
- [x] `go build ./...`, `go vet ./internal/api/...`, `go run ./scripts/archcheck`, `gofmt -l` — clean.
- [x] `TestOnboardingStep2NamesTheAgeGroupItNoLongerAccepts` (the original API-2 regression) — still
  green.
- Full `go test ./internal/api/... -timeout 20m|30m`: not re-run locally. The first attempt hit the
  20-minute wall and printed a goroutine-dump panic; this machine runs several agents' worktrees
  concurrently and `internal/api`'s DB-integration suite is documented in TESTING.md as sitting at
  that edge even alone. Per instruction, not retrying locally — CI's own `internal/api` lane will
  confirm the full package.
