### PR TITLE
docs(cycle-prediction): name the luteal window an outlier filter

### DIFF
--- a/changelog.d/luteal-window-is-a-heuristic-filter.md
+++ b/changelog.d/luteal-window-is-a-heuristic-filter.md
@@ -1,0 +1,9 @@
+### Changed
+
+- **The 10–20 day luteal window is now documented as the outlier filter it is.**
+  `docs/cycle-prediction.md` no longer calls the window physiological or treats a sample outside it
+  as a bad reading: it filters *inferred* lengths before they are averaged, a luteal phase at or
+  below its floor is ordinary rather than a fault, and a dropped sample says nothing about the
+  owner's body. The doc also states that the 14-day value left standing when too few samples
+  survive is the model's constant and must not be shown as a personalised luteal phase. The filter
+  itself is unchanged.

--- a/docs/cycle-prediction.md
+++ b/docs/cycle-prediction.md
@@ -161,16 +161,24 @@ These are the exact cases asserted by the reference tests.
   cervical-mucus entries place the ovulation inside past cycles, each of those
   observations becomes a luteal length by Step 2a and the average of them
   replaces the default. A cycle whose inferred luteal length falls outside a
-  physiological 10–20 day window is **discarded**, not pulled to the nearest
-  edge of it — an implausible inference is treated as a bad reading rather than
-  as a 10 or a 20 — and the refinement needs at least two surviving cycles, so
-  a single odd reading cannot move the estimate on its own. The cervical-mucus
-  signal estimates ovulation as the day after the last egg-white (peak-quality)
-  mucus day of the cycle; self-observed peak days can differ from reference
-  ovulation by a day or more, which is another reason the inferred luteal
-  length stays an estimate. With little or no such data the fixed 14-day
-  default stands. Individual luteal phases vary (commonly 11–17 days), which is
-  one reason predictions remain estimates.
+  10–20 day window is **discarded** from that average rather than pulled to the
+  nearest edge of it, and the refinement needs at least two surviving cycles, so
+  a single odd reading cannot move the estimate on its own. That window is an
+  engineering outlier filter over *inferred* lengths, not a clinical boundary:
+  luteal phases at or below its floor occur and are ordinary — a TTC cohort
+  anchored on ovulation tests put 18 % of cycles at 11 days or fewer counting
+  the ovulation day itself, which is 10 or fewer on the count this document
+  uses, which excludes it — so a discarded sample is one this inference declines
+  to average, never a measurement shown to be wrong and never a statement about
+  the owner's body. The cervical-mucus signal estimates ovulation as the day
+  after the last egg-white (peak-quality) mucus day of the cycle; self-observed
+  peak days can differ from reference ovulation by a day or more, which is
+  another reason the inferred luteal length stays an estimate. With little or no
+  such data, or with fewer than two surviving samples, the fixed 14-day default
+  stands — it is the model's constant, not a value observed from this owner, and
+  no surface may present it as evidence of a personalised luteal phase.
+  Individual luteal phases vary (commonly 11–17 days), which is one reason
+  predictions remain estimates.
 - For irregular cycles the app widens the prediction into a range rather than a
   single date. The range and variability statistics (shortest/longest cycle and
   the sample standard deviation) are computed over the same recent-cycle window

--- a/internal/services/cycle_signals.go
+++ b/internal/services/cycle_signals.go
@@ -25,16 +25,18 @@ const (
 	bbtThirdDayMarginCelsius = 0.2
 )
 
-// maxPlausibleLutealPhaseDays is the ceiling of the plausibility window the
-// observed-luteal inference filters its per-cycle samples through; the floor is
-// minLutealPhaseDays. It belongs to this file rather than to the luteal-phase
-// const family in cycles.go because it is an outlier-rejection threshold owned
-// by the inference, not a property of the cycle model: a length past it means
-// the ovulation signal was misread (a stray egg-white day early in the cycle, a
-// thermal shift picked up from a disturbed reading), so the cycle is dropped
-// from the sample rather than clamped into it. The prediction-time bound is a
-// different quantity — maxSupportedLutealPhase (cycles.go), computed from the
-// cycle length.
+// maxPlausibleLutealPhaseDays is the ceiling of the window the observed-luteal
+// inference filters its per-cycle samples through; the floor is
+// minLutealPhaseDays. Both ends are an engineering outlier filter, not a
+// clinical boundary: a sample outside them is one this inference declines to
+// average, which is not evidence that the reading was wrong. Lengths at or
+// below the floor occur in ordinary cycles, so dropping a short sample says
+// nothing about the owner. The window belongs to this file rather than to the
+// luteal-phase const family in cycles.go because it is owned by the inference,
+// not by the cycle model; the prediction-time bound is a different quantity —
+// maxSupportedLutealPhase (cycles.go), computed from the cycle length. Moving
+// either end is a medical-wording change as much as a numeric one: see
+// docs/cycle-prediction.md, "How cycle length and luteal phase are chosen".
 //
 // Both ends bound the parameter in CalcOvulationDay's reading of it: the count
 // of days that FOLLOW ovulation. They are NOT bounds on the calendar span from


### PR DESCRIPTION
**What was wrong.** `docs/cycle-prediction.md` called the 10–20 day luteal filter a
"physiological window" and said a length outside it "is treated as a bad reading". Neither is
true: the window is an engineering outlier filter over *inferred* lengths, and a luteal phase at
or below its floor is ordinary — a TTC cohort anchored on ovulation tests put 18 % of cycles at
≤11 days counting the ovulation day, which is ≤10 on this codebase's count (`calcLutealPhase`
excludes it). The same doc let the surviving 14-day default read as a refined, owner-specific
value. The const comment in `cycle_signals.go` carried the same claim ("a length past it means
the ovulation signal was misread").

**What changed.** Doc paragraph and const comment only. The window is named an outlier filter and
not a clinical boundary; a dropped sample is one the inference declines to average, not a proven
bad measurement; the 14-day fallback is stated to be the model constant and not evidence of a
personalised luteal phase. `maxPlausibleLutealPhaseDays`, `minLutealPhaseDays` and the filter's
behaviour are unchanged — no executable line moves.

**Evidence.** Doc/comment-only: no behaviour to reproduce, so no red-on-base test. `go build` and
`gofmt -l` clean on `internal/services`. The AST-reading guards see no change. Release row C13.

**Rollback.** `git revert` — nothing depends on the wording.
