### PR TITLE
fix(services/bbt): judge the not-measured sentinel in the owner's unit

### DIFF
--- a/changelog.d/bbt-sentinel-in-the-input-unit.md
+++ b/changelog.d/bbt-sentinel-in-the-input-unit.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- **An impossible temperature is no longer saved as an empty one.** For an account tracking in
+  Fahrenheit, any entry from just above 0 °F up to 32 °F was quietly filed as "not measured" —
+  the day saved without a word, the reading gone — because the "no measurement" test ran on the
+  converted Celsius value instead of on what was typed. The test now runs in the account's own
+  unit, so 0 or less still means "not measured" and anything above it is judged against the
+  physiological range and refused if it falls outside.

--- a/changelog.d/bbt-sentinel-in-the-input-unit.md
+++ b/changelog.d/bbt-sentinel-in-the-input-unit.md
@@ -6,7 +6,8 @@
   converted Celsius value instead of on what was typed. It now runs in the account's own unit: 0
   or less still means "not measured", and anything above it is judged against the physiological
   range and refused if it falls outside. The day form rejects such a value in the browser, so it
-  was reachable through the JSON API, or from the form with scripts off.
+  was reachable through the JSON API, or from the form with scripts off. An infinity typed into
+  the form is refused the same way, where a negative one used to be filed as "not measured" too.
 - **A hidden field can no longer refuse the day it is not part of.** A form save from an account
   that hides temperature or cycle factors no longer loses the whole entry to a value in the hidden
   field: the form's hidden fields are not read at all — on an existing day the stored reading is

--- a/changelog.d/bbt-sentinel-in-the-input-unit.md
+++ b/changelog.d/bbt-sentinel-in-the-input-unit.md
@@ -9,5 +9,5 @@
   was reachable through the JSON API, or from the form with scripts off.
 - **A hidden field can no longer refuse the day it is not part of.** A form save from an account
   that hides temperature or cycle factors no longer loses the whole entry to a value in the hidden
-  field: the form's hidden fields are not read at all — on an existing day the stored value is
+  field: the form's hidden fields are not read at all — on an existing day the stored reading is
   kept, on a new day the field starts empty. JSON bodies carry every field they send.

--- a/changelog.d/bbt-sentinel-in-the-input-unit.md
+++ b/changelog.d/bbt-sentinel-in-the-input-unit.md
@@ -7,8 +7,7 @@
   or less still means "not measured", and anything above it is judged against the physiological
   range and refused if it falls outside. The day form rejects such a value in the browser, so it
   was reachable through the JSON API, or from the form with scripts off.
-- **A hidden field can no longer refuse the day it is not part of.** A save from an account that
-  hides temperature, sex activity, cervical mucus, cycle factors or notes was never about those
-  fields — each keeps the value already stored — yet an unexpected value arriving in one of them
-  still rejected the whole entry, and the Fahrenheit account above lost the day over a
-  temperature it does not even record. Such a value is now dropped before the entry is checked.
+- **A hidden field can no longer refuse the day it is not part of.** A form save from an account
+  that hides temperature or cycle factors no longer loses the whole entry to a value in the hidden
+  field: the form's hidden fields are not read at all — on an existing day the stored value is
+  kept, on a new day the field starts empty. JSON bodies carry every field they send.

--- a/changelog.d/bbt-sentinel-in-the-input-unit.md
+++ b/changelog.d/bbt-sentinel-in-the-input-unit.md
@@ -3,6 +3,12 @@
 - **An impossible temperature is no longer saved as an empty one.** For an account tracking in
   Fahrenheit, any entry from just above 0 °F up to 32 °F was quietly filed as "not measured" —
   the day saved without a word, the reading gone — because the "no measurement" test ran on the
-  converted Celsius value instead of on what was typed. The test now runs in the account's own
-  unit, so 0 or less still means "not measured" and anything above it is judged against the
-  physiological range and refused if it falls outside.
+  converted Celsius value instead of on what was typed. It now runs in the account's own unit: 0
+  or less still means "not measured", and anything above it is judged against the physiological
+  range and refused if it falls outside. The day form rejects such a value in the browser, so it
+  was reachable through the JSON API, or from the form with scripts off.
+- **A hidden field can no longer refuse the day it is not part of.** A save from an account that
+  hides temperature, sex activity, cervical mucus, cycle factors or notes was never about those
+  fields — each keeps the value already stored — yet an unexpected value arriving in one of them
+  still rejected the whole entry, and the Fahrenheit account above lost the day over a
+  temperature it does not even record. Such a value is now dropped before the entry is checked.

--- a/docs/export.md
+++ b/docs/export.md
@@ -73,7 +73,7 @@ Field semantics:
 | `flow` | string | One of `none`, `spotting`, `light`, `medium`, `heavy`. |
 | `mood_rating` | integer | User-selected mood scale. Zero means unset. |
 | `sex_activity` | string | One of `none`, `protected`, `unprotected`. |
-| `bbt` | float | Basal body temperature in Celsius, always — storage is canonical Celsius regardless of the account's display unit, and export emits the stored value unconverted. Emitted only when measured; the key is absent on unmeasured days. On import, an absent key, an explicit `null`, or a legacy `0` are all read as "not measured". |
+| `bbt` | float | Basal body temperature in Celsius, always — storage is canonical Celsius regardless of the account's display unit, and export emits the stored value unconverted. Emitted only when measured; the key is absent on unmeasured days. On import, an absent key, an explicit `null`, or a legacy `0` are all read as "not measured"; a value outside the accepted range is read as "not measured" too, like any other malformed field, rather than rejecting the day. |
 | `cervical_mucus` | string | One of `none`, `dry`, `moist`, `creamy`, `eggwhite`. |
 | `pregnancy_test` | string | One of `none`, `negative`, `positive`. |
 | `cycle_factors` | array of strings | Factor keys recorded that day, from the closed catalog `stress`, `illness`, `travel`, `sleep_disruption`, `medication_change`. Any other key is dropped on import. |

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -570,13 +570,18 @@ components:
       type: object
       description: |
         Day entry payload. A JSON body replaces the whole record with exactly
-        what it states: every field it sends is validated, and an omitted field
-        is written as its default. Hidden-field preservation belongs to the form
-        body the browser day editor posts, not here — for a field the account
-        hides in its tracking preferences (BBT, cervical mucus, sex activity,
-        cycle factors, notes) that form carries no input, the request is not
-        read for one, and an update keeps the stored value while a new day
-        starts the field empty.
+        what it states: every field it sends is read, and an omitted field is
+        written as its default. Read is not the same as validated — a
+        temperature outside the accepted range is refused with 400, an unknown
+        spelling of sex_activity, cervical_mucus or pregnancy_test collapses to
+        "none", and notes are trimmed. Hidden-field preservation belongs to the
+        form body the browser day editor posts, not here — for a field the
+        account hides in its tracking preferences (BBT, cervical mucus, sex
+        activity, cycle factors, notes) that form carries no input, the request
+        is not read for one, and an update keeps what is already stored under
+        the same rules a sent value gets: a stored temperature outside the
+        accepted range is no reading and comes back empty. A new day starts the
+        field empty.
       properties:
         is_period:
           type: boolean

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -595,7 +595,9 @@ components:
             Basal body temperature in the unit selected per account (°C or °F).
             Omitted or null means not measured. On write, a null, an omitted
             field, or a non-positive value (legacy 0 sentinel) is stored as
-            "not measured".
+            "not measured"; the non-positive test is applied to the value as
+            sent, in the account's unit, so a positive value outside the
+            physiological range is refused with 400 rather than emptied.
         cervical_mucus:
           type: string
           enum: [none, dry, moist, creamy, eggwhite]

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1798,9 +1798,11 @@ paths:
       tags: [days]
       summary: Upsert a day's entry (owner only).
       description: |
-        Creates a new row when missing or updates the existing row. Hidden-field
-        preservation rules apply for tracking preferences (BBT, mucus, sex
-        activity, cycle factors, notes).
+        Creates a new row when missing or updates the existing row. The JSON body
+        below carries every field it sends: an omitted field is cleared, and an
+        impossible value is refused rather than stored as "not measured".
+        Hidden-field preservation is a property of the form body the browser day
+        editor posts, which this operation does not describe.
       requestBody:
         required: true
         content:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -937,9 +937,13 @@ components:
           type: [number, "null"]
           format: float
           description: >-
-            Emitted only when measured; absent otherwise. On import, absent,
-            null, or a non-positive value (legacy 0 sentinel) all mean "not
-            measured".
+            Emitted only when measured; absent otherwise. Always Celsius,
+            whatever unit the account displays. On import, absent, null, or a
+            non-positive value (legacy 0 sentinel) all mean "not measured". A
+            value outside the accepted range is read as "not measured" like any
+            other malformed field, not rejected — an import restores the file
+            around it instead of refusing the day, which is the opposite of what
+            a day write does with the same value.
         cervical_mucus:
           type: string
           enum: [none, dry, moist, creamy, eggwhite]

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -569,10 +569,14 @@ components:
     DayPayload:
       type: object
       description: |
-        Day entry payload. Hidden-field preservation: when the caller omits a
-        field that the user has chosen to hide in their tracking preferences
-        (BBT, cervical mucus, sex activity, cycle factors, notes), the previous
-        value is preserved on update rather than overwritten with the default.
+        Day entry payload. A JSON body replaces the whole record with exactly
+        what it states: every field it sends is validated, and an omitted field
+        is written as its default. Hidden-field preservation belongs to the form
+        body the browser day editor posts, not here — for a field the account
+        hides in its tracking preferences (BBT, cervical mucus, sex activity,
+        cycle factors, notes) that form carries no input, the request is not
+        read for one, and an update keeps the stored value while a new day
+        starts the field empty.
       properties:
         is_period:
           type: boolean
@@ -597,7 +601,9 @@ components:
             field, or a non-positive value (legacy 0 sentinel) is stored as
             "not measured"; the non-positive test is applied to the value as
             sent, in the account's unit, so a positive value outside the
-            physiological range is refused with 400 rather than emptied.
+            physiological range is refused with 400 rather than emptied (a form
+            save from an account that hides temperature does not read the field
+            at all).
         cervical_mucus:
           type: string
           enum: [none, dry, moist, creamy, eggwhite]

