### PR TITLE
docs(readme): state the Go version the project builds with, and guard it

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
   <a href="https://github.com/ovumcy/ovumcy-web/commits/main"><img src="https://img.shields.io/github/last-commit/ovumcy/ovumcy-web" alt="Last Commit"></a>
   <a href="https://www.gnu.org/licenses/agpl-3.0"><img src="https://img.shields.io/badge/License-AGPL%20v3-blue.svg" alt="License: AGPL v3"></a>
   <a href="https://pkg.go.dev/github.com/ovumcy/ovumcy-web"><img src="https://pkg.go.dev/badge/github.com/ovumcy/ovumcy-web.svg" alt="Go Reference"></a>
-  <a href="https://go.dev/"><img src="https://img.shields.io/badge/Go-1.26.6+-00ADD8?logo=go" alt="Go Version"></a>
+  <a href="https://go.dev/"><img src="https://img.shields.io/badge/Go-1.27.1+-00ADD8?logo=go" alt="Go Version"></a>
   <a href="https://github.com/ovumcy/ovumcy-web/actions/workflows/docker-image.yml"><img src="https://img.shields.io/badge/Docker-ready-2496ED?logo=docker" alt="Docker"></a>
   <a href="https://github.com/ovumcy/ovumcy-web/blob/main/docs/self-hosted.md"><img src="https://img.shields.io/badge/Self--hosted-yes-2ea44f" alt="Self-hosted"></a>
   <a href="https://github.com/ovumcy/ovumcy-web#privacy-and-security"><img src="https://img.shields.io/badge/Telemetry-none-2ea44f" alt="No telemetry"></a>
@@ -324,7 +324,7 @@ For production-style setups:
 
 Requirements:
 
-- Go 1.26.6+
+- Go 1.27.1+
 - Node.js 22+
 
 ```bash

--- a/changelog.d/readme-go-version-matches-the-toolchain.md
+++ b/changelog.d/readme-go-version-matches-the-toolchain.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- **The README now states the Go version the project actually builds with.** The badge and the
+  build prerequisites still said Go 1.26.6 after the toolchain moved to 1.27.0 and then 1.27.1, so
+  anyone building from source was told a version that no longer matches `go.mod` or the builder
+  image.

--- a/changelog.d/readme-go-version-matches-the-toolchain.md
+++ b/changelog.d/readme-go-version-matches-the-toolchain.md
@@ -1,6 +1,9 @@
 ### Fixed
 
-- **The README now states the Go version the project actually builds with.** The badge and the
-  build prerequisites still said Go 1.26.6 after the toolchain moved to 1.27.0 and then 1.27.1, so
-  anyone building from source was told a version that no longer matches `go.mod` or the builder
-  image.
+- **The README now states the Go version the project actually builds with, and a guard keeps it
+  that way.** The badge and the build prerequisites still said Go 1.26.6 after the toolchain moved
+  to 1.27.0 and then 1.27.1, so anyone building from source was told a version that no longer
+  matches `go.mod` or the builder image. Both lines are now compared against `go.mod`'s `go`
+  directive by `scripts/readmeversion`, which is the only thing that can catch this: every workflow
+  resolves its own toolchain with `go-version-file: go.mod`, so CI stays green whatever the README
+  claims.

--- a/scripts/readmeversion/main_test.go
+++ b/scripts/readmeversion/main_test.go
@@ -40,6 +40,135 @@ var envImageAssignment = regexp.MustCompile(`(?m)^[ \t]*(?:export[ \t]+)?OVUMCY_
 // ovumcyImageRef matches the published runtime image at an exact release tag.
 var ovumcyImageRef = regexp.MustCompile(`^ghcr\.io/ovumcy/ovumcy-web:v(\d+\.\d+\.\d+)$`)
 
