### PR TITLE
test(openapi): judge the redirect a JSON caller gets, not exclude it

### DIFF
--- a/changelog.d/guard-sees-the-redirects-a-json-caller-gets.md
+++ b/changelog.d/guard-sees-the-redirects-a-json-caller-gets.md
@@ -12,8 +12,11 @@
   its JSON arm. Dropping the exclusion without those two reddened 20 operations, 18 of them falsely.
   - Two things stop the quieter guard from being a blind one. A new test,
     `TestStatusReachTellsARedirectJSONCallersGetFromOneTheyDoNot`, runs the analyser over source
-    written for it — a bare fall-through, an `acceptsJSON` early return, the shared switch, and an
-    `acceptsJSON` arm that does *not* return — and each case also asserts a status the walk must
-    still find, so a run that reached nothing cannot pass as a run that found nothing. The sweep itself now fails when it
+    written for it — a bare fall-through, an `acceptsJSON` early return, the shared switch written
+    both qualified and not, that switch with an initializer, and an `acceptsJSON` arm that does
+    *not* return — and each case also asserts a status the walk must still find, so a run that
+    reached nothing cannot pass as a run that found nothing. The switch narrowing matches its JSON
+    arm by the constant's NAME rather than one spelling of it, and walks the initializer, because
+    it is the one narrowing here whose misses hide a JSON status instead of an HTML one. The sweep itself now fails when it
     judged fewer than 40 `/api/v1` operations, because a route table that failed to load and a
     clean tree print the same nothing.

--- a/changelog.d/guard-sees-the-redirects-a-json-caller-gets.md
+++ b/changelog.d/guard-sees-the-redirects-a-json-caller-gets.md
@@ -17,6 +17,7 @@
     *not* return — and each case also asserts a status the walk must still find, so a run that
     reached nothing cannot pass as a run that found nothing. The switch narrowing matches its JSON
     arm by the constant's NAME rather than one spelling of it, and walks the initializer, because
-    it is the one narrowing here whose misses hide a JSON status instead of an HTML one. The sweep itself now fails when it
-    judged fewer than 40 `/api/v1` operations, because a route table that failed to load and a
-    clean tree print the same nothing.
+    it is the one narrowing here whose misses hide a JSON status instead of an HTML one. The sweep
+    itself now fails when it judged fewer `/api/v1` operations than `docs/openapi.yaml` declares —
+    a floor read out of the spec rather than written beside it, because a route table that failed
+    to load and a clean tree print the same nothing.

--- a/changelog.d/guard-sees-the-redirects-a-json-caller-gets.md
+++ b/changelog.d/guard-sees-the-redirects-a-json-caller-gets.md
@@ -1,0 +1,19 @@
+### Internal
+
+- **The per-operation status guard now judges redirects instead of excluding them.**
+  `TestOpenAPIOperationsDeclareEveryStatusTheirOwnHandlerChainCanEmit` listed `303` as
+  cross-cutting, on the argument that any handler may reach the shared content-negotiation helper
+  regardless of its own logic. That is true of the helper and false of a handler that falls through
+  to `c.Redirect()` with nothing answering the JSON caller first — which is how both 2FA mutations
+  redirected an `Accept: application/json` client to a page, undeclared, on a green `main`. The
+  exclusion is gone and the surface question is answered where it is asked: the walk now reads an
+  `if acceptsJSON(c) { … return … }` as ending the JSON caller's request, so later statements in
+  that block are the HTML surface, and reads `switch responseFormat(c)` the same way, walking only
+  its JSON arm. Dropping the exclusion without those two reddened 20 operations, 18 of them falsely.
+  - Two things stop the quieter guard from being a blind one. A new test,
+    `TestStatusReachTellsARedirectJSONCallersGetFromOneTheyDoNot`, runs the analyser over source
+    written for it — a bare fall-through, an `acceptsJSON` early return, the shared switch, and an
+    `acceptsJSON` arm that does *not* return — and each case also asserts a status the walk must
+    still find, so a run that reached nothing cannot pass as a run that found nothing. The sweep itself now fails when it
+    judged fewer than 40 `/api/v1` operations, because a route table that failed to load and a
+    clean tree print the same nothing.

--- a/changelog.d/guard-sees-the-redirects-a-json-caller-gets.md
+++ b/changelog.d/guard-sees-the-redirects-a-json-caller-gets.md
@@ -9,7 +9,8 @@
   exclusion is gone and the surface question is answered where it is asked: the walk now reads an
   `if acceptsJSON(c) { … return … }` as ending the JSON caller's request, so later statements in
   that block are the HTML surface, and reads `switch responseFormat(c)` the same way, walking only
