### PR TITLE
test(services/bbt): characterise the 3-over-6 window and name what it is not

### DIFF
--- a/changelog.d/bbt-detector-gaps-and-disturbance.md
+++ b/changelog.d/bbt-detector-gaps-and-disturbance.md
@@ -1,0 +1,15 @@
+### Changed
+
+- **The temperature-shift documentation now says what the detector is and what it is not.**
+  `docs/cycle-prediction.md` lists every surface the one detector feeds and spells out where the
+  applied "3-over-6" rule departs from the full symptothermal protocol on purpose: no second
+  indicator cross-checks a shift, a slow rise is never rescued by a fourth day, a day tagged
+  `illness` or `sleep_disruption` is dropped whole, and the six values behind the coverline are
+  recordings rather than calendar days, so skipped mornings lengthen the window backwards. The
+  confirmed day stays an estimate inferred from a signal, and no accuracy interval is promised for
+  it.
+
+### Internal
+
+- Characterisation tests pin the window's behaviour across skipped and disturbed days, and pin
+  that a rise climbing in steps below the margin is not confirmed.

--- a/docs/cycle-prediction.md
+++ b/docs/cycle-prediction.md
@@ -223,13 +223,17 @@ deliberate rather than gaps:
   it as a change of phase. Here the temperature rule stands alone; the
   cervical-mucus signal is a separate fallback estimate used when no shift is
   found, never a cross-check on one that was.
-- **No slow-rise exceptions — the detector is stricter.** Reference methods
+- **No slow-rise exception — the detector is stricter.** Reference methods
   carry exception rules that rescue a rise whose third day misses the 0.2 °C
   margin, by waiting for a fourth day that only has to stay above the coverline.
-  This detector has none: a rise that climbs in steps smaller than the margin is
-  never confirmed at all, because the coverline slides with each candidate day,
-  so the first elevated readings enter the window that the days after them are
-  measured against and lift the bar to their own level.
+  This detector has none. What decides a candidate is how far its third day
+  stands above the coverline, not how large a single step was: three days
+  climbing 0.1 °C each do confirm over a flat window, because the third of them
+  is 0.3 °C above it. What is never rescued is a rise that falls short on its
+  third day and keeps climbing afterwards — the coverline is recomputed for each
+  candidate from the six recordings before it, so those first elevated readings
+  join the window the later days are measured against and lift the bar to their
+  own level.
 - **A disturbed day is dropped whole.** An `illness` or `sleep_disruption` tag
   removes the reading from the detection series without asking whether its value
   actually stands out from its neighbours — broader than the reference method's

--- a/docs/cycle-prediction.md
+++ b/docs/cycle-prediction.md
@@ -186,11 +186,14 @@ ovulation day: the luteal-phase inference, the calendar's ovulation markers
 (tentative on the projection, solid on the confirmed day), the dashboard's
 ovulation line, the JSON overview's `ovulation_date` / `ovulation_confirmed`,
 and the coverline + probable-ovulation marker on the stats BBT chart. For the
-current cycle they all read one resolver, so they can never disagree, and that
-cycle's detection series runs through the owner's today rather than to the
-projected next-period start — a shift that arrives after the projected date has
-passed is still this cycle's. The rule applied is the classical symptothermal
-("3-over-6") one:
+current cycle the calendar, the dashboard and the JSON overview read one
+resolver and the chart shares its detection window, so a shift names one day
+wherever it is shown; the chart is the one surface that keeps its marker while
+the others withhold every date (an overdue cycle, unpredictable mode, a
+pregnancy pause, the first cycle). That window runs through the owner's today
+rather than to the projected next-period start — a shift that arrives after the
+projected date has passed is still this cycle's. The rule applied is the
+classical symptothermal ("3-over-6") one:
 
 - **Coverline** — the maximum of the **6 immediately preceding** recorded,
   undisturbed temperatures. The maximum (not the mean) is used so ordinary
@@ -234,8 +237,8 @@ deliberate rather than gaps:
   occupy a slot in the six either.
 - **The six are recordings, not calendar days.** A morning left unrecorded
   lengthens the window backwards instead of shrinking it, and any number of gaps
