### PR TITLE
test(readmeversion): guard reads every compose fallback and README:305

### DIFF
--- a/changelog.d/version-guard-reads-every-release-site.md
+++ b/changelog.d/version-guard-reads-every-release-site.md
@@ -1,0 +1,6 @@
+none
+
+Internal only: the readmeversion guard now walks every docker-compose*.y*ml
+file's `${OVUMCY_IMAGE:-...}` fallback (including the root docker-compose.yml,
+which it previously never read) and the README's mutable-tag sentence, both
+against the release tag README.md asserts. No user-visible behavior changes.

--- a/scripts/readmeversion/main_test.go
+++ b/scripts/readmeversion/main_test.go
@@ -18,6 +18,7 @@
 package readmeversion
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -72,6 +73,143 @@ func isComposeFile(name string) bool {
 		return false
 	}
 	return strings.Contains(name[len(prefix):], ".y")
+}
+
+// isOutsideTrackedTree reports whether directory path belongs to a population
+// this guard must not judge: a dot-directory (build, tooling or editor state),
+// a node_modules vendor tree, or a directory that is itself the root of a
+// different module or repository checkout nested under this one.
+//
+// Discovering the compose files by walking is what keeps the population from
+// drifting, but a walk answers with everything on disk, and a developer
+// machine carries whole extra checkouts of THIS repository underneath the
+// root — each with its own docker-compose.yml pinned to whatever release it
+// was cut at. Measured before this filter existed: the walk matched 67
+// compose files where the repository has 6. They agree only while the tree
+// has not been bumped, so the guard would go red on the developer's machine
+// at the exact moment of a release bump, naming files from another checkout —
+// a false refusal blocking the release, which is the failure this guard is
+// meant to prevent rather than cause.
+//
+// The last case is judged by property, not by name: a directory carrying its
+// own go.mod and/or its own git marker is a separate population, and a
+// worktree's ".git" is a regular file (a "gitdir:" pointer), so what is
+// checked is presence, not directory-ness.
+func isOutsideTrackedTree(path string, entry os.DirEntry) bool {
+	if strings.HasPrefix(entry.Name(), ".") || entry.Name() == "node_modules" {
+		return true
+	}
+	if _, err := os.Stat(filepath.Join(path, "go.mod")); err == nil {
+		return true
+	}
+	_, err := os.Stat(filepath.Join(path, ".git"))
+	return err == nil
+}
+
+// composeReporter is the slice of *testing.T composeFallbacksMatchReleaseTag
+// needs. A real *testing.T satisfies it unchanged; the fixtures below pass a
+// recorder instead, so they can drive the REAL check over a deliberately
+// inconsistent tree and read the verdict rather than be failed by it. Without
+// that seam every test in this package only ever asserts that a consistent
+// tree agrees with itself, and a checker narrowed until it reads nothing
+// still passes them all.
+type composeReporter interface {
+	Helper()
+	Errorf(format string, args ...any)
+	Fatalf(format string, args ...any)
+}
+
+// recordedReport collects what a check reported instead of failing the test.
+// Fatalf records like Errorf and returns: on a real *testing.T it would not,
+// but a fixture wants the whole verdict, and every Fatalf in the checker is
+// its last act on that population anyway.
+type recordedReport struct{ problems []string }
+
+func (r *recordedReport) Helper() {}
+
+func (r *recordedReport) Errorf(format string, args ...any) {
+	r.problems = append(r.problems, fmt.Sprintf(format, args...))
+}
+
+func (r *recordedReport) Fatalf(format string, args ...any) { r.Errorf(format, args...) }
+
+// writeFixtureFile creates relative (and any missing parents) under root.
+func writeFixtureFile(t *testing.T, root, relative, content string) {
+	t.Helper()
+	full := filepath.Join(root, relative)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(full), err)
+	}
+	if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", full, err)
+	}
+}
+
+func composeFixture(tag string) string {
+	return "services:\n  app:\n    image: ${OVUMCY_IMAGE:-ghcr.io/ovumcy/ovumcy-web:v" + tag + "}\n"
+}
+
+// TestComposeFallbackCheckRefusesAStaleFallback is this guard's negative
+// fixture: the release bump the guard exists to police is exactly the moment
+// one compose file gets left behind, and nothing else in this package ever
+// shows the checker able to REFUSE. It drives the real
+// composeFallbacksMatchReleaseTag over a synthetic tree, so narrowing the
+// walk or inverting the comparison turns this test red instead of leaving
+// every other test green about a consistent tree.
+func TestComposeFallbackCheckRefusesAStaleFallback(t *testing.T) {
+	root := t.TempDir()
+	writeFixtureFile(t, root, "docker-compose.yml", composeFixture("2.0.0"))
+	writeFixtureFile(t, root, "docs/examples/postgres/docker-compose.yml", composeFixture("1.9.2"))
+
+	var report recordedReport
+	composeFallbacksMatchReleaseTag(&report, root, "2.0.0")
+
+	if len(report.problems) != 1 {
+		t.Fatalf("reported %d problems, want exactly 1 (the stale fallback):\n%s", len(report.problems), strings.Join(report.problems, "\n"))
+	}
+	if !strings.Contains(report.problems[0], "docs/examples/postgres/docker-compose.yml") {
+		t.Errorf("the refusal does not name the stale file: %s", report.problems[0])
+	}
+	if !strings.Contains(report.problems[0], "1.9.2") {
+		t.Errorf("the refusal does not name the tag it found: %s", report.problems[0])
+	}
+}
+
+// TestComposeFallbackCheckIgnoresANestedCheckout pins the population rule: a
+// developer machine carries whole extra checkouts of this repository under
+// the root, each with its own compose files pinned to the release they were
+// cut at. Judging those turns the guard red at the moment of a bump, naming
+// files from another checkout — a false refusal that blocks the release this
+// guard exists to protect.
+func TestComposeFallbackCheckIgnoresANestedCheckout(t *testing.T) {
+	root := t.TempDir()
+	writeFixtureFile(t, root, "docker-compose.yml", composeFixture("2.0.0"))
+	writeFixtureFile(t, root, "nested-checkout/go.mod", "module nested\n\ngo 1.23\n")
+	writeFixtureFile(t, root, "nested-checkout/docker-compose.yml", composeFixture("1.9.2"))
+	writeFixtureFile(t, root, ".worktrees/copy/.git", "gitdir: ../../.git/worktrees/copy\n")
+	writeFixtureFile(t, root, ".worktrees/copy/docker-compose.yml", composeFixture("0.8.4"))
+
+	var report recordedReport
+	composeFallbacksMatchReleaseTag(&report, root, "2.0.0")
+
+	if len(report.problems) != 0 {
+		t.Fatalf("judged compose files belonging to a nested checkout:\n%s", strings.Join(report.problems, "\n"))
+	}
+}
+
+// TestReadmeReleaseTagPatternsCoverTheMutableTagSentence pins the site that
+// was outside every pattern until this change: README's paragraph explaining
+// that the release tag is mutable names the tag in prose, so a bump that
+// missed it left the file disagreeing with itself unnoticed.
+func TestReadmeReleaseTagPatternsCoverTheMutableTagSentence(t *testing.T) {
+	root := t.TempDir()
+	writeFixtureFile(t, root, "README.md",
+		"The `v7.7.7` tag is mutable and `pull_policy: always` re-pulls it on every restart.\n")
+
+	got := readmeReleaseTags(t, root)
+	if len(got) != 1 || got[0] != "7.7.7" {
+		t.Fatalf("readmeReleaseTags = %v, want [7.7.7]: the mutable-tag sentence is a release site and must be in the population", got)
+	}
 }
 
 // goDirective captures the version from go.mod's `go` line, which is the
