### PR TITLE
fix(auth): refuse OIDC identity-link confirmation when local sign-in is off

### DIFF
--- a/changelog.d/fix-oidc-link-confirm-local-signin-gate.md
+++ b/changelog.d/fix-oidc-link-confirm-local-signin-gate.md
@@ -1,0 +1,11 @@
+### Security
+
+- **Confirming an OIDC identity link no longer hands out a session on an oidc-only instance.**
+  `/auth/oidc/link/confirm` checks a local password to confirm a pre-existing account before
+  linking it to an OIDC identity — the same anti-takeover step `Login`, `ForgotPassword`, and the
+  auth pages already refuse to run once an operator turns `OIDC_LOGIN_MODE=oidc_only` on. This route
+  was the one place that check still ran anyway, and a correct password still ended in a live
+  session. The identity link itself stays reachable — it is the only way a pre-existing
+  local-password account ever links to OIDC once local sign-in is off, and refusing it would strand
+  that account for good — but the link no longer signs the browser in directly: the account signs in
+  on its next OIDC round-trip instead, through the identity it just linked.

--- a/internal/api/auth_oidc_regressions_test.go
+++ b/internal/api/auth_oidc_regressions_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gofiber/fiber/v3"
 	"github.com/ovumcy/ovumcy-web/internal/db"
 	"github.com/ovumcy/ovumcy-web/internal/models"
 	"github.com/ovumcy/ovumcy-web/internal/security"