-  is tolerated; implementations that score the window over calendar days
-  typically stop at one missing day of six.
+  is tolerated; a published implementation that scores the window over calendar
+  days (Zhu et al., 2021) allows one missing day of six and no more.
 
 The date it produces is an inference from a signal, not an observation of
 ovulation: the day before the first elevated reading. Prospective work comparing

--- a/docs/cycle-prediction.md
+++ b/docs/cycle-prediction.md
@@ -181,10 +181,16 @@ These are the exact cases asserted by the reference tests.
 
 Basal body temperature rises ~0.2–0.5 °C after ovulation (progesterone from the
 corpus luteum is thermogenic), so a sustained rise *confirms ovulation
-retrospectively*. One shared detector drives the luteal-phase inference, the
-calendar's tentative-ovulation signal, and the coverline + probable-ovulation
-marker on the stats BBT chart, so those surfaces can never disagree. It applies
-the classical symptothermal ("3-over-6") rule:
+retrospectively*. One shared detector drives every surface that names an
+ovulation day: the luteal-phase inference, the calendar's ovulation markers
+(tentative on the projection, solid on the confirmed day), the dashboard's
+ovulation line, the JSON overview's `ovulation_date` / `ovulation_confirmed`,
+and the coverline + probable-ovulation marker on the stats BBT chart. For the
+current cycle they all read one resolver, so they can never disagree, and that
+cycle's detection series runs through the owner's today rather than to the
+projected next-period start — a shift that arrives after the projected date has
+passed is still this cycle's. The rule applied is the classical symptothermal
+("3-over-6") one:
 
 - **Coverline** — the maximum of the **6 immediately preceding** recorded,
   undisturbed temperatures. The maximum (not the mean) is used so ordinary
@@ -204,10 +210,46 @@ the classical symptothermal ("3-over-6") rule:
   no marker, and the luteal inference falls back to the cervical-mucus signal
   or the 14-day default.
 
-The stats chart draws the coverline only once a shift is confirmed — until
-then there is nothing physiologically meaningful to draw. Even a confirmed
-shift remains an estimate (±1–2 days), never a fact: prospective studies find
-BBT alone identifies the ovulation day imperfectly, so treat the marker as
+**What this detector is not.** The rule above is the *temperature* half of a
+symptothermal method, applied to recorded, undisturbed readings. It is not the
+full fertility-awareness protocol those methods define, and the differences are
+deliberate rather than gaps:
+
+- **No double-check against a second indicator.** Symptothermal protocols
+  confirm a thermal shift against cervical mucus or the cervix before treating
+  it as a change of phase. Here the temperature rule stands alone; the
+  cervical-mucus signal is a separate fallback estimate used when no shift is
+  found, never a cross-check on one that was.
+- **No slow-rise exceptions — the detector is stricter.** Reference methods
+  carry exception rules that rescue a rise whose third day misses the 0.2 °C
+  margin, by waiting for a fourth day that only has to stay above the coverline.
+  This detector has none: a rise that climbs in steps smaller than the margin is
+  never confirmed at all, because the coverline slides with each candidate day,
+  so the first elevated readings enter the window that the days after them are
+  measured against and lift the bar to their own level.
+- **A disturbed day is dropped whole.** An `illness` or `sleep_disruption` tag
+  removes the reading from the detection series without asking whether its value
+  actually stands out from its neighbours — broader than the reference method's
+  bracketing of a single outlying value, and the reason a tagged day does not
+  occupy a slot in the six either.
+- **The six are recordings, not calendar days.** A morning left unrecorded
+  lengthens the window backwards instead of shrinking it, and any number of gaps
+  is tolerated; implementations that score the window over calendar days
+  typically stop at one missing day of six.
+
+The date it produces is an inference from a signal, not an observation of
+ovulation: the day before the first elevated reading. Prospective work comparing
+home temperature records against an LH-anchored reference finds that first
+elevated reading follows the anchor by days on average (Zhu et al., *JMIR
+mHealth and uHealth*, 2021: 2.7 ± 1.9 days after LH+1 in that cohort). A
+confirmed shift therefore says an ovulation has already happened — it is not a
+forecast, and not a method of contraception.
+
+The stats chart draws the coverline only once a shift is confirmed — until then
+there is nothing physiologically meaningful to draw. Even a confirmed shift
+remains an estimate, never a fact, and no individual accuracy interval is
+promised: the day is inferred from the signal, and, as above, the first elevated
+reading lags the LH-anchored day by days on average. Treat the marker as
 indicative, not diagnostic.
 
 ## First cycle — what is computed but not shown