-  its JSON arm. Dropping the exclusion without those two reddened 20 operations, 18 of them falsely.
+  its JSON arm. Measured on `10d4b7c8`, before either fix: dropping the exclusion alone reddened 20
+  operations, of which the two 2FA ones were the only real findings; with both narrowings, none.
   - Two things stop the quieter guard from being a blind one. A new test,
     `TestStatusReachTellsARedirectJSONCallersGetFromOneTheyDoNot`, runs the analyser over source
     written for it — a bare fall-through, an `acceptsJSON` early return, the shared switch written

--- a/internal/api/openapi_operation_reachability_test.go
+++ b/internal/api/openapi_operation_reachability_test.go
@@ -117,11 +117,17 @@ func TestOpenAPIOperationsDeclareEveryStatusTheirOwnHandlerChainCanEmit(t *testi
 	}
 
 	// A guard that reached no route and a guard that found nothing print the
-	// same nothing. The floor is the population, not the verdict: the spec
-	// documents dozens of /api/v1 operations, so a run that judged a handful
-	// judged a route table that failed to load.
-	if len(seen) < 40 {
-		t.Fatalf("walked %d /api/v1 operations, want at least 40; the route table did not load", len(seen))
+	// same nothing. The floor is the population, not the verdict — and it is
+	// read out of the spec rather than written down here, so it tracks the
+	// document instead of dating from whenever someone last counted. The two
+	// sets are the same operations by TestOpenAPIContractMatchesRegisteredRoutes,
+	// which fails first and by name if they ever diverge; here their SIZE is all
+	// that is asked, as the cheapest statement that a route table failing to
+	// load cannot satisfy.
+	specOperations := openAPIV1Routes(t, filepath.Join(repoRoot, "docs", "openapi.yaml"))
+	if len(seen) < len(specOperations) {
+		t.Fatalf("walked %d /api/v1 operations against %d in the spec; the route table did not load",
+			len(seen), len(specOperations))
 	}
 
 	if len(offenders) == 0 {

--- a/internal/api/openapi_operation_reachability_test.go
+++ b/internal/api/openapi_operation_reachability_test.go
@@ -116,12 +116,116 @@ func TestOpenAPIOperationsDeclareEveryStatusTheirOwnHandlerChainCanEmit(t *testi
 		offenders = append(offenders, operation+": emits "+strings.Join(labels, ", ")+" but docs/openapi.yaml does not declare it there")
 	}
 
+	// A guard that reached no route and a guard that found nothing print the
+	// same nothing. The floor is the population, not the verdict: the spec
+	// documents dozens of /api/v1 operations, so a run that judged a handful
+	// judged a route table that failed to load.
+	if len(seen) < 40 {
+		t.Fatalf("walked %d /api/v1 operations, want at least 40; the route table did not load", len(seen))
+	}
+
 	if len(offenders) == 0 {
 		return
 	}
 	sort.Strings(offenders)
 	t.Errorf("operations whose handler chain can emit a status docs/openapi.yaml never declares for that operation:\n  %s",
 		strings.Join(offenders, "\n  "))
+}
+
+// TestStatusReachTellsARedirectJSONCallersGetFromOneTheyDoNot exercises the
+// analyser itself, on source written for it. The sibling test above can only
+// ever report what the tree happens to contain, so once 303 stopped being
+// excluded wholesale its silence proved nothing: a narrowing that suppressed
+// every redirect and a narrowing that suppressed the right ones read the same.
+// Each case therefore carries a status the walk MUST still find, so a run that
+// reached nothing cannot pass as a run that found nothing.
+func TestStatusReachTellsARedirectJSONCallersGetFromOneTheyDoNot(t *testing.T) {
+	const source = `package api
+
+func redirectsEveryNonHTMXCaller(c fiber.Ctx) error {
+	if !ok {
+		return c.Status(fiber.StatusUnauthorized).JSON(nil)
+	}
+	if isHTMX(c) {
+		return c.SendStatus(fiber.StatusNoContent)
+	}
+	return c.Redirect().Status(fiber.StatusSeeOther).To("/settings")
+}
+
+func answersJSONBeforeRedirecting(c fiber.Ctx) error {
+	if isHTMX(c) {
+		return c.SendStatus(fiber.StatusNoContent)
+	}
+	if acceptsJSON(c) {
+		return c.Status(fiber.StatusAccepted).JSON(nil)
+	}
+	return c.Redirect().Status(fiber.StatusSeeOther).To("/settings")
+}
+
+func redirectsThroughTheSharedHelper(c fiber.Ctx) error {
+	switch responseFormat(c) {
+	case httpx.ResponseFormatJSON:
+		return c.Status(fiber.StatusAccepted).JSON(nil)
+	default:
+		return c.Redirect().Status(fiber.StatusSeeOther).To("/settings")
+	}
+}
+
+func redirectsWhenTheJSONArmFallsThrough(c fiber.Ctx) error {
+	if acceptsJSON(c) {
+		c.Status(fiber.StatusAccepted)
+	}
+	return c.Redirect().Status(fiber.StatusSeeOther).To("/settings")
+}
+`
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "reach_fixture.go", source, 0)
+	if err != nil {
+		t.Fatalf("parse fixture: %v", err)
+	}
+	funcs := make(map[string][]*ast.FuncDecl)
+	transport := make(map[*ast.FuncDecl]bool)
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			continue
+		}
+		funcs[fn.Name.Name] = append(funcs[fn.Name.Name], fn)
+		transport[fn] = true
+	}
+
+	statusByIdentifier := knownFiberStatusIdentifiers(t)
+
+	for _, testCase := range []struct {
+		name     string
+		redirect bool
+		floor    int
+	}{
+		// The bare fall-through: nothing between the HTMX arm and the redirect,
+		// so a JSON caller lands on it. This is the shape both 2FA mutations had.
+		{name: "redirectsEveryNonHTMXCaller", redirect: true, floor: http.StatusUnauthorized},
+		// The JSON caller has already left; the redirect below is HTML-only.
+		{name: "answersJSONBeforeRedirecting", redirect: false, floor: http.StatusAccepted},
+		// Same question asked as a switch, which is how redirectOrJSON asks it.
+		{name: "redirectsThroughTheSharedHelper", redirect: false, floor: http.StatusAccepted},
+		// An acceptsJSON arm that does NOT return decides nothing: execution
+		// continues into the redirect for the JSON caller too.
+		{name: "redirectsWhenTheJSONArmFallsThrough", redirect: true, floor: http.StatusAccepted},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			reach := newStatusReach(funcs, transport, statusByIdentifier)
+			reach.walkFunc(funcs[testCase.name][0], 0, nil)
+			emittable := reach.emittable()
+
+			if !emittable[testCase.floor] {
+				t.Fatalf("walk found no %d; it reached nothing, so its verdict on the redirect means nothing",
+					testCase.floor)
+			}
+			if got := emittable[http.StatusSeeOther]; got != testCase.redirect {
+				t.Errorf("sees the 303 = %v, want %v", got, testCase.redirect)
+			}
+		})
+	}
 }
 
 // handlerFuncName extracts the bare Go function/method name a fiber.Handler
