### PR TITLE
fix(security): ignore operator-created secret paths in .gitignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,22 @@
 .github
 .local
 
+# The same operator-created class .gitignore covers: the secret key and CA
+# bundle docker-compose.yml has the operator place beside this file, private
+# keys and keystores, and the backup dumps and archives of the backup contract
+# in docs/self-hosted.md. The Dockerfile copies an explicit list and would not
+# reach them anyway, so this keeps them out of the context sent to the daemon
+# rather than out of a layer. `*.sql` is absent on purpose: migrations/ is
+# copied into the build.
+secrets/
+certs/
+backups/
+*.pem
+*.key
+*.p12
+*.pfx
+*.jks
+
 .env
 .env.*
 !.env.example

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,15 @@ docs/screenshots/ovumcy-social-preview.png
 scripts/take-screenshots.mjs
 scripts/record-demo.mjs
 docs/demo.mp4
+
+# Deployment secrets: docker-compose.yml documents mounting these paths as
+# operator-created, file-backed secrets (app secret key, OIDC CA bundle).
+# Ignore the whole class so a locally created secret can't be committed by
+# accident.
+secrets/
+certs/
+*.pem
+*.key
+*.p12
+*.pfx
+*.jks

--- a/.gitignore
+++ b/.gitignore
@@ -63,12 +63,21 @@ scripts/take-screenshots.mjs
 scripts/record-demo.mjs
 docs/demo.mp4
 
-# Deployment secrets: docker-compose.yml documents mounting these paths as
-# operator-created, file-backed secrets (app secret key, OIDC CA bundle).
-# Ignore the whole class so a locally created secret can't be committed by
-# accident.
+# Files the deployment documentation tells the operator to create in the
+# working copy, and which carry a secret or personal data once they exist:
+# the file-backed app secret key and the OIDC CA bundle mounted by
+# docker-compose.yml, private keys and keystores in any of the shapes a
+# reverse-proxy or an identity provider hands out, and the database dumps and
+# volume archives of the backup contract in docs/self-hosted.md, which that
+# document requires be treated as sensitive health data. Ignoring the class is
+# what keeps an inattentive `git add` from committing one.
+#
+# Deliberately NOT `*.sql` or `*.tgz` on their own: migrations/ is tracked SQL,
+# so a bare extension rule would swallow a new migration silently. The backup
+# contract writes into backups/, and that is the path this covers.
 secrets/
 certs/
+backups/
 *.pem
 *.key
 *.p12

--- a/changelog.d/gitignore-covers-operator-secret-paths.md
+++ b/changelog.d/gitignore-covers-operator-secret-paths.md
@@ -1,0 +1,8 @@
+### Security
+
+- **`.gitignore` now covers the secret paths the deployment doc tells the operator to create.**
+  `docker-compose.yml` documents mounting a file-backed app secret key from `./secrets/` and a
+  private OIDC CA bundle from `./certs/`, but neither directory nor the common private-key/keystore
+  extensions (`*.pem`, `*.key`, `*.p12`, `*.pfx`, `*.jks`) were ignored — a secret created by
+  following the compose instructions could be committed by an inattentive `git add`. No such file
+  was ever tracked; this closes the gap before one is.

--- a/changelog.d/gitignore-covers-operator-secret-paths.md
+++ b/changelog.d/gitignore-covers-operator-secret-paths.md
@@ -1,10 +1,14 @@
 ### Security
 
-- **`.gitignore` now covers the secret paths the deployment doc tells the operator to create.**
-  `docker-compose.yml` documents mounting a file-backed app secret key from `./secrets/` and a
-  private OIDC CA bundle from `./certs/`, but neither directory nor the common private-key/keystore
-  extensions (`*.pem`, `*.key`, `*.p12`, `*.pfx`, `*.jks`) were ignored — a secret created by
-  following the compose instructions could be committed by an inattentive `git add`. No file of
-  that class is tracked today, and no tracked file became ignored by the change; whether one was
-  ever added and later removed is a question only a full-history scan answers, and that scan is a
-  release step of its own.
+- **The ignore files now cover the sensitive paths the deployment documentation tells the operator
+  to create.** `docker-compose.yml` has the operator place a file-backed app secret key under
+  `./secrets/` and a private OIDC CA bundle under `./certs/`, and the backup contract writes
+  database dumps and volume archives into `./backups/` while requiring they be treated as sensitive
+  health data — none of those paths, nor the usual private-key and keystore extensions, were
+  ignored, so following the documented procedure left a secret or a dump one inattentive `git add`
+  away from a commit, and inside the context of a local `docker build`. Both `.gitignore` and
+  `.dockerignore` now carry the class. A bare `*.sql` rule is deliberately absent: the tracked
+  migration directory is SQL and is copied into the image, and an extension rule would swallow a
+  new migration without saying so. No file of the class is tracked, and no tracked file became
+  ignored; whether one was ever added and later removed is a question only a full-history scan
+  answers, and that scan is a release step of its own.

--- a/changelog.d/gitignore-covers-operator-secret-paths.md
+++ b/changelog.d/gitignore-covers-operator-secret-paths.md
@@ -4,5 +4,7 @@
   `docker-compose.yml` documents mounting a file-backed app secret key from `./secrets/` and a
   private OIDC CA bundle from `./certs/`, but neither directory nor the common private-key/keystore
   extensions (`*.pem`, `*.key`, `*.p12`, `*.pfx`, `*.jks`) were ignored — a secret created by
-  following the compose instructions could be committed by an inattentive `git add`. No such file
-  was ever tracked; this closes the gap before one is.
+  following the compose instructions could be committed by an inattentive `git add`. No file of
+  that class is tracked today, and no tracked file became ignored by the change; whether one was
+  ever added and later removed is a question only a full-history scan answers, and that scan is a
+  release step of its own.


### PR DESCRIPTION
## Summary
- `docker-compose.yml` tells the operator to mount a secret key from `./secrets/`
  and an OIDC CA bundle from `./certs/`, but neither the directories nor common
  key/keystore extensions were in `.gitignore`.
- Adds `secrets/`, `certs/`, `*.pem`, `*.key`, `*.p12`, `*.pfx`, `*.jks` under a
  short comment naming the reason (operator-created deployment secrets).
- No tracked file matches any of these patterns (verified before landing).

## Test plan
- [x] Repro: dummy files at all 7 paths were visible to git before the fix
      (`check-ignore` exit 1, `status --porcelain` listed them).
- [x] Positive control: same 7 paths ignored after the fix, each naming its
      `.gitignore` rule line, exit 0.
- [x] Negative control: `git ls-files -i -c --exclude-standard` is empty; no
      tracked file (e.g. `README.md`, `docker-compose.yml`) became ignored.