@@ -1129,6 +1130,180 @@ func TestCompleteOIDCLinkConfirmationWithLocalAuthDisabledRefusesUnavailable(t *
 	payload := decodeFlashCookieForTest(t, flashCookie.Value)
 	if payload.AuthError != authOIDCLinkConfirmUnavailableErrorSpec().Key {
 		t.Fatalf("expected flash auth_error %q, got %q", authOIDCLinkConfirmUnavailableErrorSpec().Key, payload.AuthError)
+	}
+}
+
+// TestCompleteOIDCLinkConfirmationRefusesEntirelyWhenLocalSignInDisabled locks
+// F2: on an oidc-only instance (the operator turned the instance-level local
+// sign-in toggle off), a correct password must not be accepted at all — the
+// same refusal Login gives in that state (authLocalSignInDisabledErrorSpec,
+// /login redirect, no auth cookie), checked at the same point in the handler
+// Login checks it (first, before anything else runs).
+//
+// Critically, ConfirmAndLinkIdentity must NOT run either. Gating only the
+// session mint and leaving the identity link itself open would not close F2:
+// the link is a PERMANENT (issuer, subject) -> account binding, and the
+// password that authorizes it is exactly the credential the operator
+// disabled — the realistic reason to disable it being that it leaked. An
+// attacker holding that leaked password could drive the OIDC callback with an
+// IdP identity carrying the victim's email, hit
+// ErrOIDCLinkRequiresConfirmation, post the password here, and — if the link
+// were allowed through — sign in through the newly linked identity on the
+// very next OIDC round-trip with no password prompt at all. See
+// TestOIDCLinkConfirmRefusalWhileDisabledLeavesNoPersistentBinding for that
+// second leg pinned end-to-end.
+func TestCompleteOIDCLinkConfirmationRefusesEntirelyWhenLocalSignInDisabled(t *testing.T) {
+	t.Parallel()
+
+	stub := newStubOIDCWorkflowService(true)
+	stub.localPublicAuthEnabled = false
+	app, database := newOnboardingTestAppWithOptions(t, onboardingTestAppOptions{
+		cookieSecure: true,
+		oidcService:  stub,
+	})
+	user := createOnboardingTestUser(t, database, "link-oidc-only@example.com", "StrongPass1", true)
+
+	pendingPayload, err := newOIDCLinkPendingPayload(time.Now().UTC(), user.ID, "https://idp.example", "subject-oidc-only", user.Email)
+	if err != nil {
+		t.Fatalf("newOIDCLinkPendingPayload: %v", err)
+	}
+	cookie := sealLinkPendingCookieForTest(t, pendingPayload)
+
+	postRequest := httptest.NewRequest(http.MethodPost, oidcLinkConfirmPath, strings.NewReader(url.Values{
+		"password": {"StrongPass1"},
+	}.Encode()))
+	postRequest.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	postRequest.Header.Set("Cookie", oidcLinkPendingCookieName+"="+cookie)
+
+	response := mustAppResponse(t, app, postRequest)
+	assertStatusCode(t, response, http.StatusSeeOther)
+	if location := response.Header.Get("Location"); location != "/login" {
+		t.Fatalf("expected redirect to /login when local sign-in is disabled, got %q", location)
+	}
+	if authCookie := responseCookie(response.Cookies(), authCookieName); authCookie != nil && strings.TrimSpace(authCookie.Value) != "" {
+		t.Fatal("did not expect an auth cookie when local sign-in is disabled instance-wide")
+	}
+	flashCookie := responseCookie(response.Cookies(), flashCookieName)
+	if flashCookie == nil {
+		t.Fatal("expected flash cookie explaining the refusal")
+	}
+	payload := decodeFlashCookieForTest(t, flashCookie.Value)
+	// Exactly Login's refusal spec, not a bespoke one: same helper, same key.
+	wantSpec := authLocalSignInDisabledErrorSpec()
+	if wantSpec.Status != fiber.StatusForbidden {
+		t.Fatalf("test fixture assumption broken: authLocalSignInDisabledErrorSpec status changed to %d", wantSpec.Status)
+	}
+	if payload.AuthError != wantSpec.Key {
+		t.Fatalf("expected flash auth_error %q (Login's own local-sign-in-disabled key), got %q", wantSpec.Key, payload.AuthError)
+	}
+
+	// The identity link must NOT have gone through: authorizing a permanent
+	// binding with the disabled password is the actual defect, not merely
+	// issuing a session with it.
+	if stub.lastConfirmLinkUserID != 0 {
+		t.Fatalf("expected ConfirmAndLinkIdentity NOT to run while local sign-in is disabled, but it ran for user id %d", stub.lastConfirmLinkUserID)
+	}
+}
+
+// TestOIDCLinkConfirmRefusalWhileDisabledLeavesNoPersistentBinding pins the
+// two-step path the F2 review asked for end-to-end: attempt to link while
+// local sign-in is off, confirm the refusal left no standing identity link,
+// then attempt to sign in again through the same (issuer, subject) pair the
+// first attempt tried to establish. Because the refusal above never called
+// ConfirmAndLinkIdentity, the account is exactly as unlinked as before either
+// request — so the second OIDC round-trip must still land on the
+// link-confirmation challenge (ErrOIDCLinkRequiresConfirmation again), never
+// silently issue a session through a now-linked identity. This is the
+// assertion that closes the gap the review found: gating only the first
+// request's session mint would have left the attacker a session on the very
+// next attempt, with no further password prompt; gating the link itself means
+// the next attempt is challenged exactly like the first one was.
+func TestOIDCLinkConfirmRefusalWhileDisabledLeavesNoPersistentBinding(t *testing.T) {
+	t.Parallel()
+
+	stub := newStubOIDCWorkflowService(true)
+	stub.localPublicAuthEnabled = false
+	targetUser := models.User{
+		ID:                 91,
+		Role:               models.RoleOwner,
+		AuthSessionVersion: 1,
+		LocalAuthEnabled:   true,
+		Email:              "link-no-backdoor@example.com",
+	}
+	claims := &security.OIDCClaims{
+		Issuer:  "https://idp.example",
+		Subject: "subject-no-backdoor",
+		Email:   targetUser.Email,
+	}
+	stub.result = services.OIDCLoginResult{User: targetUser, PendingLinkClaims: claims}
+	stub.authErr = services.ErrOIDCLinkRequiresConfirmation
+
+	app, database := newOnboardingTestAppWithOptions(t, onboardingTestAppOptions{
+		cookieSecure: true,
+		oidcService:  stub,
+	})
+	// The account the pending-link claims resolve to must actually exist and
+	// carry the password the attacker is assumed to hold, or FindByID inside
+	// CompleteOIDCLinkConfirmation refuses before reaching the gate under test.
+	user := createOnboardingTestUser(t, database, targetUser.Email, "StrongPass1", true)
+	stub.result.User.ID = user.ID
+
+	// Leg 1: drive a full OIDC callback into the link-confirmation hand-off,
+	// same as TestOIDCCallbackPendingLinkSealsCookieAndRedirectsToConfirmPage.
+	oidcRoundTrip := func() *http.Response {
+		startResponse := mustAppResponse(t, app, httptest.NewRequest(http.MethodGet, "/auth/oidc/start", nil))
+		stateCookie := responseCookie(startResponse.Cookies(), oidcStateCookieName)
+		if stateCookie == nil {
+			t.Fatal("expected OIDC state cookie from start flow")
+		}
+		callbackRequest := httptest.NewRequest(http.MethodPost, security.OIDCCallbackPath, strings.NewReader(url.Values{
+			"state": {stub.lastStartState},
+			"code":  {"provider-code"},
+		}.Encode()))
+		callbackRequest.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		callbackRequest.Header.Set("Cookie", stateCookie.String())
+		return mustAppResponse(t, app, callbackRequest)
+	}
+
+	firstCallback := oidcRoundTrip()
+	assertStatusCode(t, firstCallback, http.StatusSeeOther)
+	if location := firstCallback.Header.Get("Location"); location != oidcLinkConfirmPath {
+		t.Fatalf("expected first OIDC round-trip to land on the link-confirm challenge, got %q", location)
+	}
+	linkCookie := responseCookie(firstCallback.Cookies(), oidcLinkPendingCookieName)
+	if linkCookie == nil || strings.TrimSpace(linkCookie.Value) == "" {
+		t.Fatal("expected a sealed link-pending cookie from the first OIDC round-trip")
+	}
+
+	// Attempt the link with the attacker's (correct, leaked) password while
+	// local sign-in is disabled — must be refused, and must NOT link.
+	confirmRequest := httptest.NewRequest(http.MethodPost, oidcLinkConfirmPath, strings.NewReader(url.Values{
+		"password": {"StrongPass1"},
+	}.Encode()))
+	confirmRequest.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	confirmRequest.Header.Set("Cookie", oidcLinkPendingCookieName+"="+linkCookie.Value)
+	confirmResponse := mustAppResponse(t, app, confirmRequest)
+	assertStatusCode(t, confirmResponse, http.StatusSeeOther)
+	if location := confirmResponse.Header.Get("Location"); location != "/login" {
+		t.Fatalf("expected the link attempt to be refused to /login, got %q", location)
+	}
+	if stub.lastConfirmLinkUserID != 0 {
+		t.Fatalf("expected the refused link attempt to leave no binding, but ConfirmAndLinkIdentity ran for user id %d", stub.lastConfirmLinkUserID)
+	}
+
+	// Leg 2: a second OIDC round-trip for the identical (issuer, subject) pair
+	// — modeling the DB truth left behind by leg 1, where nothing was linked,
+	// so the service still returns ErrOIDCLinkRequiresConfirmation rather than
+	// resolving through a linked identity. If the earlier refusal had failed
+	// to stop the link, this is exactly the request that would have come back
+	// with a live session instead.
+	secondCallback := oidcRoundTrip()
+	assertStatusCode(t, secondCallback, http.StatusSeeOther)
+	if location := secondCallback.Header.Get("Location"); location != oidcLinkConfirmPath {
+		t.Fatalf("expected the second OIDC round-trip to be challenged again, got %q", location)
+	}
+	if authCookie := responseCookie(secondCallback.Cookies(), authCookieName); authCookie != nil && strings.TrimSpace(authCookie.Value) != "" {
+		t.Fatal("expected no auth cookie on the second OIDC round-trip: no identity was ever linked")
 	}
 }
 