+// goDirective captures the version from go.mod's `go` line, which is the
+// minimum toolchain that can build this module and the same value every
+// workflow resolves through `go-version-file: go.mod`.
+var goDirective = regexp.MustCompile(`(?m)^go[ \t]+(\d+\.\d+(?:\.\d+)?)[ \t]*$`)
+
+// readmeGoVersionSites are the places README.md tells a reader which Go a
+// source build needs. Each keys on the LABEL and captures to a delimiter
+// rather than matching a version shape, for the same reason envImageAssignment
+// does: a pattern anchored to the shape it expects SKIPS a site written any
+// other way, and a skipped site is precisely the one that drifts unnoticed.
+var readmeGoVersionSites = []struct {
+	what string
+	re   *regexp.Regexp
+}{
+	{"the Go version badge", regexp.MustCompile(`img\.shields\.io/badge/Go-([^-]*)-`)},
+	{"the Requirements list", regexp.MustCompile(`(?m)^[ \t]*-[ \t]+Go[ \t]+(\S+)`)},
+}
+
+// TestReadmeGoVersionMatchesGoMod asserts both README.md statements of the
+// required Go version agree with go.mod's `go` directive.
+//
+// Nothing else catches this. Every workflow takes its toolchain from
+// `go-version-file: go.mod`, so CI stays green no matter what the README
+// claims, and the drift is only visible to someone building from source — who
+// finds out by installing the wrong toolchain. It has already happened twice:
+// the badge and the Requirements line sat at `Go 1.26+` against a stricter
+// go.mod, were corrected by hand to `1.26.6+`, and then survived the 1.27.0 and
+// 1.27.1 bumps unchanged. Two hand corrections of the same two lines is the
+// argument for a guard rather than a third.
+//
+// It fails closed: finding no site at all is a failure, so a rewording that
+// stops matching cannot quietly stop being checked. A captured value that does
+// not begin with a digit is reported rather than skipped — the same rule the
+// image-pin walk applies, since a value nothing can parse is a value nobody is
+// comparing.
+func TestReadmeGoVersionMatchesGoMod(t *testing.T) {
+	root := repoRoot(t)
+	want := goModVersion(t, root)
+	content := readmeContent(t, root)
+
+	sites := 0
+	for _, site := range readmeGoVersionSites {
+		for _, m := range site.re.FindAllSubmatch(content, -1) {
+			raw := strings.TrimSpace(string(m[1]))
+			got := strings.TrimSuffix(raw, "+")
+			if got == "" || got[0] < '0' || got[0] > '9' {
+				t.Errorf("README.md %s reads %q, which is not a Go version, so nothing can compare it against go.mod", site.what, raw)
+				continue
+			}
+			sites++
+			if got != want {
+				t.Errorf(
+					"README.md %s states Go %s while go.mod requires %s; a reader building from source installs a toolchain that cannot build this module, and no workflow catches it because every one of them resolves its toolchain with go-version-file: go.mod",
+					site.what, got, want,
+				)
+			}
+		}
+	}
+	if sites == 0 {
+		t.Fatal("no Go version statement found in README.md: the drift guard has nothing to check")
+	}
+}
+
+// TestReadmeGoVersionSitesKeyOnTheirLabel proves the patterns above find a site
+// by its label rather than by the version shape it happens to carry today, on
+// inline fixtures rather than the real README. A two-component version, a
+// four-component one and a stale value all have to be FOUND — being found is
+// what lets the comparison report them.
+func TestReadmeGoVersionSitesKeyOnTheirLabel(t *testing.T) {
+	badge := readmeGoVersionSites[0].re
+	requirements := readmeGoVersionSites[1].re
+
+	for _, tc := range []struct {
+		name string
+		re   *regexp.Regexp
+		line string
+		want string
+	}{
+		{"badge, patch version", badge, `<img src="https://img.shields.io/badge/Go-1.27.1+-00ADD8?logo=go" alt="Go Version">`, "1.27.1+"},
+		{"badge, minor version", badge, `<img src="https://img.shields.io/badge/Go-1.26+-00ADD8?logo=go">`, "1.26+"},
+		{"badge, stale value", badge, `<img src="https://img.shields.io/badge/Go-1.20.0+-00ADD8?logo=go">`, "1.20.0+"},
+		{"badge, no plus", badge, `<img src="https://img.shields.io/badge/Go-1.27.1-00ADD8?logo=go">`, "1.27.1"},
+		{"requirements, patch version", requirements, "- Go 1.27.1+", "1.27.1+"},
+		{"requirements, indented", requirements, "  -   Go 1.27.1+", "1.27.1+"},
+		{"requirements, no plus", requirements, "- Go 1.27.1", "1.27.1"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := tc.re.FindStringSubmatch(tc.line)
+			if m == nil {
+				t.Fatalf("%q: site not found, so its version would never be compared", tc.line)
+			}
+			if got := strings.TrimSpace(m[1]); got != tc.want {
+				t.Fatalf("%q: captured %q, want %q", tc.line, got, tc.want)
+			}
+		})
+	}
+
+	for _, tc := range []struct {
+		name string
+		re   *regexp.Regexp
+		line string
+	}{
+		{"a different badge", badge, `<img src="https://img.shields.io/badge/Docker-ready-2496ED?logo=docker">`},
+		{"a requirements entry for something else", requirements, "- Node.js 22+"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if m := tc.re.FindStringSubmatch(tc.line); m != nil {
+				t.Fatalf("%q: matched %q, but this line states no Go version", tc.line, m[1])
+			}
+		})
+	}
+}
+
+// goModVersion reads the `go` directive. It fails closed for its callers: a
+// go.mod the pattern cannot read aborts rather than leaving the comparison
+// running against an empty string, which every README value would fail.
+func goModVersion(t *testing.T, root string) string {
+	t.Helper()
+	content, err := os.ReadFile(filepath.Join(root, "go.mod"))
+	if err != nil {
+		t.Fatalf("read go.mod: %v", err)
+	}
+	m := goDirective.FindSubmatch(content)
+	if m == nil {
+		t.Fatal("no `go` directive found in go.mod: nothing to compare README.md against")
+	}
+	return string(m[1])
+}
+
 // TestReadmeReleaseTagsAgree asserts every occurrence of the current release
 // tag in README.md is the same version. It fails closed: finding zero
 // occurrences is itself a failure, so a rewording that stops matching the
