### PR TITLE
fix(services): clear OvulationImpossible under fertility suppression

### DIFF
--- a/changelog.d/fix-ovulation-impossible-cleared-under-fertility-suppression.md
+++ b/changelog.d/fix-ovulation-impossible-cleared-under-fertility-suppression.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Ovulation-impossibility claim no longer survives fertility suppression.** `GET /api/v1/stats/overview` (and every other surface fed by the shared published-stats adapter) used to publish `ovulation_impossible: true` even while `suppression.fertility` was also `true` — a claim derived from the same fertility projection the suppression withholds. It is now cleared alongside the ovulation date and fertile window whenever fertility is suppressed.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -833,7 +833,12 @@ components:
             `ovulation_date` is null.
         ovulation_impossible:
           type: boolean
-          description: No ovulation can be placed in the running cycle at all.
+          description: >-
+            No ovulation can be placed in the running cycle at all. Always
+            `false` when `suppression.fertility` is true — the underlying
+            claim is itself derived from the fertility projection, so it is
+            withheld along with `ovulation_date` and the fertile window
+            rather than surviving beside a suppressed one.
         fertility_window_start:
           type: [string, "null"]
           format: date

--- a/internal/services/prediction_published_stats.go
+++ b/internal/services/prediction_published_stats.go
@@ -61,6 +61,14 @@ func PublishedStats(user *models.User, stats CycleStats) (CycleStats, Prediction
 	if suppression.FertilitySuppressed {
 		stats.OvulationDate = time.Time{}
 		stats.OvulationExact = false
+		// OvulationImpossible is itself a claim derived from the fertility
+		// projection (clearPredictedCycleWindow in cycles.go sets it exactly
+		// where it also clears OvulationDate/OvulationExact/the window), so it
+		// travels with the rest of this tier rather than surviving it: a
+		// consumer must never read suppression.fertility=true beside an
+		// ovulation-impossibility claim computed from the data that
+		// suppression says is not to be published.
+		stats.OvulationImpossible = false
 		stats.FertilityWindowStart = time.Time{}
 		stats.FertilityWindowEnd = time.Time{}
 		stats.CurrentFertility = FertilityStatusUnknown

--- a/internal/services/prediction_published_stats_test.go
+++ b/internal/services/prediction_published_stats_test.go
@@ -231,6 +231,38 @@ func TestPublishedStatsClearsEveryDateItsVerdictRefuses(t *testing.T) {
 	}
 }
 
+// TestPublishedStatsClearsOvulationImpossibleUnderFertilitySuppression pins
+// MED-3: OvulationImpossible is itself a claim derived from the fertility
+// projection (clearPredictedCycleWindow in cycles.go sets it exactly where it
+// also clears OvulationDate/OvulationExact/the window), so it must not
+// outlive fertility suppression any more than those fields do. Before this
+// fix a consumer could read suppression.fertility=true beside
+// ovulation_impossible=true — a claim derived from data the suppression says
+// is not to be published.
+func TestPublishedStatsClearsOvulationImpossibleUnderFertilitySuppression(t *testing.T) {
+	stats := publishedStatsBase()
+	// Reproduce the state clearPredictedCycleWindow leaves behind (impossible
+	// paired with an already-empty date/window) and add an UNRELATED
+	// suppression signal (pregnancy pause) on top, so the case isolates
+	// whether the fertility gate clears the flag rather than whether the
+	// window computation itself does.
+	stats.OvulationDate = time.Time{}
+	stats.OvulationExact = false
+	stats.OvulationImpossible = true
+	stats.FertilityWindowStart = time.Time{}
+	stats.FertilityWindowEnd = time.Time{}
+	stats.PregnancyPaused = true
+
+	published, verdict := PublishedStats(&models.User{}, stats)
+
+	if !verdict.FertilitySuppressed {
+		t.Fatal("test setup: expected pregnancy pause to suppress fertility")
+	}
+	if published.OvulationImpossible {
+		t.Fatalf("published ovulation_impossible=true alongside suppression.fertility=true under %v", verdict.Reasons)
+	}
+}
+
 // TestPublishedStatsKeepsThePhaseTheProjectionDoesNotSpeakFor pins the
 // orthogonality rather than leaving it to a comment.
 //


### PR DESCRIPTION
## What
`PublishedStats` cleared `OvulationDate`, `OvulationExact`, the fertility window and
`CurrentFertility` under fertility suppression, but left `OvulationImpossible` untouched. Now
cleared in the same block.

## Why
`OvulationImpossible` is itself derived from the fertility projection, so publishing it under
`suppression.fertility: true` was a contract ambiguity (MED-3): a claim computed from data the
suppression says is not to be published.

## Risk
Low, `internal/services` only. Every other fertility-derived `CycleStats` field was already
cleared at this site; recorded-history and the phase field are intentionally untouched.

## How verified
Test added beside existing suppression cases; reverted the fix to confirm it fails naming this
defect, then restored. Build, vet, lint and package tests clean. `docs/openapi.yaml` updated.
