### PR TITLE
fix(auth): gate OIDC login on the account's second factor

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -143,6 +143,7 @@ Policy-level claims (threat model in/out-of-scope, design rationale, marketing-s
 | `MustChangePassword` targets are routed to `/reset-password` instead of receiving an auth cookie | `TestCompleteOIDCLinkConfirmationRoutesMustChangePasswordToReset` in [internal/api/auth_oidc_regressions_test.go](internal/api/auth_oidc_regressions_test.go) |
 | `ConfirmAndLinkIdentity` provider/storage failures clear the pending cookie | `TestCompleteOIDCLinkConfirmationConfirmLinkErrorMappingClearsCookie` in [internal/api/auth_oidc_regressions_test.go](internal/api/auth_oidc_regressions_test.go) |
 | Successful link emits a sanitized `auth.oidc_link_confirm linked` security event | `TestCompleteOIDCLinkConfirmationEmitsAuditLogOnSuccess` in [internal/api/auth_oidc_regressions_test.go](internal/api/auth_oidc_regressions_test.go) |
+| A later OIDC sign-in through an already-linked identity is gated on the account's second factor the same way local login is: `RequiresTOTP` routes to `/auth/2fa` before `setAuthCookie`, and `MustChangePassword` still outranks it | `TestOIDCCallbackForLinkedTOTPAccountGatesOnTheSecondFactor` in [internal/api/auth_oidc_regressions_test.go](internal/api/auth_oidc_regressions_test.go); `TestOIDCLoginServiceAuthenticateSetsRequiresTOTPForLinkedTOTPAccount`, `TestOIDCLoginServiceAuthenticateMustChangePasswordOutranksRequiresTOTP` in [internal/services/oidc_login_service_test.go](internal/services/oidc_login_service_test.go) |
 
 ### Register Enumeration Residual
 

--- a/changelog.d/fix-oidc-login-gates-on-totp.md
+++ b/changelog.d/fix-oidc-login-gates-on-totp.md
@@ -1,0 +1,13 @@
+### Security
+
+- **Breaking (auth behavior): signing in through OIDC to an account that already has TOTP enabled
+  now requires the second factor, the same way local sign-in does.** The OIDC callback resolved an
+  already-linked `(issuer, subject)` straight to a session — `CompleteOIDCLogin` had no TOTP check
+  anywhere on that path, unlike the local login route, which redirects a TOTP-enabled account to
+  `/auth/2fa` before ever issuing a cookie. `OIDCLoginService.Authenticate` now reports
+  `RequiresTOTP` the same way `LoginService.Authenticate` reports it for local login, and the OIDC
+  callback gates on it before `setAuthCookie`, ordered the same way: an account also carrying
+  `must_change_password` still goes to the forced-reset flow first, never to the 2FA challenge —
+  the sanctioned escape hatch for a TOTP secret that can no longer be decrypted after a `SECRET_KEY`
+  rotation is unaffected. Operators whose SSO users have TOTP enabled will see those accounts
+  challenged for a code on their next OIDC sign-in where they were not before.

--- a/docs/security/oidc-and-sessions.md
+++ b/docs/security/oidc-and-sessions.md
@@ -15,7 +15,9 @@ This defends against the malicious / sloppy upstream IdP scenario: a provider th
 
 The confirmation step is refused if the existing account has no local password (`local_auth_enabled=false`). Multi-provider linking onto such accounts is intentionally out of scope for the unauthenticated login path — that has to happen through a future authenticated Settings flow, which is not yet shipped.
 
-When the target account has TOTP enabled, the link-confirmation form additionally requires a valid 6-digit code submitted alongside the password. The handler invokes the same `TOTPService.ValidateCode` path as `/api/v1/sessions/2fa-challenge`, including replay rejection (`ErrTOTPReplayed`) and the per-`(client_ip, user_id)` failure counter. Without this gate, an attacker who has only the victim's password — and uses a malicious or sloppy upstream IdP to assert their email — could obtain a session for a 2FA-protected account without ever holding the second factor, and the linked identity would persist for future OIDC sign-ins.
+When the target account has TOTP enabled, the link-confirmation form additionally requires a valid 6-digit code submitted alongside the password. The handler invokes the same `TOTPService.ValidateCode` path as `/api/v1/sessions/2fa-challenge`, including replay rejection (`ErrTOTPReplayed`) and the per-`(client_ip, user_id)` failure counter. Without this gate, an attacker who has only the victim's password — and uses a malicious or sloppy upstream IdP to assert their email — could obtain a session for a 2FA-protected account without ever holding the second factor.
+
+A later sign-in through that same already-linked identity is a separate code path (`CompleteOIDCLogin` → `authenticateLinkedIdentity`, not the link-confirm flow above) and is gated the same way: `OIDCLoginService.Authenticate` sets `RequiresTOTP` whenever the resolved account has TOTP enabled and is not also routed through `MustChangePassword`, and the handler redirects to `/auth/2fa` before ever calling `setAuthCookie` — the same ordering and the same signal the local login path (`handlers_auth_session_login.go`) uses.
 
 ## Session Invalidation on Credential Rotation
 

--- a/internal/api/auth_oidc_regressions_test.go
+++ b/internal/api/auth_oidc_regressions_test.go
@@ -451,6 +451,108 @@ func TestOIDCCallbackResetRequiredRedirectsToResetPassword(t *testing.T) {
 	}
 }
 
