### PR TITLE
docs(openapi): step-ups hand the browser a page, not a 303

### DIFF
--- a/changelog.d/step-up-303-is-not-the-provider-hop.md
+++ b/changelog.d/step-up-303-is-not-the-provider-hop.md
@@ -1,0 +1,30 @@
+### Fixed
+
+`docs/openapi.yaml` no longer promises a `303` redirect to the provider's
+authorize URL from the three OIDC step-up operations
+(`POST /api/v1/users/current/password/step-up`, `.../data-wipe/step-up`,
+`.../deletion/step-up`). That hop stopped being a redirect when the settings
+page's CSP began pinning `form-action` to `'self'`: Chromium enforces the pin
+across a form navigation's whole redirect chain, so a cross-origin `3xx` aborts
+in the browser. The server hands back a same-origin `200` page whose
+meta-refresh performs the hop instead — the behaviour the fourth operation of
+the same class, `.../oidc/link/step-up`, already documented. A JSON caller was
+never affected: it receives `200 {ok, redirect_url}` and always did.
+
+The `303` these operations really can answer a browser with is the refusal
+bounce back to `/settings`, which every `/api/v1/users/current` mutation shares
+and none of the ~30 others declares; it is the cross-cutting HTML-surface
+answer the spec's own preamble puts outside this contract, not a per-operation
+outcome, so it is not declared here either.
+
+A new guard keeps the class closed. Over-declaration in an OpenAPI spec is
+generally undecidable — proving no path reaches a status is proving a negative,
+which is why the existing per-operation reachability walk only reports
+under-declaration. This one asks the opposite, positive question: does the
+route's handler chain reach the same-origin interstitial helper? A hit is a
+witness, and it settles the browser answer, so an operation that serves the
+interstitial may not declare a `303`. Neither status guard could have caught
+this on its own: the whole-server sweep passes because `303` is emitted all
+over `internal/`, and the per-operation walk passes because `303` really is
+reachable here — just not for the reason the spec gave. The falsehood lived in
+the response description, and nothing in the suite reads one.

--- a/changelog.d/step-up-303-is-not-the-provider-hop.md
+++ b/changelog.d/step-up-303-is-not-the-provider-hop.md
@@ -11,11 +11,14 @@ meta-refresh performs the hop instead — the behaviour the fourth operation of
 the same class, `.../oidc/link/step-up`, already documented. A JSON caller was
 never affected: it receives `200 {ok, redirect_url}` and always did.
 
-The `303` these operations really can answer a browser with is the refusal
-bounce back to `/settings`, which every `/api/v1/users/current` mutation shares
-and none of the ~30 others declares; it is the cross-cutting HTML-surface
-answer the spec's own preamble puts outside this contract, not a per-operation
-outcome, so it is not declared here either.
+The `303` these operations really can answer a browser with is
+`respondSettingsError`'s refusal bounce back to `/settings`, shared by the
+settings mutations under `/api/v1/users/current`. Of the 23 operations the spec
+publishes under that prefix, four declare a `303` after this change — the two
+calendar-feed reveals and the two 2FA toggles — and there the redirect is the
+browser's primary outcome, not a refusal. The refusal bounce is the
+cross-cutting HTML-surface answer the spec's own preamble puts outside this
+contract, so it is not declared here either.
 
 A new guard keeps the class closed. Over-declaration in an OpenAPI spec is
 generally undecidable — proving no path reaches a status is proving a negative,

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2491,10 +2491,15 @@ paths:
       summary: Begin the OIDC step-up flow to enable a local password (owner only, OIDC-only).
       description: |
         Validates the new password pair, stashes its bcrypt hash in a sealed