--- a/internal/api/handlers_auth_oidc_link_confirm.go
+++ b/internal/api/handlers_auth_oidc_link_confirm.go
@@ -99,6 +99,39 @@ func (handler *Handler) ShowOIDCLinkConfirmPage(c fiber.Ctx) error {
 // account and, on success, persists the OIDC identity link and issues a fresh
 // auth session for the target user.
 func (handler *Handler) CompleteOIDCLinkConfirmation(c fiber.Ctx) error {
+	// Same instance-level gate, same point in the handler, as Login
+	// (handlers_auth_session_login.go): checked first, before anything else
+	// runs. The password verified below is exactly the factor the operator
+	// switched off, and it authorizes more than the session this handler used
+	// to mint directly — it authorizes ConfirmAndLinkIdentity, a PERMANENT
+	// binding of an attacker-supplied (issuer, subject) to the target account.
+	// Gating only the session mint and leaving the link itself unguarded does
+	// not close that: an attacker who holds the leaked password the operator
+	// disabled local sign-in over — the realistic reason to disable it — can
+	// still drive the OIDC callback with an IdP identity carrying the victim's
+	// email, hit ErrOIDCLinkRequiresConfirmation, post that password here to
+	// commit the link, and then sign in through the identity just linked on
+	// the very next OIDC round-trip — no password prompt at all the second
+	// time, because authenticateLinkedIdentity never asks. A gate placed after
+	// the link is one hop deep, not a gate.
+	//
+	// This narrows the self-service migration path: a genuine pre-existing
+	// local-password account cannot link its own OIDC identity while local
+	// sign-in is off, and there is currently no `ovumcy` CLI subcommand that
+	// links an identity on the operator's behalf (checked: cmd/ovumcy/commands.go
+	// exposes reset-password/users/notify/webhook/repair, nothing OIDC-shaped).
+	// That gap is real but is not this fix's to close — re-enabling local
+	// sign-in for the account's one linking round-trip, or an operator-run SQL
+	// insert into oidc_identities, are the only ways in today. Silently
+	// authenticating a takeover through the one arm left open is worse than
+	// that gap.
+	if !handler.localPublicAuthEnabled() {
+		spec := authLocalSignInDisabledErrorSpec()
+		handler.logSecurityError(c, "auth.oidc_link_confirm", spec)
+		handler.setFlashCookie(c, FlashPayload{AuthError: spec.Key})
+		return c.Redirect().Status(fiber.StatusSeeOther).To("/login")
+	}
+
 	payload, ok := handler.readOIDCLinkPendingCookie(c)
 	if !ok {
 		handler.clearOIDCLinkPendingCookie(c)

--- a/internal/api/handlers_auth_session_recovery.go
+++ b/internal/api/handlers_auth_session_recovery.go
@@ -95,11 +95,20 @@ func (handler *Handler) ResetPassword(c fiber.Ctx) error {
 	// verified at issuance, so this is the account's POSTURE, not session
 	// issuance parity.
 	//
-	// A FORCED token is the opposite case and must survive the gate: the two
-	// paths that mint one — CompleteOIDCLogin and CompleteOIDCLinkConfirmation —
-	// are exactly the paths still live under oidc_only, and refusing their redeem
-	// would strand an owner whose account carries must_change_password with no
-	// way to clear it.
+	// A FORCED token is the opposite case and must survive the gate.
+	// CompleteOIDCLogin mints one unconditionally under oidc_only — it never
+	// checks a local password, so there is nothing here for it to leak.
+	// CompleteOIDCLinkConfirmation also mints one, but (unlike CompleteOIDCLogin)
+	// it now refuses outright while local sign-in is off — the password it
+	// checks to authorize the identity link is exactly the credential the
+	// operator switched off, and authorizing that link is a bigger leak than
+	// the session this gate was written to stop, so gating only the session and
+	// leaving the link open is not a fix. A CompleteOIDCLinkConfirmation token
+	// can therefore only be minted while local sign-in is still on; this arm
+	// only has to cover it redeeming after the operator flips the toggle off in
+	// the few minutes between minting and redemption, and still refusing that
+	// redeem would strand an owner whose account carries must_change_password
+	// with no way to clear it.
 	if !forced && !handler.localPublicAuthEnabled() {
 		handler.clearResetPasswordCookie(c)
 		spec := authLocalRecoveryDisabledErrorSpec()


### PR DESCRIPTION
## Summary
- `/auth/oidc/link/confirm` (`CompleteOIDCLinkConfirmation`) verified a local password and could
  mint a full session — and, more importantly, persist a permanent `(issuer, subject) -> account`
  identity binding — on an instance where the operator had turned local sign-in off
  (`OIDC_LOGIN_MODE=oidc_only`). It was the one auth route that didn't share the instance-level gate
  `Login`, `ForgotPassword`, and the auth pages all apply.
- The gate now sits first in the handler, exactly where `Login` checks it, and refuses the whole
  request — password check, TOTP step-up, and `ConfirmAndLinkIdentity` included — not only the final
  `setAuthCookie`.

## Judgment call (revised after review)
My first pass gated only the direct session mint and left `ConfirmAndLinkIdentity` reachable,
reasoning that the identity link is the only route a pre-existing local-password account has to link
its OIDC identity, and refusing it would strand that account. Review caught that this doesn't close
F2, it relocates it one hop:

- The realistic reason an operator disables local sign-in is a leaked password. An attacker holding
  that password can drive `/auth/oidc/callback` with an IdP identity carrying the victim's email,
  get `ErrOIDCLinkRequiresConfirmation`, and post the leaked password to `/auth/oidc/link/confirm`.
  With only the session gated, that request still committed the link. The very next OIDC round-trip
  then resolves through the identity just linked — `authenticateLinkedIdentity` never asks for a
  password — and mints a session with no further password check, ever. What the disabled password
  bought the attacker was not a session directly, but a **permanent credential binding that yields
  one on demand**. That is a worse outcome than the original single-session defect, not a narrower
  fix of it.
- I checked whether an operator-side route exists to link an identity on the legitimate account's
  behalf instead: `cmd/ovumcy/commands.go` only dispatches `reset-password`, `users`, `healthcheck`,
  `readycheck`, `notify`, `webhook`, `repair` — nothing links an OIDC identity. Building one is a real
  gap but is a CLI feature addition, out of scope for this fix.
- Given no in-scope way to preserve self-service linking without also preserving the password-leak
  exploit, I went back to the literal instruction: gate the whole handler at the same point `Login`
  gates itself (first statement, before any of the request is processed), matching `Login`'s exact
  idiom. This narrows the self-service migration path — a genuine pre-existing local-password account
  cannot link on its own while local sign-in is off — but an operator can still get such an account
  in (temporarily re-enable local sign-in for the one round-trip, or insert the `oidc_identities` row
  directly), and neither leaves a passwordless-forever backdoor the way the narrower gate did.

`internal/api/handlers_auth_session_recovery.go`'s existing forced-reset carve-out comment (from an
earlier, already-merged PR) claimed `CompleteOIDCLinkConfirmation` is "exactly the paths still live
under oidc_only" — true before this change, no longer true after it, since the handler now refuses
before it could ever mint a forced-reset token while local sign-in is off. Updated that comment in
place (no behavior change there) so it doesn't misstate reachability post-fix: a
`CompleteOIDCLinkConfirmation`-minted forced token can now only be minted while local sign-in is
still on, and the redeem-side carve-out only has to cover the toggle flipping off in the few minutes
between mint and redeem, not steady-state `oidc_only` operation for this handler.

## Where the gate lives
`internal/api/handlers_auth_oidc_link_confirm.go`, first statement of `CompleteOIDCLinkConfirmation`
— same point, same idiom as `Login` (`handlers_auth_session_login.go:13-14`):
`!handler.localPublicAuthEnabled()` → `authLocalSignInDisabledErrorSpec()` → `logSecurityError` →
flash `AuthError` → `303` to `/login`. No JSON/HTMX branch: this handler has none anywhere else in the
file, so the refusal stays flash+redirect only, matching every other refusal already here.

## Tests (`internal/api/auth_oidc_regressions_test.go`)
- `TestCompleteOIDCLinkConfirmationRefusesEntirelyWhenLocalSignInDisabled`: local public auth off +
  correct password → `303` to `/login`, no auth cookie, flash `AuthError` equals
  `authLocalSignInDisabledErrorSpec().Key` (status asserted as 403), **and**
  `ConfirmAndLinkIdentity` did NOT run.
- `TestOIDCLinkConfirmRefusalWhileDisabledLeavesNoPersistentBinding` (the two-step pin the review
  asked for): drives a full `/auth/oidc/start` → `/auth/oidc/callback` round-trip into the
  link-confirmation hand-off, submits the correct password while local sign-in is off (refused, no
  link persisted), then drives a **second** full OIDC round-trip for the identical (issuer, subject)
  pair and asserts it lands on the link-confirm challenge again — not a session — pinning that the
  refusal left no standing binding an attacker could cash in on the next request.
- `TestCompleteOIDCLinkConfirmationWithCorrectPasswordLinksAndIssuesAuthCookie` (pre-existing,
  unchanged): local public auth on (the stub's default) + correct password → link + session still
  issued — covers "still works when on".
- Induced the defect twice by gutting the new `if` (condition forced to `false`, call site left
  wired) and rerunning the two new tests: both failed, redirecting to `/dashboard` instead of
  `/login` at the exact assertion lines naming the pre-fix behavior. Restored the fix and diffed
  against pre-induction snapshots to confirm an exact restore both times.

## Test runs
- `go test ./internal/api/... -run 'TestCompleteOIDCLinkConfirmation|TestOIDCLinkConfirmRefusalWhileDisabledLeavesNoPersistentBinding|TestOIDCCallbackPendingLink|TestCompleteOIDCLogin' -v`: all PASS.
- `golangci-lint run ./internal/api/...`: 0 issues.
- Full `go test ./internal/api/... -timeout 30m`: **PASS**,
  `ok github.com/ovumcy/ovumcy-web/internal/api 1704.534s`, exit 0 (two earlier attempts at 20m/25m
  budgets hit `panic: test timed out` with no `--- FAIL:` lines — no assertion failed, the
  DB-integration package just didn't finish in that budget, consistent with TESTING.md's own note
  that it "sits at that edge"; likely contention from other agents sharing this machine, given
  golangci-lint itself refused concurrent runs at the same time. The 30m run completed clean).
- Re-ran after rebasing onto latest `origin/main` (clean, no conflicts): targeted OIDC link-confirm
  tests still PASS, `go build ./...` clean.
