### PR TITLE
fix(scripts): mutation baseline refuses an unmatched or empty target

### DIFF
--- a/changelog.d/mutation-wrapper-refuses-no-work.md
+++ b/changelog.d/mutation-wrapper-refuses-no-work.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- `scripts/mutation.sh baseline <slug>` no longer reports success when `<slug>` matches no
+  registered target: it now exits non-zero and lists the valid plain and shard-form slugs instead
+  of printing "baseline JSON written" having invoked gremlins zero times. `verify-shards` likewise
+  refuses a registered sharded package whose directory has zero non-test `.go` files instead of
+  treating an empty partition as a covered one.

--- a/changelog.d/mutation-wrapper-refuses-no-work.md
+++ b/changelog.d/mutation-wrapper-refuses-no-work.md
@@ -1,7 +1,13 @@
 ### Fixed
 
-- `scripts/mutation.sh baseline <slug>` no longer reports success when `<slug>` matches no
-  registered target: it now exits non-zero and lists the valid plain and shard-form slugs instead
-  of printing "baseline JSON written" having invoked gremlins zero times. `verify-shards` likewise
-  refuses a registered sharded package whose directory has zero non-test `.go` files instead of
-  treating an empty partition as a covered one.
+- **`scripts/mutation.sh` no longer reports success for a baseline run that mutated nothing.**
+  `baseline <slug>` exits non-zero and lists the valid plain and shard-form slugs when the slug
+  matches no registered target, instead of printing "baseline JSON written" having invoked gremlins
+  zero times. A shard number written with a leading zero (`internal_api_08`) is refused rather than
+  silently accepted: the range test failed on the octal literal inside an `if`, where `set -e` does
+  not apply, so the shard was admitted and then run as shard 8 modulo the shard count — a different
+  slice under the requested name. The accepted set now matches the one the error message
+  advertises. A registered sharded package with no non-test Go source is refused at the baseline
+  site as well as in `verify-shards`, because an empty exclusion list turns a shard run into a full
+  unsharded run of the package under that shard's name; and `verify-shards` now reports a
+  registry entry whose directory is missing apart from one whose directory is empty.

