### PR TITLE
build: bump the Go toolchain to 1.27.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -326,12 +326,12 @@ jobs:
     # key hands every later run the OLD binary out of cache, silently, while the
     # workflow reads as though it had been bumped.
     env:
-      # git SHA for v0.6.1 (tag 2025.1.1): b8ec13ce4d00445d75da053c47498e6f9ec5d7d6 (verified via go list -m -json)
-      STATICCHECK_VERSION: v0.6.1
+      # git SHA for v0.8.1 (tag 2026.2.1): 1285a6a5ec1e0ebb658f49e82b6c566a878cc3cb (verified via go list -m -json)
+      STATICCHECK_VERSION: v0.8.1
       # git SHA for golang.org/x/tools v0.49.0: 18332fec72972efbb8ab9881984fec2d8cfc2b58 (verified via go list -m -json)
       DEADCODE_VERSION: v0.49.0
-      # git SHA for v2.12.2: c0d3ddc9cf3faa61a4e378e879ece580256d76e5 (verified via go list -m -json)
-      GOLANGCI_LINT_VERSION: v2.12.2
+      # git SHA for v2.13.2: 27774aaf853a4fd21f1dd5e69439459dc1b26e68 (verified via go list -m -json)
+      GOLANGCI_LINT_VERSION: v2.13.2
       # git SHA for v1.7.12: 914e7df21a07ef503a81201c76d2b11c789d3fca (verified via go list -m -json)
       ACTIONLINT_VERSION: v1.7.12
       # git SHA for v1.6.0: 5348b744d0983d85713295ea08a20cca1654a45e (verified via go list -m -json)

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -49,8 +49,8 @@ jobs:
           cache: true
 
       - name: Install gosec
-        # git SHA for v2.22.4: 6decf96c3d272d5a8bbdcf9fddb5789d0be16a8d (verified via go list -m -json)
-        run: go install github.com/securego/gosec/v2/cmd/gosec@v2.22.4
+        # git SHA for v2.29.0: deb54465fea23d19a77f037e11e6589021f8501d (verified via go list -m -json)
+        run: go install github.com/securego/gosec/v2/cmd/gosec@v2.29.0
 
       - name: Prepare security artifact directory
         run: mkdir -p .tmp/security

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@
 # now asserts the equality (`Builder toolchain matches go.mod` in
 # .github/workflows/ci.yml), and Dependabot is told to leave pre-release tags of
 # this image alone.
-FROM golang:1.26.6-alpine3.24@sha256:3889b425f035be855a72fb4755265311293b6d414521f0a519d819df32222d83 AS builder
+FROM golang:1.27.0-alpine3.24@sha256:4c9fe60190a2a3350ddc51de80d0224b8a6698d12bdfc999fee45ea9d6c46dbc AS builder
 WORKDIR /src
 
 COPY go.mod go.sum ./

