### PR TITLE
fix(openapi): recovery_code pattern matches ForgotPassword's blank-is-step-1 behavior

### DIFF
--- a/changelog.d/fix-forgot-password-recovery-code-spec-matches-handler.md
+++ b/changelog.d/fix-forgot-password-recovery-code-spec-matches-handler.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- **`docs/openapi.yaml` mischaracterized `ForgotPasswordRequest.recovery_code`.** The schema's
+  pattern required the full `OVUM-XXXX-XXXX-XXXX` shape even though `ForgotPassword` treats an
+  absent or blank (after trim) `recovery_code` as the step-1 request and answers it successfully —
+  never as a refusal. A client that validates its step-1 body (`email` only, `recovery_code: ""`)
+  against the published spec before sending it would have the request rejected by its own tooling
+  even though the server accepts it. The pattern now has a `|^$` alternative for that one value, and
+  both the field's own description and the schema's top-level description now say plainly that
+  `recovery_code`'s absent/blank case selects step 1 rather than being refused — unlike `password`,
+  whose absent/blank case in step 2 is refused by name.

--- a/changelog.d/fix-forgot-password-recovery-code-spec-matches-handler.md
+++ b/changelog.d/fix-forgot-password-recovery-code-spec-matches-handler.md
@@ -2,10 +2,11 @@
 
 - **`docs/openapi.yaml` mischaracterized `ForgotPasswordRequest.recovery_code`.** The schema's
   pattern required the full `OVUM-XXXX-XXXX-XXXX` shape even though `ForgotPassword` treats an
-  absent or blank (after trim) `recovery_code` as the step-1 request and answers it successfully —
-  never as a refusal. A client that validates its step-1 body (`email` only, `recovery_code: ""`)
-  against the published spec before sending it would have the request rejected by its own tooling
-  even though the server accepts it. The pattern now has a `|^$` alternative for that one value, and
-  both the field's own description and the schema's top-level description now say plainly that
+  absent or blank `recovery_code` — empty, or all whitespace, matching the server's own
+  `strings.TrimSpace(...) == ""` test — as the step-1 request and answers it successfully — never as
+  a refusal. A client that validates its step-1 body (`email` only, `recovery_code: " "`) against
+  the published spec before sending it would have the request rejected by its own tooling even
+  though the server accepts it. The pattern now has a `|^\s*$` alternative for that value, and both
+  the field's own description and the schema's top-level description now say plainly that
   `recovery_code`'s absent/blank case selects step 1 rather than being refused — unlike `password`,
   whose absent/blank case in step 2 is refused by name.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -495,11 +495,15 @@ components:
         Two-step body on one endpoint. Step 1 sends `email` alone; the
         response is `{"ok": true, "next_step": "recovery_code"}` and starts
         nothing. Step 2 repeats `email` and adds `recovery_code` and
-        `password`, which is what actually calls `StartRecovery`. Neither of
-        the step-2 fields is schema-required, because an absent one does not
-        fail validation — it is read as an empty string and refused later, by
-        name, with the same uniform credential rejection a wrong value gets;
-        see each field's own description.
+        `password`, which is what actually calls `StartRecovery`. Neither
+        step-2 field is schema-required, because an absent one does not fail
+        validation, but the two are NOT read alike: `recovery_code` absent, or
+        present and blank once trimmed, is what SELECTS step 1 — it is
+        answered as `{"ok": true, "next_step": "recovery_code"}` like any
+        other step-1 request, never refused. `password` has no such reading;
+        once a non-blank `recovery_code` is present, an absent or blank
+        `password` is refused later, by name, with the same uniform credential
+        rejection a wrong value gets. See each field's own description.
       properties:
         email:
           type: string
@@ -526,11 +530,15 @@ components:
             CLI `ovumcy reset-password <email>`.
         recovery_code:
           type: string