+// TestOIDCCallbackForLinkedTOTPAccountGatesOnTheSecondFactor pins session
+// issuance parity (docs/security/oidc-and-sessions.md) between the OIDC login
+// path and the local login path: an OIDC callback that resolves to an
+// already-linked identity whose account has TOTP enabled must NOT mint an
+// ovumcy_auth cookie directly off the exchange. It has to set the same
+// pending-TOTP cookie the local login path sets (RequiresTOTP, mirroring
+// LoginResult) and land on /auth/2fa; only completing that challenge may
+// issue the session. Before this fix CompleteOIDCLogin fell straight through
+// to setAuthCookie with no TOTP check anywhere on the path.
+func TestOIDCCallbackForLinkedTOTPAccountGatesOnTheSecondFactor(t *testing.T) {
+	t.Parallel()
+
+	stub := newStubOIDCWorkflowService(true)
+	stub.authURL = "https://id.example.com/authorize"
+
+	secretKey := []byte(testHandlerSecretKey)
+	app, database := newOnboardingTestAppWithOptions(t, onboardingTestAppOptions{
+		cookieSecure: true,
+		oidcService:  stub,
+	})
+	user := createOnboardingTestUser(t, database, "oidc-totp@example.com", "StrongPass1", true)
+	rawSecret := setupTOTPForUser(t, database, user.ID, secretKey)
+
+	var linked models.User
+	if err := database.First(&linked, user.ID).Error; err != nil {
+		t.Fatalf("reload user: %v", err)
+	}
+	if !linked.TOTPEnabled {
+		t.Fatal("expected TOTP enabled on the account after setup")
+	}
+
+	// The stub bypasses OIDCLoginService.Authenticate's own computation, so the
+	// result carries RequiresTOTP exactly as the real service would derive it
+	// for this account (TOTP enabled, MustChangePassword false) — the handler
+	// gate under test is what consumes this field, not what computes it.
+	stub.result = services.OIDCLoginResult{
+		User:         linked,
+		RequiresTOTP: true,
+	}
+
+	startResponse := mustAppResponse(t, app, httptest.NewRequest(http.MethodGet, "/auth/oidc/start", nil))
+	stateCookie := responseCookie(startResponse.Cookies(), oidcStateCookieName)
+	if stateCookie == nil {
+		t.Fatal("expected OIDC state cookie from start flow")
+	}
+
+	callbackRequest := httptest.NewRequest(http.MethodPost, security.OIDCCallbackPath, strings.NewReader(url.Values{
+		"state": {stub.lastStartState},
+		"code":  {"provider-code"},
+	}.Encode()))
+	callbackRequest.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	callbackRequest.Header.Set("Cookie", stateCookie.String())
+
+	callbackResponse := mustAppResponse(t, app, callbackRequest)
+	assertStatusCode(t, callbackResponse, http.StatusSeeOther)
+	if location := callbackResponse.Header.Get("Location"); location != "/auth/2fa" {
+		t.Fatalf("expected redirect to /auth/2fa, got %q", location)
+	}
+	if authCookie := responseCookie(callbackResponse.Cookies(), authCookieName); authCookie != nil && strings.TrimSpace(authCookie.Value) != "" {
+		t.Fatal("did not expect an auth cookie before the TOTP challenge is completed")
+	}
+	pendingCookie := responseCookie(callbackResponse.Cookies(), totpPendingCookieName)
+	if pendingCookie == nil || strings.TrimSpace(pendingCookie.Value) == "" {
+		t.Fatal("expected a TOTP pending cookie from the OIDC callback")
+	}
+
+	codec, err := newSecureCookieCodec(secretKey)
+	if err != nil {
+		t.Fatalf("newSecureCookieCodec: %v", err)
+	}
+	decoded, err := codec.open(totpPendingCookieName, pendingCookie.Value)
+	if err != nil {
+		t.Fatalf("open pending cookie: %v", err)
+	}
+	var pendingPayload totpPendingCookiePayload
+	if err := json.Unmarshal(decoded, &pendingPayload); err != nil {
+		t.Fatalf("unmarshal pending payload: %v", err)
+	}
+	if pendingPayload.UserID != linked.ID {
+		t.Fatalf("pending cookie user_id = %d, want %d", pendingPayload.UserID, linked.ID)
+	}
+
+	// Completing the challenge with a valid code is what may issue the
+	// session — never the callback itself.
+	code, err := totp.GenerateCode(rawSecret, time.Now())
+	if err != nil {
+		t.Fatalf("GenerateCode: %v", err)
+	}
+	challengeRequest := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/2fa-challenge", strings.NewReader(url.Values{
+		"code": {code},
+	}.Encode()))
+	challengeRequest.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	challengeRequest.Header.Set("Cookie", totpPendingCookieName+"="+pendingCookie.Value)
+
+	challengeResponse := mustAppResponse(t, app, challengeRequest)
+	assertStatusCode(t, challengeResponse, http.StatusSeeOther)
+	sessionCookie := responseCookie(challengeResponse.Cookies(), authCookieName)
+	if sessionCookie == nil || strings.TrimSpace(sessionCookie.Value) == "" {
+		t.Fatal("expected an auth cookie after completing the TOTP challenge")
+	}
+}
+
 func newStubOIDCWorkflowService(enabled bool) *stubOIDCWorkflowService {
 	return &stubOIDCWorkflowService{
 		enabled:                enabled,

--- a/internal/api/auth_oidc_regressions_test.go
+++ b/internal/api/auth_oidc_regressions_test.go
@@ -485,10 +485,19 @@ func TestOIDCCallbackForLinkedTOTPAccountGatesOnTheSecondFactor(t *testing.T) {
 	// The stub bypasses OIDCLoginService.Authenticate's own computation, so the
 	// result carries RequiresTOTP exactly as the real service would derive it
 	// for this account (TOTP enabled, MustChangePassword false) — the handler
-	// gate under test is what consumes this field, not what computes it.
+	// gate under test is what consumes this field, not what computes it. Logout
+	// is also populated, as buildLogoutState would for a provider with
+	// end-session support, so the callback has to stage it under an opaque id
+	// rather than discard it — the parity this test exists to pin.
 	stub.result = services.OIDCLoginResult{
 		User:         linked,
 		RequiresTOTP: true,
+		Logout: &services.OIDCLogoutState{
+			UserID:                linked.ID,
+			EndSessionEndpoint:    "https://idp.example.com/logout",
+			IDTokenHint:           "eyJhbGciOiJSUzI1NiJ9.header.signature",
+			PostLogoutRedirectURL: "https://app.example.com/",
+		},
 	}
 
 	startResponse := mustAppResponse(t, app, httptest.NewRequest(http.MethodGet, "/auth/oidc/start", nil))
@@ -532,6 +541,19 @@ func TestOIDCCallbackForLinkedTOTPAccountGatesOnTheSecondFactor(t *testing.T) {
 	if pendingPayload.UserID != linked.ID {
 		t.Fatalf("pending cookie user_id = %d, want %d", pendingPayload.UserID, linked.ID)
 	}
+	pendingLogoutStateID := strings.TrimSpace(pendingPayload.OIDCLogoutStateID)
+	if pendingLogoutStateID == "" {
+		t.Fatal("expected the pending cookie to carry an opaque OIDC logout-state id, since the stubbed result carries provider-logout material")
+	}
+
+	logoutStateSvc := services.NewOIDCLogoutStateService(db.NewRepositories(database).OIDCLogout)
+	stagedState, stagedFound, err := logoutStateSvc.Load(context.Background(), pendingLogoutStateID, linked.ID, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("load staged logout state: %v", err)
+	}
+	if !stagedFound || stagedState.EndSessionEndpoint != stub.result.Logout.EndSessionEndpoint {
+		t.Fatalf("expected the callback to stage the provider-logout material under the opaque id, got found=%v state=%#v", stagedFound, stagedState)
+	}
 
 	// Completing the challenge with a valid code is what may issue the
 	// session — never the callback itself.
@@ -550,6 +572,125 @@ func TestOIDCCallbackForLinkedTOTPAccountGatesOnTheSecondFactor(t *testing.T) {
 	sessionCookie := responseCookie(challengeResponse.Cookies(), authCookieName)
 	if sessionCookie == nil || strings.TrimSpace(sessionCookie.Value) == "" {
 		t.Fatal("expected an auth cookie after completing the TOTP challenge")
+	}
+
+	// The provider-logout material must have followed the session onto its
+	// real id — the whole point of staging it under the opaque id above — and
+	// the staging row itself must be gone rather than left behind as a second,
+	// orphaned copy.
+	newSessionID := mustExtractAuthSessionIDFromCookieHeader(t, sessionCookie.Name+"="+sessionCookie.Value)
+	movedState, movedFound, err := logoutStateSvc.Load(context.Background(), newSessionID, linked.ID, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("load relocated logout state: %v", err)
+	}
+	if !movedFound || movedState.EndSessionEndpoint != stub.result.Logout.EndSessionEndpoint {
+		t.Fatalf("expected the TOTP challenge to relocate the logout state onto the new session id, got found=%v state=%#v", movedFound, movedState)
+	}
+	_, stillStaged, err := logoutStateSvc.Load(context.Background(), pendingLogoutStateID, linked.ID, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("load staging row after relocation: %v", err)
+	}
+	if stillStaged {
+		t.Fatal("expected the opaque staging row to be deleted once its state moved to the real session id")
+	}
+}
+
+// TestOIDCCallbackForLinkedTOTPAccountWithNoLogoutStateCompletesChallengeCleanly
+// covers the other half of the same parity: when the OIDC result carries no
+// provider-logout material at all (Logout == nil — no end_session_endpoint,
+// or provider logout disabled), the pending cookie carries no logout-state id,
+// completing the challenge mints the session with no OIDC logout row attached
+// to it, and the bridge cookie is cleared exactly as the direct, non-gated
+// OIDC success path clears it.
+func TestOIDCCallbackForLinkedTOTPAccountWithNoLogoutStateCompletesChallengeCleanly(t *testing.T) {
+	t.Parallel()
+
+	stub := newStubOIDCWorkflowService(true)
+	stub.authURL = "https://id.example.com/authorize"
+
+	secretKey := []byte(testHandlerSecretKey)
+	app, database := newOnboardingTestAppWithOptions(t, onboardingTestAppOptions{
+		cookieSecure: true,
+		oidcService:  stub,
+	})
+	user := createOnboardingTestUser(t, database, "oidc-totp-no-logout@example.com", "StrongPass1", true)
+	rawSecret := setupTOTPForUser(t, database, user.ID, secretKey)
+
+	var linked models.User
+	if err := database.First(&linked, user.ID).Error; err != nil {
+		t.Fatalf("reload user: %v", err)
+	}
+
+	stub.result = services.OIDCLoginResult{
+		User:         linked,
+		RequiresTOTP: true,
+		Logout:       nil,
+	}
+
+	startResponse := mustAppResponse(t, app, httptest.NewRequest(http.MethodGet, "/auth/oidc/start", nil))
+	stateCookie := responseCookie(startResponse.Cookies(), oidcStateCookieName)
+	if stateCookie == nil {
+		t.Fatal("expected OIDC state cookie from start flow")
+	}
+	callbackRequest := httptest.NewRequest(http.MethodPost, security.OIDCCallbackPath, strings.NewReader(url.Values{
+		"state": {stub.lastStartState},
+		"code":  {"provider-code"},
+	}.Encode()))
+	callbackRequest.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	callbackRequest.Header.Set("Cookie", stateCookie.String())
+	callbackResponse := mustAppResponse(t, app, callbackRequest)
+	assertStatusCode(t, callbackResponse, http.StatusSeeOther)
+
+	pendingCookie := responseCookie(callbackResponse.Cookies(), totpPendingCookieName)
+	if pendingCookie == nil || strings.TrimSpace(pendingCookie.Value) == "" {
+		t.Fatal("expected a TOTP pending cookie from the OIDC callback")
+	}
+	codec, err := newSecureCookieCodec(secretKey)
+	if err != nil {
+		t.Fatalf("newSecureCookieCodec: %v", err)
+	}
+	decoded, err := codec.open(totpPendingCookieName, pendingCookie.Value)
+	if err != nil {
+		t.Fatalf("open pending cookie: %v", err)
+	}
+	var pendingPayload totpPendingCookiePayload
+	if err := json.Unmarshal(decoded, &pendingPayload); err != nil {
+		t.Fatalf("unmarshal pending payload: %v", err)
+	}
+	if strings.TrimSpace(pendingPayload.OIDCLogoutStateID) != "" {
+		t.Fatalf("expected no OIDC logout-state id when the result carries no logout material, got %q", pendingPayload.OIDCLogoutStateID)
+	}
+
+	code, err := totp.GenerateCode(rawSecret, time.Now())
+	if err != nil {
+		t.Fatalf("GenerateCode: %v", err)
+	}
+	challengeRequest := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/2fa-challenge", strings.NewReader(url.Values{
+		"code": {code},
+	}.Encode()))
+	challengeRequest.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	challengeRequest.Header.Set("Cookie", totpPendingCookieName+"="+pendingCookie.Value)
+	challengeResponse := mustAppResponse(t, app, challengeRequest)
+	assertStatusCode(t, challengeResponse, http.StatusSeeOther)
+
+	sessionCookie := responseCookie(challengeResponse.Cookies(), authCookieName)
+	if sessionCookie == nil || strings.TrimSpace(sessionCookie.Value) == "" {
+		t.Fatal("expected an auth cookie after completing the TOTP challenge")
+	}
+	newSessionID := mustExtractAuthSessionIDFromCookieHeader(t, sessionCookie.Name+"="+sessionCookie.Value)
+
+	logoutStateSvc := services.NewOIDCLogoutStateService(db.NewRepositories(database).OIDCLogout)
+	_, found, err := logoutStateSvc.Load(context.Background(), newSessionID, linked.ID, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("load logout state for new session: %v", err)
+	}
+	if found {
+		t.Fatal("expected no OIDC logout state attached to a session minted with no logout material to carry")
+	}
+
+	bridgeCookie := responseCookie(challengeResponse.Cookies(), oidcLogoutBridgeCookieName)
+	if bridgeCookie == nil || strings.TrimSpace(bridgeCookie.Value) != "" {
+		t.Fatal("expected the TOTP challenge to clear the OIDC logout bridge cookie, same as every other session-mint path")
 	}
 }
 

--- a/internal/api/handlers_auth_2fa.go
+++ b/internal/api/handlers_auth_2fa.go
@@ -12,7 +12,7 @@ import (
 // ShowTOTPChallengePage renders the 2FA code entry page after a successful
 // password login when the user has TOTP enabled.
 func (handler *Handler) ShowTOTPChallengePage(c fiber.Ctx) error {
-	_, _, err := handler.parseTOTPPendingCookie(c)
+	_, _, _, err := handler.parseTOTPPendingCookie(c)
 	if err != nil {
 		// No valid pending cookie — send back to login.
 		return c.Redirect().Status(fiber.StatusSeeOther).To("/login")
@@ -50,7 +50,7 @@ func parseTOTPChallengeCode(c fiber.Ctx) string {
 // VerifyTOTPLogin validates the 6-digit TOTP code submitted on the challenge page.
 // On success it issues the auth session cookie and redirects to the dashboard.
 func (handler *Handler) VerifyTOTPLogin(c fiber.Ctx) error {
-	userID, rememberMe, err := handler.parseTOTPPendingCookie(c)
+	userID, rememberMe, oidcLogoutStateID, err := handler.parseTOTPPendingCookie(c)
 	if err != nil {
 		spec := totpSessionExpiredErrorSpec()
 		handler.logSecurityError(c, "auth.2fa", spec)
@@ -106,11 +106,39 @@ func (handler *Handler) VerifyTOTPLogin(c fiber.Ctx) error {
 	handler.totpService.ResetAttempts(handler.secretKey, c.IP(), userID)
 	handler.clearTOTPPendingCookie(c)
 
-	if _, err := handler.setAuthCookie(c, &user, rememberMe); err != nil {
+	sessionID, err := handler.setAuthCookie(c, &user, rememberMe)
+	if err != nil {
 		spec := authSessionCreateErrorSpec()
 		handler.logSecurityError(c, "auth.2fa", spec)
 		return handler.respondMappedError(c, spec)
 	}
+
+	// A challenge raised by CompleteOIDCLogin (the account had TOTP enabled,
+	// so the OIDC callback deferred the session it would otherwise have
+	// minted) staged any provider-logout material under an opaque id carried
+	// in the pending cookie above, because no session id existed yet at that
+	// point to key it by. Relocate it onto the session id this request just
+	// minted, mirroring CompleteOIDCLogin's own Save/Delete shape so a
+	// TOTP-gated OIDC sign-in ends up with exactly the same provider-logout
+	// integration a non-gated one gets. A challenge with no such id — local
+	// login, or an OIDC login whose account carried no logout state — takes
+	// the Delete arm, which is a no-op against the session id this request
+	// just minted.
+	if oidcLogoutStateID != "" {
+		if err := handler.moveOIDCLogoutState(c.Context(), oidcLogoutStateID, sessionID, userID, time.Now()); err != nil {
+			// codecov:ignore:start -- defensive: moveOIDCLogoutState only returns a
+			// non-nil error from its own storage-error arms, which are independently
+			// marked defensive at their own site
+			spec := authSessionCreateErrorSpec()
+			handler.logSecurityError(c, "auth.2fa", spec)
+			handler.clearSessionEndCookies(c)
+			return handler.respondMappedError(c, spec)
+			// codecov:ignore:end
+		}
+	} else {
+		_ = handler.oidcLogoutStateSvc.Delete(c.Context(), sessionID, userID)
+	}
+	handler.clearOIDCLogoutBridgeCookie(c)
 
 	handler.logSecurityEvent(c, "auth.2fa", "success")
 	return redirectOrJSON(c, "/")

--- a/internal/api/handlers_auth_2fa.go
+++ b/internal/api/handlers_auth_2fa.go
@@ -126,9 +126,11 @@ func (handler *Handler) VerifyTOTPLogin(c fiber.Ctx) error {
 	// just minted.
 	if oidcLogoutStateID != "" {
 		if err := handler.moveOIDCLogoutState(c.Context(), oidcLogoutStateID, sessionID, userID, time.Now()); err != nil {
-			// codecov:ignore:start -- defensive: moveOIDCLogoutState only returns a
-			// non-nil error from its own storage-error arms, which are independently
-			// marked defensive at their own site
+			// codecov:ignore:start -- defensive: this call site always passes a
+			// non-empty, freshly Saved oldSessionID against the real DB-backed
+			// service, so a non-nil error here can only come from a genuine storage
+			// fault; moveOIDCLogoutState's own arms are unit-tested directly against
+			// a stub store (handlers_auth_oidc_move_logout_state_test.go)
 			spec := authSessionCreateErrorSpec()
 			handler.logSecurityError(c, "auth.2fa", spec)
 			handler.clearSessionEndCookies(c)

--- a/internal/api/handlers_auth_oidc.go
+++ b/internal/api/handlers_auth_oidc.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"html"
+	"strings"
 	"time"
 
 	"github.com/gofiber/fiber/v3"
@@ -129,11 +130,42 @@ func (handler *Handler) CompleteOIDCLogin(c fiber.Ctx) error {
 	// after MustChangePassword for the same reason the local path orders it
 	// there — a forced reset outranks TOTP.
 	if result.RequiresTOTP {
-		if err := handler.setTOTPPendingCookie(c, result.User.ID, false); err != nil {
+		// No session id exists yet to key result.Logout by — setAuthCookie
+		// below is exactly what this branch is deferring — so a non-nil
+		// Logout is staged under a freshly minted opaque id instead, and only
+		// that id (never end_session_endpoint or id_token_hint) travels in
+		// the sealed pending-TOTP cookie. VerifyTOTPLogin relocates the row
+		// onto the real session id once the challenge succeeds
+		// (handlers_auth_2fa.go); an OIDC login with no logout state to carry
+		// leaves the id empty, same as a local login.
+		var oidcLogoutStateID string
+		if result.Logout != nil {
+			pendingID, genErr := services.GenerateAuthSessionID()
+			if genErr != nil {
+				// codecov:ignore:start -- defensive: crypto/rand failure
+				spec := authSessionCreateErrorSpec()
+				handler.logSecurityError(c, "auth.oidc_callback", spec)
+				handler.setFlashCookie(c, FlashPayload{AuthError: spec.Key})
+				return c.Redirect().Status(fiber.StatusSeeOther).To("/login")
+				// codecov:ignore:end
+			}
+			if err := handler.oidcLogoutStateSvc.Save(c.Context(), pendingID, *result.Logout, time.Now()); err != nil {
+				// codecov:ignore:start -- defensive: fails only on a storage error
+				spec := authSessionCreateErrorSpec()
+				handler.logSecurityError(c, "auth.oidc_callback", spec)
+				handler.setFlashCookie(c, FlashPayload{AuthError: spec.Key})
+				return c.Redirect().Status(fiber.StatusSeeOther).To("/login")
+				// codecov:ignore:end
+			}
+			oidcLogoutStateID = pendingID
+		}
+		if err := handler.setTOTPPendingCookie(c, result.User.ID, false, oidcLogoutStateID); err != nil {
+			// codecov:ignore:start -- defensive: the sealed cookie writer fails only on an AEAD seal error
 			spec := authSessionCreateErrorSpec()
 			handler.logSecurityError(c, "auth.oidc_callback", spec)
 			handler.setFlashCookie(c, FlashPayload{AuthError: spec.Key})
 			return c.Redirect().Status(fiber.StatusSeeOther).To("/login")
+			// codecov:ignore:end
 		}
 		handler.logSecurityEvent(c, "auth.oidc_callback", "totp_required")
 		return c.Redirect().Status(fiber.StatusSeeOther).To("/auth/2fa")
@@ -175,6 +207,39 @@ func (handler *Handler) CompleteOIDCLogin(c fiber.Ctx) error {
 		securityEventField("newly_linked", boolString(result.NewlyLinked)),
 	)
 	return c.Redirect().Status(fiber.StatusSeeOther).To(services.PostLoginRedirectPath(&result.User))
+}
+
+// moveOIDCLogoutState relocates one owner's provider-logout material from
+// oldSessionID (an opaque id minted only to key the row before a real session
+// existed — see the RequiresTOTP branch in CompleteOIDCLogin above) onto
+// newSessionID, the session id the TOTP challenge just minted
+// (handlers_auth_2fa.go). A row that fails validOIDCLogoutState — the same
+// check the direct, non-gated OIDC login path never has to make, because
+// buildLogoutState only ever produces a valid one — or that Load cannot find,
+// is defensive: oldSessionID is generated and Saved a few minutes earlier in
+// this same pending-TOTP window by this same code path, so in practice both
+// arms are unreachable without a storage fault between the two calls.
+func (handler *Handler) moveOIDCLogoutState(ctx context.Context, oldSessionID string, newSessionID string, userID uint, now time.Time) error {
+	if handler == nil || handler.oidcLogoutStateSvc == nil {
+		return nil
+	}
+	oldSessionID = strings.TrimSpace(oldSessionID)
+	newSessionID = strings.TrimSpace(newSessionID)
+	if oldSessionID == "" || newSessionID == "" || oldSessionID == newSessionID {
+		return nil
+	}
+
+	logoutState, found, err := handler.oidcLogoutStateSvc.Load(ctx, oldSessionID, userID, now)
+	if err != nil || !found {
+		return err // codecov:ignore -- defensive: Load fails only on a storage error, and a not-found row would mean the Save a few lines up in CompleteOIDCLogin never happened
+	}
+	if !validOIDCLogoutState(logoutState) {
+		return handler.oidcLogoutStateSvc.Delete(ctx, oldSessionID, userID) // codecov:ignore -- defensive: the state this reads was Saved by buildLogoutState a few minutes earlier in this same request chain, which never produces an invalid one
+	}
+	if err := handler.oidcLogoutStateSvc.Save(ctx, newSessionID, logoutState, now); err != nil {
+		return err // codecov:ignore -- defensive: Save fails only on a storage error
+	}
+	return handler.oidcLogoutStateSvc.Delete(ctx, oldSessionID, userID)
 }
 
 func oidcRequestContext(c fiber.Ctx) (context.Context, context.CancelFunc) {

--- a/internal/api/handlers_auth_oidc.go
+++ b/internal/api/handlers_auth_oidc.go
@@ -213,12 +213,13 @@ func (handler *Handler) CompleteOIDCLogin(c fiber.Ctx) error {
 // oldSessionID (an opaque id minted only to key the row before a real session
 // existed — see the RequiresTOTP branch in CompleteOIDCLogin above) onto
 // newSessionID, the session id the TOTP challenge just minted
-// (handlers_auth_2fa.go). A row that fails validOIDCLogoutState — the same
-// check the direct, non-gated OIDC login path never has to make, because
-// buildLogoutState only ever produces a valid one — or that Load cannot find,
-// is defensive: oldSessionID is generated and Saved a few minutes earlier in
-// this same pending-TOTP window by this same code path, so in practice both
-// arms are unreachable without a storage fault between the two calls.
+// (handlers_auth_2fa.go). Its only production caller reaches this having
+// Saved oldSessionID's row itself a few minutes earlier in the same
+// pending-TOTP window, so the not-found, invalid-state and storage-error
+// arms below are not expected to fire in practice — but the function takes
+// plain arguments and a *Handler wired to a stub store drives each of them
+// directly (handlers_auth_oidc_move_logout_state_test.go), so none of it is
+// suppressed here.
 func (handler *Handler) moveOIDCLogoutState(ctx context.Context, oldSessionID string, newSessionID string, userID uint, now time.Time) error {
 	if handler == nil || handler.oidcLogoutStateSvc == nil {
 		return nil
@@ -231,13 +232,13 @@ func (handler *Handler) moveOIDCLogoutState(ctx context.Context, oldSessionID st
 
 	logoutState, found, err := handler.oidcLogoutStateSvc.Load(ctx, oldSessionID, userID, now)
 	if err != nil || !found {
-		return err // codecov:ignore -- defensive: Load fails only on a storage error, and a not-found row would mean the Save a few lines up in CompleteOIDCLogin never happened
+		return err
 	}
 	if !validOIDCLogoutState(logoutState) {
-		return handler.oidcLogoutStateSvc.Delete(ctx, oldSessionID, userID) // codecov:ignore -- defensive: the state this reads was Saved by buildLogoutState a few minutes earlier in this same request chain, which never produces an invalid one
+		return handler.oidcLogoutStateSvc.Delete(ctx, oldSessionID, userID)
 	}
 	if err := handler.oidcLogoutStateSvc.Save(ctx, newSessionID, logoutState, now); err != nil {
-		return err // codecov:ignore -- defensive: Save fails only on a storage error
+		return err
 	}
 	return handler.oidcLogoutStateSvc.Delete(ctx, oldSessionID, userID)
 }

--- a/internal/api/handlers_auth_oidc.go
+++ b/internal/api/handlers_auth_oidc.go
@@ -121,6 +121,24 @@ func (handler *Handler) CompleteOIDCLogin(c fiber.Ctx) error {
 		return c.Redirect().Status(fiber.StatusSeeOther).To("/reset-password")
 	}
 
+	// Session issuance parity with the local login path
+	// (handlers_auth_session_login.go): a linked identity re-authenticating
+	// here must clear the same second factor an ordinary sign-in would, gated
+	// on the same OIDCLoginService.Authenticate-computed signal the local
+	// path uses (RequiresTOTP, not the raw TOTPEnabled flag), and checked
+	// after MustChangePassword for the same reason the local path orders it
+	// there — a forced reset outranks TOTP.
+	if result.RequiresTOTP {
+		if err := handler.setTOTPPendingCookie(c, result.User.ID, false); err != nil {
+			spec := authSessionCreateErrorSpec()
+			handler.logSecurityError(c, "auth.oidc_callback", spec)
+			handler.setFlashCookie(c, FlashPayload{AuthError: spec.Key})
+			return c.Redirect().Status(fiber.StatusSeeOther).To("/login")
+		}
+		handler.logSecurityEvent(c, "auth.oidc_callback", "totp_required")
+		return c.Redirect().Status(fiber.StatusSeeOther).To("/auth/2fa")
+	}
+
 	sessionID, err := handler.setAuthCookie(c, &result.User, false)
 	if err != nil {
 		spec := authSessionCreateErrorSpec()

--- a/internal/api/handlers_auth_oidc_link_confirm.go
+++ b/internal/api/handlers_auth_oidc_link_confirm.go
@@ -190,11 +190,14 @@ func (handler *Handler) CompleteOIDCLinkConfirmation(c fiber.Ctx) error {
 	// the local-password Login flow that redirects TOTP-enabled accounts to
 	// /auth/2fa before issuing a session. Without this gate, an attacker with
 	// the victim's password plus a malicious/sloppy upstream IdP (the threat
-	// link-confirm was added to mitigate) could obtain a session for a
-	// TOTP-protected account without ever holding the second factor — and the
-	// linked identity would persist for future OIDC sign-ins. Keep the link
-	// pending cookie alive on TOTP failure so the user can retry within TTL,
-	// same as wrong-password.
+	// link-confirm was added to mitigate) could obtain the session issued a
+	// few lines down for a TOTP-protected account without ever holding the
+	// second factor. A subsequent OIDC sign-in through the now-linked identity
+	// no longer compounds that: CompleteOIDCLogin gates a linked identity's
+	// re-authentication on the same second factor (OIDCLoginResult.RequiresTOTP),
+	// so this gate's job is only the session minted right here, not any future
+	// one. Keep the link pending cookie alive on TOTP failure so the user can
+	// retry within TTL, same as wrong-password.
 	if targetUser.TOTPEnabled {
 		if spec, ok := handler.verifyTOTPForLinkConfirm(c, &targetUser); !ok {
 			handler.logSecurityError(c, "auth.oidc_link_confirm", spec)

--- a/internal/api/handlers_auth_oidc_move_logout_state_test.go
+++ b/internal/api/handlers_auth_oidc_move_logout_state_test.go
@@ -1,0 +1,206 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+	"github.com/ovumcy/ovumcy-web/internal/services"
+)
+
+// moveLogoutStateStub is a test-local stub for services.OIDCLogoutStateStore,
+// scoped to driving moveOIDCLogoutState's own decisions directly rather than
+// through an HTTP round trip: the not-found arm, the invalid-state arm, and
+// the Save-error arm are all storage-shaped outcomes a stub can produce on
+// demand, without needing a live database or a full OIDC+TOTP request chain.
+type moveLogoutStateStub struct {
+	findRecord models.OIDCLogoutState
+	findFound  bool
+	findErr    error
+	findCalls  int
+
+	savedSessionID string
+	saveErr        error
+	saveCalls      int
+
+	deleteBySessionID string
+	deleteByUserID    uint
+	deleteCalls       int
+}
+
+func (s *moveLogoutStateStub) Save(ctx context.Context, state *models.OIDCLogoutState) error {
+	s.saveCalls++
+	if state != nil {
+		s.savedSessionID = state.SessionID
+	}
+	return s.saveErr
+}
+
+func (s *moveLogoutStateStub) FindBySessionID(ctx context.Context, sessionID string, userID uint) (models.OIDCLogoutState, bool, error) {
+	s.findCalls++
+	if s.findErr != nil {
+		return models.OIDCLogoutState{}, false, s.findErr
+	}
+	return s.findRecord, s.findFound, nil
+}
+
+func (s *moveLogoutStateStub) DeleteBySessionID(ctx context.Context, sessionID string, userID uint) error {
+	s.deleteCalls++
+	s.deleteBySessionID = sessionID
+	s.deleteByUserID = userID
+	return nil
+}
+
+func (s *moveLogoutStateStub) DeleteExpired(ctx context.Context, cutoff time.Time) error {
+	return nil
+}
+
+// validMoveLogoutStateRecord returns a record that passes validOIDCLogoutState,
+// so a test using it exercises the Save/Delete arm of moveOIDCLogoutState
+// rather than the invalid-state Delete-only arm.
+func validMoveLogoutStateRecord(ownerID uint) models.OIDCLogoutState {
+	return models.OIDCLogoutState{
+		UserID:                ownerID,
+		EndSessionEndpoint:    "https://idp.example.com/logout",
+		IDTokenHint:           "eyJhbGciOiJSUzI1NiJ9.header.signature",
+		PostLogoutRedirectURL: "https://app.example.com/",
+	}
+}
+
+// TestMoveOIDCLogoutStateNilHandlerIsANoOp pins the `handler == nil` arm of
+// the guard at the top of moveOIDCLogoutState — unreachable through any HTTP
+// handler (a request always carries a real *Handler), but a direct call is
+// cheap and the guard is otherwise silently unverified.
+func TestMoveOIDCLogoutStateNilHandlerIsANoOp(t *testing.T) {
+	var handler *Handler
+	if err := handler.moveOIDCLogoutState(context.Background(), "old-session", "new-session", 7, time.Now()); err != nil {
+		t.Fatalf("expected a nil handler to no-op, got %v", err)
+	}
+}
+
+// TestMoveOIDCLogoutStateNilServiceIsANoOp pins the `oidcLogoutStateSvc == nil`
+// arm of the same guard.
+func TestMoveOIDCLogoutStateNilServiceIsANoOp(t *testing.T) {
+	handler := &Handler{}
+	if err := handler.moveOIDCLogoutState(context.Background(), "old-session", "new-session", 7, time.Now()); err != nil {
+		t.Fatalf("expected a handler with no logout-state service to no-op, got %v", err)
+	}
+}
+
+// TestMoveOIDCLogoutStateEmptyOrIdenticalSessionIDsAreANoOp pins every operand
+// of the second guard: an empty old id, an empty new id, and the two ids
+// already being equal all skip the relocation without touching the store.
+func TestMoveOIDCLogoutStateEmptyOrIdenticalSessionIDsAreANoOp(t *testing.T) {
+	cases := []struct {
+		name string
+		old  string
+		new  string
+	}{
+		{name: "empty old session id", old: "", new: "new-session"},
+		{name: "empty new session id", old: "old-session", new: ""},
+		{name: "identical session ids", old: "same-session", new: "same-session"},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			store := &moveLogoutStateStub{findFound: true, findRecord: validMoveLogoutStateRecord(7)}
+			handler := &Handler{oidcLogoutStateSvc: services.NewOIDCLogoutStateService(store)}
+			if err := handler.moveOIDCLogoutState(context.Background(), testCase.old, testCase.new, 7, time.Now()); err != nil {
+				t.Fatalf("expected a no-op, got %v", err)
+			}
+			if store.findCalls != 0 {
+				t.Fatalf("expected no store lookup before the session-id guard, got %d calls", store.findCalls)
+			}
+		})
+	}
+}
+
+// TestMoveOIDCLogoutStateNotFoundIsANoOp pins the not-found arm: nothing was
+// staged under oldSessionID (or it already expired out from under the
+// service), so the relocation is a quiet no-op rather than an error — the
+// session the TOTP challenge just minted simply carries no logout state,
+// same as an OIDC login whose account had none to begin with.
+func TestMoveOIDCLogoutStateNotFoundIsANoOp(t *testing.T) {
+	store := &moveLogoutStateStub{findFound: false}
+	handler := &Handler{oidcLogoutStateSvc: services.NewOIDCLogoutStateService(store)}
+	if err := handler.moveOIDCLogoutState(context.Background(), "old-session", "new-session", 7, time.Now()); err != nil {
+		t.Fatalf("expected a not-found row to no-op rather than error, got %v", err)
+	}
+	if store.saveCalls != 0 {
+		t.Fatal("did not expect a Save when nothing was found to relocate")
+	}
+}
+
+// TestMoveOIDCLogoutStateLoadErrorPropagates pins the other half of the same
+// guard: a genuine storage error reading oldSessionID's row (not merely a
+// miss) propagates to the caller instead of being swallowed as a quiet no-op.
+func TestMoveOIDCLogoutStateLoadErrorPropagates(t *testing.T) {
+	store := &moveLogoutStateStub{findErr: errors.New("storage unavailable")}
+	handler := &Handler{oidcLogoutStateSvc: services.NewOIDCLogoutStateService(store)}
+	if err := handler.moveOIDCLogoutState(context.Background(), "old-session", "new-session", 7, time.Now()); err == nil {
+		t.Fatal("expected the Load error to propagate")
+	}
+}
+
+// TestMoveOIDCLogoutStateInvalidRecordDeletesWithoutSaving pins the
+// !validOIDCLogoutState arm: a row that Load found but that fails the same
+// validity check buildLogoutState's own output always satisfies is dropped —
+// deleted under the old id, never carried forward to the new one.
+func TestMoveOIDCLogoutStateInvalidRecordDeletesWithoutSaving(t *testing.T) {
+	store := &moveLogoutStateStub{
+		findFound: true,
+		findRecord: models.OIDCLogoutState{
+			UserID: 7,
+			// EndSessionEndpoint deliberately blank: fails validOIDCLogoutState's
+			// first check before any URL parsing.
+		},
+	}
+	handler := &Handler{oidcLogoutStateSvc: services.NewOIDCLogoutStateService(store)}
+	if err := handler.moveOIDCLogoutState(context.Background(), "old-session", "new-session", 7, time.Now()); err != nil {
+		t.Fatalf("expected an invalid record to be dropped without error, got %v", err)
+	}
+	if store.saveCalls != 0 {
+		t.Fatal("did not expect a Save for a record that fails validOIDCLogoutState")
+	}
+	if store.deleteCalls != 1 || store.deleteBySessionID != "old-session" || store.deleteByUserID != 7 {
+		t.Fatalf("expected the invalid row deleted from the old session id for its owner, got calls=%d sessionID=%q userID=%d", store.deleteCalls, store.deleteBySessionID, store.deleteByUserID)
+	}
+}
+
+// TestMoveOIDCLogoutStateSaveErrorPropagates pins the Save-error arm: a valid
+// record that the store fails to persist under the new session id surfaces
+// the error to the caller (VerifyTOTPLogin tears the session down on it)
+// rather than silently dropping the logout state.
+func TestMoveOIDCLogoutStateSaveErrorPropagates(t *testing.T) {
+	store := &moveLogoutStateStub{
+		findFound:  true,
+		findRecord: validMoveLogoutStateRecord(7),
+		saveErr:    errors.New("storage unavailable"),
+	}
+	handler := &Handler{oidcLogoutStateSvc: services.NewOIDCLogoutStateService(store)}
+	if err := handler.moveOIDCLogoutState(context.Background(), "old-session", "new-session", 7, time.Now()); err == nil {
+		t.Fatal("expected the Save error to propagate")
+	}
+	if store.deleteCalls != 0 {
+		t.Fatal("did not expect the old row deleted when the Save onto the new session id failed")
+	}
+}
+
+// TestMoveOIDCLogoutStateValidRecordMovesAndDeletesOld pins the happy path
+// directly (the HTTP-level round trip in auth_oidc_regressions_test.go pins
+// the same shape end to end): a valid record found under the old session id
+// is saved under the new one, then deleted from the old one.
+func TestMoveOIDCLogoutStateValidRecordMovesAndDeletesOld(t *testing.T) {
+	store := &moveLogoutStateStub{findFound: true, findRecord: validMoveLogoutStateRecord(7)}
+	handler := &Handler{oidcLogoutStateSvc: services.NewOIDCLogoutStateService(store)}
+	if err := handler.moveOIDCLogoutState(context.Background(), "old-session", "new-session", 7, time.Now()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if store.saveCalls != 1 || store.savedSessionID != "new-session" {
+		t.Fatalf("expected the record saved under the new session id, got calls=%d sessionID=%q", store.saveCalls, store.savedSessionID)
+	}
+	if store.deleteCalls != 1 || store.deleteBySessionID != "old-session" {
+		t.Fatalf("expected the old session id's row deleted, got calls=%d sessionID=%q", store.deleteCalls, store.deleteBySessionID)
+	}
+}

--- a/internal/api/handlers_auth_session_login.go
+++ b/internal/api/handlers_auth_session_login.go
@@ -104,7 +104,7 @@ func (handler *Handler) Login(c fiber.Ctx) error {
 	}
 
 	if result.RequiresTOTP {
-		if err := handler.setTOTPPendingCookie(c, result.User.ID, credentials.RememberMe); err != nil {
+		if err := handler.setTOTPPendingCookie(c, result.User.ID, credentials.RememberMe, ""); err != nil {
 			spec := authSessionCreateErrorSpec()
 			handler.logSecurityError(c, "auth.login", spec)
 			return handler.respondMappedError(c, spec)

--- a/internal/api/sealed_cookie_ttl_mutation_test.go
+++ b/internal/api/sealed_cookie_ttl_mutation_test.go
@@ -137,7 +137,7 @@ func TestTOTPPendingCookieExpiryHonorsFiveMinuteTTL(t *testing.T) {
 	handler := ttlMutationTestHandler()
 	app := fiber.New()
 	app.Get("/set", func(c fiber.Ctx) error {
-		if err := handler.setTOTPPendingCookie(c, 42, true); err != nil {
+		if err := handler.setTOTPPendingCookie(c, 42, true, ""); err != nil {
 			t.Fatalf("setTOTPPendingCookie: %v", err)
 		}
 		return c.SendStatus(http.StatusNoContent)

--- a/internal/api/sealed_payload_expiry_sweep_test.go
+++ b/internal/api/sealed_payload_expiry_sweep_test.go
@@ -191,10 +191,10 @@ var sealedCookieExpiryProbes = map[string]sealedCookieExpiryProbe{
 	},
 	totpPendingCookieName: {
 		mint: func(handler *Handler, c fiber.Ctx) error {
-			return handler.setTOTPPendingCookie(c, sealedExpirySweepUserID, false)
+			return handler.setTOTPPendingCookie(c, sealedExpirySweepUserID, false, "")
 		},
 		honours: func(handler *Handler, c fiber.Ctx) bool {
-			userID, _, err := handler.parseTOTPPendingCookie(c)
+			userID, _, _, err := handler.parseTOTPPendingCookie(c)
 			return err == nil && userID != 0
 		},
 	},

--- a/internal/api/totp_cookies.go
+++ b/internal/api/totp_cookies.go
@@ -15,6 +15,17 @@ type totpPendingCookiePayload struct {
 	UserID     uint      `json:"user_id"`
 	RememberMe bool      `json:"remember_me,omitempty"`
 	ExpiresAt  time.Time `json:"expires_at"`
+	// OIDCLogoutStateID is an opaque reference into oidc_logout_states, set
+	// only when the challenge this cookie is pending for was raised by an
+	// OIDC callback whose account carried provider-logout material
+	// (result.Logout != nil in CompleteOIDCLogin). It is never the material
+	// itself — end_session_endpoint and id_token_hint stay server-side,
+	// exactly as the OIDC logout bridge cookie already keeps them out of any
+	// cookie — only the lookup key travels here, sealed like the rest of the
+	// payload. VerifyTOTPLogin consumes it to relocate the row onto the
+	// session id the challenge finally mints; empty means either a local
+	// login or an OIDC login with no logout state to carry.
+	OIDCLogoutStateID string `json:"oidc_logout_state_id,omitempty"`
 }
 
 type totpSetupCookiePayload struct {
@@ -30,11 +41,12 @@ var (
 	totpSetupCookieSpec   = sealedCookieSpec{name: totpSetupCookieName, path: "/"}
 )
 
-func (handler *Handler) setTOTPPendingCookie(c fiber.Ctx, userID uint, rememberMe bool) error {
+func (handler *Handler) setTOTPPendingCookie(c fiber.Ctx, userID uint, rememberMe bool, oidcLogoutStateID string) error {
 	payload := totpPendingCookiePayload{
-		UserID:     userID,
-		RememberMe: rememberMe,
-		ExpiresAt:  time.Now().Add(totpPendingCookieTTL),
+		UserID:            userID,
+		RememberMe:        rememberMe,
+		ExpiresAt:         time.Now().Add(totpPendingCookieTTL),
+		OIDCLogoutStateID: strings.TrimSpace(oidcLogoutStateID),
 	}
 	serialized, err := json.Marshal(payload)
 	if err != nil {
@@ -46,7 +58,9 @@ func (handler *Handler) setTOTPPendingCookie(c fiber.Ctx, userID uint, rememberM
 }
 
 // parseTOTPPendingCookie decodes and validates the TOTP pending cookie.
-// Returns the userID, rememberMe flag, and any error (including expiry).
+// Returns the userID, rememberMe flag, the opaque OIDC logout-state reference
+// (empty when there is none — see totpPendingCookiePayload.OIDCLogoutStateID),
+// and any error (including expiry).
 //
 // Every rejection clears the cookie on the way out, the way the other sealed
 // readers in this package do. Both TOTP cookies are session-scoped at path "/",
@@ -58,38 +72,38 @@ func (handler *Handler) setTOTPPendingCookie(c fiber.Ctx, userID uint, rememberM
 // clear, and a later caller added without it silently reintroduces the leak.
 // A missing value is the one branch that clears nothing: there is no value to
 // retract, and an empty cookie is already the cleared state.
-func (handler *Handler) parseTOTPPendingCookie(c fiber.Ctx) (uint, bool, error) {
+func (handler *Handler) parseTOTPPendingCookie(c fiber.Ctx) (uint, bool, string, error) {
 	raw := strings.TrimSpace(c.Cookies(totpPendingCookieName))
 	if raw == "" {
-		return 0, false, errors.New("totp pending cookie missing")
+		return 0, false, "", errors.New("totp pending cookie missing")
 	}
 
 	codec, err := handler.cookieCodec()
 	if err != nil {
 		handler.clearTOTPPendingCookie(c)
-		return 0, false, err
+		return 0, false, "", err
 	}
 	decoded, err := codec.open(totpPendingCookieName, raw)
 	if err != nil {
 		handler.clearTOTPPendingCookie(c)
-		return 0, false, errors.New("totp pending cookie invalid")
+		return 0, false, "", errors.New("totp pending cookie invalid")
 	}
 
 	var payload totpPendingCookiePayload
 	if err := json.Unmarshal(decoded, &payload); err != nil {
 		handler.clearTOTPPendingCookie(c)
-		return 0, false, errors.New("totp pending cookie malformed")
+		return 0, false, "", errors.New("totp pending cookie malformed")
 	}
 	if payload.UserID == 0 {
 		handler.clearTOTPPendingCookie(c)
-		return 0, false, errors.New("totp pending cookie missing user id")
+		return 0, false, "", errors.New("totp pending cookie missing user id")
 	}
 	if time.Now().After(payload.ExpiresAt) {
 		handler.clearTOTPPendingCookie(c)
-		return 0, false, errors.New("totp pending cookie expired")
+		return 0, false, "", errors.New("totp pending cookie expired")
 	}
 
-	return payload.UserID, payload.RememberMe, nil
+	return payload.UserID, payload.RememberMe, strings.TrimSpace(payload.OIDCLogoutStateID), nil
 }
 
 // clearTOTPPendingCookie removes the TOTP pending cookie.

--- a/internal/api/totp_cookies_test.go
+++ b/internal/api/totp_cookies_test.go
@@ -26,13 +26,13 @@ func newTOTPCookieTestApp(t *testing.T, secretKey []byte) (*fiber.App, *Handler)
 	app.Get("/seal-pending", func(c fiber.Ctx) error {
 		userID := uint(fiber.Query(c, "user_id", 0))
 		remember := fiber.Query(c, "remember_me", false)
-		if err := handler.setTOTPPendingCookie(c, userID, remember); err != nil {
+		if err := handler.setTOTPPendingCookie(c, userID, remember, ""); err != nil {
 			return c.Status(fiber.StatusInternalServerError).SendString(err.Error())
 		}
 		return c.SendStatus(fiber.StatusOK)
 	})
 	app.Get("/parse-pending", func(c fiber.Ctx) error {
-		uid, remember, err := handler.parseTOTPPendingCookie(c)
+		uid, remember, _, err := handler.parseTOTPPendingCookie(c)
 		if err != nil {
 			return c.Status(fiber.StatusBadRequest).SendString(err.Error())
 		}

--- a/internal/services/oidc_login_service.go
+++ b/internal/services/oidc_login_service.go
@@ -74,6 +74,14 @@ type OIDCLoginResult struct {
 	NewlyLinked     bool
 	AutoProvisioned bool
 	Logout          *OIDCLogoutState
+	// RequiresTOTP mirrors LoginResult.RequiresTOTP (login_service.go): set
+	// when the resolved account has TOTP enabled and is not also routed
+	// through the MustChangePassword branch — that branch outranks TOTP for
+	// the same reason it does on the local login path. The handler must gate
+	// on this exactly as it gates the local login result: set the
+	// pending-TOTP cookie and redirect to /auth/2fa before ever calling
+	// setAuthCookie.
+	RequiresTOTP bool
 	// PendingLinkClaims is non-nil only when Authenticate returned
 	// ErrOIDCLinkRequiresConfirmation. The handler stores these in a sealed
 	// short-lived cookie and dispatches to the link-confirmation step, where a
@@ -247,6 +255,11 @@ func (service *OIDCLoginService) Authenticate(ctx context.Context, code string, 
 	if err != nil {
 		return OIDCLoginResult{}, err
 	}
+	// Session issuance parity (docs/security/oidc-and-sessions.md): a linked
+	// identity re-authenticating here must clear the same second factor the
+	// local login path requires, computed the same way — MustChangePassword
+	// outranks TOTP, mirroring LoginService.Authenticate.
+	result.RequiresTOTP = !result.User.MustChangePassword && result.User.TOTPEnabled
 	result.Logout = service.buildLogoutState(exchange.Session, result.User.ID)
 	return result, nil
 }

--- a/internal/services/oidc_login_service_test.go
+++ b/internal/services/oidc_login_service_test.go
@@ -370,6 +370,106 @@ func TestOIDCLoginServiceAuthenticateRejectsUnverifiedEmail(t *testing.T) {
 // that still calls linkIdentity inline — the existing-email path now requires
 // confirmation and links through ConfirmAndLinkIdentity instead, covered
 // separately).
+// TestOIDCLoginServiceAuthenticateSetsRequiresTOTPForLinkedTOTPAccount pins
+// session issuance parity (docs/security/oidc-and-sessions.md) at the service
+// layer: an OIDC callback resolving to an already-linked identity whose
+// account has TOTP enabled must come back with RequiresTOTP set, the same
+// signal LoginResult.RequiresTOTP carries for the local login path
+// (login_service.go). The handler gates on this field rather than on the raw
+// User.TOTPEnabled value; this test is what proves the service actually
+// derives it.
+func TestOIDCLoginServiceAuthenticateSetsRequiresTOTPForLinkedTOTPAccount(t *testing.T) {
+	t.Parallel()
+
+	identities := &stubOIDCIdentityStore{
+		found: true,
+		identity: models.OIDCIdentity{
+			ID:      9,
+			UserID:  7,
+			Issuer:  "https://id.example.com",
+			Subject: "owner-subject",
+		},
+	}
+	users := &stubOIDCUserStore{
+		byID: models.User{
+			ID:          7,
+			Role:        models.RoleOwner,
+			TOTPEnabled: true,
+		},
+	}
+	service := NewOIDCLoginService(&stubOIDCProviderClient{
+		enabled: true,
+		exchange: security.OIDCExchangeResult{
+			Claims: security.OIDCClaims{
+				Issuer:        "https://id.example.com",
+				Subject:       "owner-subject",
+				Email:         "owner@example.com",
+				EmailVerified: true,
+			},
+		},
+	}, identities, users, nil)
+
+	result, err := service.Authenticate(context.Background(), "code", "verifier", "nonce", time.Time{})
+	if err != nil {
+		t.Fatalf("Authenticate() unexpected error: %v", err)
+	}
+	if !result.RequiresTOTP {
+		t.Fatal("expected RequiresTOTP for a linked identity whose account has TOTP enabled")
+	}
+}
+
+// TestOIDCLoginServiceAuthenticateMustChangePasswordOutranksRequiresTOTP pins
+// the same ordering decision the local login path pins
+// (TestLoginServiceForcedResetOutranksTOTPForAnAccountWithBothFlags): an
+// account carrying BOTH MustChangePassword and TOTPEnabled must not raise
+// RequiresTOTP. The handler routes MustChangePassword to the forced-reset
+// flow first, and that flow is the sanctioned skip of the second factor
+// (docs/security/known-disclosures.md); a RequiresTOTP that won here would
+// contradict the routing the handler actually performs.
+func TestOIDCLoginServiceAuthenticateMustChangePasswordOutranksRequiresTOTP(t *testing.T) {
+	t.Parallel()
+
+	identities := &stubOIDCIdentityStore{
+		found: true,
+		identity: models.OIDCIdentity{
+			ID:      9,
+			UserID:  7,
+			Issuer:  "https://id.example.com",
+			Subject: "owner-subject",
+		},
+	}
+	users := &stubOIDCUserStore{
+		byID: models.User{
+			ID:                 7,
+			Role:               models.RoleOwner,
+			TOTPEnabled:        true,
+			MustChangePassword: true,
+		},
+	}
+	service := NewOIDCLoginService(&stubOIDCProviderClient{
+		enabled: true,
+		exchange: security.OIDCExchangeResult{
+			Claims: security.OIDCClaims{
+				Issuer:        "https://id.example.com",
+				Subject:       "owner-subject",
+				Email:         "owner@example.com",
+				EmailVerified: true,
+			},
+		},
+	}, identities, users, nil)
+
+	result, err := service.Authenticate(context.Background(), "code", "verifier", "nonce", time.Time{})
+	if err != nil {
+		t.Fatalf("Authenticate() unexpected error: %v", err)
+	}
+	if result.RequiresTOTP {
+		t.Fatal("expected MustChangePassword to outrank RequiresTOTP, mirroring the local login path's ordering")
+	}
+	if !result.User.MustChangePassword {
+		t.Fatal("expected the returned user to still carry MustChangePassword for the handler's own reset routing")
+	}
+}
+
 func TestOIDCLoginServiceAuthenticateMapsLinkPersistenceFailure(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What

`CompleteOIDCLogin` minted a session for an already-linked OIDC identity with no TOTP check
anywhere on the path, unlike local login. `OIDCLoginService.Authenticate` now reports
`RequiresTOTP` the same way `LoginService.Authenticate` does, and the OIDC callback gates on it
before `setAuthCookie`, redirecting to `/auth/2fa` exactly as local login does.

## Why

Session issuance parity: every path that mints `ovumcy_auth` must verify as many factors as
ordinary sign-in. An account's OIDC identity being linked once should not let every later sign-in
skip a second factor the account owner turned on.

## Risk

Breaking behavior change: an SSO account with TOTP enabled will now be challenged on OIDC sign-in
where it previously was not. `MustChangePassword` still outranks the TOTP gate (same ordering as
local login), so the forced-reset escape hatch for an undecryptable TOTP secret after a
`SECRET_KEY` rotation is unaffected.

## How verified

`go build ./...`, `go vet ./...`, `golangci-lint run ./internal/api/... ./internal/services/...`
all clean. Targeted tests for `internal/services` and the touched `internal/api` OIDC/login/2FA
regressions pass, coverage scoped across both packages. Proof-on-defect: gutted the handler gate
and the service's `RequiresTOTP` computation separately; each induced red named the exact
assertion, then both were restored.
