### PR TITLE
test(bootstrap): scope the wiring guard to the current module's tree

### DIFF
--- a/changelog.d/bootstrap-guard-scans-its-own-module.md
+++ b/changelog.d/bootstrap-guard-scans-its-own-module.md
@@ -1,0 +1,13 @@
+none
+
+Test-only fix: the `TestOnlyBootstrapBuildsRepositories` guard walked the
+entire physical directory tree under the module root, so a nested checkout of
+another repository (or another worktree of this one) sitting under it — with
+its own `go.mod`, its own git marker, and any leftover file that happened to
+contain the exact `db.NewRepositories(` text the guard looks for — made the
+guard fail on an otherwise-unchanged product tree. The walk now stops at any
+directory that is itself the root of a different module or repository
+checkout (its own `go.mod` and/or its own git marker), plus dot-directories
+and `node_modules`, and no longer relies on a hardcoded list of directory
+names. The guard still catches an unwired `db.NewRepositories(` call anywhere
+inside the tracked tree.

--- a/internal/bootstrap/repositories_wiring_guard_test.go
+++ b/internal/bootstrap/repositories_wiring_guard_test.go
@@ -146,8 +146,8 @@ func TestWiringScanCatchesAnUnwiredCallOutsideBootstrap(t *testing.T) {
 
 // TestWiringScanIgnoresANestedRepositoryCheckout reproduces TS-M19: a
 // checkout of another repository (or another worktree of this one) sitting
-// physically under the module root — complete with its own go.mod, its own
-// git marker, and a stale file that happens to contain the exact
+// physically under the module root — carrying its own module or repository
+// marker and a stale file that happens to contain the exact
 // db.NewRepositories( text the guard looks for — must not make the guard
 // fail on an otherwise-unchanged product tree. The nested checkout is a
 // different population; the guard's job is this module's tracked tree only.
@@ -155,11 +155,24 @@ func TestWiringScanIgnoresANestedRepositoryCheckout(t *testing.T) {
 	root := t.TempDir()
 	writeFixtureFile(t, root, "go.mod", "module fixture\n\ngo 1.23\n")
 
-	const nested = "nested-checkout"
-	writeFixtureFile(t, root, filepath.Join(nested, "go.mod"), "module nestedfixture\n\ngo 1.23\n")
-	writeFixtureFile(t, root, filepath.Join(nested, ".git"), "gitdir: ../../.git/worktrees/nested-checkout\n")
-	writeFixtureFile(t, root, filepath.Join(nested, "internal", "old", "stale.go"),
-		"package old\n\nfunc build() {\n\tdb.NewRepositories(nil)\n}\n")
+	// Two markers, and each fixture carries only ONE of them, because either
+	// alone makes a directory a separate population and a fixture carrying
+	// both proves neither check on its own: a worktree of this repository has
+	// a go.mod and a .git pointer file, while a checkout of a project that is
+	// not written in Go has a .git and no go.mod at all.
+	for _, nested := range []struct {
+		what   string
+		dir    string
+		marker string
+		body   string
+	}{
+		{"a nested Go module", "nested-module", "go.mod", "module nestedfixture\n\ngo 1.23\n"},
+		{"a nested checkout that is not a Go module", "nested-checkout", ".git", "gitdir: ../../.git/worktrees/nested-checkout\n"},
+	} {
+		writeFixtureFile(t, root, filepath.Join(nested.dir, nested.marker), nested.body)
+		writeFixtureFile(t, root, filepath.Join(nested.dir, "internal", "old", "stale.go"),
+			"package old\n\nfunc build() {\n\tdb.NewRepositories(nil)\n}\n")
+	}
 
 	result, err := scanRepositoryWiring(root)
 	if err != nil {

--- a/internal/bootstrap/repositories_wiring_guard_test.go
+++ b/internal/bootstrap/repositories_wiring_guard_test.go
@@ -23,14 +23,45 @@ import (
 func TestOnlyBootstrapBuildsRepositories(t *testing.T) {
 	root := repositoryRoot(t)
 
-	var offenders []string
-	found := 0
+	result, err := scanRepositoryWiring(root)
+	if err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+
+	// Anti-vacuity: this package's own call must be among the matches, or the
+	// scan found nothing for a reason that has nothing to do with the rule.
+	if result.found == 0 {
+		t.Fatal("the scan matched no production call to db.NewRepositories at all, including this package's own: it is measuring nothing")
+	}
+
+	if len(result.offenders) > 0 {
+		t.Fatalf("these build repositories without the calendar-feed restore fence, so their feed writes leave no record a backup restore cannot undo — call bootstrap.BuildRepositories instead: %v", result.offenders)
+	}
+}
+
+// wiringScanResult is the population scanRepositoryWiring judged: how many
+// production call sites it matched, and which of those lie outside the one
+// constructor allowed to hold them.
+type wiringScanResult struct {
+	found     int
+	offenders []string
+}
+
+// scanRepositoryWiring walks root — the tracked tree of a single Go module —
+// for production (non-test) Go source calling db.NewRepositories(, and
+// reports every call site that is not in internal/bootstrap.
+//
+// root is a parameter, rather than always repositoryRoot(t), so the walk and
+// its filtering can be exercised directly against a fixture, independent of
+// this repository's own tree.
+func scanRepositoryWiring(root string) (wiringScanResult, error) {
+	var result wiringScanResult
 	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 		if entry.IsDir() {
-			if name := entry.Name(); name == ".git" || name == "node_modules" || name == ".tmp" {
+			if path != root && isOutsideTrackedTree(path, entry) {
 				return filepath.SkipDir
 			}
 			return nil
@@ -45,29 +76,112 @@ func TestOnlyBootstrapBuildsRepositories(t *testing.T) {
 		if !strings.Contains(string(source), "db.NewRepositories(") {
 			return nil
 		}
-		found++
+		result.found++
 		relative, err := filepath.Rel(root, path)
 		if err != nil {
 			return err
 		}
 		if filepath.ToSlash(filepath.Dir(relative)) != "internal/bootstrap" {
-			offenders = append(offenders, filepath.ToSlash(relative))
+			result.offenders = append(result.offenders, filepath.ToSlash(relative))
 		}
 		return nil
 	})
+	sort.Strings(result.offenders)
+	return result, err
+}
+
+// isOutsideTrackedTree reports whether directory path lies outside the
+// tracked tree of the module the walk started in: a dot-directory
+// (build/tooling state — .git, .tmp, an editor's or another agent's own
+// dotfile area — never part of the tracked source tree), a node_modules
+// vendor tree, or a directory that is itself the root of a *different*
+// module or repository checkout nested under this one.
+//
+// The last case is judged by property, not by name: a directory carrying
+// its own go.mod and/or its own git marker is a separate population — a
+// worktree's ".git" is a regular file (a "gitdir:" pointer), not a
+// directory, so what is checked is presence, not directory-ness. A
+// hardcoded list of nested-checkout directory names would be the same
+// defect in a new wrapper; this checks what makes a directory a module or
+// repository root, not what it happens to be called.
+func isOutsideTrackedTree(path string, entry fs.DirEntry) bool {
+	if strings.HasPrefix(entry.Name(), ".") {
+		return true
+	}
+	if entry.Name() == "node_modules" {
+		return true
+	}
+	if _, err := os.Stat(filepath.Join(path, "go.mod")); err == nil {
+		return true
+	}
+	if _, err := os.Stat(filepath.Join(path, ".git")); err == nil {
+		return true
+	}
+	return false
+}
+
+// TestWiringScanCatchesAnUnwiredCallOutsideBootstrap is the guard's positive
+// control: nested-checkout filtering must not have quietly disabled
+// detection of a real violation living inside the tracked tree itself.
+func TestWiringScanCatchesAnUnwiredCallOutsideBootstrap(t *testing.T) {
+	root := t.TempDir()
+	writeFixtureFile(t, root, "go.mod", "module fixture\n\ngo 1.23\n")
+	writeFixtureFile(t, root, filepath.Join("internal", "bootstrap", "repositories.go"),
+		"package bootstrap\n\nfunc BuildRepositories() {\n\tdb.NewRepositories(nil)\n}\n")
+	writeFixtureFile(t, root, filepath.Join("internal", "api", "handlers.go"),
+		"package api\n\nfunc unwired() {\n\tdb.NewRepositories(nil)\n}\n")
+
+	result, err := scanRepositoryWiring(root)
 	if err != nil {
-		t.Fatalf("walk %s: %v", root, err)
+		t.Fatalf("scanRepositoryWiring(%s): %v", root, err)
 	}
-
-	// Anti-vacuity: this package's own call must be among the matches, or the
-	// scan found nothing for a reason that has nothing to do with the rule.
-	if found == 0 {
-		t.Fatal("the scan matched no production call to db.NewRepositories at all, including this package's own: it is measuring nothing")
+	if result.found != 2 {
+		t.Fatalf("found = %d, want 2 (one wired in internal/bootstrap, one unwired in internal/api)", result.found)
 	}
+	if len(result.offenders) != 1 || result.offenders[0] != "internal/api/handlers.go" {
+		t.Fatalf("offenders = %v, want exactly [internal/api/handlers.go]: the guard must still catch a real violation inside the tracked tree", result.offenders)
+	}
+}
 
-	sort.Strings(offenders)
-	if len(offenders) > 0 {
-		t.Fatalf("these build repositories without the calendar-feed restore fence, so their feed writes leave no record a backup restore cannot undo — call bootstrap.BuildRepositories instead: %v", offenders)
+// TestWiringScanIgnoresANestedRepositoryCheckout reproduces TS-M19: a
+// checkout of another repository (or another worktree of this one) sitting
+// physically under the module root — complete with its own go.mod, its own
+// git marker, and a stale file that happens to contain the exact
+// db.NewRepositories( text the guard looks for — must not make the guard
+// fail on an otherwise-unchanged product tree. The nested checkout is a
+// different population; the guard's job is this module's tracked tree only.
+func TestWiringScanIgnoresANestedRepositoryCheckout(t *testing.T) {
+	root := t.TempDir()
+	writeFixtureFile(t, root, "go.mod", "module fixture\n\ngo 1.23\n")
+
+	const nested = "nested-checkout"
+	writeFixtureFile(t, root, filepath.Join(nested, "go.mod"), "module nestedfixture\n\ngo 1.23\n")
+	writeFixtureFile(t, root, filepath.Join(nested, ".git"), "gitdir: ../../.git/worktrees/nested-checkout\n")
+	writeFixtureFile(t, root, filepath.Join(nested, "internal", "old", "stale.go"),
+		"package old\n\nfunc build() {\n\tdb.NewRepositories(nil)\n}\n")
+
+	result, err := scanRepositoryWiring(root)
+	if err != nil {
+		t.Fatalf("scanRepositoryWiring(%s): %v", root, err)
+	}
+	if len(result.offenders) != 0 {
+		t.Fatalf("scan reported %v from inside a nested repository checkout, a population it must not judge", result.offenders)
+	}
+	if result.found != 0 {
+		t.Fatalf("scan counted %d match(es) inside a nested repository checkout; it should never have descended into it", result.found)
+	}
+}
+
+// writeFixtureFile creates relative (and any missing parent directories)
+// under root with the given content, for building walk fixtures.
+func writeFixtureFile(t *testing.T, root, relative, content string) {
+	t.Helper()
+	full := filepath.Join(root, relative)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(full), err)
+	}
+	if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", full, err)
 	}
 }
 

--- a/internal/bootstrap/repositories_wiring_guard_test.go
+++ b/internal/bootstrap/repositories_wiring_guard_test.go
@@ -91,11 +91,12 @@ func scanRepositoryWiring(root string) (wiringScanResult, error) {
 }
 
 // isOutsideTrackedTree reports whether directory path lies outside the
-// tracked tree of the module the walk started in: a dot-directory
-// (build/tooling state — .git, .tmp, an editor's or another agent's own
-// dotfile area — never part of the tracked source tree), a node_modules
-// vendor tree, or a directory that is itself the root of a *different*
-// module or repository checkout nested under this one.
+// population this guard judges — the Go source of the module the walk
+// started in: a dot-directory (build, tooling or editor state; a tracked
+// one such as .github carries no Go source, so none of them can hold a
+// call site this guard is about), a node_modules vendor tree, or a
+// directory that is itself the root of a *different* module or repository
+// checkout nested under this one.
 //
 // The last case is judged by property, not by name: a directory carrying
 // its own go.mod and/or its own git marker is a separate population — a


### PR DESCRIPTION
Wrong: `TestOnlyBootstrapBuildsRepositories` walked every physical directory
under the module root, so a nested checkout of another repository or
worktree — its own `go.mod`, its own git marker, plus any leftover file
matching `db.NewRepositories(` — made the guard fail on an unchanged product
tree.

Changed: the walk is now bounded to the current module's tracked tree —
extracted into `scanRepositoryWiring`/`isOutsideTrackedTree`, parameterized
on root so a fixture can drive it. A directory is out of scope if it is a
dot-directory, `node_modules`, or itself the root of a different module or
repository checkout (own `go.mod` and/or own git marker) — judged by
property, never a hardcoded name list.

Risk: test-only; no production code path changed.

Verified: repro (red) on the unfixed filtering with a nested-checkout
fixture, fix turns it green, gutted-fix reproduces the exact red, a second
fixture proves the guard still catches a real unwired call inside the
tracked tree, `go test ./internal/bootstrap/ -count=1` and
`golangci-lint run ./internal/bootstrap/...` both clean.