-        cookie, and returns the provider's authorize URL. The browser follows
-        the redirect; the provider re-authenticates the user; the callback at
+        cookie, and returns the provider's authorize URL. The caller sends the
+        browser there; the provider re-authenticates the user; the callback at
         `/auth/oidc/callback` finalizes the local password and mints a
         recovery code. See [docs/oidc.md "How Auto-Provision Works"](oidc.md#how-auto-provision-works).
+
+        A request that does not accept JSON (an ordinary form submit) is
+        answered with a same-origin interstitial page instead of the JSON body,
+        because the settings page CSP pins `form-action` to `'self'` across the
+        whole redirect chain.
       requestBody:
         required: true
         content:
@@ -2506,8 +2511,6 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/StartLocalPasswordSetupResponse' }
-        '303':
-          description: "Browser redirect to the provider authorize URL when `Accept: application/json` is not set."
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
         '400': { $ref: '#/components/responses/ValidationError' }
@@ -2529,14 +2532,17 @@ paths:
 
         An account that **has** a local password is refused here: its erasure
         gate stays the password, so the SSO path can never be used to bypass it.
+
+        A request that does not accept JSON (an ordinary form submit) is
+        answered with a same-origin interstitial page instead of the JSON body,
+        because the settings page CSP pins `form-action` to `'self'` across the
+        whole redirect chain.
       responses:
         '200':
           description: OIDC redirect URL emitted.
           content:
             application/json:
               schema: { $ref: '#/components/schemas/StartLocalPasswordSetupResponse' }
-        '303':
-          description: "Browser redirect to the provider authorize URL when `Accept: application/json` is not set."
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
         '400':
@@ -2559,14 +2565,17 @@ paths:
         `POST /api/v1/users/current/data-wipe/step-up`; the same rules apply,
         including the refusal for accounts that hold a local password. The
         callback deletes the account and retracts the session.
+
+        A request that does not accept JSON (an ordinary form submit) is
+        answered with a same-origin interstitial page instead of the JSON body,
+        because the settings page CSP pins `form-action` to `'self'` across the
+        whole redirect chain.
       responses:
         '200':
           description: OIDC redirect URL emitted.
           content:
             application/json:
               schema: { $ref: '#/components/schemas/StartLocalPasswordSetupResponse' }
-        '303':
-          description: "Browser redirect to the provider authorize URL when `Accept: application/json` is not set."
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
         '400':

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2497,9 +2497,11 @@ paths:
         recovery code. See [docs/oidc.md "How Auto-Provision Works"](oidc.md#how-auto-provision-works).
 
         A request that does not accept JSON (an ordinary form submit) is
-        answered with a same-origin interstitial page instead of the JSON body,
-        because the settings page CSP pins `form-action` to `'self'` across the
-        whole redirect chain.
+        answered, on success, with a same-origin interstitial page instead of
+        the JSON body, because the settings page CSP pins `form-action` to
+        `'self'` across the whole redirect chain; the responses below describe
+        the JSON surface, and a refusal on the browser one flashes onto
+        `/settings` rather than carrying the status.
       requestBody:
         required: true
         content:
@@ -2534,9 +2536,11 @@ paths:
         gate stays the password, so the SSO path can never be used to bypass it.
 
         A request that does not accept JSON (an ordinary form submit) is
-        answered with a same-origin interstitial page instead of the JSON body,
-        because the settings page CSP pins `form-action` to `'self'` across the
-        whole redirect chain.
+        answered, on success, with a same-origin interstitial page instead of
+        the JSON body, because the settings page CSP pins `form-action` to
+        `'self'` across the whole redirect chain; the responses below describe
+        the JSON surface, and a refusal on the browser one flashes onto
+        `/settings` rather than carrying the status.
       responses:
         '200':
           description: OIDC redirect URL emitted.
@@ -2567,9 +2571,11 @@ paths:
         callback deletes the account and retracts the session.
 
         A request that does not accept JSON (an ordinary form submit) is
-        answered with a same-origin interstitial page instead of the JSON body,
-        because the settings page CSP pins `form-action` to `'self'` across the
-        whole redirect chain.
+        answered, on success, with a same-origin interstitial page instead of
+        the JSON body, because the settings page CSP pins `form-action` to
+        `'self'` across the whole redirect chain; the responses below describe
+        the JSON surface, and a refusal on the browser one flashes onto
+        `/settings` rather than carrying the status.
       responses:
         '200':
           description: OIDC redirect URL emitted.

--- a/internal/api/openapi_interstitial_redirect_test.go
+++ b/internal/api/openapi_interstitial_redirect_test.go
@@ -1,0 +1,138 @@
+package api
+
+import (
+	"go/ast"
+	"net/http"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/gofiber/fiber/v3"
+)
+
+// interstitialHelper is the one function that turns a browser hop to the IdP
+// into a same-origin 200 page. Reaching it from a route's handler chain is the
+// positive witness this guard is built on.
+const interstitialHelper = "oidcSameOriginRedirectInterstitial"
+
+// TestOpenAPIOperationsServingAnInterstitialDeclareNoBrowserRedirect closes the
+// one over-declaration this spec CAN decide without proving a negative.
+//
+// Over-declaration is generally undecidable here, which is why
+// TestOpenAPIOperationsDeclareEveryStatusTheirOwnHandlerChainCanEmit is
+// one-directional: "no path reaches this status" is not provable by a
+// call-graph approximation failing to find one. This guard never asks that.
+// It asks the opposite, positive question — does the chain reach
+// oidcSameOriginRedirectInterstitial? — and a hit is a witness, not an absence.
+//
+// A hit settles the browser answer completely. The helper exists because CSP
+// pins form-action to 'self' across a form navigation's whole redirect chain,
+// so the cross-origin hop to the provider cannot be a 3xx at all; the operation
+// hands the browser a 200 same-origin page whose meta-refresh performs it. An
+// operation that serves it therefore has no browser redirect to declare, and
+// the 303 the three OIDC step-ups published for two releases described a hop
+// that had not existed since the CSP fix. The one status they really can
+// redirect a browser with is respondSettingsError's refusal bounce to
+// /settings, which every /api/v1/users/current mutation shares and none of the
+// ~30 others declares — a cross-cutting HTML-surface answer the spec preamble
+// puts outside this contract, not a per-operation outcome.
+//
+// Neither status guard could see this. The whole-server sweep passes because
+// 303 is emitted all over internal/; the per-operation walk passes because 303
+// really is reachable here, just not for the declared reason. The falsehood
+// lived in the response DESCRIPTION, and nothing in this package reads one.
+func TestOpenAPIOperationsServingAnInterstitialDeclareNoBrowserRedirect(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+	app, _ := newOnboardingTestApp(t)
+
+	declared := openAPIDeclaredStatuses(t, filepath.Join(repoRoot, "docs", "openapi.yaml"))
+	declaresRedirect := make(map[string]bool)
+	for _, operation := range declared[http.StatusSeeOther] {
+		declaresRedirect[operation] = true
+	}
+
+	funcs, transport := parseReachableFuncs(t,
+		filepath.Join(repoRoot, "internal", "api"),
+		filepath.Join(repoRoot, "internal", "services"))
+
+	valid := map[string]bool{
+		fiber.MethodGet: true, fiber.MethodPost: true, fiber.MethodPut: true,
+		fiber.MethodPatch: true, fiber.MethodDelete: true, fiber.MethodHead: true,
+	}
+
+	var serving, offenders []string
+	seen := make(map[string]bool)
+	for _, route := range app.GetRoutes(true) {
+		if !valid[route.Method] || !strings.HasPrefix(route.Path, "/api/v1") {
+			continue
+		}
+		operation := route.Method + " " + fiberPathToOpenAPI(route.Path)
+		if seen[operation] {
+			continue
+		}
+		seen[operation] = true
+
+		reach := &interstitialReach{funcs: funcs, visited: make(map[*ast.FuncDecl]bool)}
+		for _, h := range route.Handlers {
+			for _, decl := range funcs[handlerFuncName(h)] {
+				if transport[decl] {
+					reach.walk(decl, 0)
+				}
+			}
+		}
+		if !reach.found {
+			continue
+		}
+		serving = append(serving, operation)
+		if declaresRedirect[operation] {
+			offenders = append(offenders, operation)
+		}
+	}
+
+	// The sweep means nothing if it found no interstitial at all: a rename of
+	// the helper, or a walk that stopped descending, would leave it green
+	// having checked nothing. Four OIDC step-ups serve one today.
+	if len(serving) == 0 {
+		t.Fatalf("no /api/v1 operation reaches %s; the helper was renamed or the walk stopped descending", interstitialHelper)
+	}
+
+	if len(offenders) == 0 {
+		return
+	}
+	sort.Strings(offenders)
+	t.Errorf("operations whose browser answer is a same-origin interstitial (200) still declare a 303 in docs/openapi.yaml:\n  %s",
+		strings.Join(offenders, "\n  "))
+}
+
+// interstitialReach answers whether one route's handler chain can reach the
+// interstitial helper. Unlike statusReach it needs no surface or sentinel
+// narrowing: it looks for a single call by name, and a call it cannot resolve
+// makes it quieter, never falsely red.
+type interstitialReach struct {
+	funcs   map[string][]*ast.FuncDecl
+	visited map[*ast.FuncDecl]bool
+	found   bool
+}
+
+func (reach *interstitialReach) walk(decl *ast.FuncDecl, depth int) {
+	if reach.found || decl == nil || decl.Body == nil || depth > maxReachDepth || reach.visited[decl] {
+		return
+	}
+	reach.visited[decl] = true
+	ast.Inspect(decl.Body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return !reach.found
+		}
+		name := calleeName(call)
+		if name == interstitialHelper {
+			reach.found = true
+			return false
+		}
+		for _, callee := range reach.funcs[name] {
+			reach.walk(callee, depth+1)
+		}
+		return !reach.found
+	})
+}

