### PR TITLE
build: pin acorn, which the sweep's check O now needs

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@playwright/test": "1.62.1",
     "@tailwindcss/cli": "^4.3.3",
     "@types/node": "^26.3.0",
+    "acorn": "8.16.0",
     "eslint": "10.9.1",
     "globals": "17.11.0",
     "htmx.org": "2.0.10",


### PR DESCRIPTION
Check O in `governance-check.mjs` tokenizes hook sources with acorn instead of a hand-rolled scanner. It resolved only transitively through eslint, so an upgrade there could have removed it silently.

Must land with or before ovumcy/ovumcy-governance#16, which is where the check itself lives.