@@ -202,16 +306,22 @@ const maxReachDepth = 8
 // business logic makes: 500 is the universal default arm of every domain
 // error-mapping switch (already documented centrally, not per-operation, by
 // the ErrorHandler's total-resolution contract and
-// TestOpenAPIDocumentsEveryTransportStatusTheEnvelopeCovers); 303 is emitted
-// by the shared JSON/HTMX content-negotiation helper any handler MAY reach
-// regardless of its own logic, and the spec's own preamble scopes documented
-// responses to the JSON surface. An operation that documents 303 as an actual
-// primary outcome (the two-step password-reset flow) is unaffected — this
-// exclusion only suppresses it as a MISSING-declaration finding, it does not
-// forbid declaring it.
+// TestOpenAPIDocumentsEveryTransportStatusTheEnvelopeCovers).
+//
+// 303 was listed here too until the analyser could tell the two kinds of
+// redirect apart. The reason given was that any handler MAY reach the shared
+// content-negotiation helper regardless of its own logic — true of the helper,
+// and true of the shared error responder, but not of a handler that falls
+// through to c.Redirect() with nothing answering the JSON caller first. Both
+// 2FA mutations did exactly that and the exclusion hid it: `PUT` and
+// `DELETE /api/v1/users/current/2fa` redirected an `Accept: application/json`
+// client to a page, undeclared, on a green main. The exclusion is gone and the
+// surface question is now answered where it is asked — see statusReach's third
+// and fourth narrowings, which read an `acceptsJSON` early return and a
+// `switch responseFormat(c)` arm. Removing it wholesale, without those two,
+// reddened 20 operations of which 18 were false.
 var crossCuttingStatus = map[int]bool{
 	http.StatusInternalServerError: true,
-	http.StatusSeeOther:            true,
 }
 
 // guardSet is one case clause's sentinel errors, read as a disjunction: the arm
