### PR TITLE
test(ci): required environment checks fail closed instead of skipping quiet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -838,6 +838,16 @@ jobs:
         # internal/services is NOT here: it is sharded in race-services above.
         # These four trees ran 100 s of the lane's 589 s together, so they stay
         # whole — splitting them would buy nothing and cost a job.
+        #
+        # No OVUMCY_REQUIRE_POSTGRES here, deliberately, and it is not an
+        # oversight to be tidied up: internal/db and internal/i18n do reach
+        # internal/testdb's gate, so a broken database would skip those cases
+        # quietly on this lane. test-go-rest OWNS that suite and declares the
+        # variable; a lane declares what it owns, and this one only brushes it.
+        # Declaring it here would instead start running container-backed tests
+        # under the race detector on a required lane — real added cost and a
+        # new failure surface, bought for a verdict test-go-rest already gives
+        # on the same commit.
         env:
           CGO_ENABLED: "1"
         # `-timeout 20m`: the declared budget from the coverage lanes above.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,18 @@ jobs:
     if: ${{ !cancelled() && needs.changes.outputs.run_unit != 'false' }}
     permissions:
       contents: read
+
+    # internal/api carries the timezone/zoneinfo regressions (calendar,
+    # export, day-upsert canonicalization); scripts/racepartition splits this
+    # package's tests by NAME across the three shards below, so any shard may
+    # draw one. Without this variable a runner whose tzdata is missing or
+    # broken SKIPS them instead of failing, and no job here asserted they ran
+    # — see internal/testenv's OVUMCY_REQUIRE_TZDATA gate. The ubuntu runner
+    # always ships tzdata, so an absence here is a broken runner, never a
+    # legitimate developer-host allowance.
+    env:
+      OVUMCY_REQUIRE_TZDATA: "1"
+
     outputs:
       # coverage-merge has to know how many profiles it is owed, and the shard
       # count lives in exactly ONE place: the matrix below. Every shard writes
@@ -168,8 +180,24 @@ jobs:
     # test-go-shard — a lane with no Postgres test would only be asserting
     # something about a suite it does not run — and it is absent from a
     # developer machine, where no docker still means "not my test to run".
+    #
+    # This is also the only lane that runs scripts/releasegate,
+    # scripts/backuprestoredoc and scripts/changelogd (via `go list
+    # ./scripts/...` below) and the whole of internal/services — the bash the
+    # release gate's and the runbook's own scripts run under, the docker the
+    # runbook's named-volume commands and the docker-image build both compose
+    # a step so the postgres/docker overlap; the git changelogd's fixture repo
+    # builds; and the tzdata every cycle/day timezone regression in
+    # internal/services loads. The ubuntu runner ships all four; an absence
+    # here means the runner is broken, not that a developer skipped a tool
+    # they were never going to install. See internal/testenv for the shared
+    # gate these variables arm (OVUMCY_REQUIRE_<RESOURCE>, one switch each).
     env:
       OVUMCY_REQUIRE_POSTGRES: "1"
+      OVUMCY_REQUIRE_BASH: "1"
+      OVUMCY_REQUIRE_DOCKER: "1"
+      OVUMCY_REQUIRE_GIT: "1"
+      OVUMCY_REQUIRE_TZDATA: "1"
 
     steps:
       - name: Checkout
@@ -721,6 +749,15 @@ jobs:
     if: ${{ !cancelled() && needs.changes.outputs.run_race != 'false' }}
     permissions:
       contents: read
+
+    # internal/services carries the tz/zoneinfo cycle regressions, split by
+    # name across the shards below exactly as test-go-shard splits
+    # internal/api — any shard may draw one. Same reasoning as test-go-shard's
+    # OVUMCY_REQUIRE_TZDATA: the ubuntu runner always has tzdata, so its
+    # absence here is a broken runner.
+    env:
+      OVUMCY_REQUIRE_TZDATA: "1"
+
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,15 +183,24 @@ jobs:
     #
     # This is also the only lane that runs scripts/releasegate,
     # scripts/backuprestoredoc and scripts/changelogd (via `go list
-    # ./scripts/...` below) and the whole of internal/services — the bash the
-    # release gate's and the runbook's own scripts run under, the docker the
-    # runbook's named-volume commands and the docker-image build both compose
-    # a step so the postgres/docker overlap; the git changelogd's fixture repo
-    # builds; and the tzdata every cycle/day timezone regression in
-    # internal/services loads. The ubuntu runner ships all four; an absence
-    # here means the runner is broken, not that a developer skipped a tool
-    # they were never going to install. See internal/testenv for the shared
-    # gate these variables arm (OVUMCY_REQUIRE_<RESOURCE>, one switch each).
+    # ./scripts/...` below) and the whole of internal/services, and each of the
+    # four resources below is owed by one of them:
+    #
+    #   bash    — the release gate's own script and the runbook's documented
+    #             commands are run through a shell, not reassembled as argv.
+    #   docker  — the runbook's named-volume backup and restore commands are
+    #             executed for real, against real volumes. This lane is where
+    #             they belong because it is the one already provisioned for
+    #             containers (OVUMCY_REQUIRE_POSTGRES above); declaring docker
+    #             on a lane that has none would assert a check nothing runs.
+    #   git     — changelogd builds a fixture repository to probe against.
+    #   tzdata  — every cycle/day timezone regression in internal/services
+    #             loads an IANA zone.
+    #
+    # The ubuntu runner ships all four, so an absence here means the runner is
+    # broken, not that a developer skipped a tool they were never going to
+    # install. See internal/testenv for the shared gate these variables arm
+    # (OVUMCY_REQUIRE_<RESOURCE>, one switch each).
     env:
       OVUMCY_REQUIRE_POSTGRES: "1"
       OVUMCY_REQUIRE_BASH: "1"

--- a/changelog.d/test-required-environment-fails-closed.md
+++ b/changelog.d/test-required-environment-fails-closed.md
@@ -1,0 +1,11 @@
+### Internal
+
+- **A required CI check can no longer disappear behind a `t.Skipf`.** `bash`/`docker`/`git`
+  absence and a missing tz database were skipped identically to an operational failure — bash
+  answering garbage, docker's daemon not responding, git exiting non-zero, zoneinfo parsing wrong —
+  so a misconfigured runner reported the same quiet green as a developer machine that never
+  installed the tool. `internal/testenv` now gives every site one fail-closed switch per resource
+  (`OVUMCY_REQUIRE_BASH`/`DOCKER`/`GIT`/`TZDATA`), armed on the lane that owns each check in
+  `ci.yml`: absence skips only where the lane never declared the resource mandatory, and an
+  operational error always fails, on every machine. `dashboard_today_request_timezone_regression_test.go`'s
+  previously unconditional `t.Skip` is now the same conditional absence check as the rest.

--- a/internal/api/calendar_negative_offset_timezone_regression_test.go
+++ b/internal/api/calendar_negative_offset_timezone_regression_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/ovumcy/ovumcy-web/internal/services"
+	"github.com/ovumcy/ovumcy-web/internal/testenv"
 )
 
 // TestCycleStartSavedWithoutTimezoneRendersOnLocalDayInNegativeOffset