--- a/scripts/mutation.sh
+++ b/scripts/mutation.sh
@@ -174,6 +174,17 @@ verify_one_partition() {
   local total_count union_file
   echo ">> verifying $base partition ($pkg_dir, $total shards)"
   total_count="$(shard_files "$pkg_dir" | wc -l | tr -d ' ')"
+  # A registered sharded package with zero non-test .go files is a
+  # misconfiguration (stale SHARDED_PKGS entry, wrong path, files moved away),
+  # not a legitimate empty partition: the union-vs-total comparison below would
+  # accept 0 == 0 as "no gaps, no overlaps" and print OK having verified
+  # nothing. A single shard within a non-empty package coming up empty (more
+  # shards than files) stays legitimate and is not rejected here — only the
+  # whole-population case is.
+  if [[ "$total_count" -eq 0 ]]; then
+    echo "::error::$base ($pkg_dir) has zero non-test .go files — a registered sharded package must not be empty" >&2
+    return 1
+  fi
   union_file="$(mktemp)"
 
   local shard_num
@@ -250,17 +261,37 @@ run_baseline() {
     return
   fi
 
+  local matched=0
   for pkg in "${TARGETS[@]}"; do
     local slug
     slug="$(echo "$pkg" | sed 's#^\./##; s#/#_#g')"
     if [[ -n "$only" && "$slug" != "$only" ]]; then
       continue
     fi
+    matched=1
     echo ">> baseline mutation: $pkg"
     "$GREMLINS" unleash "$pkg" \
       --workers "$WORKERS" \
       --output "$TMP_DIR/${slug}.json"
   done
+  # A pkg-slug argument that matches neither a plain TARGETS slug nor a
+  # registered shard form (handled in the branch above) must not report
+  # success: silently running zero mutation targets and still printing
+  # "baseline JSON written" would let a typoed CI matrix entry pass green
+  # having tested nothing.
+  if [[ "$matched" -eq 0 ]]; then
+    echo "error: '$only' does not match any baseline target" >&2
+    echo "valid targets:" >&2
+    for pkg in "${TARGETS[@]}"; do
+      echo "  $(echo "$pkg" | sed 's#^\./##; s#/#_#g')" >&2
+    done
+    for entry in "${SHARDED_PKGS[@]}"; do
+      local base dir count
+      IFS=: read -r base dir count <<<"$entry"
+      echo "  ${base}_1..${count}" >&2
+    done
+    exit 2
+  fi
   echo ">> baseline JSON written to $TMP_DIR/ (commit a summary into $BASELINE_DIR/ once reviewed)"
 }
 

--- a/scripts/mutation.sh
+++ b/scripts/mutation.sh
@@ -273,6 +273,15 @@ run_baseline() {
     # package under a shard's name — reporting success for work no shard was
     # supposed to do. Checked here rather than trusted from verify-shards:
     # that is a separate command nobody is required to have run.
+    # Same two outcomes verify_one_partition separates, and separated here for
+    # the same reason: without this, a registry entry whose directory has moved
+    # kills the run with a bare `find: ... No such file or directory` (pipefail
+    # carries it out of the assignment below), leaving the operator to work out
+    # that the fault is a stale registry rather than a broken package.
+    if [[ ! -d "$pkg_dir" ]]; then
+      echo "error: $base ($pkg_dir) is not a directory — the SHARDED_PKGS entry names a path that does not exist" >&2
+      exit 1
+    fi
     local shard_population
     shard_population="$(shard_files "$pkg_dir" | wc -l | tr -d ' ')"
     if [[ "$shard_population" -eq 0 ]]; then

--- a/scripts/mutation.sh
+++ b/scripts/mutation.sh
@@ -173,6 +173,15 @@ verify_one_partition() {
   local base="$1" pkg_dir="$2" total="$3"
   local total_count union_file
   echo ">> verifying $base partition ($pkg_dir, $total shards)"
+  # Checked before counting, because the count cannot tell the two apart and
+  # `|| rc=1` at the call site disables set -e for this whole function: a
+  # missing directory makes `find` fail, `wc -l` still prints 0, and the
+  # refusal below would report a registered package as EMPTY when the real
+  # fault is that its path is gone. Two outcomes, two messages.
+  if [[ ! -d "$pkg_dir" ]]; then
+    echo "::error::$base ($pkg_dir) is not a directory — the SHARDED_PKGS entry names a path that does not exist" >&2
+    return 1
+  fi
   total_count="$(shard_files "$pkg_dir" | wc -l | tr -d ' ')"
   # A registered sharded package with zero non-test .go files is a
   # misconfiguration (stale SHARDED_PKGS entry, wrong path, files moved away),
@@ -235,7 +244,16 @@ run_baseline() {
   # mutate a *subset* of a package's files rather than a distinct package path,
   # via repeated --exclude-files on the same target. The slug base selects the
   # package directory and shard count from the SHARDED_PKGS registry.
-  if [[ "$only" =~ ^(internal_api|internal_services)_([0-9]+)$ ]]; then
+  # The shard number is matched WITHOUT a leading zero on purpose, so the set
+  # this accepts is exactly the "base_1..N" the unmatched-target error below
+  # advertises. Accepting "08" was worse than cosmetic: `(( 08 > total ))`
+  # fails on the octal literal, that failure is inside an `if` condition where
+  # set -e does not apply, the test therefore reads false, and the shard is
+  # accepted — then `awk 'NR % total == shard % total'` reads "08" as 8 and
+  # runs shard 3's files under shard 8's name, reporting success. A typoed CI
+  # matrix entry passing green is the very thing this dispatch is meant to
+  # refuse.
+  if [[ "$only" =~ ^(internal_api|internal_services)_([1-9][0-9]*)$ ]]; then
     local base="${BASH_REMATCH[1]}"
     local shard_num="${BASH_REMATCH[2]}"
     local pkg_dir total
@@ -247,6 +265,19 @@ run_baseline() {
     if (( shard_num < 1 || shard_num > total )); then
       echo "error: shard '$only' out of range (1..$total)" >&2
       exit 2
+    fi
+    # The same zero-population refusal verify_one_partition applies, at the
+    # site that actually runs gremlins. shard_exclude_args names the files to
+    # EXCLUDE, so a package with no non-test .go files yields an empty array
+    # and the invocation below degrades into a full, unsharded run of the
+    # package under a shard's name — reporting success for work no shard was
+    # supposed to do. Checked here rather than trusted from verify-shards:
+    # that is a separate command nobody is required to have run.
+    local shard_population
+    shard_population="$(shard_files "$pkg_dir" | wc -l | tr -d ' ')"
+    if [[ "$shard_population" -eq 0 ]]; then
+      echo "error: $base ($pkg_dir) has zero non-test .go files, so shard $shard_num would mutate the whole package rather than its own slice" >&2
+      exit 1
     fi
     local slug="$only"
     echo ">> baseline mutation: $pkg_dir (shard $shard_num/$total)"


### PR DESCRIPTION
## Summary

- `mutation.sh baseline <slug>` reported success on an unmatched slug: the plain-target
  loop matched nothing, gremlins ran zero times, yet it still printed "baseline JSON
  written" at exit 0. It now tracks whether any target matched and refuses with the
  list of valid plain/shard slugs when it didn't.
- `verify_one_partition` accepted a registered sharded package with zero non-test `.go`
  files as a covered partition (0 == 0). It now refuses that case explicitly; a single
  empty shard within a non-empty package stays legitimate.
- This is local-wrapper behavior only — CI's own report check is separate and unaffected.

## Test plan

- Repro on the pre-fix script with a stub `gremlins`: unknown slug gave exit 0, "baseline
  JSON written", zero stub invocations.
- Gutted-fix control reproduces the same false-success.
- Positive controls: unknown slug now exits 2 with the valid-target list; a correct plain
  slug invokes the stub once; no `--only` invokes it for all 3 `TARGETS`; a valid shard
  form (`internal_api_2`) still selects the right file subset, an out-of-range shard
  still refuses as before.
- Zero-population control: `verify_one_partition` against an empty directory exits 1.