@@ -187,10 +316,7 @@ func envImageValue(raw string) string {
 // cannot silently turn a guard built on this tag into a no-op.
 func readmeReleaseTags(t *testing.T, root string) []string {
 	t.Helper()
-	content, err := os.ReadFile(filepath.Join(root, "README.md"))
-	if err != nil {
-		t.Fatalf("read README.md: %v", err)
-	}
+	content := readmeContent(t, root)
 
 	var found []string
 	for _, re := range releaseTagPatterns {
@@ -202,6 +328,18 @@ func readmeReleaseTags(t *testing.T, root string) []string {
 		t.Fatal("no release-tag occurrences found in README.md: the drift guard has nothing to check")
 	}
 	return found
+}
+
+// readmeContent reads README.md or aborts. Both drift guards above compare
+// against it, and a read error must stop them rather than let either run over
+// empty bytes and pass by finding nothing.
+func readmeContent(t *testing.T, root string) []byte {
+	t.Helper()
+	content, err := os.ReadFile(filepath.Join(root, "README.md"))
+	if err != nil {
+		t.Fatalf("read README.md: %v", err)
+	}
+	return content
 }
 
 func repoRoot(t *testing.T) string {

--- a/scripts/readmeversion/main_test.go
+++ b/scripts/readmeversion/main_test.go
@@ -82,17 +82,19 @@ var readmeGoVersionSites = []struct {
 // 1.27.1 bumps unchanged. Two hand corrections of the same two lines is the
 // argument for a guard rather than a third.
 //
-// It fails closed: finding no site at all is a failure, so a rewording that
-// stops matching cannot quietly stop being checked. A captured value that does
-// not begin with a digit is reported rather than skipped — the same rule the
-// image-pin walk applies, since a value nothing can parse is a value nobody is
-// comparing.
+// It fails closed PER SITE: each one must yield at least one comparison, so a
+// rewording that stops matching is reported by name rather than absorbed by
+// the site that still matches. A single total across both sites would be the
+// trap envImageAssignment's comment describes — the remaining match keeps the
+// count non-zero and the guard reports success having checked half of what it
+// names. A captured value that does not begin with a digit is reported rather
+// than skipped, the same rule the image-pin walk applies, since a value
+// nothing can parse is a value nobody is comparing.
 func TestReadmeGoVersionMatchesGoMod(t *testing.T) {
 	root := repoRoot(t)
 	want := goModVersion(t, root)
 	content := readmeContent(t, root)
 
-	sites := 0
 	for _, site := range readmeGoVersionSites {
 		scope := content
 		if site.within != nil {
@@ -103,6 +105,12 @@ func TestReadmeGoVersionMatchesGoMod(t *testing.T) {
 			}
 			scope = block[1]
 		}
+
+		// Counted PER SITE, not across all of them. A single total is the trap
+		// envImageAssignment's comment describes: one site going dark stays
+		// invisible while the other keeps the count non-zero, and the guard
+		// reports success having checked half of what it names.
+		compared := 0
 		for _, m := range site.re.FindAllSubmatch(scope, -1) {
 			raw := strings.TrimSpace(string(m[1]))
 			got := strings.TrimSuffix(raw, "+")
@@ -110,7 +118,7 @@ func TestReadmeGoVersionMatchesGoMod(t *testing.T) {
 				t.Errorf("README.md %s reads %q, which is not a Go version, so nothing can compare it against go.mod", site.what, raw)
 				continue
 			}
-			sites++
+			compared++
 			if got != want {
 				t.Errorf(
 					"README.md %s states Go %s while go.mod requires %s; a reader building from source installs a toolchain that cannot build this module, and no workflow catches it because every one of them resolves its toolchain with go-version-file: go.mod",
@@ -118,9 +126,9 @@ func TestReadmeGoVersionMatchesGoMod(t *testing.T) {
 				)
 			}
 		}
-	}
-	if sites == 0 {
-		t.Fatal("no Go version statement found in README.md: the drift guard has nothing to check")
+		if compared == 0 {
+			t.Errorf("README.md %s matched no Go version, so that site is no longer being compared against go.mod", site.what)
+		}
 	}
 }
 

--- a/scripts/readmeversion/main_test.go
+++ b/scripts/readmeversion/main_test.go
@@ -45,17 +45,29 @@ var ovumcyImageRef = regexp.MustCompile(`^ghcr\.io/ovumcy/ovumcy-web:v(\d+\.\d+\
 // workflow resolves through `go-version-file: go.mod`.
 var goDirective = regexp.MustCompile(`(?m)^go[ \t]+(\d+\.\d+(?:\.\d+)?)[ \t]*$`)
 
+// readmeRequirementsBlock captures the bullet list under the `Requirements:`
+// line of the manual build instructions. The Go entry is found INSIDE this
+// block rather than anywhere in the file, because "- Go " is not a
+// collision-free key the way envImageAssignment's OVUMCY_IMAGE is: a bullet
+// reading "- Go modules are vendored" is ordinary prose, and a scan over the
+// whole README would read it as a version statement and go red on it.
+var readmeRequirementsBlock = regexp.MustCompile(`(?ms)^Requirements:\n\n((?:[ \t]*-[^\n]*\n)+)`)
+
 // readmeGoVersionSites are the places README.md tells a reader which Go a
 // source build needs. Each keys on the LABEL and captures to a delimiter
 // rather than matching a version shape, for the same reason envImageAssignment
 // does: a pattern anchored to the shape it expects SKIPS a site written any
 // other way, and a skipped site is precisely the one that drifts unnoticed.
+// `within`, when set, narrows the search to submatch 1 of that pattern first —
+// the label alone is then only as specific as it needs to be inside the block
+// it belongs to.
 var readmeGoVersionSites = []struct {
-	what string
-	re   *regexp.Regexp
+	what   string
+	within *regexp.Regexp
+	re     *regexp.Regexp
 }{
-	{"the Go version badge", regexp.MustCompile(`img\.shields\.io/badge/Go-([^-]*)-`)},
-	{"the Requirements list", regexp.MustCompile(`(?m)^[ \t]*-[ \t]+Go[ \t]+(\S+)`)},
+	{"the Go version badge", nil, regexp.MustCompile(`img\.shields\.io/badge/Go-([^-]*)-`)},
+	{"the Requirements list", readmeRequirementsBlock, regexp.MustCompile(`(?m)^[ \t]*-[ \t]+Go[ \t]+(\S+)`)},
 }
 
 // TestReadmeGoVersionMatchesGoMod asserts both README.md statements of the
@@ -82,7 +94,16 @@ func TestReadmeGoVersionMatchesGoMod(t *testing.T) {
 
 	sites := 0
 	for _, site := range readmeGoVersionSites {
-		for _, m := range site.re.FindAllSubmatch(content, -1) {
+		scope := content
+		if site.within != nil {
+			block := site.within.FindSubmatch(content)
+			if block == nil {
+				t.Errorf("README.md no longer has the block %s lives in, so that site is no longer being checked at all", site.what)
+				continue
+			}
+			scope = block[1]
+		}
+		for _, m := range site.re.FindAllSubmatch(scope, -1) {
 			raw := strings.TrimSpace(string(m[1]))
 			got := strings.TrimSuffix(raw, "+")
 			if got == "" || got[0] < '0' || got[0] > '9' {
@@ -150,6 +171,29 @@ func TestReadmeGoVersionSitesKeyOnTheirLabel(t *testing.T) {
 				t.Fatalf("%q: matched %q, but this line states no Go version", tc.line, m[1])
 			}
 		})
+	}
+}
+
+// TestRequirementsSiteIgnoresProseOutsideItsBlock is the regression for the
+// label collision. "- Go " is not a collision-free key the way OVUMCY_IMAGE
+// is: a bullet reading "- Go modules are vendored" is ordinary prose, and an
+// unscoped scan reads it as a version statement and goes red on it. Confining
+// the site to the Requirements block leaves only the entry that belongs to it.
+func TestRequirementsSiteIgnoresProseOutsideItsBlock(t *testing.T) {
+	site := readmeGoVersionSites[1]
+	readme := []byte("## Notes\n\n- Go modules are vendored\n- Go generate is not used\n\n" +
+		"Requirements:\n\n- Go 1.27.1+\n- Node.js 22+\n\n```bash\nmake build\n```\n")
+
+	block := site.within.FindSubmatch(readme)
+	if block == nil {
+		t.Fatal("Requirements block not found in the fixture, so the site would go unchecked")
+	}
+	matches := site.re.FindAllSubmatch(block[1], -1)
+	if len(matches) != 1 {
+		t.Fatalf("expected exactly the Requirements entry, got %d matches", len(matches))
+	}
+	if got := string(matches[0][1]); got != "1.27.1+" {
+		t.Fatalf("captured %q, want %q", got, "1.27.1+")
 	}
 }
 


### PR DESCRIPTION
## What

The README's Go badge and its build prerequisites both said 1.26.6, while `go.mod` and the builder
image are on 1.27.1. Both lines now read 1.27.1, and `scripts/readmeversion` compares them against
`go.mod`'s `go` directive from here on.

## Why the guard, not just the fix

This is the second occurrence. The same two lines sat at `Go 1.26+`, were corrected by hand to
`1.26.6+`, then survived the 1.27.0 and 1.27.1 bumps unchanged. Nothing catches it: every workflow
resolves its toolchain with `go-version-file: go.mod` and never reads the README, so CI is green
whatever the text claims, and only someone building from source finds out.

## Risk

Documentation plus one test. The guard keys on each site's label rather than on a version shape, so
a reworded badge is still found; it fails closed when no site matches, and reports an unparsable
value instead of skipping it.

## Verified

Both sites induced red independently and the README restored byte-identical; full
`./scripts/readmeversion` suite green; `gofmt` clean; `changelogd check` OK.