--- a/internal/services/cycle_signals_window_characterization_test.go
+++ b/internal/services/cycle_signals_window_characterization_test.go
@@ -194,8 +194,11 @@ func TestBBTShiftWindowTakesSixRecordedValuesWhateverTheGapCount(t *testing.T) {
 // the day is gone from the series entirely: the sixth value back moves one
 // recorded day further, exactly as an unrecorded day makes it move. A tagged day
 // is dropped whole, without asking whether its value stands out from the
-// window — Sensiplan's Ausklammern removes at most an outlying value and keeps
-// the day's place in the count.
+// window. The reference rule this departs from — bracketing at most a single
+// outlying value while keeping the day's place in the count — is taken from a
+// secondary account of Sensiplan; the primary text was not obtained, so the
+// comparison is stated as the source of the product's rule, not as a quotation
+// of it.
 func TestBBTShiftDisturbedDayDoesNotConsumeAWindowSlot(t *testing.T) {
 	cases := []struct {
 		name          string
@@ -244,11 +247,16 @@ func TestBBTShiftDisturbedDayDoesNotConsumeAWindowSlot(t *testing.T) {
 // the source protocol: Sensiplan's first exception rule accepts a rise whose
 // third day misses the 0.2 °C margin by waiting for a fourth day, which only has
 // to stay above the coverline — it would confirm this cycle on the evening of
-// cycle day 15. The product never does, and the reason is not the margin alone:
-// the coverline SLIDES with the candidate, so the first elevated days of a slow
-// rise enter the window of every later candidate and lift the line to their own
-// level. A rise that climbs in steps smaller than the margin therefore raises
-// the bar it is being measured against, and no candidate in it can qualify.
+// cycle day 15. The product never does.
+//
+// The reason is not that the steps are small. A candidate is judged on how far
+// its THIRD day stands above the coverline, so a run climbing 0.1 °C a day over
+// a flat window does confirm — that third day is 0.3 °C above it. This fixture
+// fails because its three elevated days are all 36.30 against a 36.20 window:
+// 0.1 °C short on the third. What then stops every later candidate is the
+// coverline being recomputed from the six recordings before it — from cycle day
+// 13 on, the window already contains a 36.30, and no day of this rise is
+// strictly above it. The 36.50 on day 15 arrives with only itself left.
 func TestBBTShiftSlowRiseIsNotConfirmed(t *testing.T) {
 	readings := []cyclesignalsWindowReading{
 		{cycleDay: 6, value: 36.20},

--- a/internal/services/cycle_signals_window_characterization_test.go
+++ b/internal/services/cycle_signals_window_characterization_test.go
@@ -48,8 +48,10 @@ func cyclesignalsWindowLogs(t *testing.T, readings []cyclesignalsWindowReading) 
 
 	logs := make([]models.DailyLog, 0, len(readings))
 	for _, reading := range readings {
-		day := cycleStart.AddDate(0, 0, reading.cycleDay-1)
-		entry := cyclesignalsCovBBTLog(t, day.Format("2006-01-02"), reading.value)
+		entry := models.DailyLog{
+			Date: AddCalendarDays(cycleStart, reading.cycleDay-1, time.UTC),
+			BBT:  &reading.value,
+		}
 		if reading.disturbed {
 			entry.CycleFactorKeys = []string{models.CycleFactorIllness}
 		}

--- a/internal/services/cycle_signals_window_characterization_test.go
+++ b/internal/services/cycle_signals_window_characterization_test.go
@@ -1,0 +1,277 @@
+package services
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+)
+
+// These tests CHARACTERISE the rule the BBT detector applies and its deliberate
+// departures from the full symptothermal protocol: an expectation here changes
+// only by a product decision about the method, never as a repair.
+//
+// A third elevated day one hundredth short of the required margin is already
+// pinned by TestBBTShiftThirdDayMarginHoldsAtExactlyTwoTenths ("one hundredth
+// short of the margin is rejected") and is not restated here.
+//
+// Values sit on the 0.05 °C grid so the rounding onto stored units never decides
+// a case.
+
+// cyclesignalsWindowReading is one recorded temperature addressed by cycle day,
+// so a fixture states the gap it is about rather than hiding it in dates.
+type cyclesignalsWindowReading struct {
+	cycleDay  int
+	value     float64
+	disturbed bool
+}
+
+const (
+	cyclesignalsWindowCycleStart = "2026-01-01"
+	cyclesignalsWindowNextStart  = "2026-01-29"
+)
+
+// cyclesignalsWindowShift is the elevated run every fixture below ends with. It
+// clears BOTH coverlines its fixtures can produce, and clears the third-day
+// margin above either with room to spare, so a case here turns on the window
+// that was measured and never on the run that followed it: the margin boundary
+// belongs to TestBBTShiftThirdDayMarginHoldsAtExactlyTwoTenths.
+var cyclesignalsWindowShift = []cyclesignalsWindowReading{
+	{cycleDay: 12, value: 36.40},
+	{cycleDay: 13, value: 36.40},
+	{cycleDay: 14, value: 36.60},
+}
+
+func cyclesignalsWindowLogs(t *testing.T, readings []cyclesignalsWindowReading) []models.DailyLog {
+	t.Helper()
+	cycleStart := cyclesignalsCovDay(t, cyclesignalsWindowCycleStart)
+
+	logs := make([]models.DailyLog, 0, len(readings))
+	for _, reading := range readings {
+		day := cycleStart.AddDate(0, 0, reading.cycleDay-1)
+		entry := cyclesignalsCovBBTLog(t, day.Format("2006-01-02"), reading.value)
+		if reading.disturbed {
+			entry.CycleFactorKeys = []string{models.CycleFactorIllness}
+		}
+		logs = append(logs, entry)
+	}
+	return logs
+}
+
+// cyclesignalsWindowDetect runs the same two steps every owner surface runs, and
+// returns the coverline the surfaces themselves never expose: a yes/no answer
+// cannot tell two window definitions apart when both of them confirm the shift.
+func cyclesignalsWindowDetect(t *testing.T, readings []cyclesignalsWindowReading) (int, float64, bool) {
+	t.Helper()
+	points := collectCycleBBTPoints(
+		cyclesignalsWindowLogs(t, readings),
+		cyclesignalsCovDay(t, cyclesignalsWindowCycleStart),
+		cyclesignalsCovDay(t, cyclesignalsWindowNextStart),
+		time.UTC,
+	)
+	return detectBBTShiftFirstHighDay(bbtSeriesFromPoints(points))
+}
+
+// TestBBTShiftWindowReachesBackPastAnUnrecordedDay characterises what the six
+// are counted over: recorded values, not the six calendar days preceding the
+// candidate. A skipped morning therefore lengthens the window backwards, and a
+// warm reading old enough that a calendar window would have dropped it still
+// sets the coverline. The two cases differ only in that oldest reading; both
+// confirm the shift, so only the coverline separates the two readings of the
+// rule.
+func TestBBTShiftWindowReachesBackPastAnUnrecordedDay(t *testing.T) {
+	cases := []struct {
+		name          string
+		oldestValue   float64
+		wantCoverline float64
+	}{
+		{
+			name:          "the sixth value back is the warm cycle day 5",
+			oldestValue:   36.35,
+			wantCoverline: 36.35,
+		},
+		{
+			name:          "control: a flat cycle day 5 lowers the same coverline",
+			oldestValue:   36.20,
+			wantCoverline: 36.20,
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			readings := append([]cyclesignalsWindowReading{
+				{cycleDay: 5, value: testCase.oldestValue},
+				{cycleDay: 6, value: 36.20},
+				{cycleDay: 7, value: 36.20},
+				{cycleDay: 8, value: 36.20},
+				// Cycle day 9 is not recorded.
+				{cycleDay: 10, value: 36.20},
+				{cycleDay: 11, value: 36.20},
+			}, cyclesignalsWindowShift...)
+
+			firstHighDay, coverline, ok := cyclesignalsWindowDetect(t, readings)
+			if !ok {
+				t.Fatal("expected a confirmed shift across the unrecorded day")
+			}
+			if firstHighDay != 12 {
+				t.Errorf("first elevated cycle day = %d, want 12", firstHighDay)
+			}
+			if coverline != testCase.wantCoverline {
+				t.Errorf("coverline = %v, want %v", coverline, testCase.wantCoverline)
+			}
+
+			ovulation := inferBBTOvulationDate(
+				cyclesignalsWindowLogs(t, readings),
+				cyclesignalsCovDay(t, cyclesignalsWindowCycleStart),
+				cyclesignalsCovDay(t, cyclesignalsWindowNextStart),
+				time.UTC,
+			)
+			if got := ovulation.Format("2006-01-02"); got != "2026-01-11" {
+				t.Errorf("ovulation estimate = %s, want 2026-01-11 (cycle day 11)", got)
+			}
+		})
+	}
+}
+
+// TestBBTShiftWindowTakesSixRecordedValuesWhateverTheGapCount characterises how
+// many gaps the window tolerates: any number, because the six are recordings.
+// Zhu et al. (JMIR Mhealth Uhealth, 2021) instead score the window over calendar
+// days and allow one missing day of six; a window holding only four of its six
+// calendar days, as here, yields no detection under that reading. Which of the
+// two is preferable is a product question — this pins which one ships.
+func TestBBTShiftWindowTakesSixRecordedValuesWhateverTheGapCount(t *testing.T) {
+	cases := []struct {
+		name          string
+		oldestValue   float64
+		wantCoverline float64
+	}{
+		{
+			name:          "two gaps pull the window back to cycle day 4",
+			oldestValue:   36.35,
+			wantCoverline: 36.35,
+		},
+		{
+			name:          "control: a flat cycle day 4 lowers the same coverline",
+			oldestValue:   36.20,
+			wantCoverline: 36.20,
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			readings := append([]cyclesignalsWindowReading{
+				{cycleDay: 4, value: testCase.oldestValue},
+				{cycleDay: 5, value: 36.20},
+				// Cycle days 6 and 8 are not recorded.
+				{cycleDay: 7, value: 36.20},
+				{cycleDay: 9, value: 36.20},
+				{cycleDay: 10, value: 36.20},
+				{cycleDay: 11, value: 36.20},
+			}, cyclesignalsWindowShift...)
+
+			firstHighDay, coverline, ok := cyclesignalsWindowDetect(t, readings)
+			if !ok {
+				t.Fatal("expected a confirmed shift across two unrecorded days")
+			}
+			if firstHighDay != 12 {
+				t.Errorf("first elevated cycle day = %d, want 12", firstHighDay)
+			}
+			if coverline != testCase.wantCoverline {
+				t.Errorf("coverline = %v, want %v", coverline, testCase.wantCoverline)
+			}
+		})
+	}
+}
+
+// TestBBTShiftDisturbedDayDoesNotConsumeAWindowSlot characterises the second
+// half of the disturbance rule. Its first half — a warm disturbed reading does
+// not inflate the coverline — is
+// TestCycleSignals_InferBBTOvulationDate_IllnessDayExcludedFromCoverline, which
+// reads the rule through the ovulation date. Here the excluded reading is
+// ordinary, so nothing is inflated and the only observable difference is that
+// the day is gone from the series entirely: the sixth value back moves one
+// recorded day further, exactly as an unrecorded day makes it move. A tagged day
+// is dropped whole, without asking whether its value stands out from the
+// window — Sensiplan's Ausklammern removes at most an outlying value and keeps
+// the day's place in the count.
+func TestBBTShiftDisturbedDayDoesNotConsumeAWindowSlot(t *testing.T) {
+	cases := []struct {
+		name          string
+		disturbed     bool
+		wantCoverline float64
+	}{
+		{
+			name:          "an illness-tagged cycle day 9 leaves the window six recordings deep",
+			disturbed:     true,
+			wantCoverline: 36.35,
+		},
+		{
+			name:          "control: the same reading untagged fills the slot and drops the coverline",
+			disturbed:     false,
+			wantCoverline: 36.20,
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			readings := append([]cyclesignalsWindowReading{
+				{cycleDay: 5, value: 36.35},
+				{cycleDay: 6, value: 36.20},
+				{cycleDay: 7, value: 36.20},
+				{cycleDay: 8, value: 36.20},
+				{cycleDay: 9, value: 36.20, disturbed: testCase.disturbed},
+				{cycleDay: 10, value: 36.20},
+				{cycleDay: 11, value: 36.20},
+			}, cyclesignalsWindowShift...)
+
+			firstHighDay, coverline, ok := cyclesignalsWindowDetect(t, readings)
+			if !ok {
+				t.Fatal("expected a confirmed shift")
+			}
+			if firstHighDay != 12 {
+				t.Errorf("first elevated cycle day = %d, want 12", firstHighDay)
+			}
+			if coverline != testCase.wantCoverline {
+				t.Errorf("coverline = %v, want %v", coverline, testCase.wantCoverline)
+			}
+		})
+	}
+}
+
+// TestBBTShiftSlowRiseIsNotConfirmed characterises the strictest departure from
+// the source protocol: Sensiplan's first exception rule accepts a rise whose
+// third day misses the 0.2 °C margin by waiting for a fourth day, which only has
+// to stay above the coverline — it would confirm this cycle on the evening of
+// cycle day 15. The product never does, and the reason is not the margin alone:
+// the coverline SLIDES with the candidate, so the first elevated days of a slow
+// rise enter the window of every later candidate and lift the line to their own
+// level. A rise that climbs in steps smaller than the margin therefore raises
+// the bar it is being measured against, and no candidate in it can qualify.
+func TestBBTShiftSlowRiseIsNotConfirmed(t *testing.T) {
+	readings := []cyclesignalsWindowReading{
+		{cycleDay: 6, value: 36.20},
+		{cycleDay: 7, value: 36.20},
+		{cycleDay: 8, value: 36.20},
+		{cycleDay: 9, value: 36.20},
+		{cycleDay: 10, value: 36.20},
+		{cycleDay: 11, value: 36.20},
+		{cycleDay: 12, value: 36.30},
+		{cycleDay: 13, value: 36.30},
+		{cycleDay: 14, value: 36.30},
+		{cycleDay: 15, value: 36.50},
+	}
+
+	if firstHighDay, coverline, ok := cyclesignalsWindowDetect(t, readings); ok {
+		t.Fatalf("expected no shift for a stepwise rise, got first elevated day %d over coverline %v", firstHighDay, coverline)
+	}
+
+	ovulation := inferBBTOvulationDate(
+		cyclesignalsWindowLogs(t, readings),
+		cyclesignalsCovDay(t, cyclesignalsWindowCycleStart),
+		cyclesignalsCovDay(t, cyclesignalsWindowNextStart),
+		time.UTC,
+	)
+	if !ovulation.IsZero() {
+		t.Fatalf("expected no ovulation estimate from a stepwise rise, got %s", ovulation.Format("2006-01-02"))
+	}
+}


### PR DESCRIPTION
## What
Characterisation tests for the shared "3-over-6" BBT detector, and the documentation paragraph that
names what the rule is and what it is not. No production code changed.

## Why
The window's unit (six *recorded* undisturbed values, not the six calendar days before the
candidate), the whole-day drop of a disturbance-tagged reading, and the refusal of a rise that
climbs in steps below the margin were behaviours nothing pinned. `docs/cycle-prediction.md` also
listed three of the detector's consumers where there are now five behind one resolver, and promised
a "±1–2 days" accuracy no source supports.

## Risk
None: tests and documentation only; `internal/services/cycle_signals.go` is untouched.

## How verified
`gofmt -l ./internal` (no output), `go vet ./internal/services` (exit 0),
`golangci-lint run ./internal/services/...` (0 issues),
`go test ./internal/services -run 'CycleSignals|BBTShift|Coverline|Characteri' -count=1` (exit 0),
`go run ./scripts/changelogd check` (OK). Excision, retaken with the test file this PR ships:
dropping `isBBTDisturbedLog` from the detection filter reddens exactly the tagged case of
`TestBBTShiftDisturbedDayDoesNotConsumeAWindowSlot` among the new tests; gutting the third-day
margin — and, separately, loosening its comparison to `<=` — reddens the margin cases in the
stored-units tests and leaves the window tests green. The detector was restored from a snapshot and
diffed clean afterwards.

Stacked on #733; merges after it.