@@ -222,16 +332,28 @@ type guardSet []string
 // statusReach walks one route's handler chain and answers which fiber.Status*
 // values that chain can emit.
 //
-// Two narrowings keep it from claiming statuses the JSON contract can never
-// show. Both drop statuses rather than add them, so they can only make the
-// check quieter, never falsely red:
+// Four narrowings keep it from claiming statuses the JSON contract can never
+// show. All of them drop statuses rather than add them, so they can only make
+// the check quieter, never falsely red — which is also why each one is written
+// to recognise a single exact spelling and fall through on anything else:
 //
-//   - Content negotiation. A status emitted only inside an isHTMX(c) or
-//     !acceptsJSON(c) arm belongs to the HTML surface, which the spec's own
-//     preamble puts outside this contract — the same argument crossCuttingStatus
-//     makes for 303, applied where it lives instead of per status code. The
-//     shared error responder answers HTMX with 200 and error markup, and four
-//     handlers answer it with 204; neither is a JSON outcome.
+//   - Content negotiation, asked as a guard. A status emitted only inside an
+//     isHTMX(c) or !acceptsJSON(c) arm belongs to the HTML surface, which the
+//     spec's own preamble puts outside this contract. The shared error responder
+//     answers HTMX with 200 and error markup, and four handlers answer it with
+//     204; neither is a JSON outcome.
+//   - Content negotiation, asked as an early return. `if acceptsJSON(c) { …
+//     return … }` ends the JSON caller's request, so every LATER statement in
+//     that block is the HTML surface too — the redirect at the bottom of a
+//     settings mutation above all. This one needs statement ORDER, which is why
+//     walk descends into a block by its List instead of letting ast.Inspect
+//     flatten it, and it is what separates a handler that answers a JSON caller
+//     from one that redirects it. Without it, 18 operations that answer JSON
+//     perfectly well read as redirecting it.
+//   - Content negotiation, asked as a switch. `switch responseFormat(c)` is the
+//     same question again, and redirectOrJSON — reachable from most mutations —
+//     puts c.JSON on its JSON arm and the 303 on its default one. Only the JSON
+//     arm is walked.
 //   - Shared error mappers. A status inside `case errors.Is(err, ErrX):` is
 //     credited only when ErrX is producible somewhere in the same chain. Two
 //     handlers share mapDayUpsertError but only the cycle-start one can raise