--- a/changelog.d/go-1.27-toolchain-bump.md
+++ b/changelog.d/go-1.27-toolchain-bump.md
@@ -1,0 +1,7 @@
+none
+
+Go toolchain bump to 1.27.0 (`go.mod`, the Dockerfile builder stage, and the pinned CI scanner
+versions that needed to catch up: `gosec` v2.29.0, `golangci-lint` v2.13.2, `staticcheck` v0.8.1).
+Supersedes dependabot#635, which moved only the Dockerfile and could not go green on its own
+(`Builder toolchain matches go.mod` compares the image tag against `go.mod`'s `go` directive). No
+product behavior changes; nothing here is user-visible.

--- a/cmd/ovumcy/env.go
+++ b/cmd/ovumcy/env.go
@@ -25,7 +25,7 @@ func getEnvInt(key string, fallback int) int {
 
 	parsed, err := strconv.Atoi(value)
 	if err != nil || parsed < 1 {
-		log.Printf("invalid %s=%q, using fallback %d", key, value, fallback)
+		log.Printf("invalid %s=%q, using fallback %d", key, value, fallback) // #nosec G706 -- key is a compile-time literal and value is os.Getenv(key), read once at boot (main.go's mustLoadRuntimeConfig) from the operator's own deployment env; same operator-managed-startup-configuration boundary as the G304 exception on internal/security/local_file.go, never reachable from a request.
 		return fallback
 	}
 	return parsed
@@ -43,7 +43,7 @@ func getEnvIntInRange(key string, fallback, minValue, maxValue int) int {
 
 	parsed, err := strconv.Atoi(value)
 	if err != nil || parsed < minValue || parsed > maxValue {
-		log.Printf("invalid %s=%q, using fallback %d", key, value, fallback)
+		log.Printf("invalid %s=%q, using fallback %d", key, value, fallback) // #nosec G706 -- same operator-managed-startup-configuration boundary as getEnvInt above: value is read once at boot from the operator's own env, never from a request.
 		return fallback
 	}
 	return parsed
@@ -57,7 +57,7 @@ func getEnvDuration(key string, fallback time.Duration) time.Duration {
 
 	parsed, err := time.ParseDuration(value)
 	if err != nil || parsed < time.Second {
-		log.Printf("invalid %s=%q, using fallback %s", key, value, fallback)
+		log.Printf("invalid %s=%q, using fallback %s", key, value, fallback) // #nosec G706 -- same operator-managed-startup-configuration boundary as getEnvInt above: value is read once at boot from the operator's own env, never from a request.
 		return fallback
 	}
 	return parsed
@@ -85,7 +85,7 @@ func getEnvBool(key string, fallback bool) bool {
 
 	parsed, ok := parseBoolEnvValue(value)
 	if !ok {
-		log.Printf("invalid %s=%q, using fallback %t", key, value, fallback)
+		log.Printf("invalid %s=%q, using fallback %t", key, value, fallback) // #nosec G706 -- same operator-managed-startup-configuration boundary as getEnvInt above: value is read once at boot from the operator's own env, never from a request.
 		return fallback
 	}
 	return parsed

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ovumcy/ovumcy-web
 
-go 1.26.6
+go 1.27.0
 
 require (
 	github.com/AdamKorcz/go-118-fuzz-build v0.0.0-20250520111509-a70c2aa677fa

--- a/internal/services/i18n_policy.go
+++ b/internal/services/i18n_policy.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ovumcy/ovumcy-web/internal/i18n"
 )
 
-var authErrorTranslationKeys = map[string]string{
+var authErrorTranslationKeys = map[string]string{ // #nosec G101 -- false positive: the "password"/"credentials" substrings the scanner keys on ("weak password", "invalid credentials", "password mismatch", ...) are English error-spec strings mapped to i18n message keys, never a credential value.
 	"invalid input":                  "auth.error.invalid_input",
 	"consent required":               "auth.error.consent_required",
 	"registration disabled":          "auth.error.registration_disabled",

--- a/internal/testdb/postgres.go
+++ b/internal/testdb/postgres.go
@@ -233,7 +233,7 @@ var runDockerCommandWithError = func(args ...string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), dockerTimeoutFor(args...))
 	defer cancel()
 
-	command := exec.CommandContext(ctx, "docker", args...)
+	command := exec.CommandContext(ctx, "docker", args...) // #nosec G204 -- test-only infrastructure (this file is imported solely by _test.go callers, never by cmd/ovumcy); the binary is the fixed literal "docker" and every args element is either a compile-time literal or a containerID this same package parsed out of a prior "docker run"'s own output, never external or user-supplied input.
 	output, err := command.CombinedOutput()
 	if ctx.Err() != nil && errors.Is(ctx.Err(), context.DeadlineExceeded) {
 		return "", fmt.Errorf("docker %s timed out", strings.Join(args, " "))


### PR DESCRIPTION
## Summary
- Bump `go.mod` to `go 1.27.0` and the Dockerfile builder image to `golang:1.27.0-alpine3.24@sha256:4c9fe60190a2a3350ddc51de80d0224b8a6698d12bdfc999fee45ea9d6c46dbc` (digest taken directly from dependabot#635's own diff) so `ci.yml`'s `Builder toolchain matches go.mod` check stays green. Supersedes #635, which moved only the Dockerfile and could not pass that check on its own (no `toolchain` line exists in `go.mod`; raising `go` is equivalent, so none was added).
- Bump the three pinned CI analysis tools that need 1.27-compatible `x/tools` export-data handling: `gosec` v2.22.4 → v2.29.0 (`.github/workflows/security.yml`), `golangci-lint` v2.12.2 → v2.13.2 and `staticcheck` v0.6.1 → v0.8.1 (`.github/workflows/ci.yml`). `deadcode` (v0.49.0) and `govulncheck` (v1.3.0) are left pinned — both run clean under 1.27 as-is once installed fresh (see Verification).
- Triage and suppress, with per-site justification, the 6 gosec findings v2.29.0 newly reports on this tree that v2.22.4 reported 0 of (SARIF: 0 → 6 → 0 after triage).

## gosec triage (6 findings, SARIF before/after: 0 / 6 / 0)

1. **G101 HIGH** `internal/services/i18n_policy.go:10` — **false positive**, suppressed. The flagged span is the whole `authErrorTranslationKeys` map literal; the scanner's "hardcoded credentials" heuristic keys on the literal substrings `password`/`credentials` appearing inside map-key strings such as `"weak password"`, `"invalid credentials"`, `"password mismatch"`, `"invalid current password"` — these are English error-spec text mapped to i18n message keys, never a secret value. `// #nosec G101` added on the declaration line naming exactly which substrings triggered it.
2. **G204 MEDIUM** `internal/testdb/postgres.go:236` — **false positive**, suppressed, following the repo's existing convention for test-only subprocess/path exceptions (`internal/security/local_file.go`'s G304 suppression). `internal/testdb` is imported solely by `_test.go` files (verified: no production `cmd/ovumcy` import). The binary is the fixed literal `"docker"`; every element of `args...` at the one call site is either a compile-time literal (`"run"`, `"pull"`, `"logs"`, image name, etc.) or a `containerID` this same package parsed out of a prior `docker run`'s own stdout — never external or user-supplied input.
3–6. **G706 LOW ×4** `cmd/ovumcy/env.go:28,46,60,88` — **false positives**, suppressed (new rule since v2.22.4: taint analysis flags any `os.Getenv`-derived value reaching `log.Printf`). Traced every call site: `key` is always a compile-time string literal at the call site; `value` is `os.Getenv(key)`. All four getters (`getEnvInt`, `getEnvIntInRange`, `getEnvDuration`, `getEnvBool`) are called exclusively from `cmd/ovumcy/config.go`'s `loadRuntimeConfig`, itself called exactly once, at boot, from `main.go:48` — never from any request handler or other runtime path. The only source of `value` is the operator's own deployment environment (compose file / systemd unit / `.env` passed to the container) — the same operator-managed-startup-configuration trust boundary this repo already accepts for the G304 exception on `internal/security/local_file.go`. Not genuine: no untrusted/lower-privilege actor can reach this sink, so no code fix was made, only the inline `#nosec G706` justification.

## Known residual risk (stated, not solved)
`golangci-lint` issue #6780 (panic / false positive on Go 1.27 promoted-field composite literals) is confirmed **still open** upstream, not fixed in v2.13.2 (checked the issue directly). Ran `golangci-lint run --max-issues-per-linter=0 --max-same-issues=0` on this tree under v2.13.2: **it did not panic, 0 issues.** Flagging per the task's ask in case it surfaces on a different part of the tree later.

## Verification
- `go build ./...`, `go vet ./...`, `gofmt -l .` — clean.
- `staticcheck ./cmd/... ./internal/... ./migrations/... ./scripts/... ./web/...` — clean.
- `golangci-lint run --max-issues-per-linter=0 --max-same-issues=0 <same scope>` — `0 issues`, no panic.
- `gosec -fmt sarif ./cmd/... ./internal/...` — 6 findings before triage, 0 after (see above).
- `govulncheck ./...` (v1.3.0, freshly installed under 1.27) — 0 reachable vulnerabilities.
- `deadcode -test <same scope>` (v0.49.0) — 0 findings, **after** reinstalling: the first run against a stale pre-existing `~/go/bin/deadcode` (built under go1.26.6 by earlier work on this shared machine) failed with `package requires newer Go version go1.27 (application built with go1.26)` on every package — an environment-staleness artifact, not a genuine incompatibility; CI always does a fresh `go install` per run, so this would not reproduce there. Reinstalling with the current 1.27 toolchain fixed it immediately.
- `go-licenses report ./cmd/ovumcy` (v1.6.0, `GOOS=linux CGO_ENABLED=0`, matching CI exactly) piped into `go run ./scripts/licensesdoc -check` — `licensesdoc: inventory matches the dependency report.` (one pre-existing stderr warning, `Failed to find license for modernc.org/mathutil`, unrelated to this bump — exit 0, check passes.)
- `gremlins` (v0.6.0) — version-checked only (`gremlins --version`, reinstalled under 1.27, runs fine); did **not** run the full mutation suite, which is the slow weekly CI job and out of scope for this bump's verification budget.
- `go run ./scripts/changelogd check` — OK.
- Full sanctioned suite, `go test ./cmd/... ./internal/... ./migrations/... ./scripts/... ./web/... -timeout 20m`: ran to completion (exit observed, no hang) but **is not fully green on this machine** — 9 failures, every one a Postgres-integration test (`internal/cli`, `internal/db`, `internal/services`, `scripts/backuprestoredoc`) failing on Docker/network flakiness (`wsarecv: An existing connection was forcibly closed by the remote host`, `context deadline exceeded` connecting to the ephemeral postgres container), plus `internal/api` hitting the documented 20-minute budget under load (TESTING.md already calls this "the budget, not a defect" for this exact package). None show a compile error, an assertion failure, or any other Go-1.27-specific signature — the pattern is uniformly infra timing under a shared machine running several concurrent agents' docker workloads. Deferring final confirmation to CI per instructions rather than re-running.

## Not verified
- The full sanctioned Go test suite's green status (see above — deferred to CI).
- `gremlins` full mutation run (out of scope; weekly job).
- CodeQL and Trivy (not in this task's scope; unaffected by these edits).
