### PR TITLE
fix(templates): drop the retired link-confirm page's orphaned test hooks

### DIFF
--- a/changelog.d/retired-link-confirm-drops-orphaned-test-hooks.md
+++ b/changelog.d/retired-link-confirm-drops-orphaned-test-hooks.md
@@ -1,0 +1,5 @@
+none
+
+Two test hooks on the retired OIDC link-confirm page lost their last reader when the browser lane
+stopped driving that page, and the DOM-hook guard refuses markup nothing reads. The attributes
+carried no behaviour and no styling, so nothing a user can see changes.

--- a/internal/templates/auth_oidc_link_confirm.html
+++ b/internal/templates/auth_oidc_link_confirm.html
@@ -7,7 +7,7 @@
       <h1 class="journal-title" data-title-key="auth.oidc.link_confirm.title">{{t .Messages "auth.oidc.link_confirm.title"}}</h1>
       <p class="journal-muted mt-2">{{t .Messages "auth.oidc.link_confirm.description"}}</p>
       {{if .TargetEmail}}
-      <p class="journal-muted mt-1" data-link-confirm-email>{{.TargetEmail}}</p>
+      <p class="journal-muted mt-1">{{.TargetEmail}}</p>
       {{end}}
     </div>
 
@@ -55,7 +55,7 @@
       </div>
       {{end}}
 
-      <button type="submit" class="btn-primary w-full" data-link-confirm-submit>{{t .Messages "auth.oidc.link_confirm.submit_button"}}</button>
+      <button type="submit" class="btn-primary w-full">{{t .Messages "auth.oidc.link_confirm.submit_button"}}</button>
     </form>
 
     <div class="mt-5 text-sm">


### PR DESCRIPTION
## What

Removes `data-link-confirm-email` and `data-link-confirm-submit` from the retired OIDC
link-confirm page. Both existed only for the browser lane that used to drive that page; once the
lane stopped driving it they had no reader outside `internal/templates`, and
`TestEveryTemplateDataHookIsNamedOutsideTheTemplates` refuses markup nothing reads.

## Why now

The guard is red on `main` today and reddens every PR that runs against it, while `main`'s own
last CI run predates the change that orphaned them. `data-link-confirm-totp` is untouched — it
still has a Go reader in `auth_oidc_regressions_test.go`.

## Risk

None to behaviour. The attributes carried no styling and no script; only test selectors read them.

## Verified

`go test ./internal/templates/ -run TestEveryTemplateDataHookIsNamedOutsideTheTemplates -count=1`
passes; `changelogd check` OK after committing.