@@ -29,10 +30,7 @@ import (
 // day that was originally posted to the server, regardless of the viewer's
 // locale.
 func TestCycleStartSavedWithoutTimezoneRendersOnLocalDayInNegativeOffset(t *testing.T) {
-	location, err := time.LoadLocation("America/Toronto")
-	if err != nil {
-		t.Skipf("zoneinfo for America/Toronto unavailable: %v", err)
-	}
+	location := testenv.RequireTimeZone(t, "America/Toronto")
 
 	app, database, _ := newOnboardingTestAppWithLocation(t, time.UTC)
 	user := createOnboardingTestUser(t, database, "tz-negative-offset@example.com", "StrongPass1", true)

--- a/internal/api/dashboard_today_request_timezone_regression_test.go
+++ b/internal/api/dashboard_today_request_timezone_regression_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gofiber/fiber/v3"
 	"github.com/ovumcy/ovumcy-web/internal/models"
 	"github.com/ovumcy/ovumcy-web/internal/services"
+	"github.com/ovumcy/ovumcy-web/internal/testenv"
 )
 
 func TestBuildDashboardViewDataKeepsMarchThreeAtUTCBoundary(t *testing.T) {
@@ -164,6 +165,6 @@ func timezoneWithDifferentCalendarDay(t *testing.T, nowUTC time.Time) (string, *
 		}
 	}
 
-	t.Skip("timezone data unavailable for different-calendar-day regression")
+	testenv.SkipUnlessRequired(t, "tzdata", "timezone data unavailable for different-calendar-day regression: none of %v resolved a day different from UTC", candidates)
 	return "", nil
 }

--- a/internal/api/day_upsert_canonicalization_regression_test.go
+++ b/internal/api/day_upsert_canonicalization_regression_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gofiber/fiber/v3"
 	"github.com/ovumcy/ovumcy-web/internal/models"
+	"github.com/ovumcy/ovumcy-web/internal/testenv"
 )
 
 // TestUpsertDayCanonicalizesStoredDateToUTCMidnightForRequestTimezone is the