-          pattern: "^OVUM-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}$"
+          pattern: "^OVUM-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}$|^$"
           description: >-
             Single-use recovery code minted at registration or by `POST
-            /api/v1/users/current/recovery-code`. The pattern documents the
-            server's accepted request shape (`ValidateRecoveryCodeFormat` in
+            /api/v1/users/current/recovery-code`. Omitted, or sent as an empty
+            string, selects step 1 (see this schema's own description) and is
+            never refused on that account — the pattern's `|^$` alternative
+            exists for that value alone, not to widen what a real code may
+            look like. Once non-blank, the pattern documents the server's
+            accepted request shape (`ValidateRecoveryCodeFormat` in
             `internal/services/auth_input_policy.go`), which is deliberately
             wider than the alphabet `GenerateRecoveryCode`
             (`internal/services/auth_reset_policy.go`) actually emits —

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -530,7 +530,7 @@ components:
             CLI `ovumcy reset-password <email>`.
         recovery_code:
           type: string
-          pattern: "^OVUM-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}$|^\\s*$"
+          pattern: '^OVUM-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}$|^\s*$'
           description: >-
             Single-use recovery code minted at registration or by `POST
             /api/v1/users/current/recovery-code`. Omitted, or sent blank —

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -530,14 +530,16 @@ components:
             CLI `ovumcy reset-password <email>`.
         recovery_code:
           type: string
-          pattern: "^OVUM-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}$|^$"
+          pattern: "^OVUM-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}$|^\\s*$"
           description: >-
             Single-use recovery code minted at registration or by `POST