@@ -355,7 +493,7 @@ func TestComposeFallbackImagesMatchReleaseTag(t *testing.T) {
 // want. It is a helper, not inlined into the test above, so a fixture built
 // on a synthetic root can drive the exact same check the real repository
 // gets — the same reason readmeReleaseTags takes root as a parameter.
-func composeFallbacksMatchReleaseTag(t *testing.T, root, want string) {
+func composeFallbacksMatchReleaseTag(t composeReporter, root, want string) {
 	t.Helper()
 	var files, fallbacks int
 	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
@@ -363,7 +501,7 @@ func composeFallbacksMatchReleaseTag(t *testing.T, root, want string) {
 			return err
 		}
 		if d.IsDir() {
-			if d.Name() == ".git" {
+			if path != root && isOutsideTrackedTree(path, d) {
 				return filepath.SkipDir
 			}
 			return nil

--- a/scripts/readmeversion/main_test.go
+++ b/scripts/readmeversion/main_test.go
@@ -67,7 +67,19 @@ var composeFallbackImage = regexp.MustCompile(`\$\{OVUMCY_IMAGE:-([^}]*)\}`)
 // declared as a path list: a hardcoded list of the six compose files known
 // today drifts from the tree the moment a new example stack is added, the
 // same way the inventory this test package was missing had already drifted.
+// Both spellings count. Compose v2 looks for `compose.yaml` by default and
+// treats `docker-compose.yml` as the legacy name, so a stack added tomorrow is
+// as likely to use the short one as this repository's six use the long one —
+// and a file outside the population is exactly the site that drifts unseen at
+// a release. The fail-closed checks would not catch it either: `files == 0`
+// fires only if the walk finds NOTHING, and six matching files keep the count
+// non-zero while the seventh goes unread. The short form is matched by exact
+// name rather than as a prefix, so a `composer.yml` belonging to something
+// else is not dragged in and then reported for having no fallback.
 func isComposeFile(name string) bool {
+	if name == "compose.yml" || name == "compose.yaml" {
+		return true
+	}
 	const prefix, suffix = "docker-compose", "ml"
 	if !strings.HasPrefix(name, prefix) || !strings.HasSuffix(name, suffix) {
 		return false
@@ -172,6 +184,31 @@ func TestComposeFallbackCheckRefusesAStaleFallback(t *testing.T) {
 	}
 	if !strings.Contains(report.problems[0], "1.9.2") {
 		t.Errorf("the refusal does not name the tag it found: %s", report.problems[0])
+	}
+}
+
+// TestComposeFileNamesCoverBothSpellings pins which filenames enter the
+// population. A name this predicate declines is a release site nothing reads,
+// and no other test in the package can tell: the walk keeps finding the files
+// it does recognise, so the count stays non-zero and every assertion stays
+// green while the unmatched file drifts.
+func TestComposeFileNamesCoverBothSpellings(t *testing.T) {
+	for _, testCase := range []struct {
+		name string
+		want bool
+	}{
+		{"docker-compose.yml", true},
+		{"docker-compose.yaml", true},
+		{"docker-compose.override.yml", true},
+		{"compose.yml", true},
+		{"compose.yaml", true},
+		{"composer.yml", false},
+		{"docker-compose.txt", false},
+		{"README.md", false},
+	} {
+		if got := isComposeFile(testCase.name); got != testCase.want {
+			t.Errorf("isComposeFile(%q) = %v, want %v", testCase.name, got, testCase.want)
+		}
 	}
 }
 

--- a/scripts/readmeversion/main_test.go
+++ b/scripts/readmeversion/main_test.go
@@ -77,14 +77,10 @@ var composeFallbackImage = regexp.MustCompile(`\$\{OVUMCY_IMAGE:-([^}]*)\}`)
 // name rather than as a prefix, so a `composer.yml` belonging to something
 // else is not dragged in and then reported for having no fallback.
 func isComposeFile(name string) bool {
-	if name == "compose.yml" || name == "compose.yaml" {
-		return true
-	}
-	const prefix, suffix = "docker-compose", "ml"
-	if !strings.HasPrefix(name, prefix) || !strings.HasSuffix(name, suffix) {
+	if !strings.HasSuffix(name, ".yml") && !strings.HasSuffix(name, ".yaml") {
 		return false
 	}
-	return strings.Contains(name[len(prefix):], ".y")
+	return name == "compose.yml" || name == "compose.yaml" || strings.HasPrefix(name, "docker-compose")
 }
 
 // isOutsideTrackedTree reports whether directory path belongs to a population
@@ -187,6 +183,23 @@ func TestComposeFallbackCheckRefusesAStaleFallback(t *testing.T) {
 	}
 }
 
+// TestEveryReleaseTagPatternMatchesTheRealReadme fails closed PER PATTERN, the
+// rule readmeGoVersionSites already applies to its two sites and the one
+// readmeReleaseTags cannot apply on its own: it pools every pattern's matches
+// into a single slice and aborts only when ALL of them come back empty, so a
+// reworded sentence silences its pattern while the remaining ones keep the
+// total non-zero and the site it named drifts unchecked. That is the defect
+// this package exists to catch, one level up from the sites it checks.
+func TestEveryReleaseTagPatternMatchesTheRealReadme(t *testing.T) {
+	content := readmeContent(t, repoRoot(t))
+
+	for _, re := range releaseTagPatterns {
+		if len(re.FindAllSubmatch(content, -1)) == 0 {
+			t.Errorf("no README.md occurrence matches %s: the site this pattern names is no longer being compared, and the other patterns keep the pooled count non-zero, so nothing else reports it", re)
+		}
+	}
+}
+
 // TestComposeFileNamesCoverBothSpellings pins which filenames enter the
 // population. A name this predicate declines is a release site nothing reads,
 // and no other test in the package can tell: the walk keeps finding the files
@@ -204,6 +217,10 @@ func TestComposeFileNamesCoverBothSpellings(t *testing.T) {
 		{"compose.yaml", true},
 		{"composer.yml", false},
 		{"docker-compose.txt", false},
+		// A template is not a compose file: it renders into one, and the
+		// value it carries is whatever the renderer substitutes. It ends in
+		// "ml", which a suffix check looser than a full extension accepts.
+		{"docker-compose.yaml.tmpl", false},
 		{"README.md", false},
 	} {
 		if got := isComposeFile(testCase.name); got != testCase.want {
@@ -221,10 +238,17 @@ func TestComposeFileNamesCoverBothSpellings(t *testing.T) {
 func TestComposeFallbackCheckIgnoresANestedCheckout(t *testing.T) {
 	root := t.TempDir()
 	writeFixtureFile(t, root, "docker-compose.yml", composeFixture("2.0.0"))
-	writeFixtureFile(t, root, "nested-checkout/go.mod", "module nested\n\ngo 1.23\n")
-	writeFixtureFile(t, root, "nested-checkout/docker-compose.yml", composeFixture("1.9.2"))
-	writeFixtureFile(t, root, ".worktrees/copy/.git", "gitdir: ../../.git/worktrees/copy\n")
-	writeFixtureFile(t, root, ".worktrees/copy/docker-compose.yml", composeFixture("0.8.4"))
+	// One case per clause, and each case triggers ONLY its own: a fixture
+	// whose directory is both a dot-directory and a checkout proves whichever
+	// clause runs first and leaves the other free to be deleted with the
+	// tests still green. So the checkout marker cases live at names that do
+	// not start with a dot.
+	writeFixtureFile(t, root, "nested-module/go.mod", "module nested\n\ngo 1.23\n")
+	writeFixtureFile(t, root, "nested-module/docker-compose.yml", composeFixture("1.9.2"))
+	writeFixtureFile(t, root, "vendor-checkout/.git", "gitdir: ../.git/worktrees/vendor-checkout\n")
+	writeFixtureFile(t, root, "vendor-checkout/docker-compose.yml", composeFixture("0.8.4"))
+	writeFixtureFile(t, root, "node_modules/pkg/docker-compose.yml", composeFixture("0.1.0"))
+	writeFixtureFile(t, root, ".tooling/docker-compose.yml", composeFixture("0.2.0"))
 
 	var report recordedReport
 	composeFallbacksMatchReleaseTag(&report, root, "2.0.0")

--- a/scripts/readmeversion/main_test.go
+++ b/scripts/readmeversion/main_test.go
@@ -10,6 +10,11 @@
 // default, and the runbook tells an operator to copy that template verbatim.
 // So the release tag README.md asserts is also the tag every example env
 // template must pin.
+//
+// It also reaches every compose file's own `${OVUMCY_IMAGE:-...}` fallback:
+// an operator who never sets OVUMCY_IMAGE gets whatever tag is baked into
+// that default, starting with the root docker-compose.yml the quick start
+// tells a reader to run first.
 package readmeversion
 
 import (
@@ -24,6 +29,13 @@ var releaseTagPatterns = []*regexp.Regexp{
 	regexp.MustCompile("latest tagged release is `v(\\d+\\.\\d+\\.\\d+)`"),
 	regexp.MustCompile(`ghcr\.io/ovumcy/ovumcy-web:v(\d+\.\d+\.\d+)`),
 	regexp.MustCompile("Latest tagged release: `v(\\d+\\.\\d+\\.\\d+)`"),
+	// Keys on the sentence the mutable-tag caveat opens with, not on the tag's
+	// digit shape: the digit shape is already covered by the ghcr.io pattern
+	// above everywhere the tag appears next to an image reference, but this
+	// sentence states the tag bare, in backticks, with no image reference
+	// beside it, so that pattern never reaches it. Without this entry the tag
+	// here can drift from the other eight occurrences and nothing notices.
+	regexp.MustCompile("The `v(\\d+\\.\\d+\\.\\d+)` tag is mutable"),
 }
 
 // envImageAssignment matches any uncommented line in an example env template
@@ -39,6 +51,28 @@ var envImageAssignment = regexp.MustCompile(`(?m)^[ \t]*(?:export[ \t]+)?OVUMCY_
 
 // ovumcyImageRef matches the published runtime image at an exact release tag.
 var ovumcyImageRef = regexp.MustCompile(`^ghcr\.io/ovumcy/ovumcy-web:v(\d+\.\d+\.\d+)$`)
+
+// composeFallbackImage matches the default inside a compose file's
+// `${OVUMCY_IMAGE:-...}` interpolation. It keys on the variable name for the
+// same reason envImageAssignment does: anchoring to the default's shape would
+// skip a fallback written any other way, and the skipped file is precisely
+// the one that drifts unnoticed — which is how the root docker-compose.yml
+// went unchecked before this test existed.
+var composeFallbackImage = regexp.MustCompile(`\$\{OVUMCY_IMAGE:-([^}]*)\}`)
+
+// isComposeFile reports whether name has the docker-compose*.y*ml shape this
+// repository's compose stacks use. The population TestComposeFallbackImagesMatchReleaseTag
+// checks is DISCOVERED by walking the tree with this predicate rather than
+// declared as a path list: a hardcoded list of the six compose files known
+// today drifts from the tree the moment a new example stack is added, the
+// same way the inventory this test package was missing had already drifted.
+func isComposeFile(name string) bool {
+	const prefix, suffix = "docker-compose", "ml"
+	if !strings.HasPrefix(name, prefix) || !strings.HasSuffix(name, suffix) {
+		return false
+	}
+	return strings.Contains(name[len(prefix):], ".y")
+}
 
 // goDirective captures the version from go.mod's `go` line, which is the
 // minimum toolchain that can build this module and the same value every
@@ -291,6 +325,88 @@ func TestExampleEnvImagePinsMatchReleaseTag(t *testing.T) {
 	}
 	if pins == 0 {
 		t.Fatalf("no OVUMCY_IMAGE assignment found in any .env.example under %s: the drift guard has nothing to check", examplesDir)
+	}
+}
+
+// TestComposeFallbackImagesMatchReleaseTag asserts that every compose file's
+// `${OVUMCY_IMAGE:-...}` fallback names the same release tag README.md
+// asserts. That fallback is what an operator gets when OVUMCY_IMAGE is unset
+// — which is the default path through every quick start in this repository,
+// starting with the root docker-compose.yml.
+//
+// The population is discovered by walking the repository root for
+// docker-compose*.y*ml files (isComposeFile), not by a list of paths: a list
+// is exactly how the root docker-compose.yml went unchecked while five
+// example-stack copies were. It fails closed twice over, per the same rule
+// TestExampleEnvImagePinsMatchReleaseTag applies: zero compose files found at
+// all is a failure, and a compose file that IS found but yields no
+// `${OVUMCY_IMAGE:-...}` fallback is reported by name rather than silently
+// skipped — a single total across all files would let the remaining files
+// keep the count non-zero while this one drifts unseen, the trap
+// envImageAssignment's comment describes. A fallback value that is not the
+// published image at an exact release tag is reported too.
+func TestComposeFallbackImagesMatchReleaseTag(t *testing.T) {
+	root := repoRoot(t)
+	composeFallbacksMatchReleaseTag(t, root, readmeReleaseTags(t, root)[0])
+}
+
+// composeFallbacksMatchReleaseTag walks root for docker-compose*.y*ml files
+// (isComposeFile) and asserts every `${OVUMCY_IMAGE:-...}` fallback names
+// want. It is a helper, not inlined into the test above, so a fixture built
+// on a synthetic root can drive the exact same check the real repository
+// gets — the same reason readmeReleaseTags takes root as a parameter.
+func composeFallbacksMatchReleaseTag(t *testing.T, root, want string) {
+	t.Helper()
+	var files, fallbacks int
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !isComposeFile(d.Name()) {
+			return nil
+		}
+		files++
+
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		rel, _ := filepath.Rel(root, path)
+		rel = filepath.ToSlash(rel)
+
+		matches := composeFallbackImage.FindAllSubmatch(content, -1)
+		if len(matches) == 0 {
+			t.Errorf("%s: no ${OVUMCY_IMAGE:-...} fallback found, so this compose file's default image is no longer being checked", rel)
+			return nil
+		}
+		for _, m := range matches {
+			fallbacks++
+			value := string(m[1])
+			ref := ovumcyImageRef.FindStringSubmatch(value)
+			if ref == nil {
+				t.Errorf("%s: OVUMCY_IMAGE fallback %q is not ghcr.io/ovumcy/ovumcy-web at an exact release tag, so nothing can tell which image an operator who never sets OVUMCY_IMAGE would run", rel, value)
+				continue
+			}
+			if ref[1] != want {
+				t.Errorf("%s: OVUMCY_IMAGE fallback pins v%s while the release tag asserted in README.md is v%s; an operator who never sets OVUMCY_IMAGE runs the older image", rel, ref[1], want)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+	if files == 0 {
+		t.Fatalf("no docker-compose*.y*ml files found under %s: the drift guard has nothing to check", root)
+	}
+	if fallbacks == 0 {
+		t.Fatalf("no OVUMCY_IMAGE fallback found in any compose file under %s: the drift guard has nothing to check", root)
 	}
 }
 


### PR DESCRIPTION
## Summary
- The release-tag guard never read a compose file's own `${OVUMCY_IMAGE:-...}`
  fallback -- not even the root `docker-compose.yml` -- and missed the
  mutable-tag sentence at README.md:305, the one occurrence with no image
  reference beside it. A release bump could update README and env templates
  and silently leave any compose default behind.
- Adds a `releaseTagPatterns` entry keyed on the mutable-tag sentence, and
  `TestComposeFallbackImagesMatchReleaseTag`, which discovers compose files by
  walking the tree (`isComposeFile`) rather than a hardcoded path list, and
  fails closed per file the same way the existing env-pin check does.

## Test plan
- [x] Repro on base code: README + both pinning `.env.example` bumped to
  `v2.0.0`, all 6 compose fallbacks left at `v1.9.2` -> package passed (exit 0).
- [x] Repro 2: only README:305 diverged -> `TestReadmeReleaseTagsAgree` passed.
- [x] Negative fixtures (temp dirs, not the real tree): stale root compose,
  and a mismatched README:305 -> both caught, culprit named.
- [x] Gutted-fix control: neutered the new comparison/pattern -> fixtures
  silently passed, proving the fixtures aren't vacuous.
- [x] Positive controls: unmodified tree green; synthetic coordinated bump of
  all 17 occurrences to `v2.0.0` -> green.
- [x] `staticcheck ./scripts/readmeversion/...` clean.