@@ -34,10 +35,7 @@ func TestUpsertDayCanonicalizesStoredDateToUTCMidnightForRequestTimezone(t *test
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			location, err := time.LoadLocation(tt.timezoneName)
-			if err != nil {
-				t.Skipf("zoneinfo for %s unavailable: %v", tt.timezoneName, err)
-			}
+			location := testenv.RequireTimeZone(t, tt.timezoneName)
 
 			app, database, _ := newOnboardingTestAppWithLocation(t, time.UTC)
 			user := createOnboardingTestUser(t, database, tt.email, "StrongPass1", true)

--- a/internal/api/export_regressions_test.go
+++ b/internal/api/export_regressions_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gofiber/fiber/v3"
 	"github.com/ovumcy/ovumcy-web/internal/models"
 	"github.com/ovumcy/ovumcy-web/internal/services"
+	"github.com/ovumcy/ovumcy-web/internal/testenv"
 )
 
 func TestExportCSVRespectsRequestedDateRange(t *testing.T) {
@@ -428,10 +429,7 @@ func TestExportSummaryUsesRequestTimezoneForRangeParsing(t *testing.T) {
 	app, database := newOnboardingTestApp(t)
 	user := createOnboardingTestUser(t, database, "export-summary-timezone@example.com", "StrongPass1", true)
 
-	location, err := time.LoadLocation("Pacific/Kiritimati")
-	if err != nil {
-		t.Skipf("load Pacific/Kiritimati timezone: %v", err)
-	}
+	location := testenv.RequireTimeZone(t, "Pacific/Kiritimati")
 
 	localDay := time.Date(2026, time.March, 13, 0, 0, 0, 0, location)
 	if err := database.Create(&models.DailyLog{

--- a/internal/reminders/next_run_test.go
+++ b/internal/reminders/next_run_test.go
@@ -3,18 +3,17 @@ package reminders
 import (
 	"testing"
 	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/testenv"
 )
 
-// mustLoadLocation loads an IANA zone or skips the test when the platform lacks
-// the tz database (some minimal Windows dev boxes). The Linux runtime that ships
-// always has it, and CI validates there.
+// mustLoadLocation loads an IANA zone, skipping only on a genuine absence of
+// the tz database (some minimal Windows dev boxes) — and failing instead on a
+// lane that set OVUMCY_REQUIRE_TZDATA, since the Linux runtime that ships
+// always has it and CI is meant to validate there.
 func mustLoadLocation(t *testing.T, name string) *time.Location {
 	t.Helper()
-	loc, err := time.LoadLocation(name)
-	if err != nil {
-		t.Skipf("timezone %q unavailable on this platform: %v", name, err)
-	}
-	return loc
+	return testenv.RequireTimeZone(t, name)
 }
 
 // TestNextRunBasicSameDayAndRollover covers the non-DST core: when the target

--- a/internal/services/cycle_baseline_coverage_test.go
+++ b/internal/services/cycle_baseline_coverage_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/ovumcy/ovumcy-web/internal/models"
+	"github.com/ovumcy/ovumcy-web/internal/testenv"
 )
 
 // cyclebaselineCovOwner builds a minimal RoleOwner user with the supplied
@@ -317,10 +318,7 @@ func TestCycleBaseline_ProjectCycleStartRollsToNewCycleAcrossDST(t *testing.T) {
 	// 28*24-1h span to 27 elapsed days, so it reported cycleDay 28 of the SAME
 	// cycle instead of rolling over. CalendarDaysBetween yields the true 28
 	// elapsed days, so the projection advances to the new cycle at day 1.
-	loc, err := time.LoadLocation("Europe/Berlin")
-	if err != nil {
-		t.Skipf("tz database unavailable: %v", err)
-	}
+	loc := testenv.RequireTimeZone(t, "Europe/Berlin")
 	lp := time.Date(2026, time.March, 15, 0, 0, 0, 0, loc)
 	today := time.Date(2026, time.April, 12, 0, 0, 0, 0, loc)
 

--- a/internal/services/cycle_bounds_and_day_diff_test.go
+++ b/internal/services/cycle_bounds_and_day_diff_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/ovumcy/ovumcy-web/internal/models"
+	"github.com/ovumcy/ovumcy-web/internal/testenv"
 )
 
 // TestCycleLengthsCountsCalendarDaysAcrossADSTTransition pins the arithmetic at
@@ -18,22 +19,18 @@ import (
 // The same shortfall shows up with no transition involved whenever one operand
 // is a location midnight and the other a UTC one.
 //
-// A missing zone database SKIPS this test rather than failing it, which is the
-// answer the other five tz-dependent tests in this package already give
-// (cycle_baseline_coverage_test.go, cycle_projection_reference_test.go,
-// cycle_signals_mutation_round2_test.go, dashboard_cycle_test.go,
-// dashboard_reminder_banner_test.go). The module imports time/tzdata nowhere, so
-// zones come from the host: on one without zoneinfo this demonstration goes
-// quiet. What does NOT go quiet there is TestCalendarDayDiffBarrier, which reads
-// the source rather than the clock and refuses the shape with no zone database
-// at all — so the class stays barred even where this proof of it cannot run.
+// A missing zone database SKIPS this test on a developer machine — the same
+// answer the other tz-dependent tests in this package give, all routed
+// through testenv.RequireTimeZone — and FAILS it on a lane that set
+// OVUMCY_REQUIRE_TZDATA. The module imports time/tzdata nowhere, so zones come
+// from the host. What never goes quiet, on any machine, is
+// TestCalendarDayDiffBarrier, which reads the source rather than the clock
+// and refuses the shape with no zone database at all — so the class stays
+// barred even where this proof of it cannot run.
 func TestCycleLengthsCountsCalendarDaysAcrossADSTTransition(t *testing.T) {
 	t.Parallel()
 
-	berlin, err := time.LoadLocation("Europe/Berlin")
-	if err != nil {
-		t.Skipf("tz database unavailable: %v", err)
-	}
+	berlin := testenv.RequireTimeZone(t, "Europe/Berlin")
 
 	starts := []time.Time{
 		time.Date(2026, time.March, 28, 0, 0, 0, 0, berlin),

--- a/internal/services/cycle_luteal_round_trip_test.go
+++ b/internal/services/cycle_luteal_round_trip_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/ovumcy/ovumcy-web/internal/models"
+	"github.com/ovumcy/ovumcy-web/internal/testenv"
 )
 
 // The round-trip invariant pinned here: an ovulation OBSERVED on cycle day N
@@ -236,10 +237,7 @@ func TestInferredLutealPhaseRoundTripsAcrossDSTAndTimezones(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			location, err := time.LoadLocation(testCase.zone)
-			if err != nil {
-				t.Skipf("tz database unavailable for %q: %v", testCase.zone, err)
-			}
+			location := testenv.RequireTimeZone(t, testCase.zone)
 
 			logs := lutealRoundTripLogs(t, testCase.origin, cycleLength, []int{testCase.observed, testCase.observed}, testCase.kind)
 			nextCycleStart := CalendarDay(testCase.origin.AddDate(0, 0, 2*cycleLength), location)

--- a/internal/services/cycle_projection_reference_test.go
+++ b/internal/services/cycle_projection_reference_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/testenv"
 )
 
 // This file consumes the ADDITIVE "projection" section of the shared
@@ -91,11 +93,7 @@ func projectionLocation(t *testing.T, name string) *time.Location {
 	if name == "" || name == "UTC" {
 		return time.UTC
 	}
-	loc, err := time.LoadLocation(name)
-	if err != nil {
-		t.Skipf("tz database unavailable for %q: %v", name, err)
-	}
-	return loc
+	return testenv.RequireTimeZone(t, name)
 }
 
 // projectionDate parses a fixture "YYYY-MM-DD" as midnight in loc, matching how

--- a/internal/services/cycle_signals_mutation_round2_test.go
+++ b/internal/services/cycle_signals_mutation_round2_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/ovumcy/ovumcy-web/internal/models"
+	"github.com/ovumcy/ovumcy-web/internal/testenv"
 )
 
 func TestCycleSignals_InferUserLutealPhase_UnchangedByDSTTransitionInCycle(t *testing.T) {
@@ -18,10 +19,7 @@ func TestCycleSignals_InferUserLutealPhase_UnchangedByDSTTransitionInCycle(t *te
 	// 19*24-1h cycle span down to 18 in Toronto and drag the inferred phase to
 	// 12 there while UTC saw 13 — a location-dependent skew this test guards
 	// against.
-	loc, err := time.LoadLocation("America/Toronto")
-	if err != nil {
-		t.Skipf("tz database unavailable: %v", err)
-	}
+	loc := testenv.RequireTimeZone(t, "America/Toronto")
 	day := func(s string) time.Time { return cyclesignalsCovDay(t, s) }
 
 	logs := []models.DailyLog{

--- a/internal/services/dashboard_cycle_test.go
+++ b/internal/services/dashboard_cycle_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/ovumcy/ovumcy-web/internal/models"
+	"github.com/ovumcy/ovumcy-web/internal/testenv"
 )
 
 func TestDashboardCycleReferenceLengthPrefersObservedAverage(t *testing.T) {
@@ -49,10 +50,7 @@ func TestCompletedCycleTrendLengths(t *testing.T) {
 // to UTC-midnight and yields the true 28, agreeing with CycleLengths (which
 // operates on UTC-midnight starts and is immune to the location skew).
 func TestCompletedCycleTrendLengthsDSTSpringForward(t *testing.T) {
-	loc, err := time.LoadLocation("Europe/Berlin")
-	if err != nil {
-		t.Skipf("tz database unavailable: %v", err)
-	}
+	loc := testenv.RequireTimeZone(t, "Europe/Berlin")
 
 	logs := []models.DailyLog{
 		{Date: mustParseDashboardDay(t, "2026-03-15"), IsPeriod: true},

--- a/internal/services/dashboard_reminder_banner_test.go
+++ b/internal/services/dashboard_reminder_banner_test.go
@@ -3,6 +3,8 @@ package services
 import (
 	"testing"
 	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/testenv"
 )
 
 // TestDashboardReminderBannerDaysUntilDSTSpringForward guards the day count
@@ -12,10 +14,7 @@ import (
 // int(predictedDate.Sub(today).Hours()/24) truncated to 1. CalendarDaysBetween
 // re-anchors both to UTC-midnight and reports the true 2 days.
 func TestDashboardReminderBannerDaysUntilDSTSpringForward(t *testing.T) {
-	loc, err := time.LoadLocation("Europe/Berlin")
-	if err != nil {
-		t.Skipf("tz database unavailable: %v", err)
-	}
+	loc := testenv.RequireTimeZone(t, "Europe/Berlin")
 	today := time.Date(2026, time.March, 28, 0, 0, 0, 0, loc)
 	predicted := time.Date(2026, time.March, 30, 0, 0, 0, 0, loc)
 

--- a/internal/services/day_canonicalization_regression_test.go
+++ b/internal/services/day_canonicalization_regression_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/ovumcy/ovumcy-web/internal/models"
+	"github.com/ovumcy/ovumcy-web/internal/testenv"
 	"gorm.io/gorm"
 )
 
@@ -33,14 +34,8 @@ func TestDayServiceUpsertCanonicalizesDateToUTCMidnightPostgres(t *testing.T) {
 func runDayServiceUpsertCanonicalizesDateToUTCMidnight(t *testing.T, setup func(*testing.T) (*DayService, *gorm.DB), emailPrefix string) {
 	t.Helper()
 
-	toronto, err := time.LoadLocation("America/Toronto")
-	if err != nil {
-		t.Skipf("zoneinfo for America/Toronto unavailable: %v", err)
-	}
-	tokyo, err := time.LoadLocation("Asia/Tokyo")
-	if err != nil {
-		t.Skipf("zoneinfo for Asia/Tokyo unavailable: %v", err)
-	}
+	toronto := testenv.RequireTimeZone(t, "America/Toronto")
+	tokyo := testenv.RequireTimeZone(t, "Asia/Tokyo")
 
 	tests := []struct {
 		name     string
@@ -119,14 +114,8 @@ func TestDayServiceConsecutiveUpsertsUpdateSameRowAcrossTimezonesPostgres(t *tes
 func runDayServiceConsecutiveUpsertsUpdateSameRowAcrossTimezones(t *testing.T, setup func(*testing.T) (*DayService, *gorm.DB), emailPrefix string) {
 	t.Helper()
 
-	toronto, err := time.LoadLocation("America/Toronto")
-	if err != nil {
-		t.Skipf("zoneinfo for America/Toronto unavailable: %v", err)
-	}
-	tokyo, err := time.LoadLocation("Asia/Tokyo")
-	if err != nil {
-		t.Skipf("zoneinfo for Asia/Tokyo unavailable: %v", err)
-	}
+	toronto := testenv.RequireTimeZone(t, "America/Toronto")
+	tokyo := testenv.RequireTimeZone(t, "Asia/Tokyo")
 
 	tests := []struct {
 		name     string

--- a/internal/testenv/testenv.go
+++ b/internal/testenv/testenv.go
@@ -159,7 +159,19 @@ func tzErrorIsAbsence(err error) bool {
 func RequireTimeZone(t TestingT, name string) *time.Location {
 	t.Helper()
 
-	location, err := time.LoadLocation(name)
+	return requireTimeZone(t, name, time.LoadLocation)
+}
+
+// requireTimeZone takes the loader as an argument for the same reason
+// tzErrorIsAbsence is a named function: the corrupt-database branch below
+// cannot be provoked through time.LoadLocation without shipping a broken tz
+// database, and a dispatch on that classification that no test ever executes
+// is the unexamined judgement this package exists to replace. Only the tests
+// pass anything but time.LoadLocation.
+func requireTimeZone(t TestingT, name string, load func(string) (*time.Location, error)) *time.Location {
+	t.Helper()
+
+	location, err := load(name)
 	if err != nil {
 		// time.LoadLocation reports an absent zone and a corrupt tz database
 		// through the same error type, and only the wording separates them:

--- a/internal/testenv/testenv.go
+++ b/internal/testenv/testenv.go
@@ -1,0 +1,158 @@
+// Package testenv gives every test package one shared answer to the same
+// question: a test that cannot find a resource it needs — a binary on PATH,
+// the tz database — is answering "is it absent" and "did it misbehave once
+// found" with the SAME t.Skipf, and only the first of those two may ever
+// legitimately skip.
+//
+// An absence is a legitimate skip on a developer machine, and a failure on a
+// lane that declared the resource mandatory (SkipUnlessRequired). An
+// operational error — the resource was found but answered wrong, or a
+// daemon behind it did not respond — is always a failure, on every machine,
+// because a check that "ran" without actually exercising what it claims
+// proves nothing either way (Fail). Conflating the two into one t.Skipf is
+// exactly what lets a required check disappear under a misconfigured runner:
+// the runner reports a broken tool the same way a developer machine reports
+// one it never installed.
+//
+// Adapted from two mechanisms already in this tree: internal/testdb's
+// OVUMCY_REQUIRE_POSTGRES gate (the fail-closed env-var reading, and the rule
+// that only the docker-absent preflight may skip while every later docker
+// error fails), and scripts/publishorder's requireShellTool (verifying a
+// shell binary by running it through the same shell that will use it, not by
+// exec.LookPath alone — the check has to say the right thing, not merely
+// answer at all).
+package testenv
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// TestingT is the slice of *testing.T the helpers below need. A production
+// *testing.T satisfies it unchanged; a package's own tests can substitute a
+// recorder to observe which verdict a probe reaches without arming a real
+// skip or failure (Fatalf and Skipf never return on a real *testing.T).
+type TestingT interface {
+	Helper()
+	Fatalf(format string, args ...any)
+	Skipf(format string, args ...any)
+}
+
+// RequireEnv derives the fail-closed switch a lane sets to declare a resource
+// mandatory: RequireEnv("docker") is "OVUMCY_REQUIRE_DOCKER". A resource name
+// and its env var are always this one mechanical mapping, so a lane's
+// declaration in ci.yml and a test's probe can never drift into two
+// different spellings of the same gate.
+func RequireEnv(resource string) string {
+	return "OVUMCY_REQUIRE_" + strings.ToUpper(resource)
+}
+
+// IsRequired reports whether `resource` is mandatory on this lane, read
+// fail-closed: anything other than absent, empty, "0" or "false" arms it, so
+// an unexpected value — a typo, a future spelling of "no" — never silently
+// disarms a required resource; that would restore the exact silence this
+// package exists to remove, invisibly.
+func IsRequired(resource string) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(RequireEnv(resource)))) {
+	case "", "0", "false":
+		return false
+	default:
+		return true
+	}
+}
+
+// SkipUnlessRequired is the only function in this package that may skip a
+// test, and it may be called only for a genuine ABSENCE of `resource` — the
+// tool is not on PATH, the data is not installed. An operational error (the
+// resource was found but misbehaved) must never reach this function; call
+// Fail for that instead. If the owning lane declared `resource` required via
+// its RequireEnv variable, the same absence becomes a failure rather than a
+// quiet skip, because a lane that promised the check ran cannot report green
+// for one that never did.
+func SkipUnlessRequired(t TestingT, resource, format string, args ...any) {
+	t.Helper()
+
+	reason := fmt.Sprintf(format, args...)
+	if IsRequired(resource) {
+		t.Fatalf("%s is set, so a skipped %s check is a failure: %s", RequireEnv(resource), resource, reason)
+		return
+	}
+	t.Skipf("%s", reason)
+}
+
+// Fail always fails and never skips: call it once `resource` was found but
+// did not behave — a non-zero exit, garbage output, a daemon that never
+// answered. An operational error is a failure on every machine, whatever the
+// owning lane declared, because "found but broken" is never a legitimate
+// developer-host absence.
+func Fail(t TestingT, format string, args ...any) {
+	t.Helper()
+	t.Fatalf(format, args...)
+}
+
+// RequireLookPath resolves `name` on PATH and applies SkipUnlessRequired's
+// absence semantics on failure, returning the resolved path on success. It
+// answers only "is the binary there", never "does it work" — pair it with a
+// functional probe (ProbeShell below, for a shell) before trusting the
+// binary it found.
+func RequireLookPath(t TestingT, resource, name string) string {
+	t.Helper()
+
+	path, err := exec.LookPath(name)
+	if err != nil {
+		SkipUnlessRequired(t, resource, "%s is required: %v", name, err)
+		return ""
+	}
+	return path
+}
+
+// ProbeShell checks that a shell resolved by RequireLookPath actually runs
+// scripts the way the caller needs, by executing `probe` through it and
+// comparing the trimmed output to `want`. Windows ships shells that answer a
+// PATH lookup and then do the wrong thing once invoked — a WSL launcher stub
+// with no distro installed, a store-advertisement stand-in for python3 — so a
+// tool that does not run, or answers wrong, is an OPERATIONAL error and
+// always fails, regardless of what the owning lane declared: the resource was
+// found, so its absence never applies.
+func ProbeShell(t TestingT, shellPath, probe, want string) {
+	t.Helper()
+
+	output, err := exec.Command(shellPath, "-c", probe).Output() // #nosec G204 -- shellPath comes from RequireLookPath's exec.LookPath, and probe is always a compile-time literal supplied by the caller, never external input.
+	got := strings.TrimSpace(string(output))
+
+	switch {
+	case err != nil:
+		Fail(t, "%s -c %q did not run: %v", shellPath, probe, err)
+	case got != want:
+		Fail(t, "%s -c %q answered %q, not %q", shellPath, probe, got, want)
+	}
+}
+
+// tzdataResource names the one resource every zoneinfo-dependent regression
+// in this tree gates on. Naming it once here, rather than at each of the
+// timezone call sites, is what keeps OVUMCY_REQUIRE_TZDATA a single switch: a
+// site that spelled its own resource string ("timezone", "zoneinfo", "tz")
+// would silently split off a required-lane declaration armed against a
+// different name than what its own probe reads.
+const tzdataResource = "tzdata"
+
+// RequireTimeZone loads an IANA zone via time.LoadLocation and applies
+// SkipUnlessRequired's absence semantics under the "tzdata" resource on
+// failure — the fail-closed switch for it is OVUMCY_REQUIRE_TZDATA. Every
+// timezone-dependent regression in internal/api, internal/services and
+// internal/reminders calls this instead of handling time.LoadLocation's own
+// error, which is what lets one env var arm all of them together rather than
+// however many call sites happened to write their own t.Skipf.
+func RequireTimeZone(t TestingT, name string) *time.Location {
+	t.Helper()
+
+	location, err := time.LoadLocation(name)
+	if err != nil {
+		SkipUnlessRequired(t, tzdataResource, "zoneinfo for %s unavailable: %v", name, err)
+		return nil
+	}
+	return location
+}

--- a/internal/testenv/testenv.go
+++ b/internal/testenv/testenv.go
@@ -146,11 +146,35 @@ const tzdataResource = "tzdata"
 // internal/reminders calls this instead of handling time.LoadLocation's own
 // error, which is what lets one env var arm all of them together rather than
 // however many call sites happened to write their own t.Skipf.
+// tzErrorIsAbsence reports whether a time.LoadLocation error means the zone
+// was not found, as opposed to found and unusable. It is a named function
+// rather than an inline condition so the classification itself can be tested:
+// the malformed case cannot be provoked through LoadLocation without shipping
+// a corrupt tz database, and an untested classifier deciding skip-versus-fail
+// is the same unexamined judgement this package was written to replace.
+func tzErrorIsAbsence(err error) bool {
+	return strings.HasPrefix(err.Error(), "unknown time zone")
+}
+
 func RequireTimeZone(t TestingT, name string) *time.Location {
 	t.Helper()
 
 	location, err := time.LoadLocation(name)
 	if err != nil {
+		// time.LoadLocation reports an absent zone and a corrupt tz database
+		// through the same error type, and only the wording separates them:
+		// "unknown time zone <name>" is the absence a developer machine may
+		// legitimately skip on, while "malformed time zone information" means
+		// the database is present and broken — an operational error, and those
+		// fail everywhere. Anything not recognised as the absence is treated as
+		// operational too: an unrecognised error is not evidence that the data
+		// is missing, and defaulting the other way would leave every timezone
+		// call site in this tree — the large majority of the sites this package
+		// serves — behind exactly the silence it exists to remove.
+		if !tzErrorIsAbsence(err) {
+			Fail(t, "loading zoneinfo for %s did not fail as a plain absence, so the tz database is present and broken rather than missing: %v", name, err)
+			return nil
+		}
 		SkipUnlessRequired(t, tzdataResource, "zoneinfo for %s unavailable: %v", name, err)
 		return nil
 	}

--- a/internal/testenv/testenv_test.go
+++ b/internal/testenv/testenv_test.go
@@ -243,28 +243,26 @@ func TestRequireTimeZoneLoadsARealZone(t *testing.T) {
 	}
 }
 
-// TestRequireTimeZoneFailsOnACorruptDatabaseWhateverTheGateSays drives the
-// branch time.LoadLocation cannot produce on a sound host: an error that is not
-// a plain absence. It is asserted with the gate unset as well as set, because a
-// present-and-broken database is an operational error and those fail on every
-// machine — a case that only ran with the gate set would leave the dispatch
-// indistinguishable from SkipUnlessRequired's.
-func TestRequireTimeZoneFailsOnACorruptDatabaseWhateverTheGateSays(t *testing.T) {
+// TestRequireTimeZoneFailsOnACorruptDatabase drives the branch
+// time.LoadLocation cannot produce on a sound host: an error that is not a
+// plain absence. The gate is deliberately left UNSET, and that is the whole
+// discriminator — with it set, SkipUnlessRequired turns a misclassification
+// into a failure of its own, so a gate-set case passes against a dispatch that
+// has been deleted and pins nothing. That Fail ignores the gate is
+// TestFailNeverSkipsRegardlessOfTheGate's subject, not this one's.
+func TestRequireTimeZoneFailsOnACorruptDatabase(t *testing.T) {
+	t.Setenv(RequireEnv("tzdata"), "")
+
 	corrupt := func(string) (*time.Location, error) {
 		return nil, errors.New("malformed time zone information")
 	}
 
-	for name, gate := range map[string]string{"gate unset": "", "gate set": "1"} {
-		t.Run(name, func(t *testing.T) {
-			t.Setenv(RequireEnv("tzdata"), gate)
-			recorder := &recordingT{}
-			if got := requireTimeZone(recorder, "Europe/Berlin", corrupt); got != nil {
-				t.Fatalf("a corrupt database must not report a location; got %v", got)
-			}
-			if recorder.skipped != "" || recorder.fatal == "" {
-				t.Fatalf("a present-and-broken database must fail, never skip; got %s", recorder.verdict())
-			}
-		})
+	recorder := &recordingT{}
+	if got := requireTimeZone(recorder, "Europe/Berlin", corrupt); got != nil {
+		t.Fatalf("a corrupt database must not report a location; got %v", got)
+	}
+	if recorder.skipped != "" || recorder.fatal == "" {
+		t.Fatalf("a present-and-broken database must fail, never skip; got %s", recorder.verdict())
 	}
 }
 

--- a/internal/testenv/testenv_test.go
+++ b/internal/testenv/testenv_test.go
@@ -1,11 +1,36 @@
 package testenv
 
 import (
+	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
 	"testing"
 )
+
+// TestTimeZoneErrorClassificationSeparatesAbsenceFromCorruption pins the
+// judgement RequireTimeZone makes on time.LoadLocation's error, which is what
+// decides skip-versus-fail for every timezone site in this tree. The malformed
+// case cannot be provoked through LoadLocation without shipping a corrupt tz
+// database, so the classifier is driven directly; an unrecognised error must
+// land on the failing side, because it is not evidence the data is absent.
+func TestTimeZoneErrorClassificationSeparatesAbsenceFromCorruption(t *testing.T) {
+	for _, testCase := range []struct {
+		what      string
+		err       error
+		isAbsence bool
+	}{
+		{"the zone is not in the database", errors.New("unknown time zone America/Toronto"), true},
+		{"the database is present and corrupt", errors.New("malformed time zone information"), false},
+		{"an error this classifier has never seen", errors.New("permission denied reading zoneinfo"), false},
+	} {
+		t.Run(testCase.what, func(t *testing.T) {
+			if got := tzErrorIsAbsence(testCase.err); got != testCase.isAbsence {
+				t.Fatalf("tzErrorIsAbsence(%q) = %v, want %v: only a zone that is missing may reach the skip path", testCase.err, got, testCase.isAbsence)
+			}
+		})
+	}
+}
 
 // recordingT records the verdict a helper reaches instead of delivering it.
 // Fatalf and Skipf never return on a real *testing.T, so a test asking "which

--- a/internal/testenv/testenv_test.go
+++ b/internal/testenv/testenv_test.go
@@ -1,0 +1,279 @@
+package testenv
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// recordingT records the verdict a helper reaches instead of delivering it.
+// Fatalf and Skipf never return on a real *testing.T, so a test asking "which
+// of the two did this call reach" cannot use one directly — this substitute
+// records both and returns, letting the helper under observation run on to
+// its own `return`. Modeled on internal/testdb's recordingT.
+type recordingT struct {
+	fatal   string
+	skipped string
+}
+
+func (r *recordingT) Helper() {}
+
+func (r *recordingT) Fatalf(format string, args ...any) {
+	r.fatal = fmt.Sprintf(format, args...)
+}
+
+func (r *recordingT) Skipf(format string, args ...any) {
+	r.skipped = fmt.Sprintf(format, args...)
+}
+
+func (r *recordingT) verdict() string {
+	switch {
+	case r.fatal != "" && r.skipped != "":
+		return fmt.Sprintf("both (fatal=%q skip=%q)", r.fatal, r.skipped)
+	case r.fatal != "":
+		return "fatal: " + r.fatal
+	case r.skipped != "":
+		return "skip: " + r.skipped
+	default:
+		return "neither"
+	}
+}
+
+// TestIsRequiredReadsTheGateFailClosed pins the value handling: a gate that
+// silently disarms on an unexpected value is worse than no gate, because the
+// lane keeps reporting success. Only an absent, empty or explicitly false
+// value disarms it.
+func TestIsRequiredReadsTheGateFailClosed(t *testing.T) {
+	cases := map[string]bool{
+		"":      false,
+		" ":     false,
+		"0":     false,
+		"false": false,
+		"FALSE": false,
+		"1":     true,
+		"true":  true,
+		"yes":   true,
+		"y3s":   true,
+	}
+
+	for value, want := range cases {
+		t.Run(fmt.Sprintf("%q", value), func(t *testing.T) {
+			t.Setenv(RequireEnv("widget"), value)
+
+			if got := IsRequired("widget"); got != want {
+				t.Fatalf("%s=%q: expected required=%v, got %v", RequireEnv("widget"), value, want, got)
+			}
+		})
+	}
+}
+
+// TestRequireEnvIsTheOneMapping pins the mechanical name derivation a lane's
+// declaration and a test's probe both rely on.
+func TestRequireEnvIsTheOneMapping(t *testing.T) {
+	cases := map[string]string{
+		"docker": "OVUMCY_REQUIRE_DOCKER",
+		"bash":   "OVUMCY_REQUIRE_BASH",
+		"git":    "OVUMCY_REQUIRE_GIT",
+		"tzdata": "OVUMCY_REQUIRE_TZDATA",
+	}
+	for resource, want := range cases {
+		if got := RequireEnv(resource); got != want {
+			t.Fatalf("RequireEnv(%q) = %q, want %q", resource, got, want)
+		}
+	}
+}
+
+// TestSkipUnlessRequiredSkipsOnAbsenceWhenNotRequired is the developer-host
+// half: with the gate unset, a genuine absence is not this test's problem.
+func TestSkipUnlessRequiredSkipsOnAbsenceWhenNotRequired(t *testing.T) {
+	t.Setenv(RequireEnv("widget"), "")
+
+	recorder := &recordingT{}
+	SkipUnlessRequired(recorder, "widget", "widget is required: %v", exec.ErrNotFound)
+
+	if recorder.fatal != "" {
+		t.Fatalf("an absence must skip when the gate is unset; got %s", recorder.verdict())
+	}
+	if recorder.skipped == "" {
+		t.Fatalf("an absence must skip when the gate is unset; got %s", recorder.verdict())
+	}
+}
+
+// TestSkipUnlessRequiredFailsOnAbsenceWhenRequired is the owning-lane half:
+// the same absence becomes a failure once the lane declares the resource
+// mandatory, and the failure must name the gate that turned it into one.
+func TestSkipUnlessRequiredFailsOnAbsenceWhenRequired(t *testing.T) {
+	t.Setenv(RequireEnv("widget"), "1")
+
+	recorder := &recordingT{}
+	SkipUnlessRequired(recorder, "widget", "widget is required: %v", exec.ErrNotFound)
+
+	if recorder.skipped != "" {
+		t.Fatalf("with the gate set an absence must fail, not skip; got %s", recorder.verdict())
+	}
+	if recorder.fatal == "" {
+		t.Fatalf("with the gate set an absence must fail; got %s", recorder.verdict())
+	}
+	if !strings.Contains(recorder.fatal, RequireEnv("widget")) {
+		t.Fatalf("the failure must name the gate that turned the skip into one; got %s", recorder.verdict())
+	}
+}
+
+// TestFailNeverSkipsRegardlessOfTheGate pins the other half of the
+// absence/operational split: an operational error fails on every machine,
+// whether or not the lane declared the resource required. Fail takes no
+// resource argument at all, so there is no gate value that could route it to
+// Skipf — this exercises both settings to make that structural guarantee
+// explicit rather than assumed.
+func TestFailNeverSkipsRegardlessOfTheGate(t *testing.T) {
+	for _, gate := range []string{"", "1"} {
+		t.Run(fmt.Sprintf("gate=%q", gate), func(t *testing.T) {
+			t.Setenv(RequireEnv("widget"), gate)
+
+			recorder := &recordingT{}
+			Fail(recorder, "widget answered garbage")
+
+			if recorder.skipped != "" {
+				t.Fatalf("an operational error must never skip; got %s", recorder.verdict())
+			}
+			if recorder.fatal == "" {
+				t.Fatalf("an operational error must fail; got %s", recorder.verdict())
+			}
+		})
+	}
+}
+
+// TestRequireLookPathSkipsOnAbsenceAndFailsWhenRequired exercises the PATH
+// probe end to end against a binary name that cannot exist, the same
+// distinction TestSkipUnlessRequired... pins directly.
+func TestRequireLookPathSkipsOnAbsenceAndFailsWhenRequired(t *testing.T) {
+	const missing = "ovumcy-testenv-nonexistent-binary"
+
+	t.Run("not required", func(t *testing.T) {
+		t.Setenv(RequireEnv("widget"), "")
+		recorder := &recordingT{}
+		if got := RequireLookPath(recorder, "widget", missing); got != "" {
+			t.Fatalf("an absent binary must not report a path; got %q", got)
+		}
+		if recorder.fatal != "" || recorder.skipped == "" {
+			t.Fatalf("an absent binary must skip when the gate is unset; got %s", recorder.verdict())
+		}
+	})
+
+	t.Run("required", func(t *testing.T) {
+		t.Setenv(RequireEnv("widget"), "1")
+		recorder := &recordingT{}
+		if got := RequireLookPath(recorder, "widget", missing); got != "" {
+			t.Fatalf("an absent binary must not report a path; got %q", got)
+		}
+		if recorder.skipped != "" || recorder.fatal == "" {
+			t.Fatalf("an absent binary must fail when the gate is set; got %s", recorder.verdict())
+		}
+	})
+}
+
+// TestRequireTimeZoneSkipsOnAbsenceAndFailsWhenRequired exercises the
+// zoneinfo probe end to end against a zone name that cannot exist, pinning
+// the same absence/required distinction the PATH probe above pins for a
+// binary.
+func TestRequireTimeZoneSkipsOnAbsenceAndFailsWhenRequired(t *testing.T) {
+	const bogus = "Ovumcy/Nonexistent_Zone"
+
+	t.Run("not required", func(t *testing.T) {
+		t.Setenv(RequireEnv("tzdata"), "")
+		recorder := &recordingT{}
+		if got := RequireTimeZone(recorder, bogus); got != nil {
+			t.Fatalf("a nonexistent zone must not report a location; got %v", got)
+		}
+		if recorder.fatal != "" || recorder.skipped == "" {
+			t.Fatalf("a missing zone must skip when the gate is unset; got %s", recorder.verdict())
+		}
+	})
+
+	t.Run("required", func(t *testing.T) {
+		t.Setenv(RequireEnv("tzdata"), "1")
+		recorder := &recordingT{}
+		if got := RequireTimeZone(recorder, bogus); got != nil {
+			t.Fatalf("a nonexistent zone must not report a location; got %v", got)
+		}
+		if recorder.skipped != "" || recorder.fatal == "" {
+			t.Fatalf("a missing zone must fail when the gate is set; got %s", recorder.verdict())
+		}
+	})
+}
+
+// TestRequireTimeZoneLoadsARealZone is the positive control: a zone this
+// machine actually has must load cleanly, with neither verdict recorded.
+func TestRequireTimeZoneLoadsARealZone(t *testing.T) {
+	recorder := &recordingT{}
+	location := RequireTimeZone(recorder, "America/New_York")
+
+	if recorder.fatal != "" || recorder.skipped != "" {
+		t.Fatalf("a real zone must load without failing or skipping; got %s", recorder.verdict())
+	}
+	if location == nil {
+		t.Fatal("a real zone must return a non-nil location")
+	}
+}
+
+// bashForProbeTest resolves a real bash for the two tests below. This package
+// tests its OWN mechanism, not a production regression that a CI lane
+// promises to run, so an ordinary skip on a bash-less workstation is
+// appropriate here — every lane that runs this package's tests (ubuntu-latest)
+// has bash, so the fail-closed class this file exists to add elsewhere never
+// applies to its own harness.
+func bashForProbeTest(t *testing.T) string {
+	t.Helper()
+	path, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skipf("bash unavailable to exercise ProbeShell's own mechanism: %v", err)
+	}
+	return path
+}
+
+// TestProbeShellFailsOnATransportThatDoesNotRun pins the first operational
+// branch: a shell path that cannot even be invoked is not an absence (the
+// caller already resolved it via RequireLookPath) and must fail outright.
+func TestProbeShellFailsOnATransportThatDoesNotRun(t *testing.T) {
+	recorder := &recordingT{}
+	ProbeShell(recorder, "ovumcy-testenv-nonexistent-binary", "printf ok", "ok")
+
+	if recorder.skipped != "" {
+		t.Fatalf("a shell that does not run must fail, not skip; got %s", recorder.verdict())
+	}
+	if recorder.fatal == "" {
+		t.Fatalf("a shell that does not run must fail; got %s", recorder.verdict())
+	}
+}
+
+// TestProbeShellFailsWhenTheAnswerIsWrong pins the second operational branch:
+// a real, runnable shell that answers something other than `want` is found
+// but broken, and must fail exactly as a transport that could not run at all.
+func TestProbeShellFailsWhenTheAnswerIsWrong(t *testing.T) {
+	bash := bashForProbeTest(t)
+
+	recorder := &recordingT{}
+	ProbeShell(recorder, bash, "printf garbage", "ok")
+
+	if recorder.skipped != "" {
+		t.Fatalf("a shell answering the wrong thing must fail, not skip; got %s", recorder.verdict())
+	}
+	if recorder.fatal == "" {
+		t.Fatalf("a shell answering the wrong thing must fail; got %s", recorder.verdict())
+	}
+}
+
+// TestProbeShellPassesOnAGenuineMatch is the positive control for the two
+// failing cases above: a real shell that answers correctly reports neither
+// verdict.
+func TestProbeShellPassesOnAGenuineMatch(t *testing.T) {
+	bash := bashForProbeTest(t)
+
+	recorder := &recordingT{}
+	ProbeShell(recorder, bash, "printf ok", "ok")
+
+	if recorder.fatal != "" || recorder.skipped != "" {
+		t.Fatalf("a correct answer must neither fail nor skip; got %s", recorder.verdict())
+	}
+}

--- a/internal/testenv/testenv_test.go
+++ b/internal/testenv/testenv_test.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestTimeZoneErrorClassificationSeparatesAbsenceFromCorruption pins the
@@ -239,6 +240,31 @@ func TestRequireTimeZoneLoadsARealZone(t *testing.T) {
 	}
 	if location == nil {
 		t.Fatal("a real zone must return a non-nil location")
+	}
+}
+
+// TestRequireTimeZoneFailsOnACorruptDatabaseWhateverTheGateSays drives the
+// branch time.LoadLocation cannot produce on a sound host: an error that is not
+// a plain absence. It is asserted with the gate unset as well as set, because a
+// present-and-broken database is an operational error and those fail on every
+// machine — a case that only ran with the gate set would leave the dispatch
+// indistinguishable from SkipUnlessRequired's.
+func TestRequireTimeZoneFailsOnACorruptDatabaseWhateverTheGateSays(t *testing.T) {
+	corrupt := func(string) (*time.Location, error) {
+		return nil, errors.New("malformed time zone information")
+	}
+
+	for name, gate := range map[string]string{"gate unset": "", "gate set": "1"} {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv(RequireEnv("tzdata"), gate)
+			recorder := &recordingT{}
+			if got := requireTimeZone(recorder, "Europe/Berlin", corrupt); got != nil {
+				t.Fatalf("a corrupt database must not report a location; got %v", got)
+			}
+			if recorder.skipped != "" || recorder.fatal == "" {
+				t.Fatalf("a present-and-broken database must fail, never skip; got %s", recorder.verdict())
+			}
+		})
 	}
 }
 

--- a/scripts/backuprestoredoc/shell_test.go
+++ b/scripts/backuprestoredoc/shell_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/testenv"
 )
 
 // runbookCommandTimeout bounds one documented command. Every step here is a
@@ -80,13 +82,16 @@ func runScript(t *testing.T, dir string, script string) (string, error) {
 // redirections, the pipe and the line continuations are load-bearing parts of
 // the documented procedure — the `-T` of `docker compose exec` exists so the
 // dump can arrive on stdin — so the commands are run by a shell rather than
-// reassembled as argv.
+// reassembled as argv. Absence is a skip unless OVUMCY_REQUIRE_BASH declares
+// this lane owns the runbook check, in which case it is a failure — this
+// package is the only thing that runs the self-hosting runbook's commands at
+// all, so a lane that promised the check ran cannot report green having found
+// no shell. A bash that resolves but does not behave like one is a separate,
+// always-fatal case, checked once it is found rather than assumed.
 func bashPath(t *testing.T) string {
 	t.Helper()
 
-	path, err := exec.LookPath("bash")
-	if err != nil {
-		t.Skipf("bash is required to run the runbook's commands as written: %v", err)
-	}
+	path := testenv.RequireLookPath(t, "bash", "bash")
+	testenv.ProbeShell(t, path, "printf ok", "ok")
 	return path
 }

--- a/scripts/backuprestoredoc/volume_test.go
+++ b/scripts/backuprestoredoc/volume_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/ovumcy/ovumcy-web/internal/db"
+	"github.com/ovumcy/ovumcy-web/internal/testenv"
 	"gorm.io/gorm"
 )
 
@@ -521,15 +522,19 @@ func readVolume(t *testing.T, volume string, image string, dir string) {
 }
 
 // requireDocker skips when there is no docker to talk to, the same idiom the
-// repository's other container-backed tests use. CI has docker, so this is a
-// developer-host allowance and not a way for the guard to go quiet in the lane
-// that matters.
+// repository's other container-backed tests use — but only on a machine where
+// the owning lane has not declared docker mandatory. CI sets
+// OVUMCY_REQUIRE_DOCKER on the lane that runs this package, which turns that
+// same absence into a failure: the ubuntu runner always has docker, so
+// finding none there is a broken runner, not a developer-host allowance, and
+// this is the one guard that would otherwise go quiet about it. Every docker
+// command after this point (runDocker below) already fails rather than skips
+// on any error, so this preflight is the only place absence is even a
+// candidate for a skip.
 func requireDocker(t *testing.T) {
 	t.Helper()
 
-	if _, err := exec.LookPath("docker"); err != nil {
-		t.Skipf("docker is required to run the documented named-volume commands: %v", err)
-	}
+	testenv.RequireLookPath(t, "docker", "docker")
 }
 
 // runDocker runs one docker command with stdin, returning its stdout.

--- a/scripts/changelogd/main_test.go
+++ b/scripts/changelogd/main_test.go
@@ -3,10 +3,11 @@ package main
 import (
 	"errors"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/ovumcy/ovumcy-web/internal/testenv"
 )
 
 const fixtureChangelog = `# Changelog
@@ -623,9 +624,7 @@ func TestValidateFragmentAcceptsTheNoneMarkerAndRejectsAnEmptyFile(t *testing.T)
 // same `git diff` invocations CI runs rather than a canned string.
 func initRepo(t *testing.T) string {
 	t.Helper()
-	if _, err := exec.LookPath("git"); err != nil {
-		t.Skipf("git is not available: %v", err)
-	}
+	testenv.RequireLookPath(t, "git", "git")
 	dir := t.TempDir()
 	run(t, dir, "init", "-q", "-b", "main")
 	run(t, dir, "config", "user.email", "changelogd@example.test")

--- a/scripts/releasegate/main_test.go
+++ b/scripts/releasegate/main_test.go
@@ -47,6 +47,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ovumcy/ovumcy-web/internal/testenv"
 	"github.com/ovumcy/ovumcy-web/scripts/workflowfile"
 )
 
@@ -538,7 +539,10 @@ func runGate(t *testing.T, script string, env map[string]string, state scenario)
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
-	command := exec.CommandContext(ctx, bashPath(t), "-c", preamble+script)
+	bash := bashPath(t)
+	requireWorkingBash(t, bash)
+
+	command := exec.CommandContext(ctx, bash, "-c", preamble+script)
 	command.Env = append(os.Environ(),
 		"GITHUB_SHA=5049126faa3152cced900c304c3640e4ec724ba5",
 		"GITHUB_REPOSITORY=ovumcy/ovumcy-web",
@@ -555,15 +559,29 @@ func runGate(t *testing.T, script string, env map[string]string, state scenario)
 
 // bashPath locates the shell the workflow's `shell: bash` steps are written
 // for. Absent it, there is nothing to run the gate's own script under, and a
-// skip is honest where a Go reimplementation would not be.
+// skip is honest where a Go reimplementation would not be — unless the lane
+// running this package declared bash mandatory (OVUMCY_REQUIRE_BASH), in
+// which case the same absence is a failure: this suite is the only thing that
+// exercises the gate's real script, and a lane that promised to run it cannot
+// report green having found no shell to run it under. A bash that resolves
+// but does not behave like one is a separate, always-fatal case — see
+// requireWorkingBash below.
 func bashPath(t *testing.T) string {
 	t.Helper()
+	return testenv.RequireLookPath(t, "bash", "bash")
+}
 
-	path, err := exec.LookPath("bash")
-	if err != nil {
-		t.Skipf("bash is required to run the gate's own script as the workflow runs it: %v", err)
-	}
-	return path
+// requireWorkingBash is the operational half bashPath does not cover: a
+// binary named bash that resolves on PATH but does not run scripts the way
+// this suite's fixtures assume — a WSL launcher stub with no distro
+// installed answers a lookup exactly as a real bash does — fails the suite
+// outright, on every machine, whatever the owning lane declared. The probe
+// script matches the preamble every fixture already runs under: a shell
+// unable to report its own exit code correctly would corrupt every case in
+// this file identically.
+func requireWorkingBash(t *testing.T, path string) {
+	t.Helper()
+	testenv.ProbeShell(t, path, "printf ok", "ok")
 }
 
 // shellQuote makes a path safe to paste into the stub preamble. A temporary


### PR DESCRIPTION
## Summary
- Every "tool/data required" test skip is routed through `internal/testenv`, which separates a genuine ABSENCE (bash/docker/git not on PATH, no tz database) from an OPERATIONAL error (found but broken); only the first may skip, and only on a lane that has not declared the resource mandatory.
- `ci.yml`'s `test-go-shard`/`test-go-rest`/`race-services` jobs declare `OVUMCY_REQUIRE_{BASH,DOCKER,GIT,TZDATA}` for the resources they own, alongside the existing `OVUMCY_REQUIRE_POSTGRES`.
- Closes the one unconditional `t.Skip` in `dashboard_today_request_timezone_regression_test.go`.

## Test plan
- [x] `go build ./...`, `go vet` on every touched package
- [x] `golangci-lint run` on all touched packages: 0 issues
- [x] Repro-on-base, gutted-fix negative control, and 4 positive controls per resource (bash/docker/git/tzdata)
- [x] Full green run: `internal/testenv`, `internal/reminders`, `internal/services`, `scripts/{releasegate,backuprestoredoc,changelogd}`, `internal/api` (921s)
- [x] `go run ./scripts/changelogd check` passes
