### PR TITLE
fix(api): 2fa enable/disable answer a JSON caller with a body

### DIFF
--- a/changelog.d/fix-2fa-json-callers-get-a-body.md
+++ b/changelog.d/fix-2fa-json-callers-get-a-body.md
@@ -1,0 +1,20 @@
+### Fixed
+
+- **Enabling or disabling 2FA now answers a JSON client with a body.** `PUT` and
+  `DELETE /api/v1/users/current/2fa` content-negotiated on `HX-Request` alone: an HTMX caller got
+  the inline status markup and *everyone else* — an API client sending `Accept: application/json`
+  included — was redirected to `/settings`, a response carrying nothing a non-browser client can
+  read, and one `docs/openapi.yaml` never declared. Both now take the JSON arm their sibling
+  settings mutations (`data-wipe`, `DELETE /users/current`) already take and return the declared
+  `{"ok": true}` alongside the re-issued session cookie; the browser redirect is unchanged, and so
+  is the HTMX markup the settings page renders. The spec publishes the `200` body and states the
+  `303` as the non-JSON fallback.
+  - The contract guards did not miss this for want of walking the route table; they exclude `303`
+    on purpose. `crossCuttingStatus` in the per-operation reachability test suppresses it because
+    the shared error responder redirects any `/api/v1/users/current` path that does not accept
+    JSON, which would make the status look emittable from every operation. Lifting that exclusion
+    turns 20 operations red, and 18 of them falsely: those handlers return JSON from an
+    `if acceptsJSON(c)` arm before ever reaching the redirect, which the guard's HTML-surface
+    narrowing reads only as an `if` guard, never as an early return. Teaching it to see redirects
+    therefore needs flow sensitivity plus a per-operation verdict on each survivor, and is tracked
+    as its own change.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2653,6 +2653,11 @@ paths:
       responses:
         '200':
           description: 2FA enabled.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/OkResponse' }
+        '303':
+          description: "Browser redirect to `/settings`, which reads the success flash, when `Accept: application/json` is not set."
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
         '400': { $ref: '#/components/responses/ValidationError' }
@@ -2671,6 +2676,11 @@ paths:
       responses:
         '200':
           description: 2FA disabled.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/OkResponse' }
+        '303':
+          description: "Browser redirect to `/settings`, which reads the success flash, when `Accept: application/json` is not set."
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
         '400': { $ref: '#/components/responses/ValidationError' }

--- a/internal/api/handlers_settings_2fa.go
+++ b/internal/api/handlers_settings_2fa.go
@@ -138,6 +138,9 @@ func (handler *Handler) VerifyTOTP2FAEnrollment(c fiber.Ctx) error {
 			htmxDismissibleSuccessStatusMarkup(messages, translateMessage(messages, "settings.2fa.enabled_status")),
 		)
 	}
+	if acceptsJSON(c) {
+		return c.JSON(fiber.Map{"ok": true})
+	}
 	// The mirror image of the refusal side of this branch: a verdict has to be
 	// written to a channel its destination reads. /settings/2fa builds its
 	// template data inline and never pops the flash cookie, so a confirmation
@@ -207,6 +210,9 @@ func (handler *Handler) DisableTOTP2FA(c fiber.Ctx) error {
 		return c.Status(fiber.StatusOK).SendString(
 			htmxDismissibleSuccessStatusMarkup(messages, translateMessage(messages, "settings.2fa.disabled_status")),
 		)
+	}
+	if acceptsJSON(c) {
+		return c.JSON(fiber.Map{"ok": true})
 	}
 	// Same destination and the same slug rule as the enable arm above; fixing
 	// one of the two would leave the other rendering nothing. Landing on