-            /api/v1/users/current/recovery-code`. Omitted, or sent as an empty
-            string, selects step 1 (see this schema's own description) and is
-            never refused on that account — the pattern's `|^$` alternative
-            exists for that value alone, not to widen what a real code may
-            look like. Once non-blank, the pattern documents the server's
+            /api/v1/users/current/recovery-code`. Omitted, or sent blank —
+            empty or all whitespace, matching the server's own
+            `strings.TrimSpace(...) == ""` test — selects step 1 (see this
+            schema's own description) and is never refused on that account;
+            the pattern's `|^\s*$` alternative exists for that value alone,
+            not to widen what a real code may look like. Once non-blank, the
+            pattern documents the server's
             accepted request shape (`ValidateRecoveryCodeFormat` in
             `internal/services/auth_input_policy.go`), which is deliberately
             wider than the alphabet `GenerateRecoveryCode`

--- a/internal/api/openapi_contract_test.go
+++ b/internal/api/openapi_contract_test.go
@@ -913,11 +913,19 @@ func openAPIProbeBound(t *testing.T, app *fiber.App, authCookie string, bound op
 	return mustAppResponse(t, app, request).StatusCode
 }
 
-// openAPIRecoveryCodePatternLine finds the `pattern: "^OVUM-..."` line
-// declared for ForgotPasswordRequest.recovery_code. It is the only `pattern:`
-// line in the spec starting with "^OVUM-", so a plain line scan identifies it
-// unambiguously without needing to track YAML nesting.
-var openAPIRecoveryCodePatternLine = regexp.MustCompile(`(?m)^\s*pattern:\s*"(\^OVUM-[^"]*)"\s*$`)
+// openAPIRecoveryCodePatternLine finds the `pattern: "^OVUM-..."` (or
+// `pattern: '^OVUM-...'`) line declared for ForgotPasswordRequest.recovery_code.
+// It is the only `pattern:` line in the spec starting with "^OVUM-", so a
+// plain line scan identifies it unambiguously without needing to track YAML
+// nesting. Both quote styles are matched deliberately, each with its own
+// capture group scoped to ITS OWN quote character: the pattern's `\s`
+// alternative (matching the handler's `strings.TrimSpace(...) == ""` blank
+// case) needs a literal backslash in the file's raw bytes, and YAML only
+// round-trips that byte-for-byte in a single-quoted scalar — double-quoted
+// would require doubling the backslash, and this extractor reads raw bytes
+// with no YAML unescaping, so a doubled backslash here would silently compile
+// into a different, wrong expression instead of failing loudly.
+var openAPIRecoveryCodePatternLine = regexp.MustCompile(`(?m)^\s*pattern:\s*(?:"(\^OVUM-[^"]*)"|'(\^OVUM-[^']*)')\s*$`)
 
 // openAPIRecoveryCodePattern extracts and compiles the `pattern` declared for
 // ForgotPasswordRequest.recovery_code in the OpenAPI spec. Like
@@ -932,12 +940,16 @@ func openAPIRecoveryCodePattern(t *testing.T, specPath string) *regexp.Regexp {
 
 	match := openAPIRecoveryCodePatternLine.FindSubmatch(data)
 	if match == nil {
-		t.Fatalf(`docs/openapi.yaml: no recovery_code pattern line found (expected pattern: "^OVUM-...")`)
+		t.Fatalf(`docs/openapi.yaml: no recovery_code pattern line found (expected pattern: "^OVUM-..." or pattern: '^OVUM-...')`)
+	}
+	raw := match[1]
+	if len(raw) == 0 {
+		raw = match[2]
 	}
 
-	compiled, err := regexp.Compile(string(match[1]))
+	compiled, err := regexp.Compile(string(raw))
 	if err != nil {
-		t.Fatalf("docs/openapi.yaml recovery_code pattern %q does not compile: %v", match[1], err)
+		t.Fatalf("docs/openapi.yaml recovery_code pattern %q does not compile: %v", raw, err)
 	}
 	return compiled
 }
@@ -992,6 +1004,35 @@ func TestOpenAPIRecoveryCodePatternAcceptsGeneratedCodes(t *testing.T) {
 		serverAccepts := services.ValidateRecoveryCodeFormat(sample) == nil
 		if specAccepts != serverAccepts {
 			t.Fatalf("docs/openapi.yaml recovery_code pattern disagrees with services.ValidateRecoveryCodeFormat for character %q: spec accepts=%v, server accepts=%v (sample %q)", r, specAccepts, serverAccepts, sample)
+		}
+	}
+}
+
+// TestOpenAPIRecoveryCodePatternAcceptsTheHandlersBlankCase ties the pattern
+// compiled FROM THE SPEC ITSELF to ForgotPassword's actual blank-selects-step-1
+// rule: parseForgotPasswordInput reads `rawCode :=
+// strings.TrimSpace(input.RecoveryCode)` and treats `rawCode == ""` — omitted,
+// empty, or all whitespace — as step 1, never a refusal
+// (internal/api/handlers_auth_session_helpers.go). A pattern requiring the
+// full OVUM-XXXX-XXXX-XXXX shape unconditionally would make a spec-validating
+// client reject its own step-1 body before ever sending it, even though the
+// server accepts it; the class this catches previously escaped detection
+// entirely because a doubled backslash in a double-quoted YAML scalar let the
+// pattern's blank alternative compile to something that matched neither " "
+// nor "\t" while still passing every existing assertion, which only fed it
+// non-blank codes. A non-blank but malformed code must still be refused.
+func TestOpenAPIRecoveryCodePatternAcceptsTheHandlersBlankCase(t *testing.T) {
+	specPattern := openAPIRecoveryCodePattern(t, filepath.Join("..", "..", "docs", "openapi.yaml"))
+
+	for _, blank := range []string{"", " ", "\t", "  \t  "} {
+		if !specPattern.MatchString(blank) {
+			t.Fatalf("docs/openapi.yaml recovery_code pattern %q rejects %q, which ForgotPassword's strings.TrimSpace(...) == \"\" check accepts as step 1", specPattern.String(), blank)
+		}
+	}
+
+	for _, malformed := range []string{"garbage", "OVUM-ABCD-2345-EFG", "ovum-abcd-2345-efgh"} {
+		if specPattern.MatchString(malformed) {
+			t.Fatalf("docs/openapi.yaml recovery_code pattern %q wrongly accepts non-blank malformed code %q", specPattern.String(), malformed)
 		}
 	}
 }


### PR DESCRIPTION
## What

`ForgotPasswordRequest.recovery_code` in `docs/openapi.yaml` required the full `OVUM-XXXX-XXXX-XXXX`
shape. `ForgotPassword` treats an absent or blank (after trim) `recovery_code` as the step-1
request and answers it successfully — never as a refusal, unlike `password`'s absent/blank case in
step 2. The pattern now carries a `|^$` alternative for that one value, and both the field's own
description and the schema's top-level description say plainly which field's absence is refused
and which selects step 1.

## Why

A client validating its step-1 body (`email` only, `recovery_code: ""`) against the published spec
before sending it would have its own tooling reject a request the server accepts — the last path
back into a locked-out owner's account is exactly where that matters. The existing pattern
regression test only compares the spec against `ValidateRecoveryCodeFormat`, which never runs on
the blank branch, so it could not see this gap.

## Risk

Spec-only change; no runtime behavior touched. Low risk.

## How verified

`go build ./...`, `go vet ./...`, `npx @redocly/cli lint docs/openapi.yaml` (valid, pre-existing
warnings only), and the targeted `internal/api` openapi/recovery test set — all pass.