@@ -285,6 +407,41 @@ func (reach *statusReach) walkFunc(decl *ast.FuncDecl, depth int, guards []guard
 func (reach *statusReach) walk(node ast.Node, emitsStatuses bool, depth int, guards []guardSet) {
 	ast.Inspect(node, func(n ast.Node) bool {
 		switch typed := n.(type) {
+		case *ast.BlockStmt:
+			// Statements are walked in order rather than as an unordered tree,
+			// because `if acceptsJSON(c) { return c.JSON(...) }` decides the
+			// surface of everything AFTER it: a JSON caller has already left the
+			// function, so the redirect at the bottom belongs to the HTML surface
+			// as surely as one written inside an isHTMX arm. Reading only the
+			// guard's own body — which is all an unordered walk can see — is what
+			// made every redirect-answering handler look alike.
+			for _, stmt := range typed.List {
+				reach.walk(stmt, emitsStatuses, depth, guards)
+				if jsonSurfaceEarlyReturn(stmt) {
+					return false
+				}
+			}
+			return false
+		case *ast.SwitchStmt:
+			// `switch responseFormat(c)` asks the same question the if-guards
+			// ask, so its non-JSON arms are the same HTML surface: the shared
+			// redirectOrJSON helper returns c.JSON on the JSON arm and the 303
+			// only on the default one, which is why every handler that merely
+			// CALLS it looked like a handler that redirects JSON callers.
+			if typed.Tag == nil || !isResponseFormatCall(typed.Tag) {
+				return true
+			}
+			reach.walk(typed.Tag, emitsStatuses, depth, guards)
+			for _, stmt := range typed.Body.List {
+				clause, ok := stmt.(*ast.CaseClause)
+				if !ok || !jsonFormatCase(clause.List) {
+					continue
+				}
+				for _, inner := range clause.Body {
+					reach.walk(inner, emitsStatuses, depth, guards)
+				}
+			}
+			return false
 		case *ast.IfStmt:
 			if !nonJSONSurfaceGuard(typed.Cond) {
 				return true
@@ -404,6 +561,54 @@ func nonJSONSurfaceGuard(cond ast.Expr) bool {
 			if call, ok := unparen(typed.X).(*ast.CallExpr); ok && calleeName(call) == "acceptsJSON" {
 				return true
 			}
+		}
+	}
+	return false
+}
+
+// jsonSurfaceEarlyReturn reports whether a statement is `if acceptsJSON(c) {
+// … return … }` — the shape that answers the JSON caller and leaves, making
+// every later statement in the same block HTML-only.
+//
+// Three narrowings keep it from claiming an exit the JSON surface does not
+// take, since being wrong here DROPS a status rather than adding one: the
+// condition must be exactly the call (a conjunction like `acceptsJSON(c) && x`
+// still falls through whenever `x` is false), the arm must not have an else
+// (which would make the whole statement the branch, not an exit), and its body
+// must end in a return. A `panic`, a labelled break or a return buried in a
+// nested if is deliberately not read as terminal: an exit this cannot prove is
+// one it keeps walking past, which is the direction that keeps statuses.
+func jsonSurfaceEarlyReturn(stmt ast.Stmt) bool {
+	ifStmt, ok := stmt.(*ast.IfStmt)
+	if !ok || ifStmt.Else != nil || ifStmt.Init != nil || ifStmt.Body == nil {
+		return false
+	}
+	call, ok := unparen(ifStmt.Cond).(*ast.CallExpr)
+	if !ok || calleeName(call) != "acceptsJSON" {
+		return false
+	}
+	if len(ifStmt.Body.List) == 0 {
+		return false
+	}
+	_, terminal := ifStmt.Body.List[len(ifStmt.Body.List)-1].(*ast.ReturnStmt)
+	return terminal
+}
+
+// isResponseFormatCall reports whether a switch tag is the content-negotiation
+// question itself, `responseFormat(c)`. Only that spelling narrows: a switch on
+// anything else is ordinary control flow whose arms all belong to every surface.
+func isResponseFormatCall(tag ast.Expr) bool {
+	call, ok := unparen(tag).(*ast.CallExpr)
+	return ok && calleeName(call) == "responseFormat"
+}
+
+// jsonFormatCase reports whether a case clause of such a switch is its JSON
+// arm. A `default:` clause has an empty list and is therefore never one — which
+// is correct: default is where redirectOrJSON puts the browser redirect.
+func jsonFormatCase(list []ast.Expr) bool {
+	for _, expr := range list {
+		if selector, ok := unparen(expr).(*ast.SelectorExpr); ok && selector.Sel.Name == "ResponseFormatJSON" {
+			return true
 		}
 	}
 	return false

--- a/internal/api/openapi_operation_reachability_test.go
+++ b/internal/api/openapi_operation_reachability_test.go
@@ -177,6 +177,24 @@ func redirectsThroughTheSharedHelper(c fiber.Ctx) error {
 	}
 }
 
+func redirectsThroughAnUnqualifiedHelper(c fiber.Ctx) error {
+	switch responseFormat(c) {
+	case ResponseFormatJSON:
+		return c.Status(fiber.StatusAccepted).JSON(nil)
+	default:
+		return c.Redirect().Status(fiber.StatusSeeOther).To("/settings")
+	}
+}
+
+func negotiatesAfterAnInitializer(c fiber.Ctx) error {
+	switch spec := mapSomethingError(fiber.StatusConflict); responseFormat(c) {
+	case httpx.ResponseFormatJSON:
+		return c.Status(fiber.StatusAccepted).JSON(spec)
+	default:
+		return c.Redirect().Status(fiber.StatusSeeOther).To("/settings")
+	}
+}
+
 func redirectsWhenTheJSONArmFallsThrough(c fiber.Ctx) error {
 	if acceptsJSON(c) {
 		c.Status(fiber.StatusAccepted)
@@ -214,6 +232,14 @@ func redirectsWhenTheJSONArmFallsThrough(c fiber.Ctx) error {
 		{name: "answersJSONBeforeRedirecting", redirect: false, floor: http.StatusAccepted},
 		// Same question asked as a switch, which is how redirectOrJSON asks it.
 		{name: "redirectsThroughTheSharedHelper", redirect: false, floor: http.StatusAccepted},
+		// The same switch with the constant unqualified, as httpx would write
+		// it. The floor is the JSON arm's own status: matching only the
+		// qualified spelling skips that arm, which hides a JSON status rather
+		// than an HTML one.
+		{name: "redirectsThroughAnUnqualifiedHelper", redirect: false, floor: http.StatusAccepted},
+		// The initializer runs before any arm is chosen, so its 409 is emittable
+		// to a JSON caller and must survive the narrowing.
+		{name: "negotiatesAfterAnInitializer", redirect: false, floor: http.StatusConflict},
 		// An acceptsJSON arm that does NOT return decides nothing: execution
 		// continues into the redirect for the JSON caller too.
 		{name: "redirectsWhenTheJSONArmFallsThrough", redirect: true, floor: http.StatusAccepted},
@@ -437,6 +463,12 @@ func (reach *statusReach) walk(node ast.Node, emitsStatuses bool, depth int, gua
 			if typed.Tag == nil || !isResponseFormatCall(typed.Tag) {
 				return true
 			}
+			// The initializer and the tag run before any arm is chosen, so they
+			// run for every surface — the same reason the IfStmt arm below walks
+			// its own Init and Cond rather than skipping the whole statement.
+			if typed.Init != nil {
+				reach.walk(typed.Init, emitsStatuses, depth, guards)
+			}
 			reach.walk(typed.Tag, emitsStatuses, depth, guards)
 			for _, stmt := range typed.Body.List {
 				clause, ok := stmt.(*ast.CaseClause)
@@ -611,10 +643,24 @@ func isResponseFormatCall(tag ast.Expr) bool {
 // jsonFormatCase reports whether a case clause of such a switch is its JSON
 // arm. A `default:` clause has an empty list and is therefore never one — which
 // is correct: default is where redirectOrJSON puts the browser redirect.
+//
+// The constant is matched by NAME, qualified or not. Every other narrowing here
+// errs quiet because what it drops is the HTML surface; this one is the
+// exception — dropping the JSON arm hides a status the contract does cover — so
+// it must not be keyed on one spelling. `httpx.ResponseFormatJSON` is how the
+// transport package writes it and `ResponseFormatJSON` is how httpx itself
+// would.
 func jsonFormatCase(list []ast.Expr) bool {
 	for _, expr := range list {
-		if selector, ok := unparen(expr).(*ast.SelectorExpr); ok && selector.Sel.Name == "ResponseFormatJSON" {
-			return true
+		switch typed := unparen(expr).(type) {
+		case *ast.SelectorExpr:
+			if typed.Sel.Name == "ResponseFormatJSON" {
+				return true
+			}
+		case *ast.Ident:
+			if typed.Name == "ResponseFormatJSON" {
+				return true
+			}
 		}
 	}
 	return false


### PR DESCRIPTION
Reopened from #715 (branch renamed off the `claude/` prefix). Stacked on #714 — the first commit
here is that PR's; rebase once it merges.

**What.** `crossCuttingStatus` listed `303` as cross-cutting, on the argument that any handler may
reach the shared content-negotiation helper regardless of its own logic. True of the helper, false
of a handler falling through to `c.Redirect()` with nothing answering the JSON caller first — how
both 2FA mutations redirected a JSON client, undeclared, on a green `main`. The exclusion is gone;
the walk instead reads `if acceptsJSON(c) { … return … }` as ending the JSON caller's request (so
later statements in that block are the HTML surface) and reads `switch responseFormat(c)` the same
way, walking only its JSON arm — by the constant's name, and walking the initializer, because a
miss there would hide a JSON status rather than an HTML one.

**Measured.** Dropping the exclusion alone reddens 20 operations, 18 falsely. With the narrowings:
none. Falsifier — deleting the `acceptsJSON` arm from the two 2FA handlers and their `303`
declarations reddens exactly those two; restoring the arm alone silences it again.

**How it can go blind.** `TestStatusReachTellsARedirectJSONCallersGetFromOneTheyDoNot` runs the
analyser over six hand-written handlers, each asserting a status the walk must still find. The
sweep also fails when it judged fewer operations than the spec declares.

**Verified.** Guard suite and the 2FA tests green; `changelogd check` and `patchcov` OK.