--- a/internal/api/handlers_settings_2fa_json_success_test.go
+++ b/internal/api/handlers_settings_2fa_json_success_test.go
@@ -1,0 +1,113 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/pquerna/otp/totp"
+
+	"github.com/ovumcy/ovumcy-web/internal/services"
+)
+
+// Both 2FA mutations used to content-negotiate on HX-Request alone: an HTMX
+// caller got the status markup and EVERY other caller — an API client asking
+// for JSON included — got 303 to /settings, a response with no body at all for
+// a client that cannot follow a browser redirect. The two tests below are the
+// pair the sibling settings mutations already have (ClearAllData,
+// DeleteAccount): a JSON caller gets the ok-envelope docs/openapi.yaml declares
+// on the 200, and no Location header.
+func assert2FAOkEnvelope(t *testing.T, app *fiber.App, resp *http.Response) {
+	t.Helper()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	// The redirect is the whole regression: a 303 also carries no body, so
+	// asserting the body alone would pass on a response the client cannot use.
+	if location := resp.Header.Get("Location"); location != "" {
+		t.Errorf("JSON caller was redirected to %q; want the JSON body instead", location)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		t.Fatalf("body %q is not JSON: %v", string(body), err)
+	}
+	if decoded["ok"] != true {
+		t.Errorf("body = %q, want the ok envelope", string(body))
+	}
+	// OkResponse declares additionalProperties: false, so a second key would be
+	// a body the published schema rejects.
+	if len(decoded) != 1 {
+		t.Errorf("body = %q, want exactly the declared `ok` property", string(body))
+	}
+	// Toggling 2FA bumps auth_session_version, so the answer is only usable if
+	// it also re-issues this device's cookie — asserted here and not only on the
+	// HTMX arm, because the JSON arm returns before the redirect and a refactor
+	// moving it above refreshCurrentSession would sign the caller out on its
+	// next request with every status assertion still green.
+	refreshed := responseCookie(resp.Cookies(), authCookieName)
+	if refreshed == nil || strings.TrimSpace(refreshed.Value) == "" {
+		t.Fatal("the JSON answer must re-issue ovumcy_auth")
+	}
+	if !authCookieAuthenticates(t, app, refreshed.Value) {
+		t.Error("the re-issued cookie must authenticate; a stale session version would reject it")
+	}
+}
+
+func TestVerifyTOTP2FAEnrollmentAnswersAJSONCallerWithTheDeclaredBody(t *testing.T) {
+	ctx := newTOTPSettingsContext(t, "totp-enroll-json@example.com")
+
+	key, err := services.NewTOTPService(&dbUserRepoForTest{ctx.database}, []byte("test-secret-key"), nil).GenerateSetupKey("Ovumcy", ctx.user.Email)
+	if err != nil {
+		t.Fatalf("GenerateSetupKey: %v", err)
+	}
+	setupCookie := sealTOTPSetupCookieForTest(t, []byte("test-secret-key"), ctx.user.ID, key.Secret())
+
+	code, err := totp.GenerateCode(key.Secret(), time.Now())
+	if err != nil {
+		t.Fatalf("GenerateCode: %v", err)
+	}
+
+	form := cloneFormValues(url.Values{"code": {code}, "password": {"StrongPass1"}})
+	form.Set("csrf_token", ctx.csrfToken)
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/users/current/2fa", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept-Language", "en")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Cookie", joinCookieHeader(ctx.authCookie, cookiePair(ctx.csrfCookie), setupCookie))
+	resp, err := ctx.app.Test(req, testConfigNoTimeout)
+	if err != nil {
+		t.Fatalf("PUT /api/v1/users/current/2fa: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	assert2FAOkEnvelope(t, ctx.app, resp)
+}
+
+func TestDisableTOTP2FAAnswersAJSONCallerWithTheDeclaredBody(t *testing.T) {
+	ctx := newTOTPSettingsContext(t, "totp-disable-json@example.com")
+	if err := getTOTPServiceForTest(ctx.database).EnableTOTP(context.Background(), ctx.user.ID, "JBSWY3DPEHPK3PXP"); err != nil {
+		t.Fatalf("EnableTOTP: %v", err)
+	}
+	// EnableTOTP bumped auth_session_version, so the pre-enable cookie would
+	// die at AuthRequired and the request would never reach the handler.
+	ctx.refreshAuthCookie(t)
+
+	form := url.Values{"password": {"StrongPass1"}}
+	resp := settingsFormRequestWithCSRF(t, ctx, http.MethodDelete, "/api/v1/users/current/2fa", form,
+		map[string]string{"Accept-Language": "en", "Accept": "application/json"})
+	defer func() { _ = resp.Body.Close() }()
+
+	assert2FAOkEnvelope(t, ctx.app, resp)
+}


### PR DESCRIPTION
**What.** `PUT`/`DELETE /api/v1/users/current/2fa` negotiated on `HX-Request` alone, so every
non-HTMX caller — `Accept: application/json` included — got a bodiless `303` to `/settings` that
the spec never declared. Both now take the `acceptsJSON` arm their sibling settings mutations
already take and return `{"ok": true}` with the re-issued session cookie; browser redirect and
HTMX markup unchanged, and the spec publishes the `200` body plus the `303` fallback.

**Why the guards missed it.** `crossCuttingStatus` in
`TestOpenAPIOperationsDeclareEveryStatusTheirOwnHandlerChainCanEmit` excludes `303` deliberately.
Measured — lifting the exclusion turns 20 operations red, 18 falsely: those handlers return from
an `if acceptsJSON(c)` arm before reaching the redirect, which the HTML-surface narrowing reads as
an `if` guard, never as an early return. Teaching it to see redirects needs flow sensitivity plus
a verdict per survivor, and follows separately.

**Verified.** Rebased onto `02194edd`, so the redirect target and flash slugs are main's current
ones. `go test ./internal/api -run 'TestOpenAPI|TestVerifyTOTP|TestDisableTOTP|TestShowTOTP'`
green, `changelogd check` and `patchcov` OK. A browser form submit carries no `application/json`,
so the `e2e/auth-2fa.spec.ts` redirect flows are untouched.