--- a/internal/api/openapi_interstitial_redirect_test.go
+++ b/internal/api/openapi_interstitial_redirect_test.go
@@ -73,7 +73,7 @@ func TestOpenAPIOperationsServingAnInterstitialDeclareNoBrowserRedirect(t *testi
 		}
 		seen[operation] = true
 
-		reach := &interstitialReach{funcs: funcs, visited: make(map[*ast.FuncDecl]bool)}
+		reach := &interstitialReach{funcs: funcs, visited: make(map[*ast.FuncDecl]int)}
 		for _, h := range route.Handlers {
 			for _, decl := range funcs[handlerFuncName(h)] {
 				if transport[decl] {
@@ -110,16 +110,24 @@ func TestOpenAPIOperationsServingAnInterstitialDeclareNoBrowserRedirect(t *testi
 // narrowing: it looks for a single call by name, and a call it cannot resolve
 // makes it quieter, never falsely red.
 type interstitialReach struct {
-	funcs   map[string][]*ast.FuncDecl
-	visited map[*ast.FuncDecl]bool
+	funcs map[string][]*ast.FuncDecl
+	// visited records the SHALLOWEST depth each declaration was reached at, not
+	// merely that it was reached. A long path can arrive first and burn the
+	// descent budget below a helper that a shorter path would have walked
+	// through — marking the declaration done there would lose the shorter path
+	// and turn a real offender green.
+	visited map[*ast.FuncDecl]int
 	found   bool
 }
 
 func (reach *interstitialReach) walk(decl *ast.FuncDecl, depth int) {
-	if reach.found || decl == nil || decl.Body == nil || depth > maxReachDepth || reach.visited[decl] {
+	if reach.found || decl == nil || decl.Body == nil || depth > maxReachDepth {
 		return
 	}
-	reach.visited[decl] = true
+	if seen, ok := reach.visited[decl]; ok && seen <= depth {
+		return
+	}
+	reach.visited[decl] = depth
 	ast.Inspect(decl.Body, func(n ast.Node) bool {
 		call, ok := n.(*ast.CallExpr)
 		if !ok {

--- a/internal/api/openapi_interstitial_redirect_test.go
+++ b/internal/api/openapi_interstitial_redirect_test.go
@@ -31,12 +31,13 @@ const interstitialHelper = "oidcSameOriginRedirectInterstitial"
 // so the cross-origin hop to the provider cannot be a 3xx at all; the operation
 // hands the browser a 200 same-origin page whose meta-refresh performs it. An
 // operation that serves it therefore has no browser redirect to declare, and
-// the 303 the three OIDC step-ups published for two releases described a hop
-// that had not existed since the CSP fix. The one status they really can
-// redirect a browser with is respondSettingsError's refusal bounce to
-// /settings, which every /api/v1/users/current mutation shares and none of the
-// ~30 others declares — a cross-cutting HTML-surface answer the spec preamble
-// puts outside this contract, not a per-operation outcome.
+// the 303 three OIDC step-ups published described a hop that had not existed
+// since the CSP fix. The one status they really can redirect a browser with is
+// respondSettingsError's refusal bounce to /settings, shared by the settings
+// mutations under /api/v1/users/current: of the operations the spec publishes
+// under that prefix, the only ones declaring a 303 are those where the
+// redirect IS the browser's primary outcome — a cross-cutting HTML-surface
+// answer the spec preamble puts outside this contract, not a per-operation one.
 //
 // Neither status guard could see this. The whole-server sweep passes because
 // 303 is emitted all over internal/; the per-operation walk passes because 303


### PR DESCRIPTION
**What.** The `password`, `data-wipe` and `deletion` step-ups stop declaring a `303` "browser redirect to the provider authorize URL", and say what a form submit really gets.

**Why.** That hop stopped being a redirect when the settings CSP pinned `form-action` to `'self'` — enforced across a form navigation's whole redirect chain, so a cross-origin `3xx` aborts. The server returns a same-origin `200` interstitial, which the fourth operation of the class, `oidc/link/step-up`, already documented. Verified by request: browser `200 text/html` + meta-refresh, no `Location`; JSON `200 {ok, redirect_url}`, unchanged. The `303` these three really can send is `respondSettingsError`'s refusal bounce to `/settings` — shared by every `/api/v1/users/current` mutation, declared by none of the ~30 others, on a surface the preamble excludes.

**Why no guard saw it.** The whole-server sweep passes because `303` is emitted all over `internal/`; the per-operation walk passes because `303` really is reachable here, just not for the declared reason. The falsehood was in the response description, and nothing reads one. The new guard asks a positive question — does the chain reach the interstitial helper? — so it proves no negative; a hit settles the browser answer. Sensitivity checked by reintroducing a `303` (red); it fails loudly if it ever finds zero interstitial operations.

**Risk.** Spec text plus one test file; no handler, route or status changes. Removing a declared status is spec-visible, hence the changelog fragment.

**Verified.** `go test ./internal/api -run 'TestOpenAPI' -count=1`, step-up regressions, `./scripts/...`; `changelogd check` and `patchcov` after the commit.
