### PR TITLE
ci(scorecard): scope workflow-level permissions to none

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: ["main"]
 
-permissions: read-all
+permissions: {}
 
 jobs:
   analysis:

--- a/changelog.d/scorecard-workflow-scope-is-least-privilege.md
+++ b/changelog.d/scorecard-workflow-scope-is-least-privilege.md
@@ -1,0 +1,7 @@
+### Security
+
+- **The Scorecard workflow no longer grants `read-all` at workflow scope.** The scope only reaches
+  a job that does not inherit from it: `analysis` already declares its own full permission set
+  (`security-events: write`, `id-token: write`, `contents: read`, `actions: read`), and a job-level
+  `permissions:` block replaces the workflow-level one rather than adding to it. Workflow scope is
+  now `{}`.


### PR DESCRIPTION
`permissions: read-all` at workflow scope narrowed to `permissions: {}`.

Safe: job-level `permissions:` **replaces**, not adds to, workflow-level
permissions. The sole job `analysis` already declares its own full set
(`security-events: write`, `id-token: write`, `contents: read`,
`actions: read`) and doesn't rely on inheritance — nothing is taken away.

Per-step need, all present in the untouched job block: checkout ->
`contents: read`; scorecard-action (`publish_results: true`) -> `id-token:
write` + `actions: read`; upload-sarif -> `security-events: write`.

Verified pre-merge (no PR trigger here): `actionlint -shellcheck=` exit 0;
`go run ./scripts/changelogd check` OK; `git diff` touches one line only.

Not verified: real run fires on push/schedule/branch_protection_rule only —
watch job "Scorecard analysis" on the next `main` push.