--- a/e2e/stats-insights.spec.ts
+++ b/e2e/stats-insights.spec.ts
@@ -29,9 +29,10 @@ async function csrfToken(page: Page): Promise<string> {
 }
 
 async function saveDayBBT(page: Page, isoDate: string, bbt: number): Promise<void> {
-  // Send JSON so buildUpsertDayEntryInput skips the "preserve hidden fields"
-  // shortcut that drops BBT when the user has TrackBBT=false. JSON callers
-  // are treated as programmatic clients and the payload is taken as-is.
+  // Send JSON because a form body from an account that hides temperature does
+  // not read the bbt field at all (hiddenDayFields): the day would save with no
+  // reading on it. A JSON body is a programmatic client replacing the record
+  // with exactly what it states, so every field it sends is read.
   const response = await page.request.put(`/api/v1/days/${isoDate}`, {
     headers: {
       ...apiOriginHeader(page),

--- a/internal/api/handlers_days_upsert_validation_test.go
+++ b/internal/api/handlers_days_upsert_validation_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"math"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -350,6 +349,18 @@ const invalidDayBBTErrorKey = "invalid bbt value"
 // Both transports are swept because they reach that conversion by different
 // routes — the JSON bind hands over a parsed float, the form its own string
 // parse — and a fix applied to one of them leaves the other saving nothing.
+//
+// The three non-finite rows are form-only, and that is a property of JSON
+// rather than of this endpoint: NaN and the infinities have no spelling as a
+// JSON number, so such a body is refused while binding, under the payload
+// sentinel and not the temperature's. strconv.ParseFloat does accept all three,
+// so the form is the transport that can deliver one, and -Inf is the row that
+// matters — it is non-positive, so it reaches the "not measured" sentinel and
+// would be filed as an empty temperature with a 200.
+//
+// The stored reading is compared exactly: 97.7 °F is 36.5 °C on the stored
+// grid, so there is nothing for a tolerance to absorb except a change to that
+// grid, which is what the comparison is here to notice.
 func TestUpsertDayJudgesTheNotMeasuredSentinelInTheAccountsUnit(t *testing.T) {
 	t.Parallel()
 
@@ -358,17 +369,18 @@ func TestUpsertDayJudgesTheNotMeasuredSentinelInTheAccountsUnit(t *testing.T) {
 	updateStatsOverviewUser(t, database, user, fahrenheitBBTTrackingPreferences(true))
 	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
 
-	const storedTolerance = 1e-9
-
 	testCases := []struct {
 		name        string
 		typed       string
+		formOnly    bool
 		wantStatus  int
 		wantReading bool
 		wantStored  float64
 	}{
 		{name: "impossible positive reading is refused", typed: "20", wantStatus: http.StatusBadRequest},
 		{name: "freezing point is refused", typed: "32", wantStatus: http.StatusBadRequest},
+		{name: "not a number is refused", typed: "NaN", formOnly: true, wantStatus: http.StatusBadRequest},
+		{name: "negative infinity is refused", typed: "-Inf", formOnly: true, wantStatus: http.StatusBadRequest},
 		{name: "zero is not measured", typed: "0", wantStatus: http.StatusOK},
 		{name: "negative is not measured", typed: "-1", wantStatus: http.StatusOK},
 		{name: "ordinary reading is stored in celsius", typed: "97.7", wantStatus: http.StatusOK, wantReading: true, wantStored: 36.5},
@@ -379,6 +391,10 @@ func TestUpsertDayJudgesTheNotMeasuredSentinelInTheAccountsUnit(t *testing.T) {
 		for caseIndex, testCase := range testCases {
 			day := firstDay.AddDate(0, 0, transportIndex*len(testCases)+caseIndex)
 			dayRaw := day.Format("2006-01-02")
+
+			if testCase.formOnly && transport == "json" {
+				continue
+			}
 
 			t.Run(transport+"/"+testCase.name, func(t *testing.T) {
 				var request *http.Request
@@ -422,7 +438,7 @@ func TestUpsertDayJudgesTheNotMeasuredSentinelInTheAccountsUnit(t *testing.T) {
 				if entry.BBT == nil {
 					t.Fatalf("%s °F is a reading, got no stored temperature", testCase.typed)
 				}
-				if math.Abs(*entry.BBT-testCase.wantStored) > storedTolerance {
+				if *entry.BBT != testCase.wantStored {
 					t.Fatalf("%s °F: expected %.4f °C stored, got %.4f", testCase.typed, testCase.wantStored, *entry.BBT)
 				}
 			})
@@ -474,9 +490,14 @@ func TestUpsertDayRefusesAnImpossibleFahrenheitReadingOverHTMX(t *testing.T) {
 // the account shows and nothing else, so a value arriving in a hidden one is
 // not this write's subject; a JSON body is a client replacing the record with
 // exactly what it states, so every field it sends is its subject and is judged.
-// The same account, the same 20 °F and the same day therefore answer 400 here
-// and 200 in the table below, and the entry must not be created either way
-// round. Widening the condition (`!hasJSONBody(c)` → true) reddens this test.
+// This test and the table below differ in the transport and in nothing that
+// matters otherwise: the same two preferences (Fahrenheit, temperature hidden)
+// and the same 20 °F. Sent as JSON it is refused with 400 and no entry is
+// written at all; sent as a form it is not read, the day is saved with 200 and
+// the stored temperature survives. Each drives its own account and its own
+// dates because the two run in parallel against one database. Widening the
+// condition (resolveUpsertDayRequest's formBody → always true) reddens this
+// test.
 func TestUpsertDayRefusesAnImpossibleTemperatureSentAsJSON(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/handlers_days_upsert_validation_test.go
+++ b/internal/api/handlers_days_upsert_validation_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/gofiber/fiber/v3"
 	"github.com/ovumcy/ovumcy-web/internal/models"
 	"github.com/ovumcy/ovumcy-web/internal/services"
-	"gorm.io/gorm"
 )
 
 func TestUpsertDayNormalizesFlowWhenNotPeriod(t *testing.T) {
@@ -356,7 +355,7 @@ func TestUpsertDayJudgesTheNotMeasuredSentinelInTheAccountsUnit(t *testing.T) {
 
 	app, database := newOnboardingTestApp(t)
 	user := createOnboardingTestUser(t, database, "upsert-day-bbt-sentinel-unit@example.com", "StrongPass1", true)
-	seedFahrenheitBBTTracking(t, database, user.ID, true)
+	updateStatsOverviewUser(t, database, user, fahrenheitBBTTrackingPreferences(true))
 	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
 
 	const storedTolerance = 1e-9
@@ -441,7 +440,7 @@ func TestUpsertDayRefusesAnImpossibleFahrenheitReadingOverHTMX(t *testing.T) {
 
 	app, database := newOnboardingTestApp(t)
 	user := createOnboardingTestUser(t, database, "upsert-day-bbt-sentinel-htmx@example.com", "StrongPass1", true)
-	seedFahrenheitBBTTracking(t, database, user.ID, true)
+	updateStatsOverviewUser(t, database, user, fahrenheitBBTTrackingPreferences(true))
 	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
 
 	day := time.Date(2026, time.June, 1, 0, 0, 0, 0, time.UTC)
@@ -455,9 +454,9 @@ func TestUpsertDayRefusesAnImpossibleFahrenheitReadingOverHTMX(t *testing.T) {
 	response := mustAppResponse(t, app, request)
 	assertStatusCode(t, response, http.StatusBadRequest)
 
-	body := mustReadBodyString(t, response.Body)
-	if !strings.Contains(body, `data-flash-key="dashboard.error.invalid_bbt"`) {
-		t.Fatalf("expected the HTMX refusal to carry the bbt flash key, got %q", body)
+	root := mustParseHTMLDocument(t, mustReadBodyString(t, response.Body))
+	if htmlFlashByKey(root, "dashboard.error.invalid_bbt") == nil {
+		t.Fatalf("expected the HTMX refusal to carry the bbt flash key")
 	}
 
 	entry, err := fetchLogByDateForTest(database, user.ID, day, time.UTC)
@@ -469,63 +468,128 @@ func TestUpsertDayRefusesAnImpossibleFahrenheitReadingOverHTMX(t *testing.T) {
 	}
 }
 
-// TestUpsertDayKeepsTheDayWhenAHiddenTemperatureIsImpossible sends that same
-// impossible reading to an account that does not track BBT. Transport marks a
-// hidden field Preserve* (buildUpsertDayEntryInput) and the save replaces it
-// with the value already stored, so the incoming one is not this write's
-// subject and may not refuse the day: the mood the owner did send has to land
-// and the stored temperature has to survive untouched.
-//
-// The form transport carries the case because Preserve* is set only for a form
-// body — a JSON caller states every field explicitly and is granted no
-// preservation, so for it 20 °F stays the refusal the test above pins.
-func TestUpsertDayKeepsTheDayWhenAHiddenTemperatureIsImpossible(t *testing.T) {
+// TestUpsertDayRefusesAnImpossibleTemperatureSentAsJSON pins the transport
+// condition the hidden-field handling below rests on: hiddenDayFields grants it
+// to a FORM body only. A form is the browser day editor, which posts the fields
+// the account shows and nothing else, so a value arriving in a hidden one is
+// not this write's subject; a JSON body is a client replacing the record with
+// exactly what it states, so every field it sends is its subject and is judged.
+// The same account, the same 20 °F and the same day therefore answer 400 here
+// and 200 in the table below, and the entry must not be created either way
+// round. Widening the condition (`!hasJSONBody(c)` → true) reddens this test.
+func TestUpsertDayRefusesAnImpossibleTemperatureSentAsJSON(t *testing.T) {
 	t.Parallel()
 
 	app, database := newOnboardingTestApp(t)
-	user := createOnboardingTestUser(t, database, "upsert-day-bbt-hidden-impossible@example.com", "StrongPass1", true)
-	seedFahrenheitBBTTracking(t, database, user.ID, false)
+	user := createOnboardingTestUser(t, database, "upsert-day-bbt-hidden-json@example.com", "StrongPass1", true)
+	updateStatsOverviewUser(t, database, user, fahrenheitBBTTrackingPreferences(false))
 	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
 
-	day := time.Date(2026, time.June, 2, 0, 0, 0, 0, time.UTC)
-	seeded := models.DailyLog{UserID: user.ID, Date: day, Mood: 2, BBT: new(36.65)}
-	if err := database.Create(&seeded).Error; err != nil {
-		t.Fatalf("seed the stored day: %v", err)
-	}
-
-	form := url.Values{"flow": {models.FlowNone}, "mood": {"4"}, "bbt": {"20"}}
-	request := httptest.NewRequest(http.MethodPut, "/api/v1/days/"+day.Format("2006-01-02"), strings.NewReader(form.Encode()))
-	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	day := time.Date(2026, time.June, 10, 0, 0, 0, 0, time.UTC)
+	body := fmt.Sprintf(`{"is_period":false,"flow":%q,"symptom_ids":[],"notes":"","bbt":20}`, models.FlowNone)
+	request := httptest.NewRequest(http.MethodPut, "/api/v1/days/"+day.Format("2006-01-02"), strings.NewReader(body))
+	request.Header.Set("Content-Type", fiber.MIMEApplicationJSON)
 	request.Header.Set("Cookie", authCookie)
 
 	response := mustAppResponse(t, app, request)
-	assertStatusCode(t, response, http.StatusOK)
+	assertStatusCode(t, response, http.StatusBadRequest)
+	if got := readAPIError(t, response.Body); got != invalidDayBBTErrorKey {
+		t.Fatalf("a JSON body is granted no preservation, so 20 °F must be refused under %q, got %q", invalidDayBBTErrorKey, got)
+	}
 
 	entry, err := fetchLogByDateForTest(database, user.ID, day, time.UTC)
 	if err != nil {
 		t.Fatalf("load stored log: %v", err)
 	}
-	if entry.ID == 0 {
-		t.Fatalf("the day must still be saved, found no entry")
-	}
-	if entry.Mood != 4 {
-		t.Fatalf("expected the sent mood 4 to land, got %d", entry.Mood)
-	}
-	if entry.BBT == nil || *entry.BBT != 36.65 {
-		t.Fatalf("expected the stored temperature preserved as 36.65 °C, got %v", entry.BBT)
+	if entry.ID != 0 {
+		t.Fatalf("a refused day must not be stored, found an entry with bbt=%v", entry.BBT)
 	}
 }
 
-// seedFahrenheitBBTTracking puts the account on the Fahrenheit scale and sets
-// whether it tracks BBT at all — the two preferences every case in this file
-// reads the day form through.
-func seedFahrenheitBBTTracking(t *testing.T, database *gorm.DB, userID uint, trackBBT bool) {
-	t.Helper()
+// TestUpsertDayDoesNotReadAHiddenTemperatureField drives an account that hides
+// temperature — and tracks in Fahrenheit, where everything in (0, 32] °F is an
+// impossible reading — through the form the browser posts. A field the account
+// hides is not read at all (parseDayPayload consults hiddenDayFields), so
+// nothing that can arrive in it reaches a parser or a validator: not a value
+// the range refuses, not one strconv refuses, not one no float64 can hold. The
+// day the owner did save has to land, and the temperature already stored has to
+// come back untouched (mergePreservedDayEntryInput).
+//
+// The last row is the other half of the same rule: on a day that does not exist
+// yet there is nothing to merge, so the hidden field starts empty rather than
+// storing a reading the account cannot see or correct.
+func TestUpsertDayDoesNotReadAHiddenTemperatureField(t *testing.T) {
+	t.Parallel()
 
-	if err := database.Model(&models.User{}).Where("id = ?", userID).Updates(map[string]any{
+	app, database := newOnboardingTestApp(t)
+	user := createOnboardingTestUser(t, database, "upsert-day-bbt-hidden-impossible@example.com", "StrongPass1", true)
+	updateStatsOverviewUser(t, database, user, fahrenheitBBTTrackingPreferences(false))
+	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
+
+	const storedCelsius = 36.65
+
+	testCases := []struct {
+		name       string
+		typed      string
+		seedStored bool
+	}{
+		{name: "an impossible reading leaves the stored one alone", typed: "20", seedStored: true},
+		{name: "an unparseable value cannot refuse the day", typed: "abc", seedStored: true},
+		{name: "a magnitude no float64 holds cannot refuse the day", typed: "1e400", seedStored: true},
+		{name: "a hidden field starts empty on a day that does not exist yet", typed: "20"},
+	}
+
+	firstDay := time.Date(2026, time.June, 2, 0, 0, 0, 0, time.UTC)
+	for caseIndex, testCase := range testCases {
+		day := firstDay.AddDate(0, 0, caseIndex)
+		dayRaw := day.Format("2006-01-02")
+
+		t.Run(testCase.name, func(t *testing.T) {
+			if testCase.seedStored {
+				stored := storedCelsius
+				seeded := models.DailyLog{UserID: user.ID, Date: day, Mood: 2, BBT: &stored}
+				if err := database.Create(&seeded).Error; err != nil {
+					t.Fatalf("seed the stored day: %v", err)
+				}
+			}
+
+			form := url.Values{"flow": {models.FlowNone}, "mood": {"4"}, "bbt": {testCase.typed}}
+			request := httptest.NewRequest(http.MethodPut, "/api/v1/days/"+dayRaw, strings.NewReader(form.Encode()))
+			request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			request.Header.Set("Cookie", authCookie)
+
+			response := mustAppResponse(t, app, request)
+			assertStatusCode(t, response, http.StatusOK)
+
+			entry, err := fetchLogByDateForTest(database, user.ID, day, time.UTC)
+			if err != nil {
+				t.Fatalf("load stored log for %s: %v", dayRaw, err)
+			}
+			if entry.ID == 0 {
+				t.Fatalf("bbt=%q is not this write's subject, so %s must hold the saved day", testCase.typed, dayRaw)
+			}
+			if entry.Mood != 4 {
+				t.Fatalf("bbt=%q: expected the sent mood 4 to land, got %d", testCase.typed, entry.Mood)
+			}
+			if !testCase.seedStored {
+				if entry.BBT != nil {
+					t.Fatalf("bbt=%q: a hidden field must start empty on a new day, got %.4f °C stored", testCase.typed, *entry.BBT)
+				}
+				return
+			}
+			if entry.BBT == nil || *entry.BBT != storedCelsius {
+				t.Fatalf("bbt=%q: expected the stored temperature preserved as %.2f °C, got %v", testCase.typed, storedCelsius, entry.BBT)
+			}
+		})
+	}
+}
+
+// fahrenheitBBTTrackingPreferences is the pair of preferences the temperature
+// cases in this file drive the day form through: the account reads and writes
+// in Fahrenheit, and either tracks BBT or hides it.
+func fahrenheitBBTTrackingPreferences(trackBBT bool) map[string]any {
+	return map[string]any{
 		"temperature_unit": services.TemperatureUnitFahrenheit,
 		"track_bbt":        trackBBT,
-	}).Error; err != nil {
-		t.Fatalf("seed fahrenheit tracking preferences: %v", err)
 	}
 }

--- a/internal/api/handlers_days_upsert_validation_test.go
+++ b/internal/api/handlers_days_upsert_validation_test.go
@@ -350,13 +350,21 @@ const invalidDayBBTErrorKey = "invalid bbt value"
 // routes — the JSON bind hands over a parsed float, the form its own string
 // parse — and a fix applied to one of them leaves the other saving nothing.
 //
-// The three non-finite rows are form-only, and that is a property of JSON
-// rather than of this endpoint: NaN and the infinities have no spelling as a
-// JSON number, so such a body is refused while binding, under the payload
-// sentinel and not the temperature's. strconv.ParseFloat does accept all three,
-// so the form is the transport that can deliver one, and -Inf is the row that
-// matters — it is non-positive, so it reaches the "not measured" sentinel and
-// would be filed as an empty temperature with a 200.
+// Two rows are non-finite and form-only, and that is a property of JSON rather
+// than of this endpoint: NaN and the infinities have no spelling as a JSON
+// number, so such a body is refused while binding, under the payload sentinel
+// and not the temperature's. strconv.ParseFloat does accept them, so the form
+// is the transport that can deliver one.
+//
+// Those two rows carry different weight, and only one of them is about the
+// sentinel. -Inf is non-positive, so without the non-finite branch in
+// ConvertDayBBTToStorage it would BE the "not measured" answer and the day
+// would be filed with an empty temperature and a 200; that row is what pins the
+// branch. NaN is non-positive under no comparison, so it passes the sentinel
+// either way and reaches this 400 through IsValidDayBBT one step later — the
+// range refusing a value no comparison accepts. Its row states the class, that
+// no non-finite entry is saved as a measurement, and it is not a witness for
+// where the sentinel is read.
 //
 // The stored reading is compared exactly: 97.7 °F is 36.5 °C on the stored
 // grid, so there is nothing for a tolerance to absorb except a change to that

--- a/internal/api/handlers_days_upsert_validation_test.go
+++ b/internal/api/handlers_days_upsert_validation_test.go
@@ -3,8 +3,12 @@ package api
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
+	"math"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -327,5 +331,100 @@ func TestUpsertDayNormalizesUnknownPregnancyTest(t *testing.T) {
 	}
 	if entry.PregnancyTest != models.PregnancyTestNone {
 		t.Fatalf("expected unknown pregnancy test normalized to %q, got %q", models.PregnancyTestNone, entry.PregnancyTest)
+	}
+}
+
+// TestUpsertDayJudgesTheNotMeasuredSentinelInTheAccountsUnit walks both
+// transports of the day upsert for an account tracking in Fahrenheit. A
+// non-positive entry is the owner's "not measured" answer and saves an empty
+// temperature; a positive one is a reading, and the physiological range decides
+// it — so 20 °F and 32 °F are refused rather than filed as a day with no
+// temperature on it. The sentinel used to be read after the °F→°C conversion,
+// by which point every entry in (0, 32] °F had already turned non-positive, so
+// both refusals arrived as a 200 with a null bbt and the reading vanished
+// without the owner being told.
+//
+// Both transports are swept because they reach the conversion by different
+// routes — the JSON bind hands over a parsed float, the form its own string
+// parse — and a fix applied to one of them leaves the other saving nothing.
+func TestUpsertDayJudgesTheNotMeasuredSentinelInTheAccountsUnit(t *testing.T) {
+	t.Parallel()
+
+	app, database := newOnboardingTestApp(t)
+	user := createOnboardingTestUser(t, database, "upsert-day-bbt-sentinel-unit@example.com", "StrongPass1", true)
+	if err := database.Model(&models.User{}).Where("id = ?", user.ID).Updates(map[string]any{
+		"temperature_unit": services.TemperatureUnitFahrenheit,
+		"track_bbt":        true,
+	}).Error; err != nil {
+		t.Fatalf("seed fahrenheit tracking preferences: %v", err)
+	}
+	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
+
+	const storedTolerance = 1e-9
+
+	testCases := []struct {
+		name        string
+		typed       string
+		wantStatus  int
+		wantReading bool
+		wantStored  float64
+	}{
+		{name: "impossible positive reading is refused", typed: "20", wantStatus: http.StatusBadRequest},
+		{name: "freezing point is refused", typed: "32", wantStatus: http.StatusBadRequest},
+		{name: "zero is not measured", typed: "0", wantStatus: http.StatusOK},
+		{name: "negative is not measured", typed: "-1", wantStatus: http.StatusOK},
+		{name: "ordinary reading is stored in celsius", typed: "97.7", wantStatus: http.StatusOK, wantReading: true, wantStored: 36.5},
+	}
+
+	firstDay := time.Date(2026, time.May, 1, 0, 0, 0, 0, time.UTC)
+	for transportIndex, transport := range []string{"json", "form"} {
+		for caseIndex, testCase := range testCases {
+			day := firstDay.AddDate(0, 0, transportIndex*len(testCases)+caseIndex)
+			dayRaw := day.Format("2006-01-02")
+
+			t.Run(transport+"/"+testCase.name, func(t *testing.T) {
+				var request *http.Request
+				if transport == "json" {
+					body := fmt.Sprintf(`{"is_period":false,"flow":%q,"symptom_ids":[],"notes":"","bbt":%s}`, models.FlowNone, testCase.typed)
+					request = httptest.NewRequest(http.MethodPut, "/api/v1/days/"+dayRaw, strings.NewReader(body))
+					request.Header.Set("Content-Type", fiber.MIMEApplicationJSON)
+				} else {
+					form := url.Values{"flow": {models.FlowNone}, "bbt": {testCase.typed}}
+					request = httptest.NewRequest(http.MethodPut, "/api/v1/days/"+dayRaw, strings.NewReader(form.Encode()))
+					request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+				}
+				request.Header.Set("Cookie", authCookie)
+
+				response := mustAppResponse(t, app, request)
+				assertStatusCode(t, response, testCase.wantStatus)
+
+				entry, err := fetchLogByDateForTest(database, user.ID, day, time.UTC)
+				if err != nil {
+					t.Fatalf("load stored log for %s: %v", dayRaw, err)
+				}
+
+				if testCase.wantStatus != http.StatusOK {
+					if entry.ID != 0 {
+						t.Fatalf("%s °F was refused, so %s must hold no entry at all; found one with bbt=%v", testCase.typed, dayRaw, entry.BBT)
+					}
+					return
+				}
+				if entry.ID == 0 {
+					t.Fatalf("%s °F was accepted, so %s must hold the saved day", testCase.typed, dayRaw)
+				}
+				if !testCase.wantReading {
+					if entry.BBT != nil {
+						t.Fatalf("%s °F means not measured, got %.4f °C stored", testCase.typed, *entry.BBT)
+					}
+					return
+				}
+				if entry.BBT == nil {
+					t.Fatalf("%s °F is a reading, got no stored temperature", testCase.typed)
+				}
+				if math.Abs(*entry.BBT-testCase.wantStored) > storedTolerance {
+					t.Fatalf("%s °F: expected %.4f °C stored, got %.4f", testCase.typed, testCase.wantStored, *entry.BBT)
+				}
+			})
+		}
 	}
 }

--- a/internal/api/handlers_days_upsert_validation_test.go
+++ b/internal/api/handlers_days_upsert_validation_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gofiber/fiber/v3"
 	"github.com/ovumcy/ovumcy-web/internal/models"
 	"github.com/ovumcy/ovumcy-web/internal/services"
+	"gorm.io/gorm"
 )
 
 func TestUpsertDayNormalizesFlowWhenNotPeriod(t *testing.T) {
@@ -334,17 +335,20 @@ func TestUpsertDayNormalizesUnknownPregnancyTest(t *testing.T) {
 	}
 }
 
+// invalidDayBBTErrorKey is the key mapDayUpsertError publishes for
+// services.ErrInvalidDayBBT; the refusals below assert the owner is told which
+// field lost the save, not merely that one was lost.
+const invalidDayBBTErrorKey = "invalid bbt value"
+
 // TestUpsertDayJudgesTheNotMeasuredSentinelInTheAccountsUnit walks both
-// transports of the day upsert for an account tracking in Fahrenheit. A
+// transports of the day upsert for an account tracking in Fahrenheit: a
 // non-positive entry is the owner's "not measured" answer and saves an empty
-// temperature; a positive one is a reading, and the physiological range decides
-// it — so 20 °F and 32 °F are refused rather than filed as a day with no
-// temperature on it. The sentinel used to be read after the °F→°C conversion,
-// by which point every entry in (0, 32] °F had already turned non-positive, so
-// both refusals arrived as a 200 with a null bbt and the reading vanished
-// without the owner being told.
+// temperature, a positive one is a reading the physiological range judges, so
+// 20 °F and 32 °F are refused rather than filed as a day with no temperature on
+// it. Why the sentinel is read before the conversion rather than after:
+// services.ConvertDayBBTToStorage.
 //
-// Both transports are swept because they reach the conversion by different
+// Both transports are swept because they reach that conversion by different
 // routes — the JSON bind hands over a parsed float, the form its own string
 // parse — and a fix applied to one of them leaves the other saving nothing.
 func TestUpsertDayJudgesTheNotMeasuredSentinelInTheAccountsUnit(t *testing.T) {
@@ -352,12 +356,7 @@ func TestUpsertDayJudgesTheNotMeasuredSentinelInTheAccountsUnit(t *testing.T) {
 
 	app, database := newOnboardingTestApp(t)
 	user := createOnboardingTestUser(t, database, "upsert-day-bbt-sentinel-unit@example.com", "StrongPass1", true)
-	if err := database.Model(&models.User{}).Where("id = ?", user.ID).Updates(map[string]any{
-		"temperature_unit": services.TemperatureUnitFahrenheit,
-		"track_bbt":        true,
-	}).Error; err != nil {
-		t.Fatalf("seed fahrenheit tracking preferences: %v", err)
-	}
+	seedFahrenheitBBTTracking(t, database, user.ID, true)
 	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
 
 	const storedTolerance = 1e-9
@@ -404,6 +403,9 @@ func TestUpsertDayJudgesTheNotMeasuredSentinelInTheAccountsUnit(t *testing.T) {
 				}
 
 				if testCase.wantStatus != http.StatusOK {
+					if got := readAPIError(t, response.Body); got != invalidDayBBTErrorKey {
+						t.Fatalf("%s °F must be refused under %q, got %q", testCase.typed, invalidDayBBTErrorKey, got)
+					}
 					if entry.ID != 0 {
 						t.Fatalf("%s °F was refused, so %s must hold no entry at all; found one with bbt=%v", testCase.typed, dayRaw, entry.BBT)
 					}
@@ -426,5 +428,104 @@ func TestUpsertDayJudgesTheNotMeasuredSentinelInTheAccountsUnit(t *testing.T) {
 				}
 			})
 		}
+	}
+}
+
+// TestUpsertDayRefusesAnImpossibleFahrenheitReadingOverHTMX runs one of those
+// refusals through the arm the day form itself uses. apiError answers an HTMX
+// request with the shared status fragment rather than the JSON envelope, so the
+// key travels as data-flash-key — a 400 that reached the panel without it would
+// trade a named refusal for a silent one.
+func TestUpsertDayRefusesAnImpossibleFahrenheitReadingOverHTMX(t *testing.T) {
+	t.Parallel()
+
+	app, database := newOnboardingTestApp(t)
+	user := createOnboardingTestUser(t, database, "upsert-day-bbt-sentinel-htmx@example.com", "StrongPass1", true)
+	seedFahrenheitBBTTracking(t, database, user.ID, true)
+	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
+
+	day := time.Date(2026, time.June, 1, 0, 0, 0, 0, time.UTC)
+	form := url.Values{"flow": {models.FlowNone}, "bbt": {"20"}}
+	request := httptest.NewRequest(http.MethodPut, "/api/v1/days/"+day.Format("2006-01-02"), strings.NewReader(form.Encode()))
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	request.Header.Set("HX-Request", "true")
+	request.Header.Set("Accept-Language", "en")
+	request.Header.Set("Cookie", authCookie)
+
+	response := mustAppResponse(t, app, request)
+	assertStatusCode(t, response, http.StatusBadRequest)
+
+	body := mustReadBodyString(t, response.Body)
+	if !strings.Contains(body, `data-flash-key="dashboard.error.invalid_bbt"`) {
+		t.Fatalf("expected the HTMX refusal to carry the bbt flash key, got %q", body)
+	}
+
+	entry, err := fetchLogByDateForTest(database, user.ID, day, time.UTC)
+	if err != nil {
+		t.Fatalf("load stored log: %v", err)
+	}
+	if entry.ID != 0 {
+		t.Fatalf("a refused day must not be stored, found an entry with bbt=%v", entry.BBT)
+	}
+}
+
+// TestUpsertDayKeepsTheDayWhenAHiddenTemperatureIsImpossible sends that same
+// impossible reading to an account that does not track BBT. Transport marks a
+// hidden field Preserve* (buildUpsertDayEntryInput) and the save replaces it
+// with the value already stored, so the incoming one is not this write's
+// subject and may not refuse the day: the mood the owner did send has to land
+// and the stored temperature has to survive untouched.
+//
+// The form transport carries the case because Preserve* is set only for a form
+// body — a JSON caller states every field explicitly and is granted no
+// preservation, so for it 20 °F stays the refusal the test above pins.
+func TestUpsertDayKeepsTheDayWhenAHiddenTemperatureIsImpossible(t *testing.T) {
+	t.Parallel()
+
+	app, database := newOnboardingTestApp(t)
+	user := createOnboardingTestUser(t, database, "upsert-day-bbt-hidden-impossible@example.com", "StrongPass1", true)
+	seedFahrenheitBBTTracking(t, database, user.ID, false)
+	authCookie := loginAndExtractAuthCookie(t, app, user.Email, "StrongPass1")
+
+	day := time.Date(2026, time.June, 2, 0, 0, 0, 0, time.UTC)
+	seeded := models.DailyLog{UserID: user.ID, Date: day, Mood: 2, BBT: new(36.65)}
+	if err := database.Create(&seeded).Error; err != nil {
+		t.Fatalf("seed the stored day: %v", err)
+	}
+
+	form := url.Values{"flow": {models.FlowNone}, "mood": {"4"}, "bbt": {"20"}}
+	request := httptest.NewRequest(http.MethodPut, "/api/v1/days/"+day.Format("2006-01-02"), strings.NewReader(form.Encode()))
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	request.Header.Set("Cookie", authCookie)
+
+	response := mustAppResponse(t, app, request)
+	assertStatusCode(t, response, http.StatusOK)
+
+	entry, err := fetchLogByDateForTest(database, user.ID, day, time.UTC)
+	if err != nil {
+		t.Fatalf("load stored log: %v", err)
+	}
+	if entry.ID == 0 {
+		t.Fatalf("the day must still be saved, found no entry")
+	}
+	if entry.Mood != 4 {
+		t.Fatalf("expected the sent mood 4 to land, got %d", entry.Mood)
+	}
+	if entry.BBT == nil || *entry.BBT != 36.65 {
+		t.Fatalf("expected the stored temperature preserved as 36.65 °C, got %v", entry.BBT)
+	}
+}
+
+// seedFahrenheitBBTTracking puts the account on the Fahrenheit scale and sets
+// whether it tracks BBT at all — the two preferences every case in this file
+// reads the day form through.
+func seedFahrenheitBBTTracking(t *testing.T, database *gorm.DB, userID uint, trackBBT bool) {
+	t.Helper()
+
+	if err := database.Model(&models.User{}).Where("id = ?", userID).Updates(map[string]any{
+		"temperature_unit": services.TemperatureUnitFahrenheit,
+		"track_bbt":        trackBBT,
+	}).Error; err != nil {
+		t.Fatalf("seed fahrenheit tracking preferences: %v", err)
 	}
 }

--- a/internal/api/handlers_days_write.go
+++ b/internal/api/handlers_days_write.go
@@ -14,6 +14,43 @@ type upsertDayRequest struct {
 	day             time.Time
 	payload         dayPayload
 	cleanSymptomIDs []uint
+	hidden          preservedDayFields
+}
+
+// preservedDayFields names the day fields a request must leave to the value
+// already stored: the ones the account keeps hidden, which the day form does
+// not show and therefore does not speak for. It is resolved once per request
+// (hiddenDayFields) and read twice — parseDayPayload skips reading each hidden
+// field off the wire, buildUpsertDayEntryInput marks it Preserve* for the save
+// — so the two halves cannot disagree about which fields those are.
+type preservedDayFields struct {
+	SexActivity   bool
+	BBT           bool
+	CervicalMucus bool
+	CycleFactors  bool
+	Notes         bool
+}
+
+// hiddenDayFields resolves that set for one request. formBody carries the
+// transport condition: a form body is the day editor, which posts the fields
+// the account shows and nothing else, so a value arriving in a hidden one is
+// not this write's subject; a JSON body replaces the record with exactly what
+// the client states, so it is granted no preservation and every field it sends
+// is read and judged. Which fields an account hides is the services layer's
+// answer (TrackingVisibilityForUser), not this one's. Regression:
+// TestUpsertDayRefusesAnImpossibleTemperatureSentAsJSON.
+func hiddenDayFields(user *models.User, formBody bool) preservedDayFields {
+	if !formBody || user == nil {
+		return preservedDayFields{}
+	}
+	visibility := services.TrackingVisibilityForUser(user)
+	return preservedDayFields{
+		SexActivity:   visibility.SexChipHidden(),
+		BBT:           !user.TrackBBT,
+		CervicalMucus: !user.TrackCervicalMucus,
+		CycleFactors:  visibility.CycleFactorsHidden(),
+		Notes:         visibility.NotesFieldHidden(),
+	}
 }
 
 var (
@@ -32,7 +69,7 @@ func (handler *Handler) UpsertDay(c fiber.Ctx) error {
 		c.Context(),
 		request.user.ID,
 		request.day,
-		buildUpsertDayEntryInput(request.payload, request.cleanSymptomIDs, request.user, !hasJSONBody(c)),
+		buildUpsertDayEntryInput(request.payload, request.cleanSymptomIDs, request.hidden),
 		request.location,
 	)
 	if err != nil {
@@ -64,7 +101,8 @@ func (handler *Handler) resolveUpsertDayRequest(c fiber.Ctx) (upsertDayRequest, 
 		return upsertDayRequest{}, invalidDateErrorSpec(), false
 	}
 
-	payload, err := parseDayPayload(c, user)
+	hidden := hiddenDayFields(user, !hasJSONBody(c))
+	payload, err := parseDayPayload(c, user, hidden)
 	if err != nil {
 		return upsertDayRequest{}, invalidPayloadErrorSpec(), false
 	}
@@ -80,17 +118,11 @@ func (handler *Handler) resolveUpsertDayRequest(c fiber.Ctx) (upsertDayRequest, 
 		day:             day,
 		payload:         payload,
 		cleanSymptomIDs: cleanIDs,
+		hidden:          hidden,
 	}, APIErrorSpec{}, true
 }
 
-func buildUpsertDayEntryInput(payload dayPayload, cleanSymptomIDs []uint, user *models.User, preserveHiddenFields bool) services.DayEntryInput {
-	visibility := services.TrackingVisibilityForUser(user)
-	preserveSexActivity := preserveHiddenFields && user != nil && visibility.SexChipHidden()
-	preserveBBT := preserveHiddenFields && user != nil && !user.TrackBBT
-	preserveCervicalMucus := preserveHiddenFields && user != nil && !user.TrackCervicalMucus
-	preserveCycleFactors := preserveHiddenFields && user != nil && visibility.CycleFactorsHidden()
-	preserveNotes := preserveHiddenFields && user != nil && visibility.NotesFieldHidden()
-
+func buildUpsertDayEntryInput(payload dayPayload, cleanSymptomIDs []uint, hidden preservedDayFields) services.DayEntryInput {
 	return services.DayEntryInput{
 		IsPeriod:              payload.IsPeriod,
 		ConfirmCycleStart:     payload.ConfirmCycleStart,
@@ -103,11 +135,11 @@ func buildUpsertDayEntryInput(payload dayPayload, cleanSymptomIDs []uint, user *
 		CycleFactorKeys:       payload.CycleFactorKeys,
 		Notes:                 payload.Notes,
 		SymptomIDs:            cleanSymptomIDs,
-		PreserveSexActivity:   preserveSexActivity,
-		PreserveBBT:           preserveBBT,
-		PreserveCervicalMucus: preserveCervicalMucus,
-		PreserveCycleFactors:  preserveCycleFactors,
-		PreserveNotes:         preserveNotes,
+		PreserveSexActivity:   hidden.SexActivity,
+		PreserveBBT:           hidden.BBT,
+		PreserveCervicalMucus: hidden.CervicalMucus,
+		PreserveCycleFactors:  hidden.CycleFactors,
+		PreserveNotes:         hidden.Notes,
 	}
 }
 

--- a/internal/api/handlers_days_write.go
+++ b/internal/api/handlers_days_write.go
@@ -22,7 +22,10 @@ type upsertDayRequest struct {
 // not show and therefore does not speak for. It is resolved once per request
 // (hiddenDayFields) and read twice — parseDayPayload skips reading each hidden
 // field off the wire, buildUpsertDayEntryInput marks it Preserve* for the save
-// — so the two halves cannot disagree about which fields those are.
+// — so the two halves cannot disagree about which fields those are. That holds
+// by construction rather than by care: resolveUpsertDayRequest reads the
+// transport once and hands the same formBody, and the same resolved set, to
+// both.
 type preservedDayFields struct {
 	SexActivity   bool
 	BBT           bool
@@ -36,9 +39,16 @@ type preservedDayFields struct {
 // the account shows and nothing else, so a value arriving in a hidden one is
 // not this write's subject; a JSON body replaces the record with exactly what
 // the client states, so it is granted no preservation and every field it sends
-// is read and judged. Which fields an account hides is the services layer's
-// answer (TrackingVisibilityForUser), not this one's. Regression:
-// TestUpsertDayRefusesAnImpossibleTemperatureSentAsJSON.
+// is read. Read is not the same as validated: a temperature outside the
+// accepted range is refused with 400, an unknown spelling of sex_activity,
+// cervical_mucus or pregnancy_test collapses to "none", and notes are trimmed.
+//
+// Which fields an account hides is the services layer's answer, and all five
+// come from one TrackingVisibility so that no tracking column is negated in
+// transport. Whether the caller may write this owner's day at all is the
+// route's question — days.Put declares OwnerOnly (routes.go) — and not this
+// set's. Regression: TestUpsertDayRefusesAnImpossibleTemperatureSentAsJSON,
+// TestParseDayPayloadSkipsEveryFieldTheAccountHides.
 func hiddenDayFields(user *models.User, formBody bool) preservedDayFields {
 	if !formBody || user == nil {
 		return preservedDayFields{}
@@ -46,8 +56,8 @@ func hiddenDayFields(user *models.User, formBody bool) preservedDayFields {
 	visibility := services.TrackingVisibilityForUser(user)
 	return preservedDayFields{
 		SexActivity:   visibility.SexChipHidden(),
-		BBT:           !user.TrackBBT,
-		CervicalMucus: !user.TrackCervicalMucus,
+		BBT:           visibility.BBTFieldHidden(),
+		CervicalMucus: visibility.CervicalMucusHidden(),
 		CycleFactors:  visibility.CycleFactorsHidden(),
 		Notes:         visibility.NotesFieldHidden(),
 	}
@@ -101,8 +111,9 @@ func (handler *Handler) resolveUpsertDayRequest(c fiber.Ctx) (upsertDayRequest, 
 		return upsertDayRequest{}, invalidDateErrorSpec(), false
 	}
 
-	hidden := hiddenDayFields(user, !hasJSONBody(c))
-	payload, err := parseDayPayload(c, user, hidden)
+	formBody := !hasJSONBody(c)
+	hidden := hiddenDayFields(user, formBody)
+	payload, err := parseDayPayload(c, user, formBody, hidden)
 	if err != nil {
 		return upsertDayRequest{}, invalidPayloadErrorSpec(), false
 	}

--- a/internal/api/input_validation_day_payload_helpers.go
+++ b/internal/api/input_validation_day_payload_helpers.go
@@ -10,21 +10,29 @@ import (
 
 // parseDayPayload reads one day write off the wire. A field named in hidden is
 // not read at all in the form branch: the account keeps it out of the day form,
-// so whatever arrives under that name is not this write's subject, and reading
-// it would let it refuse the whole day right here — before the save could
-// replace it with the value already stored (mergePreservedDayEntryInput). That
-// refusal is the parser's to make, not the validator's: "abc" or 1e400 in a
-// hidden temperature never reaches a range check to be dropped by. Which fields
-// are hidden, and why a JSON body has none: hiddenDayFields. Regression:
+// so whatever arrives under that name is not this write's subject.
+//
+// Only for the temperature does the skip decide the day. Reading that field IS
+// a parse, and a parse can refuse: "abc" or 1e400 answers an error right here,
+// before the save could replace the field with the value already stored
+// (mergePreservedDayEntryInput), and no range check downstream ever sees it.
+// For the other four a read could at worst be neutralised one layer later
+// (services.dropPreservedDayEntryFields), and they are skipped anyway so that
+// "a hidden field is not read" stays one rule instead of a temperature
+// exception every reader has to rediscover.
+//
+// formBody is the transport condition, resolved once by the caller; which
+// fields are hidden, and why a JSON body has none: hiddenDayFields. Regression:
+// TestParseDayPayloadSkipsEveryFieldTheAccountHides,
 // TestUpsertDayDoesNotReadAHiddenTemperatureField.
-func parseDayPayload(c fiber.Ctx, user *models.User, hidden preservedDayFields) (dayPayload, error) {
+func parseDayPayload(c fiber.Ctx, user *models.User, formBody bool, hidden preservedDayFields) (dayPayload, error) {
 	payload := dayPayload{Flow: models.FlowNone, SymptomIDs: []uint{}}
 	temperatureUnit := services.DefaultTemperatureUnit
 	if user != nil {
 		temperatureUnit = user.TemperatureUnit
 	}
 
-	if hasJSONBody(c) {
+	if !formBody {
 		if err := c.Bind().Body(&payload); err != nil {
 			return payload, err
 		}

--- a/internal/api/input_validation_day_payload_helpers.go
+++ b/internal/api/input_validation_day_payload_helpers.go
@@ -8,7 +8,16 @@ import (
 	"github.com/ovumcy/ovumcy-web/internal/services"
 )
 
-func parseDayPayload(c fiber.Ctx, user *models.User) (dayPayload, error) {
+// parseDayPayload reads one day write off the wire. A field named in hidden is
+// not read at all in the form branch: the account keeps it out of the day form,
+// so whatever arrives under that name is not this write's subject, and reading
+// it would let it refuse the whole day right here — before the save could
+// replace it with the value already stored (mergePreservedDayEntryInput). That
+// refusal is the parser's to make, not the validator's: "abc" or 1e400 in a
+// hidden temperature never reaches a range check to be dropped by. Which fields
+// are hidden, and why a JSON body has none: hiddenDayFields. Regression:
+// TestUpsertDayDoesNotReadAHiddenTemperatureField.
+func parseDayPayload(c fiber.Ctx, user *models.User, hidden preservedDayFields) (dayPayload, error) {
 	payload := dayPayload{Flow: models.FlowNone, SymptomIDs: []uint{}}
 	temperatureUnit := services.DefaultTemperatureUnit
 	if user != nil {
@@ -29,13 +38,21 @@ func parseDayPayload(c fiber.Ctx, user *models.User) (dayPayload, error) {
 		if err != nil {
 			return payload, err
 		}
-		payload.SexActivity = strings.ToLower(strings.TrimSpace(c.FormValue("sex_activity")))
-		payload.CervicalMucus = strings.ToLower(strings.TrimSpace(c.FormValue("cervical_mucus")))
+		if !hidden.SexActivity {
+			payload.SexActivity = strings.ToLower(strings.TrimSpace(c.FormValue("sex_activity")))
+		}
+		if !hidden.CervicalMucus {
+			payload.CervicalMucus = strings.ToLower(strings.TrimSpace(c.FormValue("cervical_mucus")))
+		}
 		payload.PregnancyTest = strings.ToLower(strings.TrimSpace(c.FormValue("pregnancy_test")))
-		payload.Notes = strings.TrimSpace(c.FormValue("notes"))
-		payload.BBT, err = services.ParseDayBBTRawWithUnit(c.FormValue("bbt"), temperatureUnit)
-		if err != nil {
-			return payload, err
+		if !hidden.Notes {
+			payload.Notes = strings.TrimSpace(c.FormValue("notes"))
+		}
+		if !hidden.BBT {
+			payload.BBT, err = services.ParseDayBBTRawWithUnit(c.FormValue("bbt"), temperatureUnit)
+			if err != nil {
+				return payload, err
+			}
 		}
 
 		// symptom_ids stays deliberately lenient: an unparseable member of a
@@ -51,9 +68,11 @@ func parseDayPayload(c fiber.Ctx, user *models.User) (dayPayload, error) {
 			}
 		}
 
-		cycleFactorRaw := c.RequestCtx().PostArgs().PeekMulti("cycle_factor_keys")
-		for _, value := range cycleFactorRaw {
-			payload.CycleFactorKeys = append(payload.CycleFactorKeys, string(value))
+		if !hidden.CycleFactors {
+			cycleFactorRaw := c.RequestCtx().PostArgs().PeekMulti("cycle_factor_keys")
+			for _, value := range cycleFactorRaw {
+				payload.CycleFactorKeys = append(payload.CycleFactorKeys, string(value))
+			}
 		}
 	}
 

--- a/internal/api/input_validation_day_payload_test.go
+++ b/internal/api/input_validation_day_payload_test.go
@@ -157,7 +157,7 @@ func TestParseDayPayloadFromFormWithFahrenheitPreference(t *testing.T) {
 	request := httptest.NewRequest(http.MethodPost, "/day", strings.NewReader(form.Encode()))
 	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	payload := parseDayPayloadForUser(t, request, &models.User{TemperatureUnit: services.TemperatureUnitFahrenheit})
+	payload := parseDayPayloadForUser(t, request, &models.User{TemperatureUnit: services.TemperatureUnitFahrenheit, TrackBBT: true})
 	if payload.BBT == nil || *payload.BBT != 37.00 {
 		t.Fatalf("expected converted BBT 37.00, got %v", payload.BBT)
 	}
@@ -169,15 +169,21 @@ func TestParseDayPayloadFromJSONWithFahrenheitPreference(t *testing.T) {
 	request := httptest.NewRequest(http.MethodPost, "/day", strings.NewReader(`{"bbt":98.6}`))
 	request.Header.Set("Content-Type", fiber.MIMEApplicationJSON)
 
-	payload := parseDayPayloadForUser(t, request, &models.User{TemperatureUnit: services.TemperatureUnitFahrenheit})
+	payload := parseDayPayloadForUser(t, request, &models.User{TemperatureUnit: services.TemperatureUnitFahrenheit, TrackBBT: true})
 	if payload.BBT == nil || *payload.BBT != 37.00 {
 		t.Fatalf("expected converted BBT 37.00, got %v", payload.BBT)
 	}
 }
 
+// Every helper below hands parseDayPayload the hidden-field set the production
+// route would resolve for the same account (hiddenDayFields), rather than a
+// hand-written one: a field the account hides is not read at all, so a test
+// user that did not track it would be asserting about a field the parser is
+// entitled to skip. Hence TrackBBT on the accounts whose subject is the
+// temperature.
 func parseDayPayloadForTest(t *testing.T, request *http.Request) dayPayload {
 	t.Helper()
-	return parseDayPayloadForUser(t, request, &models.User{TemperatureUnit: services.DefaultTemperatureUnit})
+	return parseDayPayloadForUser(t, request, &models.User{TemperatureUnit: services.DefaultTemperatureUnit, TrackBBT: true})
 }
 
 func parseDayPayloadForUser(t *testing.T, request *http.Request, user *models.User) dayPayload {
@@ -185,7 +191,7 @@ func parseDayPayloadForUser(t *testing.T, request *http.Request, user *models.Us
 
 	app := fiber.New()
 	app.Post("/day", func(c fiber.Ctx) error {
-		payload, err := parseDayPayload(c, user)
+		payload, err := parseDayPayload(c, user, hiddenDayFields(user, !hasJSONBody(c)))
 		if err != nil {
 			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": err.Error()})
 		}
@@ -225,10 +231,10 @@ func parseDayPayloadStatusForForm(t *testing.T, form url.Values) int {
 func parseDayPayloadStatus(t *testing.T, request *http.Request) int {
 	t.Helper()
 
-	user := &models.User{TemperatureUnit: services.DefaultTemperatureUnit}
+	user := &models.User{TemperatureUnit: services.DefaultTemperatureUnit, TrackBBT: true}
 	app := fiber.New()
 	app.Post("/day", func(c fiber.Ctx) error {
-		if _, err := parseDayPayload(c, user); err != nil {
+		if _, err := parseDayPayload(c, user, hiddenDayFields(user, !hasJSONBody(c))); err != nil {
 			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": err.Error()})
 		}
 		return c.JSON(fiber.Map{"ok": true})

--- a/internal/api/input_validation_day_payload_test.go
+++ b/internal/api/input_validation_day_payload_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -175,15 +176,163 @@ func TestParseDayPayloadFromJSONWithFahrenheitPreference(t *testing.T) {
 	}
 }
 
+// TestParseDayPayloadSkipsEveryFieldTheAccountHides drives one form body —
+// carrying a value in every one of the five preservable fields — through an
+// account that hides each of them in turn, and then through one that hides all
+// five. A hidden field must come back at its zero value, never having been
+// read, and every field the account does show must come back exactly as sent,
+// so a skip that reaches past its own flag fails here too.
+//
+// The first row hides nothing and is the anchor: it is what makes the zero
+// values in the rows below evidence of the skip rather than of a parser that
+// reads no form at all. Dropping any single `if !hidden.X` in parseDayPayload
+// reddens the row that hides X and the all-five row.
+//
+// The temperature in the body is a well-formed reading on purpose: nothing
+// refuses 36.50 °C, so a hidden bbt coming back nil can only mean the field was
+// never read, where an unparseable value would leave the same nil consistent
+// with a refusal swallowed elsewhere. That the skip also comes BEFORE the parse
+// — where "abc" would cost the whole day — is pinned end to end by
+// TestUpsertDayDoesNotReadAHiddenTemperatureField.
+func TestParseDayPayloadSkipsEveryFieldTheAccountHides(t *testing.T) {
+	t.Parallel()
+
+	type parsedDayFields struct {
+		sexActivity   string
+		cervicalMucus string
+		notes         string
+		bbt           *float64
+		cycleFactors  []string
+	}
+
+	sentBBT := 36.50
+	sentCycleFactors := []string{models.CycleFactorStress, models.CycleFactorTravel}
+	everythingRead := parsedDayFields{
+		sexActivity:   models.SexActivityProtected,
+		cervicalMucus: models.CervicalMucusEggWhite,
+		notes:         "hello",
+		bbt:           &sentBBT,
+		cycleFactors:  sentCycleFactors,
+	}
+
+	testCases := []struct {
+		name    string
+		hide    func(user *models.User)
+		neutral func(want *parsedDayFields)
+	}{
+		{
+			name:    "an account that hides nothing reads every field",
+			hide:    func(*models.User) {},
+			neutral: func(*parsedDayFields) {},
+		},
+		{
+			name:    "a hidden sex chip",
+			hide:    func(user *models.User) { user.HideSexChip = true },
+			neutral: func(want *parsedDayFields) { want.sexActivity = models.SexActivityNone },
+		},
+		{
+			name:    "a hidden temperature",
+			hide:    func(user *models.User) { user.TrackBBT = false },
+			neutral: func(want *parsedDayFields) { want.bbt = nil },
+		},
+		{
+			name:    "a hidden cervical mucus",
+			hide:    func(user *models.User) { user.TrackCervicalMucus = false },
+			neutral: func(want *parsedDayFields) { want.cervicalMucus = models.CervicalMucusNone },
+		},
+		{
+			name:    "hidden cycle factors",
+			hide:    func(user *models.User) { user.HideCycleFactors = true },
+			neutral: func(want *parsedDayFields) { want.cycleFactors = nil },
+		},
+		{
+			name:    "a hidden notes field",
+			hide:    func(user *models.User) { user.HideNotesField = true },
+			neutral: func(want *parsedDayFields) { want.notes = "" },
+		},
+		{
+			name: "an account that hides all five",
+			hide: func(user *models.User) {
+				user.HideSexChip = true
+				user.TrackBBT = false
+				user.TrackCervicalMucus = false
+				user.HideCycleFactors = true
+				user.HideNotesField = true
+			},
+			neutral: func(want *parsedDayFields) {
+				want.sexActivity = models.SexActivityNone
+				want.bbt = nil
+				want.cervicalMucus = models.CervicalMucusNone
+				want.cycleFactors = nil
+				want.notes = ""
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			user := &models.User{
+				TemperatureUnit:    services.DefaultTemperatureUnit,
+				TrackBBT:           true,
+				TrackCervicalMucus: true,
+			}
+			testCase.hide(user)
+
+			want := everythingRead
+			testCase.neutral(&want)
+
+			form := url.Values{}
+			form.Set("sex_activity", everythingRead.sexActivity)
+			form.Set("cervical_mucus", everythingRead.cervicalMucus)
+			form.Set("notes", everythingRead.notes)
+			form.Set("bbt", strconv.FormatFloat(sentBBT, 'f', 2, 64))
+			for _, key := range sentCycleFactors {
+				form.Add("cycle_factor_keys", key)
+			}
+
+			request := httptest.NewRequest(http.MethodPost, "/day", strings.NewReader(form.Encode()))
+			request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+			payload := parseDayPayloadForUser(t, request, user)
+
+			if payload.SexActivity != want.sexActivity {
+				t.Fatalf("sex activity: expected %q, got %q", want.sexActivity, payload.SexActivity)
+			}
+			if payload.CervicalMucus != want.cervicalMucus {
+				t.Fatalf("cervical mucus: expected %q, got %q", want.cervicalMucus, payload.CervicalMucus)
+			}
+			if payload.Notes != want.notes {
+				t.Fatalf("notes: expected %q, got %q", want.notes, payload.Notes)
+			}
+			switch {
+			case want.bbt == nil && payload.BBT != nil:
+				t.Fatalf("bbt: a hidden temperature must not be read, got %v °C stored", *payload.BBT)
+			case want.bbt != nil && (payload.BBT == nil || *payload.BBT != *want.bbt):
+				t.Fatalf("bbt: expected %v °C, got %v", *want.bbt, payload.BBT)
+			}
+			if !slices.Equal(payload.CycleFactorKeys, want.cycleFactors) {
+				t.Fatalf("cycle factors: expected %#v, got %#v", want.cycleFactors, payload.CycleFactorKeys)
+			}
+		})
+	}
+}
+
 // Every helper below hands parseDayPayload the hidden-field set the production
 // route would resolve for the same account (hiddenDayFields), rather than a
 // hand-written one: a field the account hides is not read at all, so a test
 // user that did not track it would be asserting about a field the parser is
-// entitled to skip. Hence TrackBBT on the accounts whose subject is the
-// temperature.
+// entitled to skip. Hence TrackBBT and TrackCervicalMucus on the shared
+// accounts — those two columns are stored the positive way round and default to
+// false, i.e. hidden — while the three inverted ones already default to shown.
 func parseDayPayloadForTest(t *testing.T, request *http.Request) dayPayload {
 	t.Helper()
-	return parseDayPayloadForUser(t, request, &models.User{TemperatureUnit: services.DefaultTemperatureUnit, TrackBBT: true})
+	return parseDayPayloadForUser(t, request, &models.User{
+		TemperatureUnit:    services.DefaultTemperatureUnit,
+		TrackBBT:           true,
+		TrackCervicalMucus: true,
+	})
 }
 
 func parseDayPayloadForUser(t *testing.T, request *http.Request, user *models.User) dayPayload {
@@ -191,7 +340,8 @@ func parseDayPayloadForUser(t *testing.T, request *http.Request, user *models.Us
 
 	app := fiber.New()
 	app.Post("/day", func(c fiber.Ctx) error {
-		payload, err := parseDayPayload(c, user, hiddenDayFields(user, !hasJSONBody(c)))
+		formBody := !hasJSONBody(c)
+		payload, err := parseDayPayload(c, user, formBody, hiddenDayFields(user, formBody))
 		if err != nil {
 			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": err.Error()})
 		}
@@ -231,10 +381,15 @@ func parseDayPayloadStatusForForm(t *testing.T, form url.Values) int {
 func parseDayPayloadStatus(t *testing.T, request *http.Request) int {
 	t.Helper()
 
-	user := &models.User{TemperatureUnit: services.DefaultTemperatureUnit, TrackBBT: true}
+	user := &models.User{
+		TemperatureUnit:    services.DefaultTemperatureUnit,
+		TrackBBT:           true,
+		TrackCervicalMucus: true,
+	}
 	app := fiber.New()
 	app.Post("/day", func(c fiber.Ctx) error {
-		if _, err := parseDayPayload(c, user, hiddenDayFields(user, !hasJSONBody(c))); err != nil {
+		formBody := !hasJSONBody(c)
+		if _, err := parseDayPayload(c, user, formBody, hiddenDayFields(user, formBody)); err != nil {
 			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": err.Error()})
 		}
 		return c.JSON(fiber.Map{"ok": true})

--- a/internal/api/stats_overview_contract_test.go
+++ b/internal/api/stats_overview_contract_test.go
@@ -586,11 +586,14 @@ func seedStatsOverviewLog(t *testing.T, database *gorm.DB, log models.DailyLog) 
 	}
 }
 
+// updateStatsOverviewUser writes stored preferences onto a test account. It is
+// named after the file it started in but is shared across the package, so its
+// failure message names the account rather than any one surface.
 func updateStatsOverviewUser(t *testing.T, database *gorm.DB, user models.User, updates map[string]any) {
 	t.Helper()
 
 	if err := database.Model(&models.User{}).Where("id = ?", user.ID).Updates(updates).Error; err != nil {
-		t.Fatalf("update stats overview owner: %v", err)
+		t.Fatalf("update test owner: %v", err)
 	}
 }
 

--- a/internal/services/dashboard_view_service.go
+++ b/internal/services/dashboard_view_service.go
@@ -338,8 +338,8 @@ func dashboardOwnerVisibilityState(user *models.User, today time.Time, now time.
 	visibility := TrackingVisibilityForUser(user)
 	return dashboardOwnerVisibility{
 		ShowSexChip:           isOwner && visibility.ShowSexChip,
-		ShowBBTField:          isOwner && user.TrackBBT,
-		ShowCervicalMucus:     isOwner && user.TrackCervicalMucus,
+		ShowBBTField:          isOwner && visibility.ShowBBTField,
+		ShowCervicalMucus:     isOwner && visibility.ShowCervicalMucus,
 		ShowCycleFactors:      isOwner && visibility.ShowCycleFactors,
 		ShowNotesField:        isOwner && visibility.ShowNotesField,
 		AllowManualCycleStart: isOwner && IsAllowedManualCycleStartDate(today, now, location),

--- a/internal/services/day_input.go
+++ b/internal/services/day_input.go
@@ -25,6 +25,7 @@ var (
 )
 
 func NormalizeDayEntryInput(input DayEntryInput) (DayEntryInput, error) {
+	input = dropPreservedDayEntryFields(input)
 	if !IsValidDayFlow(input.Flow) {
 		return input, ErrInvalidDayFlow
 	}
@@ -61,6 +62,39 @@ func NormalizeDayEntryInput(input DayEntryInput) (DayEntryInput, error) {
 	input.BBT = normalizeStoredDayBBT(input.BBT)
 	input.Notes = TrimDayNotes(input.Notes)
 	return input, nil
+}
+
+// dropPreservedDayEntryFields empties every field this write marked Preserve*,
+// before the validation above ever reads it. A preserved field's incoming value
+// is not this write's subject — the save replaces it with the stored one
+// (mergePreservedDayEntryInput) — so it is dropped rather than allowed to
+// reject the day: transport sets the flags for the fields the account keeps
+// hidden (buildUpsertDayEntryInput), the form therefore posts them empty, and a
+// value that arrives there anyway used to cost the owner the whole save under a
+// sentinel naming a field the answer then ignored. A Fahrenheit account that
+// hides BBT is the reachable case, since everything in (0, 32] °F converts to a
+// reading below the physiological range.
+//
+// On a day that does not exist yet there is nothing to merge, and dropping is
+// then the whole answer: a hidden field starts neutral instead of storing a
+// value the account cannot see.
+func dropPreservedDayEntryFields(input DayEntryInput) DayEntryInput {
+	if input.PreserveSexActivity {
+		input.SexActivity = models.SexActivityNone
+	}
+	if input.PreserveBBT {
+		input.BBT = nil
+	}
+	if input.PreserveCervicalMucus {
+		input.CervicalMucus = models.CervicalMucusNone
+	}
+	if input.PreserveCycleFactors {
+		input.CycleFactorKeys = nil
+	}
+	if input.PreserveNotes {
+		input.Notes = ""
+	}
+	return input
 }
 
 func NormalizeDayFlow(flow string) string {

--- a/internal/services/day_input.go
+++ b/internal/services/day_input.go
@@ -64,37 +64,27 @@ func NormalizeDayEntryInput(input DayEntryInput) (DayEntryInput, error) {
 	return input, nil
 }
 
-// dropPreservedDayEntryFields empties every field this write marked Preserve*,
-// before the validation above ever reads it. A preserved field's incoming value
-// is not this write's subject — the save replaces it with the stored one
-// (mergePreservedDayEntryInput) — so it is dropped rather than allowed to
-// reject the day: transport sets the flags for the fields the account keeps
-// hidden (buildUpsertDayEntryInput), the form therefore posts them empty, and a
-// value that arrives there anyway used to cost the owner the whole save under a
-// sentinel naming a field the answer then ignored. A Fahrenheit account that
-// hides BBT is the reachable case, since everything in (0, 32] °F converts to a
-// reading below the physiological range.
+// dropPreservedDayEntryFields neutralises every field this write marked
+// Preserve*, before the validation above ever reads one. A preserved field's
+// incoming value is not this write's subject — the save replaces it with the
+// value already stored — so it may not reject the day, and merging against an
+// EMPTY stored row is exactly that neutralisation: the same path an update
+// takes with the real row, run against no row at all, so the drop and the merge
+// cannot come to list different fields.
 //
-// On a day that does not exist yet there is nothing to merge, and dropping is
-// then the whole answer: a hidden field starts neutral instead of storing a
-// value the account cannot see.
+// Transport declines to read a hidden field at all (parseDayPayload), so no
+// HTTP request delivers a value here any more; keeping the rule in the service
+// is what makes it the service's own rather than a property of one transport.
+// Even before that, only bbt and cycle factors could refuse a day this way —
+// transport normalizes sex activity and cervical mucus to a valid spelling on
+// the way in and merely trims notes — and all five are dropped so the rule does
+// not have to be re-derived from what each transport happens to sanitize.
+//
+// On a day that does not exist yet there is nothing to merge, and this is then
+// the whole answer: a hidden field starts neutral instead of storing a value
+// the account can neither see nor correct.
 func dropPreservedDayEntryFields(input DayEntryInput) DayEntryInput {
-	if input.PreserveSexActivity {
-		input.SexActivity = models.SexActivityNone
-	}
-	if input.PreserveBBT {
-		input.BBT = nil
-	}
-	if input.PreserveCervicalMucus {
-		input.CervicalMucus = models.CervicalMucusNone
-	}
-	if input.PreserveCycleFactors {
-		input.CycleFactorKeys = nil
-	}
-	if input.PreserveNotes {
-		input.Notes = ""
-	}
-	return input
+	return mergePreservedDayEntryInput(models.DailyLog{}, input)
 }
 
 func NormalizeDayFlow(flow string) string {

--- a/internal/services/day_input_test.go
+++ b/internal/services/day_input_test.go
@@ -317,38 +317,43 @@ func TestNormalizeDayEntryInputNormalizesPregnancyTest(t *testing.T) {
 }
 
 // TestNormalizeDayEntryInputDropsAPreservedFieldsIncomingValue pins the order
-// the two halves of a hidden-field save run in. Transport sets Preserve* for
-// every field the account keeps hidden (buildUpsertDayEntryInput), and
-// mergePreservedDayEntryInput then replaces each of them with the value already
-// stored — but validation runs first, so an incoming value this write had
-// already promised to ignore could refuse the whole day, under a sentinel
-// naming a field the answer never looks at. The reachable case is an account
-// that hides BBT and tracks in Fahrenheit: everything in (0, 32] °F leaves
-// ConvertDayBBTToStorage as a reading below the physiological range, and the
-// day went unsaved over a temperature nobody asked for.
+// the two halves of a hidden-field save run in. A write marks Preserve* for
+// every field the account keeps hidden, and mergePreservedDayEntryInput
+// replaces each of them with the value already stored — but validation runs
+// first, so an incoming value this write had already promised to ignore could
+// refuse the whole day, under a sentinel naming a field the answer never looks
+// at.
 //
-// Five of the six rows carry a value that IS refused on its own — the second
-// half of each subtest re-submits it without the flag and requires that
-// refusal — so the table cannot go green by dropping validation altogether.
+// No HTTP request delivers such a value any more: transport does not read a
+// hidden field at all (parseDayPayload), and even before that only bbt and
+// cycle factors could arrive here unsanitized, since transport normalizes sex
+// activity and cervical mucus to a valid spelling and merely trims notes. This
+// table is therefore the service's own contract — held for any caller, not
+// inherited from what one transport happens to filter.
+//
+// Each row asserts the whole preserved class rather than its own field: the
+// value under test neutralised AND the four neighbours the caller did send
+// returned unchanged, so a drop reaching past its own flag cannot pass. Five
+// rows carry a value that IS refused on its own and re-submit it without the
+// flag to require that refusal; the sixth, a note, has no invalid spelling, so
+// its control requires the opposite — that without the flag the note survives
+// — which is what makes the drop attributable to the flag rather than to an
+// unconditional reset.
 func TestNormalizeDayEntryInputDropsAPreservedFieldsIncomingValue(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
 		name                   string
-		incoming               DayEntryInput
+		send                   func(input *DayEntryInput)
+		neutral                func(input *DayEntryInput)
 		preserve               func(input *DayEntryInput)
-		wantDropped            func(t *testing.T, normalized DayEntryInput)
 		wantErrWithoutPreserve error
 	}{
 		{
-			name:     "a bbt outside the physiological range",
-			incoming: DayEntryInput{Flow: models.FlowNone, BBT: bbtPtr(20)},
-			preserve: func(input *DayEntryInput) { input.PreserveBBT = true },
-			wantDropped: func(t *testing.T, normalized DayEntryInput) {
-				if normalized.BBT != nil {
-					t.Fatalf("expected a preserved bbt dropped to nil, got %.4f", *normalized.BBT)
-				}
-			},
+			name:                   "a bbt outside the physiological range",
+			send:                   func(input *DayEntryInput) { input.BBT = bbtPtr(20) },
+			neutral:                func(input *DayEntryInput) { input.BBT = nil },
+			preserve:               func(input *DayEntryInput) { input.PreserveBBT = true },
 			wantErrWithoutPreserve: ErrInvalidDayBBT,
 		},
 		{
@@ -358,62 +363,38 @@ func TestNormalizeDayEntryInputDropsAPreservedFieldsIncomingValue(t *testing.T) 
 			// sentinel — and its control expects the same refusal as the row
 			// above. It is listed because a preserved bbt is dropped whatever
 			// its sign, not only when the range would have caught it.
-			name:     "a non-positive bbt",
-			incoming: DayEntryInput{Flow: models.FlowNone, BBT: bbtPtr(-1)},
-			preserve: func(input *DayEntryInput) { input.PreserveBBT = true },
-			wantDropped: func(t *testing.T, normalized DayEntryInput) {
-				if normalized.BBT != nil {
-					t.Fatalf("expected a preserved bbt dropped to nil, got %.4f", *normalized.BBT)
-				}
-			},
+			name:                   "a non-positive bbt",
+			send:                   func(input *DayEntryInput) { input.BBT = bbtPtr(-1) },
+			neutral:                func(input *DayEntryInput) { input.BBT = nil },
+			preserve:               func(input *DayEntryInput) { input.PreserveBBT = true },
 			wantErrWithoutPreserve: ErrInvalidDayBBT,
 		},
 		{
-			name:     "an unknown sex activity",
-			incoming: DayEntryInput{Flow: models.FlowNone, SexActivity: "not-an-activity"},
-			preserve: func(input *DayEntryInput) { input.PreserveSexActivity = true },
-			wantDropped: func(t *testing.T, normalized DayEntryInput) {
-				if normalized.SexActivity != models.SexActivityNone {
-					t.Fatalf("expected a preserved sex activity dropped to %q, got %q", models.SexActivityNone, normalized.SexActivity)
-				}
-			},
+			name:                   "an unknown sex activity",
+			send:                   func(input *DayEntryInput) { input.SexActivity = "not-an-activity" },
+			neutral:                func(input *DayEntryInput) { input.SexActivity = models.SexActivityNone },
+			preserve:               func(input *DayEntryInput) { input.PreserveSexActivity = true },
 			wantErrWithoutPreserve: ErrInvalidDaySexActivity,
 		},
 		{
-			name:     "an unknown cervical mucus",
-			incoming: DayEntryInput{Flow: models.FlowNone, CervicalMucus: "not-a-mucus"},
-			preserve: func(input *DayEntryInput) { input.PreserveCervicalMucus = true },
-			wantDropped: func(t *testing.T, normalized DayEntryInput) {
-				if normalized.CervicalMucus != models.CervicalMucusNone {
-					t.Fatalf("expected a preserved cervical mucus dropped to %q, got %q", models.CervicalMucusNone, normalized.CervicalMucus)
-				}
-			},
+			name:                   "an unknown cervical mucus",
+			send:                   func(input *DayEntryInput) { input.CervicalMucus = "not-a-mucus" },
+			neutral:                func(input *DayEntryInput) { input.CervicalMucus = models.CervicalMucusNone },
+			preserve:               func(input *DayEntryInput) { input.PreserveCervicalMucus = true },
 			wantErrWithoutPreserve: ErrInvalidDayCervicalMucus,
 		},
 		{
-			name:     "an unknown cycle factor",
-			incoming: DayEntryInput{Flow: models.FlowNone, CycleFactorKeys: []string{"not_a_factor"}},
-			preserve: func(input *DayEntryInput) { input.PreserveCycleFactors = true },
-			wantDropped: func(t *testing.T, normalized DayEntryInput) {
-				if len(normalized.CycleFactorKeys) != 0 {
-					t.Fatalf("expected preserved cycle factors dropped to none, got %#v", normalized.CycleFactorKeys)
-				}
-			},
+			name:                   "an unknown cycle factor",
+			send:                   func(input *DayEntryInput) { input.CycleFactorKeys = []string{"not_a_factor"} },
+			neutral:                func(input *DayEntryInput) { input.CycleFactorKeys = nil },
+			preserve:               func(input *DayEntryInput) { input.PreserveCycleFactors = true },
 			wantErrWithoutPreserve: ErrInvalidDayCycleFactors,
 		},
 		{
-			// A note has no invalid spelling, so this row cannot produce a
-			// refusal; it is here because the fifth preserved field must behave
-			// like the other four rather than be the one that still carries an
-			// ignored value into a freshly created day.
 			name:     "a note",
-			incoming: DayEntryInput{Flow: models.FlowNone, Notes: "not this write's subject"},
+			send:     func(input *DayEntryInput) { input.Notes = "not this write's subject" },
+			neutral:  func(input *DayEntryInput) { input.Notes = "" },
 			preserve: func(input *DayEntryInput) { input.PreserveNotes = true },
-			wantDropped: func(t *testing.T, normalized DayEntryInput) {
-				if normalized.Notes != "" {
-					t.Fatalf("expected a preserved note dropped to empty, got %q", normalized.Notes)
-				}
-			},
 		},
 	}
 
@@ -421,18 +402,66 @@ func TestNormalizeDayEntryInputDropsAPreservedFieldsIncomingValue(t *testing.T) 
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			preserved := testCase.incoming
+			incoming := dayEntryInputWithEveryPreservableFieldSet()
+			testCase.send(&incoming)
+			wantDropped := incoming
+			testCase.neutral(&wantDropped)
+
+			preserved := incoming
 			testCase.preserve(&preserved)
 			normalized, err := NormalizeDayEntryInput(preserved)
 			if err != nil {
 				t.Fatalf("a preserved field must not refuse the day, got %v", err)
 			}
-			testCase.wantDropped(t, normalized)
+			assertDayEntryPreservableFields(t, normalized, wantDropped)
 
-			_, err = NormalizeDayEntryInput(testCase.incoming)
-			if !errors.Is(err, testCase.wantErrWithoutPreserve) {
-				t.Fatalf("without the preserve flag the same value must answer %v, got %v", testCase.wantErrWithoutPreserve, err)
+			control, err := NormalizeDayEntryInput(incoming)
+			if testCase.wantErrWithoutPreserve != nil {
+				if !errors.Is(err, testCase.wantErrWithoutPreserve) {
+					t.Fatalf("without the preserve flag the same value must answer %v, got %v", testCase.wantErrWithoutPreserve, err)
+				}
+				return
 			}
+			if err != nil {
+				t.Fatalf("without the preserve flag this value is a valid entry, got %v", err)
+			}
+			assertDayEntryPreservableFields(t, control, incoming)
 		})
+	}
+}
+
+// dayEntryInputWithEveryPreservableFieldSet is the input every row above starts
+// from: all five preservable fields carry a valid, non-neutral value, so the
+// four a row is not testing can be required to come back exactly as sent. A row
+// starting from the zero value could not tell a drop confined to its own flag
+// from one that neutralised the lot.
+func dayEntryInputWithEveryPreservableFieldSet() DayEntryInput {
+	return DayEntryInput{
+		Flow:            models.FlowNone,
+		SexActivity:     models.SexActivityProtected,
+		BBT:             bbtPtr(36.5),
+		CervicalMucus:   models.CervicalMucusCreamy,
+		CycleFactorKeys: []string{models.CycleFactorStress},
+		Notes:           "a neighbour this write does carry",
+	}
+}
+
+func assertDayEntryPreservableFields(t *testing.T, got DayEntryInput, want DayEntryInput) {
+	t.Helper()
+
+	if got.SexActivity != want.SexActivity {
+		t.Fatalf("sex activity: expected %q, got %q", want.SexActivity, got.SexActivity)
+	}
+	if !sameDayBBT(got.BBT, want.BBT) {
+		t.Fatalf("bbt: expected %s, got %s", describeDayBBT(want.BBT), describeDayBBT(got.BBT))
+	}
+	if got.CervicalMucus != want.CervicalMucus {
+		t.Fatalf("cervical mucus: expected %q, got %q", want.CervicalMucus, got.CervicalMucus)
+	}
+	if strings.Join(got.CycleFactorKeys, ",") != strings.Join(want.CycleFactorKeys, ",") {
+		t.Fatalf("cycle factors: expected %#v, got %#v", want.CycleFactorKeys, got.CycleFactorKeys)
+	}
+	if got.Notes != want.Notes {
+		t.Fatalf("notes: expected %q, got %q", want.Notes, got.Notes)
 	}
 }

--- a/internal/services/day_input_test.go
+++ b/internal/services/day_input_test.go
@@ -334,14 +334,14 @@ func TestNormalizeDayEntryInputNormalizesPregnancyTest(t *testing.T) {
 //
 // Each row asserts the whole entry rather than its own field: the value under
 // test neutralised, the four preservable neighbours the caller did send
-// returned unchanged, and the five fields no flag can preserve — the period
-// day, its flow, the mood, the pregnancy test, the symptoms — returned
-// unchanged too, so a drop reaching past its own flag cannot pass. Five
-// rows carry a value that IS refused on its own and re-submit it without the
-// flag to require that refusal; the sixth, a note, has no invalid spelling, so
-// its control requires the opposite — that without the flag the note survives
-// — which is what makes the drop attributable to the flag rather than to an
-// unconditional reset.
+// returned unchanged, and the six fields no flag can preserve — the period
+// day, its flow, the mood, the pregnancy test, the symptoms, the cycle-start
+// answer — returned unchanged too, so a drop reaching past its own flag cannot
+// pass. Five rows carry a value that IS refused on its own and re-submit it
+// without the flag to require that refusal; the sixth, a note, has no invalid
+// spelling, so its control requires the opposite — that without the flag the
+// note survives — which is what makes the drop attributable to the flag rather
+// than to an unconditional reset.
 func TestNormalizeDayEntryInputDropsAPreservedFieldsIncomingValue(t *testing.T) {
 	t.Parallel()
 
@@ -440,28 +440,37 @@ func TestNormalizeDayEntryInputDropsAPreservedFieldsIncomingValue(t *testing.T) 
 // from one that neutralised the lot.
 //
 // The fields no flag can preserve carry values too — the period day and its
-// flow, the mood, the pregnancy test, the symptoms — because the drop runs over
-// a whole DayEntryInput and nothing in its signature confines it to the five. A
-// reset reaching past them would unset the day the owner did send, which is the
-// same defect one field further out.
+// flow, the mood, the pregnancy test, the symptoms, the cycle-start answer —
+// because the drop runs over a whole DayEntryInput and nothing in its signature
+// confines it to the five. A reset reaching past them would unset the day the
+// owner did send, which is the same defect one field further out. The
+// cycle-start answer survives the pass only on a period day, which is why the
+// fixture is one: NormalizeDayEntryInput clears it on any other.
+//
+// The cycle factors carry TWO keys, in the order normalization returns them
+// (supportedDayCycleFactorKeys), because a single key is a set every rewrite
+// agrees with: joined on a comma it answers back as itself, so the
+// element-by-element comparison below would be describing a property the
+// fixture cannot exercise.
 func dayEntryInputWithEveryDayFieldSet() DayEntryInput {
 	return DayEntryInput{
-		IsPeriod:        true,
-		Flow:            models.FlowMedium,
-		Mood:            4,
-		PregnancyTest:   models.PregnancyTestNegative,
-		SymptomIDs:      []uint{7},
-		SexActivity:     models.SexActivityProtected,
-		BBT:             bbtPtr(36.5),
-		CervicalMucus:   models.CervicalMucusCreamy,
-		CycleFactorKeys: []string{models.CycleFactorStress},
-		Notes:           "a neighbour this write does carry",
+		IsPeriod:          true,
+		Flow:              models.FlowMedium,
+		Mood:              4,
+		PregnancyTest:     models.PregnancyTestNegative,
+		SymptomIDs:        []uint{7},
+		ConfirmCycleStart: true,
+		SexActivity:       models.SexActivityProtected,
+		BBT:               bbtPtr(36.5),
+		CervicalMucus:     models.CervicalMucusCreamy,
+		CycleFactorKeys:   []string{models.CycleFactorStress, models.CycleFactorTravel},
+		Notes:             "a neighbour this write does carry",
 	}
 }
 
 // assertDayEntryFields compares a normalized entry against the whole input the
 // caller sent: first the five preservable fields, which are each row's subject,
-// then the five no flag can preserve, which are the cross-check.
+// then the six no flag can preserve, which are the cross-check.
 //
 // The slices are compared element by element. Joined into one string on a
 // comma, ["a,b"] and ["a", "b"] are the same text and two different sets, so a
@@ -501,5 +510,8 @@ func assertDayEntryFields(t *testing.T, got DayEntryInput, want DayEntryInput) {
 	}
 	if !slices.Equal(got.SymptomIDs, want.SymptomIDs) {
 		t.Fatalf("symptom ids: expected %#v, got %#v", want.SymptomIDs, got.SymptomIDs)
+	}
+	if got.ConfirmCycleStart != want.ConfirmCycleStart {
+		t.Fatalf("confirm cycle start: expected %t, got %t", want.ConfirmCycleStart, got.ConfirmCycleStart)
 	}
 }

--- a/internal/services/day_input_test.go
+++ b/internal/services/day_input_test.go
@@ -315,3 +315,124 @@ func TestNormalizeDayEntryInputNormalizesPregnancyTest(t *testing.T) {
 		t.Fatalf("expected pregnancy test %q, got %q", models.PregnancyTestPositive, normalized.PregnancyTest)
 	}
 }
+
+// TestNormalizeDayEntryInputDropsAPreservedFieldsIncomingValue pins the order
+// the two halves of a hidden-field save run in. Transport sets Preserve* for
+// every field the account keeps hidden (buildUpsertDayEntryInput), and
+// mergePreservedDayEntryInput then replaces each of them with the value already
+// stored — but validation runs first, so an incoming value this write had
+// already promised to ignore could refuse the whole day, under a sentinel
+// naming a field the answer never looks at. The reachable case is an account
+// that hides BBT and tracks in Fahrenheit: everything in (0, 32] °F leaves
+// ConvertDayBBTToStorage as a reading below the physiological range, and the
+// day went unsaved over a temperature nobody asked for.
+//
+// Five of the six rows carry a value that IS refused on its own — the second
+// half of each subtest re-submits it without the flag and requires that
+// refusal — so the table cannot go green by dropping validation altogether.
+func TestNormalizeDayEntryInputDropsAPreservedFieldsIncomingValue(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name                   string
+		incoming               DayEntryInput
+		preserve               func(input *DayEntryInput)
+		wantDropped            func(t *testing.T, normalized DayEntryInput)
+		wantErrWithoutPreserve error
+	}{
+		{
+			name:     "a bbt outside the physiological range",
+			incoming: DayEntryInput{Flow: models.FlowNone, BBT: bbtPtr(20)},
+			preserve: func(input *DayEntryInput) { input.PreserveBBT = true },
+			wantDropped: func(t *testing.T, normalized DayEntryInput) {
+				if normalized.BBT != nil {
+					t.Fatalf("expected a preserved bbt dropped to nil, got %.4f", *normalized.BBT)
+				}
+			},
+			wantErrWithoutPreserve: ErrInvalidDayBBT,
+		},
+		{
+			// The "not measured" sentinel is read in the owner's own unit, one
+			// layer up (ConvertDayBBTToStorage), so by here a non-positive value
+			// is simply a reading below the range — IsValidDayBBT knows no
+			// sentinel — and its control expects the same refusal as the row
+			// above. It is listed because a preserved bbt is dropped whatever
+			// its sign, not only when the range would have caught it.
+			name:     "a non-positive bbt",
+			incoming: DayEntryInput{Flow: models.FlowNone, BBT: bbtPtr(-1)},
+			preserve: func(input *DayEntryInput) { input.PreserveBBT = true },
+			wantDropped: func(t *testing.T, normalized DayEntryInput) {
+				if normalized.BBT != nil {
+					t.Fatalf("expected a preserved bbt dropped to nil, got %.4f", *normalized.BBT)
+				}
+			},
+			wantErrWithoutPreserve: ErrInvalidDayBBT,
+		},
+		{
+			name:     "an unknown sex activity",
+			incoming: DayEntryInput{Flow: models.FlowNone, SexActivity: "not-an-activity"},
+			preserve: func(input *DayEntryInput) { input.PreserveSexActivity = true },
+			wantDropped: func(t *testing.T, normalized DayEntryInput) {
+				if normalized.SexActivity != models.SexActivityNone {
+					t.Fatalf("expected a preserved sex activity dropped to %q, got %q", models.SexActivityNone, normalized.SexActivity)
+				}
+			},
+			wantErrWithoutPreserve: ErrInvalidDaySexActivity,
+		},
+		{
+			name:     "an unknown cervical mucus",
+			incoming: DayEntryInput{Flow: models.FlowNone, CervicalMucus: "not-a-mucus"},
+			preserve: func(input *DayEntryInput) { input.PreserveCervicalMucus = true },
+			wantDropped: func(t *testing.T, normalized DayEntryInput) {
+				if normalized.CervicalMucus != models.CervicalMucusNone {
+					t.Fatalf("expected a preserved cervical mucus dropped to %q, got %q", models.CervicalMucusNone, normalized.CervicalMucus)
+				}
+			},
+			wantErrWithoutPreserve: ErrInvalidDayCervicalMucus,
+		},
+		{
+			name:     "an unknown cycle factor",
+			incoming: DayEntryInput{Flow: models.FlowNone, CycleFactorKeys: []string{"not_a_factor"}},
+			preserve: func(input *DayEntryInput) { input.PreserveCycleFactors = true },
+			wantDropped: func(t *testing.T, normalized DayEntryInput) {
+				if len(normalized.CycleFactorKeys) != 0 {
+					t.Fatalf("expected preserved cycle factors dropped to none, got %#v", normalized.CycleFactorKeys)
+				}
+			},
+			wantErrWithoutPreserve: ErrInvalidDayCycleFactors,
+		},
+		{
+			// A note has no invalid spelling, so this row cannot produce a
+			// refusal; it is here because the fifth preserved field must behave
+			// like the other four rather than be the one that still carries an
+			// ignored value into a freshly created day.
+			name:     "a note",
+			incoming: DayEntryInput{Flow: models.FlowNone, Notes: "not this write's subject"},
+			preserve: func(input *DayEntryInput) { input.PreserveNotes = true },
+			wantDropped: func(t *testing.T, normalized DayEntryInput) {
+				if normalized.Notes != "" {
+					t.Fatalf("expected a preserved note dropped to empty, got %q", normalized.Notes)
+				}
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			preserved := testCase.incoming
+			testCase.preserve(&preserved)
+			normalized, err := NormalizeDayEntryInput(preserved)
+			if err != nil {
+				t.Fatalf("a preserved field must not refuse the day, got %v", err)
+			}
+			testCase.wantDropped(t, normalized)
+
+			_, err = NormalizeDayEntryInput(testCase.incoming)
+			if !errors.Is(err, testCase.wantErrWithoutPreserve) {
+				t.Fatalf("without the preserve flag the same value must answer %v, got %v", testCase.wantErrWithoutPreserve, err)
+			}
+		})
+	}
+}

--- a/internal/services/day_input_test.go
+++ b/internal/services/day_input_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"io/fs"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -331,9 +332,11 @@ func TestNormalizeDayEntryInputNormalizesPregnancyTest(t *testing.T) {
 // table is therefore the service's own contract — held for any caller, not
 // inherited from what one transport happens to filter.
 //
-// Each row asserts the whole preserved class rather than its own field: the
-// value under test neutralised AND the four neighbours the caller did send
-// returned unchanged, so a drop reaching past its own flag cannot pass. Five
+// Each row asserts the whole entry rather than its own field: the value under
+// test neutralised, the four preservable neighbours the caller did send
+// returned unchanged, and the five fields no flag can preserve — the period
+// day, its flow, the mood, the pregnancy test, the symptoms — returned
+// unchanged too, so a drop reaching past its own flag cannot pass. Five
 // rows carry a value that IS refused on its own and re-submit it without the
 // flag to require that refusal; the sixth, a note, has no invalid spelling, so
 // its control requires the opposite — that without the flag the note survives
@@ -402,7 +405,7 @@ func TestNormalizeDayEntryInputDropsAPreservedFieldsIncomingValue(t *testing.T) 
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			incoming := dayEntryInputWithEveryPreservableFieldSet()
+			incoming := dayEntryInputWithEveryDayFieldSet()
 			testCase.send(&incoming)
 			wantDropped := incoming
 			testCase.neutral(&wantDropped)
@@ -413,7 +416,7 @@ func TestNormalizeDayEntryInputDropsAPreservedFieldsIncomingValue(t *testing.T) 
 			if err != nil {
 				t.Fatalf("a preserved field must not refuse the day, got %v", err)
 			}
-			assertDayEntryPreservableFields(t, normalized, wantDropped)
+			assertDayEntryFields(t, normalized, wantDropped)
 
 			control, err := NormalizeDayEntryInput(incoming)
 			if testCase.wantErrWithoutPreserve != nil {
@@ -425,19 +428,29 @@ func TestNormalizeDayEntryInputDropsAPreservedFieldsIncomingValue(t *testing.T) 
 			if err != nil {
 				t.Fatalf("without the preserve flag this value is a valid entry, got %v", err)
 			}
-			assertDayEntryPreservableFields(t, control, incoming)
+			assertDayEntryFields(t, control, incoming)
 		})
 	}
 }
 
-// dayEntryInputWithEveryPreservableFieldSet is the input every row above starts
-// from: all five preservable fields carry a valid, non-neutral value, so the
-// four a row is not testing can be required to come back exactly as sent. A row
+// dayEntryInputWithEveryDayFieldSet is the input every row above starts from.
+// All five preservable fields carry a valid, non-neutral value, so the four a
+// row is not testing can be required to come back exactly as sent: a row
 // starting from the zero value could not tell a drop confined to its own flag
 // from one that neutralised the lot.
-func dayEntryInputWithEveryPreservableFieldSet() DayEntryInput {
+//
+// The fields no flag can preserve carry values too — the period day and its
+// flow, the mood, the pregnancy test, the symptoms — because the drop runs over
+// a whole DayEntryInput and nothing in its signature confines it to the five. A
+// reset reaching past them would unset the day the owner did send, which is the
+// same defect one field further out.
+func dayEntryInputWithEveryDayFieldSet() DayEntryInput {
 	return DayEntryInput{
-		Flow:            models.FlowNone,
+		IsPeriod:        true,
+		Flow:            models.FlowMedium,
+		Mood:            4,
+		PregnancyTest:   models.PregnancyTestNegative,
+		SymptomIDs:      []uint{7},
 		SexActivity:     models.SexActivityProtected,
 		BBT:             bbtPtr(36.5),
 		CervicalMucus:   models.CervicalMucusCreamy,
@@ -446,7 +459,16 @@ func dayEntryInputWithEveryPreservableFieldSet() DayEntryInput {
 	}
 }
 
-func assertDayEntryPreservableFields(t *testing.T, got DayEntryInput, want DayEntryInput) {
+// assertDayEntryFields compares a normalized entry against the whole input the
+// caller sent: first the five preservable fields, which are each row's subject,
+// then the five no flag can preserve, which are the cross-check.
+//
+// The slices are compared element by element. Joined into one string on a
+// comma, ["a,b"] and ["a", "b"] are the same text and two different sets, so a
+// comparison that reads as "the same keys" would also pass a set some
+// normalization had rewritten. A nil slice and an empty one stay equal — "no
+// cycle factors" is one answer with two spellings.
+func assertDayEntryFields(t *testing.T, got DayEntryInput, want DayEntryInput) {
 	t.Helper()
 
 	if got.SexActivity != want.SexActivity {
@@ -458,10 +480,26 @@ func assertDayEntryPreservableFields(t *testing.T, got DayEntryInput, want DayEn
 	if got.CervicalMucus != want.CervicalMucus {
 		t.Fatalf("cervical mucus: expected %q, got %q", want.CervicalMucus, got.CervicalMucus)
 	}
-	if strings.Join(got.CycleFactorKeys, ",") != strings.Join(want.CycleFactorKeys, ",") {
+	if !slices.Equal(got.CycleFactorKeys, want.CycleFactorKeys) {
 		t.Fatalf("cycle factors: expected %#v, got %#v", want.CycleFactorKeys, got.CycleFactorKeys)
 	}
 	if got.Notes != want.Notes {
 		t.Fatalf("notes: expected %q, got %q", want.Notes, got.Notes)
+	}
+
+	if got.IsPeriod != want.IsPeriod {
+		t.Fatalf("is period: expected %t, got %t", want.IsPeriod, got.IsPeriod)
+	}
+	if got.Flow != want.Flow {
+		t.Fatalf("flow: expected %q, got %q", want.Flow, got.Flow)
+	}
+	if got.Mood != want.Mood {
+		t.Fatalf("mood: expected %d, got %d", want.Mood, got.Mood)
+	}
+	if got.PregnancyTest != want.PregnancyTest {
+		t.Fatalf("pregnancy test: expected %q, got %q", want.PregnancyTest, got.PregnancyTest)
+	}
+	if !slices.Equal(got.SymptomIDs, want.SymptomIDs) {
+		t.Fatalf("symptom ids: expected %#v, got %#v", want.SymptomIDs, got.SymptomIDs)
 	}
 }

--- a/internal/services/day_service.go
+++ b/internal/services/day_service.go
@@ -166,6 +166,10 @@ func (service *DayService) DayHasDataForDate(ctx context.Context, userID uint, d
 	return false, nil
 }
 
+// UpsertDayEntry writes one owner's day. Its precondition is that callers
+// normalise the payload through NormalizeDayEntryInput first: only the update
+// branch merges anything (mergePreservedDayEntryInput), while the create branch
+// writes the fields exactly as given and applies no preservation of its own.
 func (service *DayService) UpsertDayEntry(ctx context.Context, userID uint, dayStart time.Time, payload DayEntryInput, location *time.Location) (models.DailyLog, bool, error) {
 	// Defensive normalization: collapse any time-of-day or non-UTC offset on
 	// the incoming dayStart back to canonical UTC-midnight. The intended

--- a/internal/services/day_tracking.go
+++ b/internal/services/day_tracking.go
@@ -201,15 +201,25 @@ func ConvertDayBBTToStorage(value *float64, unit string) *float64 {
 	return &rounded
 }
 
-// normalizeStoredDayBBT rounds an already-Celsius value onto the stored grid.
-// Its non-measurement branch (nil, or the old non-positive sentinel range) is
-// live for one caller: FormatDayBBTForInput, rendering a legacy 0 out of a row
-// written before BBT became nullable, which the day form has to show as an
-// empty field. At the other two sites the value has already been validated or
-// nil-ed and only the rounding applies — NormalizeDayEntryInput's closing pass
-// (day_input.go), where IsValidDayBBT refused anything non-positive one step
-// earlier, and the import (import_service.go), where normalizeExportBBT emptied
-// it.
+// normalizeStoredDayBBT rounds an already-Celsius value onto the stored grid
+// and answers nil for a non-measurement. Its two halves are reached very
+// differently.
+//
+// The nil half runs on every ordinary path: a day saved without a temperature
+// (NormalizeDayEntryInput's closing pass, day_input.go), a restored file whose
+// reading the import already emptied (normalizeExportBBT, import_service.go),
+// and a row the day form renders as an empty field (FormatDayBBTForInput).
+//
+// The non-positive half is a floor rather than a live path. Migration 024
+// rewrote the legacy 0 sentinel to NULL on both engines
+// (migrations/024_daily_logs_bbt_nullable.sql and its postgres twin), and since
+// the "not measured" answer moved into the owner's own unit no writer can store
+// a non-positive value at all — a save is refused by IsValidDayBBT one step
+// earlier, an import emptied by normalizeExportBBT. It stays for the row that
+// arrives from outside those writers: a backup taken before 024, a database
+// edited by hand. Such a row has to render as an empty field, not as a
+// measurement of zero. Regression:
+// TestFormatDayBBTForInputRendersALegacyZeroAsNotMeasured.
 //
 // Because it runs after any conversion and never learns the owner's unit, it
 // cannot be the place the sentinel is judged — ConvertDayBBTToStorage says why.

--- a/internal/services/day_tracking.go
+++ b/internal/services/day_tracking.go
@@ -154,15 +154,23 @@ func ParseDayBBTRawWithUnit(raw string, unit string) (*float64, error) {
 	return ConvertDayBBTToStorage(&value, unit), nil
 }
 
-// ConvertDayBBTToStorage takes a BBT value already expressed in the account's
-// chosen unit and converts it to the canonical stored Celsius form. It is the
-// unit-conversion half of ParseDayBBTRawWithUnit, factored out so the JSON
-// bind path — which parses its own float via encoding/json rather than a form
-// string — converts and rounds identically instead of writing whatever unit
-// the caller sent straight to storage. The "not measured" sentinel is read in
-// the unit the owner typed, before the conversion: read in Celsius afterwards
-// it also swallows every Fahrenheit entry in (0, 32], which is an impossible
-// reading the range must refuse, not an empty field.
+// ConvertDayBBTToStorage is the INPUT gate for a temperature: it takes what the
+// owner typed, in the account's own unit, and answers the canonical stored
+// Celsius form — or nil for "not measured". Both transports go through it
+// before NormalizeDayEntryInput judges the result, the form via
+// ParseDayBBTRawWithUnit's string parse and the JSON bind with the float
+// encoding/json gave it, so neither writes whatever unit the caller sent
+// straight to storage and both round identically.
+//
+// The "not measured" sentinel is read HERE, in the unit that was typed, and
+// this is the only place entitled to read it. A non-positive entry is the owner
+// saying nothing was measured; anything above it is a reading, and the
+// physiological range (IsValidDayBBT) is what then accepts or refuses it. Read
+// after the conversion instead, that same test swallowed every Fahrenheit entry
+// in (0, 32] as well — 20 °F is not an empty field, it is an impossible
+// reading — and the day was saved with a null temperature and no word to the
+// owner. This is the one full statement of that placement; the tests, the
+// changelog and the spec point back here.
 func ConvertDayBBTToStorage(value *float64, unit string) *float64 {
 	if value == nil || *value <= 0 {
 		return nil
@@ -175,10 +183,16 @@ func ConvertDayBBTToStorage(value *float64, unit string) *float64 {
 	return &rounded
 }
 
-// normalizeStoredDayBBT collapses any non-measurement (nil or a non-positive
-// value, the old sentinel range) to nil, and rounds a genuine reading. The
-// result is the canonical stored form: nil for unmeasured, a rounded pointer
-// otherwise.
+// normalizeStoredDayBBT is the STORED-side counterpart, and runs only on values
+// that are already Celsius and never passed the input gate above: a legacy 0
+// read back out of a row written before BBT became nullable
+// (FormatDayBBTForInput), a restored file's reading (import_service.go), and
+// NormalizeDayEntryInput's closing pass over whatever a service caller handed
+// it. It collapses a non-measurement (nil, or the old non-positive sentinel
+// range) to nil and rounds a genuine reading onto the stored grid.
+//
+// Because it runs after any conversion and never learns the owner's unit, it
+// cannot be the place the sentinel is judged — ConvertDayBBTToStorage says why.
 func normalizeStoredDayBBT(value *float64) *float64 {
 	if value == nil || *value <= 0 {
 		return nil

--- a/internal/services/day_tracking.go
+++ b/internal/services/day_tracking.go
@@ -159,16 +159,20 @@ func ParseDayBBTRawWithUnit(raw string, unit string) (*float64, error) {
 // unit-conversion half of ParseDayBBTRawWithUnit, factored out so the JSON
 // bind path — which parses its own float via encoding/json rather than a form
 // string — converts and rounds identically instead of writing whatever unit
-// the caller sent straight to storage.
+// the caller sent straight to storage. The "not measured" sentinel is read in
+// the unit the owner typed, before the conversion: read in Celsius afterwards
+// it also swallows every Fahrenheit entry in (0, 32], which is an impossible
+// reading the range must refuse, not an empty field.
 func ConvertDayBBTToStorage(value *float64, unit string) *float64 {
-	if value == nil {
+	if value == nil || *value <= 0 {
 		return nil
 	}
 	converted := *value
 	if NormalizeTemperatureUnit(unit) == TemperatureUnitFahrenheit {
 		converted = fahrenheitToCelsius(converted)
 	}
-	return normalizeStoredDayBBT(&converted)
+	rounded := roundStoredTemperatureValue(converted)
+	return &rounded
 }
 
 // normalizeStoredDayBBT collapses any non-measurement (nil or a non-positive

--- a/internal/services/day_tracking.go
+++ b/internal/services/day_tracking.go
@@ -178,7 +178,9 @@ func ParseDayBBTRawWithUnit(raw string, unit string) (*float64, error) {
 // changelog and the spec point back here.
 //
 // A non-finite entry is neither answer and is handed on as it stands, so the
-// range refuses it. Without that, -Inf would BE the sentinel — it is
+// range refuses it — which makes validation a PRECONDITION of every caller:
+// what comes back is a value in stored units, not a value fit to store, and the
+// two callers here both reach NormalizeDayEntryInput before anything is written. Without that, -Inf would BE the sentinel — it is
 // non-positive — and a value no thermometer can produce would be filed as the
 // owner's "nothing measured", while NaN, non-positive under no comparison, was
 // already refused. Same input, opposite outcomes, on the sign of an infinity.

--- a/internal/services/day_tracking.go
+++ b/internal/services/day_tracking.go
@@ -155,12 +155,17 @@ func ParseDayBBTRawWithUnit(raw string, unit string) (*float64, error) {
 }
 
 // ConvertDayBBTToStorage is the INPUT gate for a temperature: it takes what the
-// owner typed, in the account's own unit, and answers the canonical stored
-// Celsius form — or nil for "not measured". Both transports go through it
-// before NormalizeDayEntryInput judges the result, the form via
-// ParseDayBBTRawWithUnit's string parse and the JSON bind with the float
-// encoding/json gave it, so neither writes whatever unit the caller sent
-// straight to storage and both round identically.
+// owner typed, in the account's own unit, and answers that value converted to
+// Celsius and rounded onto the stored grid — or nil for "not measured". It
+// judges nothing beyond the sentinel: 32 °F comes back as a pointer to 0.0 and
+// 20 °F as one to -6.6667, both of them readings left for IsValidDayBBT to
+// refuse. So the order is fixed, convert HERE and validate after, and a caller
+// that validates first is judging a number in the wrong unit.
+//
+// Both transports go through it before NormalizeDayEntryInput judges the
+// result, the form via ParseDayBBTRawWithUnit's string parse and the JSON bind
+// with the float encoding/json gave it, so neither writes whatever unit the
+// caller sent straight to storage and both round identically.
 //
 // The "not measured" sentinel is read HERE, in the unit that was typed, and
 // this is the only place entitled to read it. A non-positive entry is the owner
@@ -171,8 +176,21 @@ func ParseDayBBTRawWithUnit(raw string, unit string) (*float64, error) {
 // reading — and the day was saved with a null temperature and no word to the
 // owner. This is the one full statement of that placement; the tests, the
 // changelog and the spec point back here.
+//
+// A non-finite entry is neither answer and is handed on as it stands, so the
+// range refuses it. Without that, -Inf would BE the sentinel — it is
+// non-positive — and a value no thermometer can produce would be filed as the
+// owner's "nothing measured", while NaN, non-positive under no comparison, was
+// already refused. Same input, opposite outcomes, on the sign of an infinity.
 func ConvertDayBBTToStorage(value *float64, unit string) *float64 {
-	if value == nil || *value <= 0 {
+	if value == nil {
+		return nil
+	}
+	if math.IsNaN(*value) || math.IsInf(*value, 0) {
+		nonFinite := *value
+		return &nonFinite
+	}
+	if *value <= 0 {
 		return nil
 	}
 	converted := *value
@@ -183,13 +201,15 @@ func ConvertDayBBTToStorage(value *float64, unit string) *float64 {
 	return &rounded
 }
 
-// normalizeStoredDayBBT is the STORED-side counterpart, and runs only on values
-// that are already Celsius and never passed the input gate above: a legacy 0
-// read back out of a row written before BBT became nullable
-// (FormatDayBBTForInput), a restored file's reading (import_service.go), and
-// NormalizeDayEntryInput's closing pass over whatever a service caller handed
-// it. It collapses a non-measurement (nil, or the old non-positive sentinel
-// range) to nil and rounds a genuine reading onto the stored grid.
+// normalizeStoredDayBBT rounds an already-Celsius value onto the stored grid.
+// Its non-measurement branch (nil, or the old non-positive sentinel range) is
+// live for one caller: FormatDayBBTForInput, rendering a legacy 0 out of a row
+// written before BBT became nullable, which the day form has to show as an
+// empty field. At the other two sites the value has already been validated or
+// nil-ed and only the rounding applies — NormalizeDayEntryInput's closing pass
+// (day_input.go), where IsValidDayBBT refused anything non-positive one step
+// earlier, and the import (import_service.go), where normalizeExportBBT emptied
+// it.
 //
 // Because it runs after any conversion and never learns the owner's unit, it
 // cannot be the place the sentinel is judged — ConvertDayBBTToStorage says why.

--- a/internal/services/day_tracking_mutation_test.go
+++ b/internal/services/day_tracking_mutation_test.go
@@ -54,20 +54,23 @@ func TestFormatDayBBTForInputReturnsEmptyForUnsetValue(t *testing.T) {
 	}
 }
 
-func TestParseDayBBTRawWithUnitNormalizesNonPositiveToNil(t *testing.T) {
+// TestFormatDayBBTForInputRendersALegacyZeroAsNotMeasured pins
+// normalizeStoredDayBBT's `*value <= 0` guard where that function is still
+// reached: a row written before BBT became nullable holds 0, and the day form
+// has to render it as an empty field rather than as a measurement of zero. The
+// CONDITIONALS_BOUNDARY mutant (`*value < 0`) lets the 0 through and prints
+// "0.00" °C — or "32.00" °F — into the input the owner is about to save back.
+//
+// It used to be written against ParseDayBBTRawWithUnit, which no longer reaches
+// this guard: the parse path reads the sentinel one call earlier, in the
+// owner's unit (ConvertDayBBTToStorage), and that boundary is covered by
+// TestConvertDayBBTToStorageJudgesTheSentinelInTheInputUnit.
+func TestFormatDayBBTForInputRendersALegacyZeroAsNotMeasured(t *testing.T) {
 	t.Parallel()
 
-	// A non-positive parsed value (including "-0" and "0") is not a physiological
-	// reading; normalizeStoredDayBBT's `*value <= 0` guard must collapse it to nil
-	// (not measured). The CONDITIONALS_BOUNDARY mutant (`*value < 0`) would let a
-	// parsed 0 through as a pointer to 0.0 instead of nil.
-	for _, raw := range []string{"-0", "0"} {
-		got, err := ParseDayBBTRawWithUnit(raw, TemperatureUnitCelsius)
-		if err != nil {
-			t.Fatalf("ParseDayBBTRawWithUnit(%q): unexpected error %v", raw, err)
-		}
-		if got != nil {
-			t.Fatalf("expected nil (not measured) for %q, got %v", raw, *got)
+	for _, unit := range []string{TemperatureUnitCelsius, TemperatureUnitFahrenheit} {
+		if got := FormatDayBBTForInput(bbtPtr(0), unit); got != "" {
+			t.Fatalf("a legacy stored 0 in %s must render as an empty field (not measured), got %q", TemperatureUnitSymbol(unit), got)
 		}
 	}
 }

--- a/internal/services/day_tracking_mutation_test.go
+++ b/internal/services/day_tracking_mutation_test.go
@@ -54,10 +54,12 @@ func TestFormatDayBBTForInputReturnsEmptyForUnsetValue(t *testing.T) {
 	}
 }
 
-// TestFormatDayBBTForInputRendersALegacyZeroAsNotMeasured pins
-// normalizeStoredDayBBT's `*value <= 0` guard where that function is still
-// reached: a row written before BBT became nullable holds 0, and the day form
-// has to render it as an empty field rather than as a measurement of zero. The
+// TestFormatDayBBTForInputRendersALegacyZeroAsNotMeasured pins the floor that
+// normalizeStoredDayBBT's `*value <= 0` guard is: migration 024 rewrote every
+// stored 0 to NULL and no writer can produce another one, so nothing in a
+// current database reaches it — and a row that arrives from outside those
+// writers, out of a backup taken before 024 or a database edited by hand, still
+// has to render as an empty field rather than as a measurement of zero. The
 // CONDITIONALS_BOUNDARY mutant (`*value < 0`) lets the 0 through and prints
 // "0.00" °C — or "32.00" °F — into the input the owner is about to save back.
 //

--- a/internal/services/day_tracking_test.go
+++ b/internal/services/day_tracking_test.go
@@ -129,65 +129,143 @@ func TestNormalizeTemperatureUnitDefaultsToCelsius(t *testing.T) {
 // is read there. Below 0 °F both placements agree, so a negative-only table
 // stays green over the defect — the Fahrenheit rows between 0 and 32, which
 // convert to a non-positive Celsius value, are the ones that separate them.
+//
+// The stored value is compared EXACTLY, against expectations written as the
+// grid values storage keeps, so the table states that grid rather than a
+// neighbourhood around it. The row that carries the rounding is 20 °F: without
+// roundStoredTemperatureValue it converts to -6.666666666666667 instead of
+// -6.6667. 97.7 °F is no witness for it — measured, it converts to exactly
+// 36.5 either way.
 func TestConvertDayBBTToStorageJudgesTheSentinelInTheInputUnit(t *testing.T) {
 	t.Parallel()
 
-	const tolerance = 1e-9
-
 	testCases := []struct {
-		name       string
-		unit       string
-		value      float64
-		wantStored bool
-		want       float64
+		name  string
+		unit  string
+		input *float64
+		want  *float64
 	}{
-		{name: "fahrenheit zero is not measured", unit: TemperatureUnitFahrenheit, value: 0},
-		{name: "fahrenheit negative is not measured", unit: TemperatureUnitFahrenheit, value: -1},
-		{name: "fahrenheit impossible positive stays a reading", unit: TemperatureUnitFahrenheit, value: 20, wantStored: true, want: -6.6667},
-		{name: "fahrenheit freezing point stays a reading", unit: TemperatureUnitFahrenheit, value: 32, wantStored: true, want: 0},
-		{name: "fahrenheit ordinary reading", unit: TemperatureUnitFahrenheit, value: 97.7, wantStored: true, want: 36.5},
-		{name: "celsius zero is not measured", unit: TemperatureUnitCelsius, value: 0},
-		{name: "celsius negative is not measured", unit: TemperatureUnitCelsius, value: -1},
-		{name: "celsius impossible positive stays a reading", unit: TemperatureUnitCelsius, value: 0.5, wantStored: true, want: 0.5},
-		{name: "celsius ordinary reading", unit: TemperatureUnitCelsius, value: 36.5, wantStored: true, want: 36.5},
+		{name: "no value at all is not measured", unit: TemperatureUnitFahrenheit},
+		{name: "fahrenheit zero is not measured", unit: TemperatureUnitFahrenheit, input: bbtPtr(0)},
+		{name: "fahrenheit negative is not measured", unit: TemperatureUnitFahrenheit, input: bbtPtr(-1)},
+		{name: "fahrenheit impossible positive stays a reading", unit: TemperatureUnitFahrenheit, input: bbtPtr(20), want: bbtPtr(-6.6667)},
+		{name: "fahrenheit freezing point stays a reading", unit: TemperatureUnitFahrenheit, input: bbtPtr(32), want: bbtPtr(0)},
+		{name: "fahrenheit ordinary reading", unit: TemperatureUnitFahrenheit, input: bbtPtr(97.7), want: bbtPtr(36.5)},
+		{name: "celsius zero is not measured", unit: TemperatureUnitCelsius, input: bbtPtr(0)},
+		{name: "celsius negative is not measured", unit: TemperatureUnitCelsius, input: bbtPtr(-1)},
+		{name: "celsius impossible positive stays a reading", unit: TemperatureUnitCelsius, input: bbtPtr(0.5), want: bbtPtr(0.5)},
+		{name: "celsius ordinary reading", unit: TemperatureUnitCelsius, input: bbtPtr(36.5), want: bbtPtr(36.5)},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			symbol := TemperatureUnitSymbol(testCase.unit)
-			got := ConvertDayBBTToStorage(bbtPtr(testCase.value), testCase.unit)
-
-			if !testCase.wantStored {
-				if got != nil {
-					t.Fatalf("%.2f %s: expected nil (not measured), got %.4f °C stored", testCase.value, symbol, *got)
-				}
-				return
-			}
-			if got == nil {
-				t.Fatalf("%.2f %s: a positive entry is a reading for the range to judge, got nil (not measured)", testCase.value, symbol)
-			}
-			if math.Abs(*got-testCase.want) > tolerance {
-				t.Fatalf("%.2f %s: expected %.4f °C stored, got %.4f", testCase.value, symbol, testCase.want, *got)
+			got := ConvertDayBBTToStorage(testCase.input, testCase.unit)
+			if !sameDayBBT(got, testCase.want) {
+				t.Fatalf("%s %s: expected %s stored, got %s",
+					describeDayBBT(testCase.input), TemperatureUnitSymbol(testCase.unit), describeDayBBT(testCase.want), describeDayBBT(got))
 			}
 		})
 	}
 }
 
-// TestNormalizeDayEntryInputRefusesAnImpossibleFahrenheitReading is the other
-// half of that placement: once 20 °F survives the conversion as a reading, the
-// physiological range is what refuses it (ConvertDayBBTToStorage).
-func TestNormalizeDayEntryInputRefusesAnImpossibleFahrenheitReading(t *testing.T) {
+// TestNormalizeDayEntryInputRefusesAReadingTheRangeCannotAccept is the other
+// half of that placement: once a value survives the conversion as a reading,
+// IsValidDayBBT is what refuses it, so the owner is told which field lost the
+// save instead of receiving a day filed with an empty temperature.
+//
+// 20 in either unit is the ordinary case. The three non-finite spellings are
+// there because strconv.ParseFloat accepts all of them, so the form can deliver
+// one, and because only -Inf separates the two placements: it is non-positive,
+// so without the non-finite branch in ConvertDayBBTToStorage it would BE the
+// "not measured" sentinel and answer 200 with an empty field. NaN and +Inf
+// reach the same refusal by the longer road; they are listed so the rule holds
+// over the class, not over the one member that discriminates today.
+func TestNormalizeDayEntryInputRefusesAReadingTheRangeCannotAccept(t *testing.T) {
 	t.Parallel()
 
-	input := DayEntryInput{
-		Flow: models.FlowNone,
-		BBT:  ConvertDayBBTToStorage(bbtPtr(20), TemperatureUnitFahrenheit),
+	for _, unit := range []string{TemperatureUnitCelsius, TemperatureUnitFahrenheit} {
+		for _, raw := range []string{"20", "NaN", "+Inf", "-Inf"} {
+			t.Run(raw+"/"+unit, func(t *testing.T) {
+				t.Parallel()
+
+				symbol := TemperatureUnitSymbol(unit)
+				parsed, err := ParseDayBBTRawWithUnit(raw, unit)
+				if err != nil {
+					t.Fatalf("%q is a number the form parser accepts, so the range is what must judge it; got a parse error %v", raw, err)
+				}
+				if parsed == nil {
+					t.Fatalf("%q in %s is not the owner's not-measured answer; it must reach the range as a reading", raw, symbol)
+				}
+				if _, err := NormalizeDayEntryInput(DayEntryInput{Flow: models.FlowNone, BBT: parsed}); !errors.Is(err, ErrInvalidDayBBT) {
+					t.Fatalf("%q in %s must answer %v, got %v", raw, symbol, ErrInvalidDayBBT, err)
+				}
+			})
+		}
+	}
+}
+
+// TestIsValidDayBBTRefusesNaN pins the SHAPE of the range comparison rather
+// than its bounds. `*value >= Min && *value <= Max` and the De Morgan rewrite
+// that looks equivalent to it, `!(*value < Min || *value > Max)`, agree on
+// every ordinary reading and differ on exactly one input: NaN compares false to
+// both bounds, so the rewrite calls it valid and a NaN reaches storage, where
+// it poisons every average and shift comparison the day takes part in.
+func TestIsValidDayBBTRefusesNaN(t *testing.T) {
+	t.Parallel()
+
+	notANumber := math.NaN()
+	if IsValidDayBBT(&notANumber) {
+		t.Fatalf("NaN is no reading inside the physiological range; the comparison must refuse it")
 	}
 
-	normalized, err := NormalizeDayEntryInput(input)
-	if !errors.Is(err, ErrInvalidDayBBT) {
-		t.Fatalf("expected ErrInvalidDayBBT for 20 °F, got err=%v stored=%v", err, normalized.BBT)
+	// The anchor: the same call still accepts an ordinary reading, so the
+	// refusal above is about NaN and not about a range that refuses everything.
+	inRange := 36.5
+	if !IsValidDayBBT(&inRange) {
+		t.Fatalf("%.2f °C is inside the range and must be accepted", inRange)
 	}
+}
+
+// TestParseDayBBTRawWithUnitReadsTheNotMeasuredAnswers covers the spellings the
+// day form actually posts for "I did not measure today": the field left empty,
+// and the non-positive values the sentinel accepts, in both units. Text that is
+// not a number at all stays an error — read as "not measured" instead, a typo
+// would erase a reading without a word.
+func TestParseDayBBTRawWithUnitReadsTheNotMeasuredAnswers(t *testing.T) {
+	t.Parallel()
+
+	for _, unit := range []string{TemperatureUnitCelsius, TemperatureUnitFahrenheit} {
+		symbol := TemperatureUnitSymbol(unit)
+		for _, raw := range []string{"", "0", "-0", "-1"} {
+			got, err := ParseDayBBTRawWithUnit(raw, unit)
+			if err != nil {
+				t.Fatalf("ParseDayBBTRawWithUnit(%q, %s): unexpected error %v", raw, symbol, err)
+			}
+			if got != nil {
+				t.Fatalf("%q in %s means not measured, got %s stored", raw, symbol, describeDayBBT(got))
+			}
+		}
+		if _, err := ParseDayBBTRawWithUnit("abc", unit); err == nil {
+			t.Fatalf(`ParseDayBBTRawWithUnit("abc", %s): text that is not a number must be an error, got none`, symbol)
+		}
+	}
+}
+
+// sameDayBBT compares two stored temperatures exactly: either both are "not
+// measured", or both are the same value on the stored grid. Exactness is the
+// point — see the table above on what a tolerance hides.
+func sameDayBBT(got *float64, want *float64) bool {
+	if got == nil || want == nil {
+		return got == nil && want == nil
+	}
+	return *got == *want
+}
+
+func describeDayBBT(value *float64) string {
+	if value == nil {
+		return "nil (not measured)"
+	}
+	return strconv.FormatFloat(*value, 'f', -1, 64)
 }

--- a/internal/services/day_tracking_test.go
+++ b/internal/services/day_tracking_test.go
@@ -125,14 +125,10 @@ func TestNormalizeTemperatureUnitDefaultsToCelsius(t *testing.T) {
 }
 
 // TestConvertDayBBTToStorageJudgesTheSentinelInTheInputUnit pins WHERE the
-// "not measured" sentinel is read: in the unit the owner typed, before the
-// Fahrenheit conversion rather than in stored Celsius after it. The two
-// disagree across a whole band of the Fahrenheit scale — everything from just
-// above 0 °F up to 32 °F converts to a non-positive Celsius value — so reading
-// the sentinel afterwards turned an impossible entry into an empty field and
-// saved the day with no temperature and no refusal. Below 0 °F the two answers
-// agree, which is why a negative-only table stays green over the defect; the
-// Fahrenheit rows between 0 and 32 are the ones that separate them.
+// "not measured" sentinel is read; ConvertDayBBTToStorage's own doc says why it
+// is read there. Below 0 °F both placements agree, so a negative-only table
+// stays green over the defect — the Fahrenheit rows between 0 and 32, which
+// convert to a non-positive Celsius value, are the ones that separate them.
 func TestConvertDayBBTToStorageJudgesTheSentinelInTheInputUnit(t *testing.T) {
 	t.Parallel()
 
@@ -160,9 +156,8 @@ func TestConvertDayBBTToStorageJudgesTheSentinelInTheInputUnit(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			typed := testCase.value
 			symbol := TemperatureUnitSymbol(testCase.unit)
-			got := ConvertDayBBTToStorage(&typed, testCase.unit)
+			got := ConvertDayBBTToStorage(bbtPtr(testCase.value), testCase.unit)
 
 			if !testCase.wantStored {
 				if got != nil {
@@ -182,16 +177,13 @@ func TestConvertDayBBTToStorageJudgesTheSentinelInTheInputUnit(t *testing.T) {
 
 // TestNormalizeDayEntryInputRefusesAnImpossibleFahrenheitReading is the other
 // half of that placement: once 20 °F survives the conversion as a reading, the
-// physiological range is what refuses it. While the sentinel was read after the
-// conversion this entry was accepted, silently emptied, and stored
-// indistinguishably from a day the owner never took a temperature on.
+// physiological range is what refuses it (ConvertDayBBTToStorage).
 func TestNormalizeDayEntryInputRefusesAnImpossibleFahrenheitReading(t *testing.T) {
 	t.Parallel()
 
-	typed := 20.0
 	input := DayEntryInput{
 		Flow: models.FlowNone,
-		BBT:  ConvertDayBBTToStorage(&typed, TemperatureUnitFahrenheit),
+		BBT:  ConvertDayBBTToStorage(bbtPtr(20), TemperatureUnitFahrenheit),
 	}
 
 	normalized, err := NormalizeDayEntryInput(input)

--- a/internal/services/day_tracking_test.go
+++ b/internal/services/day_tracking_test.go
@@ -1,9 +1,12 @@
 package services
 
 import (
+	"errors"
 	"math"
 	"strconv"
 	"testing"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
 )
 
 // bbtPtr builds a *float64 for BBT test inputs (nil means "not measured").
@@ -118,5 +121,81 @@ func TestNormalizeTemperatureUnitDefaultsToCelsius(t *testing.T) {
 
 	if got := NormalizeTemperatureUnit("invalid"); got != TemperatureUnitCelsius {
 		t.Fatalf("expected default %q, got %q", TemperatureUnitCelsius, got)
+	}
+}
+
+// TestConvertDayBBTToStorageJudgesTheSentinelInTheInputUnit pins WHERE the
+// "not measured" sentinel is read: in the unit the owner typed, before the
+// Fahrenheit conversion rather than in stored Celsius after it. The two
+// disagree across a whole band of the Fahrenheit scale — everything from just
+// above 0 °F up to 32 °F converts to a non-positive Celsius value — so reading
+// the sentinel afterwards turned an impossible entry into an empty field and
+// saved the day with no temperature and no refusal. Below 0 °F the two answers
+// agree, which is why a negative-only table stays green over the defect; the
+// Fahrenheit rows between 0 and 32 are the ones that separate them.
+func TestConvertDayBBTToStorageJudgesTheSentinelInTheInputUnit(t *testing.T) {
+	t.Parallel()
+
+	const tolerance = 1e-9
+
+	testCases := []struct {
+		name       string
+		unit       string
+		value      float64
+		wantStored bool
+		want       float64
+	}{
+		{name: "fahrenheit zero is not measured", unit: TemperatureUnitFahrenheit, value: 0},
+		{name: "fahrenheit negative is not measured", unit: TemperatureUnitFahrenheit, value: -1},
+		{name: "fahrenheit impossible positive stays a reading", unit: TemperatureUnitFahrenheit, value: 20, wantStored: true, want: -6.6667},
+		{name: "fahrenheit freezing point stays a reading", unit: TemperatureUnitFahrenheit, value: 32, wantStored: true, want: 0},
+		{name: "fahrenheit ordinary reading", unit: TemperatureUnitFahrenheit, value: 97.7, wantStored: true, want: 36.5},
+		{name: "celsius zero is not measured", unit: TemperatureUnitCelsius, value: 0},
+		{name: "celsius negative is not measured", unit: TemperatureUnitCelsius, value: -1},
+		{name: "celsius impossible positive stays a reading", unit: TemperatureUnitCelsius, value: 0.5, wantStored: true, want: 0.5},
+		{name: "celsius ordinary reading", unit: TemperatureUnitCelsius, value: 36.5, wantStored: true, want: 36.5},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			typed := testCase.value
+			symbol := TemperatureUnitSymbol(testCase.unit)
+			got := ConvertDayBBTToStorage(&typed, testCase.unit)
+
+			if !testCase.wantStored {
+				if got != nil {
+					t.Fatalf("%.2f %s: expected nil (not measured), got %.4f °C stored", testCase.value, symbol, *got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("%.2f %s: a positive entry is a reading for the range to judge, got nil (not measured)", testCase.value, symbol)
+			}
+			if math.Abs(*got-testCase.want) > tolerance {
+				t.Fatalf("%.2f %s: expected %.4f °C stored, got %.4f", testCase.value, symbol, testCase.want, *got)
+			}
+		})
+	}
+}
+
+// TestNormalizeDayEntryInputRefusesAnImpossibleFahrenheitReading is the other
+// half of that placement: once 20 °F survives the conversion as a reading, the
+// physiological range is what refuses it. While the sentinel was read after the
+// conversion this entry was accepted, silently emptied, and stored
+// indistinguishably from a day the owner never took a temperature on.
+func TestNormalizeDayEntryInputRefusesAnImpossibleFahrenheitReading(t *testing.T) {
+	t.Parallel()
+
+	typed := 20.0
+	input := DayEntryInput{
+		Flow: models.FlowNone,
+		BBT:  ConvertDayBBTToStorage(&typed, TemperatureUnitFahrenheit),
+	}
+
+	normalized, err := NormalizeDayEntryInput(input)
+	if !errors.Is(err, ErrInvalidDayBBT) {
+		t.Fatalf("expected ErrInvalidDayBBT for 20 °F, got err=%v stored=%v", err, normalized.BBT)
 	}
 }

--- a/internal/services/import_service.go
+++ b/internal/services/import_service.go
@@ -168,9 +168,15 @@ func (service *ImportService) ImportJSON(ctx context.Context, userID uint, raw [
 
 // planEntries validates every incoming record: it parses and canonicalizes the
 // date, rejects duplicate calendar days within the file, and normalizes every
-// field through normalizeImportEntryInput, which applies the same per-field
-// rules a day save does. It also collects the first-seen spelling of each
-// custom symptom name so the reconciler can create the missing ones.
+// field through normalizeImportEntryInput. That normalization is deliberately
+// LENIENT where a day save is strict, and the two must not be read as the same
+// rules: a save REFUSES an out-of-vocabulary enum or an out-of-range reading
+// and hands the owner back their form, while a restore has no one to ask and
+// drops the offending field to its neutral value, keeping the rest of the day —
+// the file is restored, that one field is not. Pinned by
+// TestImportServiceSanitizesGarbageValues. It also collects the first-seen
+// spelling of each custom symptom name so the reconciler can create the missing
+// ones.
 func (service *ImportService) planEntries(entries []ExportJSONEntry, location *time.Location) ([]plannedImportDay, map[string]string, int) {
 	planned := make([]plannedImportDay, 0, len(entries))
 	otherOriginals := make(map[string]string)
@@ -237,6 +243,10 @@ func normalizeImportEntryInput(entry ExportJSONEntry) DayEntryInput {
 		SexActivity: NormalizeDaySexActivity(entry.SexActivity),
 		// Rounded onto the stored grid like a day save, so a restored file
 		// cannot put a reading off the grid the shift detector compares on.
+		// The export is always Celsius, so there is no unit to judge and no
+		// ConvertDayBBTToStorage here: a reading the range refuses becomes
+		// "not measured" (normalizeExportBBT) under the per-field leniency
+		// planEntries describes, where a day save would refuse the write.
 		BBT:             normalizeStoredDayBBT(normalizeExportBBT(entry.BBT)),
 		CervicalMucus:   NormalizeDayCervicalMucus(entry.CervicalMucus),
 		PregnancyTest:   NormalizeDayPregnancyTest(entry.PregnancyTest),

--- a/internal/services/tracking_visibility.go
+++ b/internal/services/tracking_visibility.go
@@ -17,10 +17,20 @@ import "github.com/ovumcy/ovumcy-web/internal/models"
 //
 // Renaming the columns themselves is deliberately out of scope here — the
 // adapter is what makes the rename a separate, mechanical change later.
+//
+// ShowBBTField and ShowCervicalMucus join them because the QUESTION is the same
+// one — is this field on the owner's day form — even though their columns
+// (track_bbt, track_cervical_mucus) are stored the positive way round and need
+// no inversion. Only TrackingVisibilityForUser can answer them: they are not
+// derivable from TrackingHiddenColumns, so a value built by
+// TrackingVisibilityFromHiddenColumns speaks for the three inverted sections
+// alone and says nothing about these two.
 type TrackingVisibility struct {
-	ShowSexChip      bool
-	ShowCycleFactors bool
-	ShowNotesField   bool
+	ShowSexChip       bool
+	ShowCycleFactors  bool
+	ShowNotesField    bool
+	ShowBBTField      bool
+	ShowCervicalMucus bool
 }
 
 // TrackingHiddenColumns is the stored, inverted spelling of the same three
@@ -33,7 +43,9 @@ type TrackingHiddenColumns struct {
 }
 
 // TrackingVisibilityFromHiddenColumns undoes the stored inversion. It is the
-// only place in the codebase that does so.
+// only place in the codebase that does so, and it answers for the three
+// inverted sections only — the two positive columns stay at their zero value,
+// so BBTFieldHidden and CervicalMucusHidden are meaningless on its result.
 func TrackingVisibilityFromHiddenColumns(columns TrackingHiddenColumns) TrackingVisibility {
 	return TrackingVisibility{
 		ShowSexChip:      !columns.HideSexChip,
@@ -43,18 +55,25 @@ func TrackingVisibilityFromHiddenColumns(columns TrackingHiddenColumns) Tracking
 }
 
 // TrackingVisibilityForUser reads one owner's stored columns through the
-// conversion above. A nil user yields the stored defaults (all three columns
-// false), i.e. every section visible — the same answer the zero-valued user
-// row gives, so a missing user never reads as "the owner hid this".
+// conversion above and adds the two positive ones, so it is the only complete
+// answer to "which day-form fields does this account show". A nil user yields
+// the stored defaults (all three inverted columns false), i.e. every section
+// visible — the same answer the zero-valued user row gives, so a missing user
+// never reads as "the owner hid this". The two positive columns follow that
+// same row, where they are false: an account that has not opted into
+// temperature or cervical mucus does not show those fields.
 func TrackingVisibilityForUser(user *models.User) TrackingVisibility {
 	if user == nil {
 		return TrackingVisibilityFromHiddenColumns(TrackingHiddenColumns{})
 	}
-	return TrackingVisibilityFromHiddenColumns(TrackingHiddenColumns{
+	visibility := TrackingVisibilityFromHiddenColumns(TrackingHiddenColumns{
 		HideSexChip:      user.HideSexChip,
 		HideCycleFactors: user.HideCycleFactors,
 		HideNotesField:   user.HideNotesField,
 	})
+	visibility.ShowBBTField = user.TrackBBT
+	visibility.ShowCervicalMucus = user.TrackCervicalMucus
+	return visibility
 }
 
 // HiddenColumns folds a positive view model back into the stored spelling, for
@@ -80,10 +99,13 @@ func (visibility TrackingVisibility) ApplyToUser(user *models.User) {
 	user.HideNotesField = columns.HideNotesField
 }
 
-// SexChipHidden, CycleFactorsHidden and NotesFieldHidden answer the one
-// question that is genuinely negative: the day-write path preserves a stored
-// value precisely when its section is not rendered, so the owner cannot erase
-// data through a form that never showed it.
+// SexChipHidden, CycleFactorsHidden, NotesFieldHidden, BBTFieldHidden and
+// CervicalMucusHidden answer the one question that is genuinely negative: the
+// day-write path does not read a field its form never showed, and preserves the
+// stored value instead, so the owner cannot erase data through a form that
+// never showed it. All five live here so that the day-write path asks one type
+// for the whole set (hiddenDayFields) rather than negating two of the columns
+// itself.
 func (visibility TrackingVisibility) SexChipHidden() bool {
 	return !visibility.ShowSexChip
 }
@@ -94,4 +116,12 @@ func (visibility TrackingVisibility) CycleFactorsHidden() bool {
 
 func (visibility TrackingVisibility) NotesFieldHidden() bool {
 	return !visibility.ShowNotesField
+}
+
+func (visibility TrackingVisibility) BBTFieldHidden() bool {
+	return !visibility.ShowBBTField
+}
+
+func (visibility TrackingVisibility) CervicalMucusHidden() bool {
+	return !visibility.ShowCervicalMucus
 }

--- a/internal/services/tracking_visibility_test.go
+++ b/internal/services/tracking_visibility_test.go
@@ -121,6 +121,15 @@ func TestTrackingVisibilityKeepsASingleConversionPoint(t *testing.T) {
 // The price is that a legitimate reader must be entered in
 // positiveTrackingColumnAllowedFiles with the question it asks, which is where
 // the two questions are kept apart rather than blurred.
+//
+// What it does NOT see, said out loud because the sibling sweep does see it: an
+// entry here exempts the whole FILE, so a day-form read added to a file already
+// listed passes unremarked. The inverted columns can be checked line by line
+// because the defect has a spelling there — a negation outside the conversion
+// point — while a positive column reads the same whichever question it is
+// asked, so nothing in the line separates the two. An allowlist entry is
+// therefore a claim about a file's whole subject, and a file that grows a day
+// form is a reason to re-read its entry rather than to widen it.
 func TestTrackingVisibilityIsTheOnlyDayFormReaderOfTheTrackedColumns(t *testing.T) {
 	walkTrackingColumnSources(t, func(relative string, data []byte) {
 		if _, allowed := positiveTrackingColumnAllowedFiles[relative]; allowed {

--- a/internal/services/tracking_visibility_test.go
+++ b/internal/services/tracking_visibility_test.go
@@ -31,6 +31,41 @@ var trackingInversionAllowedFiles = map[string]string{
 	filepath.Join("internal", "api", "handlers_settings_tracking.go"): "binds and echoes the published v1 JSON keys",
 }
 
+// positiveTrackingColumnTokens are every spelling of the two columns stored the
+// positive way round: the Go fields and the column/wire keys. They need no
+// inversion, so the sweep above says nothing about them, yet they answer the
+// same question as the three inverted ones — does this owner's day form show
+// this field — and must reach a day form through the same view model.
+var positiveTrackingColumnTokens = []string{
+	"TrackBBT", "TrackCervicalMucus",
+	"track_bbt", "track_cervical_mucus",
+}
+
+// positiveTrackingColumnAllowedFiles are the files that may read those two
+// columns off the user row, each with the question that entitles it to.
+//
+// Two kinds of entry appear here. In the settings files the column IS the
+// subject: it is bound, stored, published and rendered there as its own toggle.
+// calendar_days.go and cycle_signals.go ask the other question — whether a
+// temperature series exists to derive a signal from at all — on surfaces that
+// render no day form, and TrackingVisibility's whole subject is the day form
+// (TrackingVisibilityForUser), so asking it there would name the wrong rule
+// even though ShowBBTField happens to carry the same bit today.
+var positiveTrackingColumnAllowedFiles = map[string]string{
+	filepath.Join("internal", "models", "user.go"):                                 "declares the persisted columns",
+	filepath.Join("internal", "db", "user_repository.go"):                          "the settings Select whitelist and the clear-data reset map name columns",
+	filepath.Join("internal", "services", "settings_service.go"):                   "the tracking update map names columns",
+	filepath.Join("internal", "services", "settings_tracking_policy.go"):           "writes the columns from one settings update",
+	filepath.Join("internal", "services", "settings_view_service.go"):              "the settings page state is those toggles",
+	filepath.Join("internal", "services", "tracking_visibility.go"):                "the single reader that turns the columns into day-form visibility",
+	filepath.Join("internal", "services", "calendar_days.go"):                      "asks whether a temperature series exists at all, not whether a day form shows the field",
+	filepath.Join("internal", "services", "cycle_signals.go"):                      "the same question, for the cycle signal derived from that series",
+	filepath.Join("internal", "api", "input_types.go"):                             "the published v1 JSON request body",
+	filepath.Join("internal", "api", "handlers_settings_tracking.go"):              "binds and echoes the published v1 JSON keys",
+	filepath.Join("internal", "api", "settings_view_helpers.go"):                   "hands the settings toggles to their template",
+	filepath.Join("internal", "templates", "components", "settings_tracking.html"): "renders the settings toggles",
+}
+
 // TestTrackingVisibilityKeepsASingleConversionPoint pins the property that
 // makes the positive view model safe: the stored inversion is undone in
 // exactly one file. A second conversion — a handler reading the raw column
@@ -42,9 +77,77 @@ var trackingInversionAllowedFiles = map[string]string{
 // files that must (columns, published v1 wire keys, the conversion point), and
 // negating one of those spellings anywhere but the conversion point.
 func TestTrackingVisibilityKeepsASingleConversionPoint(t *testing.T) {
-	repoRoot := filepath.Join("..", "..")
 	conversionPoint := filepath.Join("internal", "services", "tracking_visibility.go")
 
+	walkTrackingColumnSources(t, func(relative string, data []byte) {
+		reason, allowed := trackingInversionAllowedFiles[relative]
+		for number, line := range strings.Split(string(data), "\n") {
+			if !containsAnyToken(line, storedTrackingInversionTokens) {
+				continue
+			}
+			switch {
+			case !allowed:
+				t.Errorf(
+					"%s:%d names a stored tracking inversion (%q); read it through services.TrackingVisibility instead",
+					relative, number+1, strings.TrimSpace(line),
+				)
+			case relative != conversionPoint && negatesTrackingFlag(line):
+				t.Errorf(
+					"%s:%d negates a stored tracking flag (%q), but %s may only name it (%s); the inversion belongs in %s",
+					relative, number+1, strings.TrimSpace(line), relative, reason, conversionPoint,
+				)
+			}
+		}
+	})
+}
+
+// TestTrackingVisibilityIsTheOnlyDayFormReaderOfTheTrackedColumns pins the same
+// property for the two columns that need no inversion. Nothing negates them, so
+// the sweep above cannot see them, and the failure they hide is quieter: a
+// handler or a view builder writes `user.TrackBBT` where it means "the day form
+// shows the temperature field", the two spellings agree on the day they are
+// written, and they drift the first time the visibility answer gains a term the
+// column does not carry — a role, an onboarding state, a per-surface override.
+// The five fields would then be resolved from one type in four places and from
+// the raw row in the fifth, which is the divergence TrackingVisibility exists to
+// make impossible. It fails on one shape: naming either column outside the files
+// entitled to.
+//
+// It sweeps every production Go source and template under internal/ and cmd/ —
+// the same set as the sweep above — rather than only the transport and dashboard
+// builders where the defect was found, because the column is readable from any
+// layer and the next day-form surface need not be built in either of them; a
+// sweep scoped to today's two callers would be silent about tomorrow's third.
+// The price is that a legitimate reader must be entered in
+// positiveTrackingColumnAllowedFiles with the question it asks, which is where
+// the two questions are kept apart rather than blurred.
+func TestTrackingVisibilityIsTheOnlyDayFormReaderOfTheTrackedColumns(t *testing.T) {
+	walkTrackingColumnSources(t, func(relative string, data []byte) {
+		if _, allowed := positiveTrackingColumnAllowedFiles[relative]; allowed {
+			return
+		}
+		for number, line := range strings.Split(string(data), "\n") {
+			if !containsAnyToken(line, positiveTrackingColumnTokens) {
+				continue
+			}
+			t.Errorf(
+				"%s:%d reads a stored tracking column (%q); ask services.TrackingVisibilityForUser whether the day form shows the field. "+
+					"Only if this line asks the other question — whether the account records temperature or cervical mucus at all, on a "+
+					"surface with no day form — does it belong in positiveTrackingColumnAllowedFiles, named with that reason",
+				relative, number+1, strings.TrimSpace(line),
+			)
+		}
+	})
+}
+
+// walkTrackingColumnSources hands every source that can carry a tracking flag —
+// production Go and every server-rendered template under internal/ and cmd/ — to
+// visit, as a repo-relative path and its bytes. Both sweeps read it, so neither
+// can go quiet by looking at fewer files than the other claims.
+func walkTrackingColumnSources(t *testing.T, visit func(relative string, data []byte)) {
+	t.Helper()
+
+	repoRoot := filepath.Join("..", "..")
 	scanned := 0
 	for _, tree := range []string{"internal", "cmd"} {
 		root := filepath.Join(repoRoot, tree)
@@ -52,7 +155,7 @@ func TestTrackingVisibilityKeepsASingleConversionPoint(t *testing.T) {
 			if err != nil {
 				return err
 			}
-			if entry.IsDir() || !trackingInversionScannedFile(path) {
+			if entry.IsDir() || !trackingColumnScannedFile(path) {
 				return nil
 			}
 			relative, relErr := filepath.Rel(repoRoot, path)
@@ -64,24 +167,7 @@ func TestTrackingVisibilityKeepsASingleConversionPoint(t *testing.T) {
 				return readErr
 			}
 			scanned++
-			reason, allowed := trackingInversionAllowedFiles[relative]
-			for number, line := range strings.Split(string(data), "\n") {
-				if !containsAnyToken(line) {
-					continue
-				}
-				switch {
-				case !allowed:
-					t.Errorf(
-						"%s:%d names a stored tracking inversion (%q); read it through services.TrackingVisibility instead",
-						relative, number+1, strings.TrimSpace(line),
-					)
-				case relative != conversionPoint && negatesTrackingFlag(line):
-					t.Errorf(
-						"%s:%d negates a stored tracking flag (%q), but %s may only name it (%s); the inversion belongs in %s",
-						relative, number+1, strings.TrimSpace(line), relative, reason, conversionPoint,
-					)
-				}
-			}
+			visit(relative, data)
 			return nil
 		})
 		if err != nil {
@@ -94,9 +180,9 @@ func TestTrackingVisibilityKeepsASingleConversionPoint(t *testing.T) {
 	}
 }
 
-// trackingInversionScannedFile selects the sources that can carry the
-// inversion: production Go code and every server-rendered template.
-func trackingInversionScannedFile(path string) bool {
+// trackingColumnScannedFile selects the sources that can carry a tracking flag:
+// production Go code and every server-rendered template.
+func trackingColumnScannedFile(path string) bool {
 	switch {
 	case strings.HasSuffix(path, "_test.go"):
 		return false
@@ -107,8 +193,8 @@ func trackingInversionScannedFile(path string) bool {
 	}
 }
 
-func containsAnyToken(line string) bool {
-	for _, token := range storedTrackingInversionTokens {
+func containsAnyToken(line string, tokens []string) bool {
+	for _, token := range tokens {
 		if strings.Contains(line, token) {
 			return true
 		}
@@ -159,11 +245,18 @@ func TestTrackingVisibilityUndoesAndRedoesTheStoredInversion(t *testing.T) {
 }
 
 func TestTrackingVisibilityForUserReadsTheStoredColumns(t *testing.T) {
-	user := &models.User{HideCycleFactors: true}
+	// The account hides one inverted section and has opted into temperature but
+	// not cervical mucus, so each of the two tracked columns is asserted in the
+	// direction it is stored: a reader that inverts them, or that answers one of
+	// them from the other, disagrees with this row.
+	user := &models.User{HideCycleFactors: true, TrackBBT: true}
 
 	visibility := TrackingVisibilityForUser(user)
 	if !visibility.ShowSexChip || visibility.ShowCycleFactors || !visibility.ShowNotesField {
 		t.Fatalf("unexpected visibility for a user hiding only cycle factors: %+v", visibility)
+	}
+	if !visibility.ShowBBTField || visibility.ShowCervicalMucus {
+		t.Fatalf("the tracked columns are read as stored, not inverted: %+v", visibility)
 	}
 
 	TrackingVisibility{ShowSexChip: true, ShowCycleFactors: true, ShowNotesField: false}.ApplyToUser(user)
@@ -171,10 +264,16 @@ func TestTrackingVisibilityForUserReadsTheStoredColumns(t *testing.T) {
 		t.Fatalf("ApplyToUser wrote the wrong columns: %+v", user)
 	}
 
-	// A missing user is the stored default — every section visible — never
-	// "the owner hid this", which a zero-valued TrackingVisibility would mean.
-	if absent := TrackingVisibilityForUser(nil); !absent.ShowSexChip || !absent.ShowCycleFactors || !absent.ShowNotesField {
-		t.Fatalf("a nil user must read as fully visible, got %+v", absent)
+	// A missing user is the stored default — every inverted section visible —
+	// never "the owner hid this", which a zero-valued TrackingVisibility would
+	// mean. The two tracked columns follow that same default row, where they are
+	// false: no user, no opt-in, so those two fields are not shown.
+	absent := TrackingVisibilityForUser(nil)
+	if !absent.ShowSexChip || !absent.ShowCycleFactors || !absent.ShowNotesField {
+		t.Fatalf("a nil user must read the inverted sections as visible, got %+v", absent)
+	}
+	if absent.ShowBBTField || absent.ShowCervicalMucus {
+		t.Fatalf("a nil user has opted into neither tracked field, got %+v", absent)
 	}
 	var nilUser *models.User
 	TrackingVisibility{}.ApplyToUser(nilUser)


### PR DESCRIPTION
**What.** Three changes, one class each.

1. `ConvertDayBBTToStorage` reads the "not measured" sentinel (`value <= 0`) in the account's input unit, before the °F→°C conversion, and rounds onto the stored grid itself. A non-finite entry is handed on as it stands, so the range refuses it. `normalizeStoredDayBBT` is untouched and still owns already-stored Celsius values (day-input merge, import, form redisplay).
2. The transport no longer reads the form fields the account hides: `hiddenDayFields` builds one `preservedDayFields` set per request from `services.TrackingVisibility`, and both `parseDayPayload` and `buildUpsertDayEntryInput` take it. Services drop the incoming value of every preserved field before validation (`dropPreservedDayEntryFields`, all five fields). A JSON body carries no preservation: an omitted field is cleared, an impossible value is refused.
3. Day-form visibility has one source. `TrackingVisibility` now answers for all five fields, including the two columns stored the positive way round, and a test sweeps `internal/` and `cmd/` so no other file may read `TrackBBT`/`TrackCervicalMucus` to decide what a day form shows.

`docs/openapi.yaml` says which body preserves hidden fields and what the JSON body does instead; `docs/export.md` and the `ExportJSONEntry.bbt` description say the import stays lenient (an impossible reading restores as "not measured").

**Why.** Release plan Q3 (P2). A Fahrenheit account could send any value in (0, 32] — 20 °F converts to −6.67 °C — and the sentinel, read after the conversion, turned it into `nil`: HTTP 200, `bbt` null, an impossible reading accepted and silently dropped. `-Inf`, which the form parser accepts, went the same way. The second class is its mirror: a value in a field the account hides could refuse the whole day, because validation ran before preservation.

**Risk.** 32 °F now stores 0.00 °C, fails `IsValidDayBBT` and is refused with 400 instead of being saved as an empty field — the intended verdict, since 32 °F is not a body temperature. A form save from an account hiding a field no longer stores anything into it: on an existing day the stored value is kept, on a new day the field starts empty. Conversion and rounding are unchanged. Rollback: revert.

**How verified** (Win11 / go1.27.1; logs under the lane worktree's `.tmp/`):
- red-on-base with the FINAL tests is impossible — they name symbols the base does not have (`hiddenDayFields`, `dropPreservedDayEntryFields`, `preservedDayFields`, `TrackingVisibility.BBTFieldHidden`, `walkTrackingColumnSources`), so the proof is by excision, one per class, each in a detached worktree at this SHA:
  - sentinel read after the conversion, plus the five `if !hidden.X` parse skips disabled (`pr735-evidence-trees.py`): `gutted-services.log` — `TestConvertDayBBTToStorageJudgesTheSentinelInTheInputUnit` (the 20 °F and 32 °F rows), `TestNormalizeDayEntryInputRefusesAReadingTheRangeCannotAccept/20/f`; `gutted-api.log` — `TestUpsertDayJudgesTheNotMeasuredSentinelInTheAccountsUnit` (json and form), `TestParseDayPayloadSkipsEveryFieldTheAccountHides` (all six rows), `TestUpsertDayRefusesAnImpossibleFahrenheitReadingOverHTMX`, `TestUpsertDayRefusesAnImpossibleTemperatureSentAsJSON`, `TestUpsertDayDoesNotReadAHiddenTemperatureField`. The Celsius rows stay green, since 20 °C is positive under either order.
  - the non-finite branch removed (`pr735-evidence-trees2.py`): `gutted2-services.log` — `…RefusesAReadingTheRangeCannotAccept/-Inf/c` and `/-Inf/f`; `gutted2-api.log` — `…SentinelInTheAccountsUnit/form/negative_infinity_is_refused`. NaN is deliberately not a witness here: it is non-positive under no comparison, so it reaches the same 400 through `IsValidDayBBT` with or without the branch, and its row states the class rather than pinning the placement.
- red-before-fix for the preserve and transport classes, taken before the final test names existed: `preserve-red.log` (the services table 6/6 and the api form 400 → 200), `preserve-parse-red.log` (`bbt=abc`, `1e400`).
- green on this SHA: `go test ./internal/services -run 'BBT|Bbt|Sentinel|DayEntry|DayInput|DayTracking|Preserve|Visibility|NotMeasured|Temperature|CycleFactor' -count=1`, `go test ./internal/api -run 'OpenAPI|Day|BBT|Bbt|Hidden|Preserve|Sentinel|Visibility|Temperature' -count=1`, `go vet`, `gofmt -l` empty, `golangci-lint run ./internal/services/... ./internal/api/...` 0 issues, `changelogd check` OK (`services_pass5.log`, `api_pass6.log`, `vet_pass5.log`, `lint_pass5.log`, `changelogd_pass6.log`). Race lanes and the Postgres lane: CI on this SHA.
- Review: four `/code-review` passes to empty, then an independent opus reviewer carrying the adversarial questions too. It returned REQUEST_CHANGES on two: the PUT operation's description still promised hidden-field preservation to a JSON-only request body, and this body was two commits stale. Both are fixed here, together with the changelog naming the `-Inf` change and the converter's doc naming validation as its caller's precondition.
