### PR TITLE
test(api): feed preconditions now prove the full serve

### DIFF
--- a/changelog.d/feed-preconditions-prove-the-full-serve.md
+++ b/changelog.d/feed-preconditions-prove-the-full-serve.md
@@ -1,0 +1,7 @@
+none
+
+Test-only: internal/api's shared test app now mounts the same calendar-feed
+CSRF/rate-limit exemption production does, so the settings-regressions'
+"armed feed serves" preconditions prove the full contract (200, no
+Set-Cookie, VCALENDAR body) instead of only a status code. No production
+code changed.

--- a/internal/api/calendar_feed_regressions_test.go
+++ b/internal/api/calendar_feed_regressions_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -336,10 +337,16 @@ func TestCalendarFeedIsRateLimitedPerIP(t *testing.T) {
 	const maxRequests = 3
 	rlApp := fiber.New()
 	rlApp.Use(CalendarFeedRateLimitPrefix, limiter.New(limiter.Config{
-		// Mirrors the production mount (cmd/ovumcy/server.go): Next scopes the
-		// limiter to IsCalendarFeedRequest, the same route-shape predicate the
-		// CSRF and language skips key on, rather than the bare prefix app.Use
-		// matches on its own (method-agnostic, no trailing-slash/case folding).
+		// Next repeats the FORM of the production mount (cmd/ovumcy/server.go)
+		// so this test measures the same middleware stack production runs — not
+		// because this test proves the scope Next narrows to: every request
+		// below is a canonical feed GET, which Next admits unconditionally
+		// whether it is this narrow or as wide as the bare prefix. The scope
+		// claim — that a path under the prefix but outside the feed's route
+		// shape spends no budget — is proven on the production stack by
+		// TestCalendarFeedLimiterSpendsNoBudgetOnPathsThatReachNoFeed
+		// (cmd/ovumcy/rate_limit_scope_guard_test.go). This test asserts only
+		// the per-IP budget and the 429's Retry-After shape.
 		Next:       func(c fiber.Ctx) bool { return !IsCalendarFeedRequest(c.Method(), c.Path()) },
 		Max:        maxRequests,
 		Expiration: time.Minute,
@@ -361,8 +368,12 @@ func TestCalendarFeedIsRateLimitedPerIP(t *testing.T) {
 	if lastStatus != http.StatusTooManyRequests {
 		t.Fatalf("expected 429 after exceeding the per-IP budget, got %d", lastStatus)
 	}
-	if retryAfter == "" {
-		t.Fatalf("expected a Retry-After header on the 429")
+	seconds, err := strconv.Atoi(retryAfter)
+	if err != nil {
+		t.Fatalf("expected an integer Retry-After on the 429, got %q: %v", retryAfter, err)
+	}
+	if seconds < 1 || seconds > int(time.Minute/time.Second) {
+		t.Fatalf("expected Retry-After in [1, %d] (the window), got %d", int(time.Minute/time.Second), seconds)
 	}
 }
 
@@ -606,4 +617,55 @@ func TestCalendarFeedRestoredBackupStopsServingARevokedURL(t *testing.T) {
 		t.Fatalf("a disarmed token and an unknown one must both answer the bare no-oracle 404 %#v:\n restored: %#v\n unrelated: %#v",
 			want, restoredFingerprint, unrelatedFingerprint)
 	}
+}
+
+// TestTestAppCSRFExemptionIsExactlyProductionsShape pins
+// testCSRFMiddlewareConfig's two Next clauses
+// (test_onboarding_app_setup_helpers_test.go) on the ONE app every other
+// CSRF-enabled regression in this package shares. Until this test, nothing
+// exercised the copy that way: the only existing GET to
+// security.OIDCCallbackPath (TestOIDCCallbackFormPostModeRejectsGET) builds
+// its app without enableCSRF, and no test sends a mutating method at the feed
+// route through a CSRF-enabled app — so `Next: return true` (exempting
+// everything) or the OIDC clause losing its POST guard (exempting the
+// callback on every method) left the whole package green. The two mutation
+// subtests are negative (403, no cookie change); the third is the positive
+// anchor in the same test proving this app's CSRF machinery is not simply
+// dead — the same token still serves 200 with no Set-Cookie through it.
+func TestTestAppCSRFExemptionIsExactlyProductionsShape(t *testing.T) {
+	app, database := newOnboardingTestAppWithCSRF(t)
+	user := createOnboardingTestUser(t, database, "csrf-exemption-shape@example.com", "StrongPass1", true)
+	token := armCalendarFeedForUser(t, database, user.ID)
+
+	// Kills `Next: return true` and any widening of the feed clause past
+	// GET/HEAD: IsCalendarFeedRequest admits only those two methods, so a POST
+	// at an armed feed URL must still fail CSRF validation for want of a
+	// token — the route table has no POST handler for this path either, so a
+	// wrongly-exempted request would fall through to the 404 catch-all rather
+	// than 403, not silently succeed.
+	t.Run("a mutating method at the feed route is not exempt", func(t *testing.T) {
+		response := mustAppResponse(t, app, httptest.NewRequest(http.MethodPost, calendarFeedURL(token), nil))
+		assertStatusCode(t, response, http.StatusForbidden)
+	})
+
+	// Kills the OIDC clause losing its `c.Method() == fiber.MethodPost` guard:
+	// with the guard intact, a GET is not exempt, so the CSRF middleware's
+	// safe-method arm runs like it would for any other page and mints+sets
+	// ovumcy_csrf. Status is deliberately not asserted — form_post mode (the
+	// default this app builds under) registers no GET route at this path, and
+	// the cookie decision is made by CSRF middleware mounted ahead of routing
+	// either way.
+	t.Run("a GET at the OIDC callback is not exempt from cookie minting", func(t *testing.T) {
+		response := mustAppResponse(t, app, httptest.NewRequest(http.MethodGet, security.OIDCCallbackPath, nil))
+		if responseCookie(response.Cookies(), "ovumcy_csrf") == nil {
+			t.Fatalf("expected a GET to the OIDC callback to mint ovumcy_csrf like any other safe request, got Set-Cookie: %q", response.Header.Values("Set-Cookie"))
+		}
+	})
+
+	// Positive anchor: the feed's own GET stays exempt on this same app and
+	// token, so the two refusals above are the exemption's boundary, not a
+	// CSRF-enabled app that refuses everything.
+	t.Run("the feed's own GET stays exempt", func(t *testing.T) {
+		mustServeCalendarFeed(t, app, token, "through the CSRF-enabled test app")
+	})
 }

--- a/internal/api/calendar_feed_regressions_test.go
+++ b/internal/api/calendar_feed_regressions_test.go
@@ -336,6 +336,11 @@ func TestCalendarFeedIsRateLimitedPerIP(t *testing.T) {
 	const maxRequests = 3
 	rlApp := fiber.New()
 	rlApp.Use(CalendarFeedRateLimitPrefix, limiter.New(limiter.Config{
+		// Mirrors the production mount (cmd/ovumcy/server.go): Next scopes the
+		// limiter to IsCalendarFeedRequest, the same route-shape predicate the
+		// CSRF and language skips key on, rather than the bare prefix app.Use
+		// matches on its own (method-agnostic, no trailing-slash/case folding).
+		Next:       func(c fiber.Ctx) bool { return !IsCalendarFeedRequest(c.Method(), c.Path()) },
 		Max:        maxRequests,
 		Expiration: time.Minute,
 		LimitReached: func(c fiber.Ctx) error {

--- a/internal/api/settings_calendar_feed_regressions_test.go
+++ b/internal/api/settings_calendar_feed_regressions_test.go
@@ -102,20 +102,12 @@ func TestCalendarFeedGenerateRevealsURLOnceAndNeverAgain(t *testing.T) {
 	if !strings.Contains(revealedURL, "/calendar/feed/") || !strings.HasSuffix(revealedURL, ".ics") {
 		t.Fatalf("expected a /calendar/feed/<token>.ics URL revealed, got %q", revealedURL)
 	}
-	// Extract the token path and prove it actually serves the feed.
-	//
-	// This does NOT go through mustServeCalendarFeed: the test app mounts
-	// csrf.New only when it is built with enableCSRF, which is exactly what
-	// newSettingsSecurityTestContext asks for, and that middleware's
-	// testCSRFMiddlewareConfig carries no calendar-feed exemption, so it sets
-	// ovumcy_csrf on this GET. mustServeCalendarFeed's callers build the app
-	// without that option and so may demand no cookie at all; whether the feed
-	// route itself sets one is not this test's subject.
+	// Extract the token path and prove it actually serves the feed. ctx.app
+	// mounts testCSRFMiddlewareConfig, which carries the same calendar-feed
+	// exemption production does, so this GET is held to the full armed-feed
+	// contract like every other mustServeCalendarFeed caller.
 	token := extractFeedTokenFromURL(t, revealedURL)
-	feedResp := mustAppResponse(t, ctx.app, httptest.NewRequest(http.MethodGet, calendarFeedURL(token), nil))
-	if feedResp.StatusCode != http.StatusOK {
-		t.Fatalf("expected the revealed URL to serve the feed (200), got %d", feedResp.StatusCode)
-	}
+	mustServeCalendarFeed(t, ctx.app, token, "for the just-revealed URL")
 
 	// The reveal page retracts the cookie...
 	clearedCookie := responseCookie(revealResp.Cookies(), calendarFeedRevealCookieName)
@@ -296,13 +288,7 @@ func TestCalendarFeedRotateInvalidatesOldToken(t *testing.T) {
 	// Arm a feed directly and capture the OLD token, then confirm it serves.
 	oldToken := armCalendarFeedForUser(t, ctx.database, ctx.user.ID)
 	oldSelector := reloadUserForCalendarFeedAPI(t, ctx, ctx.user.ID).CalendarFeedSelector
-	// Not mustServeCalendarFeed: ctx.app mounts CSRF (see the comment on the
-	// same pattern in TestCalendarFeedGenerateRevealsURLOnceAndNeverAgain
-	// above), which sets its own cookie on this GET — unrelated to the feed.
-	pre := mustAppResponse(t, ctx.app, httptest.NewRequest(http.MethodGet, calendarFeedURL(oldToken), nil))
-	if pre.StatusCode != http.StatusOK {
-		t.Fatalf("precondition: old token should serve the feed, got %d", pre.StatusCode)
-	}
+	mustServeCalendarFeed(t, ctx.app, oldToken, "before the rotate")
 
 	rot := settingsFormRequestWithCSRF(t, ctx, http.MethodPost, "/api/v1/users/current/calendar-feed/rotate", url.Values{}, nil)
 	if rot.StatusCode != http.StatusSeeOther {
@@ -319,6 +305,7 @@ func TestCalendarFeedRotateInvalidatesOldToken(t *testing.T) {
 	if post.StatusCode != http.StatusNotFound {
 		t.Fatalf("expected the old token to 404 after rotate, got %d", post.StatusCode)
 	}
+	assertNoSetCookie(t, post, "the rotated-out token's 404 must not set a cookie")
 	// The old selector must not resolve any owner anymore.
 	if _, ok, err := db.NewRepositories(ctx.database).Users.FindByCalendarFeedSelector(t.Context(), oldSelector); err != nil || ok {
 		t.Fatalf("expected old selector to be unresolvable after rotate (ok=%v err=%v)", ok, err)
@@ -346,6 +333,7 @@ func TestCalendarFeedRevokeClearsColumns(t *testing.T) {
 	if feedResp.StatusCode != http.StatusNotFound {
 		t.Fatalf("expected the revoked feed URL to 404, got %d", feedResp.StatusCode)
 	}
+	assertNoSetCookie(t, feedResp, "the revoked feed's 404 must not set a cookie")
 }
 
 // TestCalendarFeedRevokeBrowserRedirectsWithFlash covers the non-JSON revoke
@@ -530,13 +518,7 @@ func TestCalendarFeedGenerateScopedToOwner(t *testing.T) {
 	if ownerAAfter.CalendarFeedSelector != ownerABefore.CalendarFeedSelector {
 		t.Fatal("owner A's feed selector must not change when owner B generates")
 	}
-	// Not mustServeCalendarFeed: ctx.app mounts CSRF, which sets its own
-	// cookie on this GET (see the comment in
-	// TestCalendarFeedGenerateRevealsURLOnceAndNeverAgain above).
-	feedA := mustAppResponse(t, ctx.app, httptest.NewRequest(http.MethodGet, calendarFeedURL(tokenA), nil))
-	if feedA.StatusCode != http.StatusOK {
-		t.Fatalf("expected owner A's feed to keep serving after owner B generate, got %d", feedA.StatusCode)
-	}
+	mustServeCalendarFeed(t, ctx.app, tokenA, "after owner B generate")
 	// Owner B got its own (distinct) selector.
 	ownerBRow := reloadUserForCalendarFeedAPI(t, ctx, ownerB.ID)
 	if ownerBRow.CalendarFeedSelector == "" || ownerBRow.CalendarFeedSelector == ownerABefore.CalendarFeedSelector {
@@ -572,17 +554,12 @@ func TestCalendarFeedRevokeScopedToOwner(t *testing.T) {
 	// satisfied by a URL that never worked. Asserted here and not in a subtest:
 	// t.Fatalf inside t.Run ends only the subtest, so a lost precondition would
 	// leave the verdicts below to run anyway and report a second, misleading
-	// failure beside it. Not mustServeCalendarFeed: ctx.app mounts CSRF, which
-	// sets its own cookie on this GET (see the comment in
-	// TestCalendarFeedGenerateRevealsURLOnceAndNeverAgain above).
+	// failure beside it.
 	for _, owner := range []struct {
 		label string
 		token string
 	}{{label: "A", token: tokenA}, {label: "B", token: tokenB}} {
-		before := mustAppResponse(t, ctx.app, httptest.NewRequest(http.MethodGet, calendarFeedURL(owner.token), nil))
-		if before.StatusCode != http.StatusOK {
-			t.Fatalf("precondition: owner %s's feed must serve before the revoke, got %d", owner.label, before.StatusCode)
-		}
+		mustServeCalendarFeed(t, ctx.app, owner.token, "for owner "+owner.label+" before the revoke")
 	}
 
 	// Owner B revokes, on owner B's own session.
@@ -611,6 +588,7 @@ func TestCalendarFeedRevokeScopedToOwner(t *testing.T) {
 	if feedB.StatusCode != http.StatusNotFound {
 		t.Fatalf("expected owner B's revoked feed URL to 404, got %d", feedB.StatusCode)
 	}
+	assertNoSetCookie(t, feedB, "owner B's revoked feed 404 must not set a cookie")
 
 	// Owner A's row is untouched and A's URL still serves.
 	ownerAAfter := reloadUserForCalendarFeedAPI(t, ctx, ctx.user.ID)
@@ -619,13 +597,7 @@ func TestCalendarFeedRevokeScopedToOwner(t *testing.T) {
 		ownerAAfter.CalendarFeedVerifierMAC != ownerABefore.CalendarFeedVerifierMAC {
 		t.Fatal("owner A's feed columns must not change when owner B revokes")
 	}
-	// Not mustServeCalendarFeed: ctx.app mounts CSRF, which sets its own
-	// cookie on this GET (see the comment in
-	// TestCalendarFeedGenerateRevealsURLOnceAndNeverAgain above).
-	feedA := mustAppResponse(t, ctx.app, httptest.NewRequest(http.MethodGet, calendarFeedURL(tokenA), nil))
-	if feedA.StatusCode != http.StatusOK {
-		t.Fatalf("expected owner A's feed to keep serving after owner B's revoke, got %d", feedA.StatusCode)
-	}
+	mustServeCalendarFeed(t, ctx.app, tokenA, "after owner B's revoke")
 }
 
 // failingCalendarFeedRepo forces the feed settings repository to error on every

--- a/internal/api/test_onboarding_app_setup_helpers_test.go
+++ b/internal/api/test_onboarding_app_setup_helpers_test.go
@@ -153,10 +153,21 @@ func newTestHandlerDependencies(database *gorm.DB, i18nManager *i18n.Manager, op
 	return dependencies
 }
 
+// testCSRFMiddlewareConfig mirrors csrfMiddlewareConfig (cmd/ovumcy/server.go)
+// exactly: the same two Next clauses, the OIDC callback exemption scoped to
+// POST and the calendar-feed skip keyed on IsCalendarFeedRequest. A narrower
+// mirror here would leave the feed's "no Set-Cookie" contract untested by
+// every regression that arms a feed through this shared test app; a wider one
+// would let a CSRF-exemption regression in this app pass while production's
+// own predicate — pinned separately by csrf_exemption_guard_test.go — stayed
+// broken, or vice versa.
 func testCSRFMiddlewareConfig(cookieSecure bool, handler *Handler) csrf.Config {
 	return csrf.Config{
 		Next: func(c fiber.Ctx) bool {
-			return c.Path() == security.OIDCCallbackPath
+			if c.Method() == fiber.MethodPost && c.Path() == security.OIDCCallbackPath {
+				return true
+			}
+			return IsCalendarFeedRequest(c.Method(), c.Path())
 		},
 		CookieName:     "ovumcy_csrf",
 		CookieSameSite: "Lax",

--- a/internal/api/test_onboarding_app_setup_helpers_test.go
+++ b/internal/api/test_onboarding_app_setup_helpers_test.go
@@ -153,14 +153,19 @@ func newTestHandlerDependencies(database *gorm.DB, i18nManager *i18n.Manager, op
 	return dependencies
 }
 
-// testCSRFMiddlewareConfig mirrors csrfMiddlewareConfig (cmd/ovumcy/server.go)
-// exactly: the same two Next clauses, the OIDC callback exemption scoped to
-// POST and the calendar-feed skip keyed on IsCalendarFeedRequest. A narrower
-// mirror here would leave the feed's "no Set-Cookie" contract untested by
-// every regression that arms a feed through this shared test app; a wider one
-// would let a CSRF-exemption regression in this app pass while production's
-// own predicate — pinned separately by csrf_exemption_guard_test.go — stayed
-// broken, or vice versa.
+// testCSRFMiddlewareConfig mirrors csrfMiddlewareConfig (cmd/ovumcy/server.go):
+// the same two Next clauses, the OIDC callback exemption scoped to POST and
+// the calendar-feed skip keyed on IsCalendarFeedRequest. Nothing type-checks
+// that this copy stays in sync with its source, so each clause is pinned
+// separately, on THIS copy, by TestTestAppCSRFExemptionIsExactlyProductionsShape
+// (calendar_feed_regressions_test.go): a mutating method at the feed route
+// still 403s (kills `Next: return true` and a feed clause widened past
+// GET/HEAD), and a GET at the OIDC callback still mints ovumcy_csrf (kills the
+// OIDC clause losing its POST-method guard). The PRODUCTION copy's own shape —
+// the exemption list, and the feed's no-cookie contract across every outcome —
+// is guarded independently, on the real app, by
+// cmd/ovumcy/csrf_exemption_guard_test.go and
+// cmd/ovumcy/calendar_feed_no_cookie_test.go.
 func testCSRFMiddlewareConfig(cookieSecure bool, handler *Handler) csrf.Config {
 	return csrf.Config{
 		Next: func(c fiber.Ctx) bool {


### PR DESCRIPTION
## What
The `internal/api` test app mounts the same calendar-feed exemption as production — its `csrf.Config.Next` is now `(POST /auth/oidc/callback) || IsCalendarFeedRequest(method, path)` — so every "armed feed serves" precondition in the settings regressions goes through `mustServeCalendarFeed` (200, no `Set-Cookie`, a VCALENDAR body) instead of a bare status check, and every "revoked feed 404" verdict also asserts no `Set-Cookie`. `TestCalendarFeedIsRateLimitedPerIP` mounts its limiter with production's `Next` predicate.

## Why
Five preconditions checked the status only because the harness set `ovumcy_csrf` on a feed GET where production does not, so a regression in the feed's no-cookie contract would have passed them. Deferred from #729 and #737.

## Risk
None to behaviour: test harness and tests only, `none` changelog fragment.

## How verified
Red on 9cd8d602 with the site conversions alone (4 tests: "precondition lost: the armed feed must not set a cookie"); gutted-1 (the old `Next`) red on 5 tests; gutted-2 (CSRF switched off) red on `TestDaysUpsertPostRejectsRequestsMissingCSRFToken`; gutted-3 (limiter `Next` removed) stays green by design — a mount form, not a killing mutation, the killing cases live in `cmd/ovumcy`. `go test ./internal/api/ -count=1 -timeout 20m` ok; `go vet`, `gofmt -l`, `golangci-lint` (0 issues), `changelogd check` clean. Logs in the lane's `.tmp/`.

## Evidence
`FEED-TESTAPP-CSRF (test-only) | this PR | 961a7f98 | go test ./internal/api/ -run 'CalendarFeed' -count=1 -v; go test ./internal/api/ -run 'OIDC|CSRF' -count=1; go test ./internal/api/ -count=1 -timeout 20m; vet; gofmt; golangci-lint; changelogd | Win11 26200 / go1.27.1 | lane .tmp/{base-red,gutted-1,gutted-2,gutted-3,oidc-csrf,api,vet,gofmt,lint}.log | 1 (base) / 1 (gutted-1, gutted-2) / 0 (fix) | red on 9cd8d602: 4 preconditions | gutted-1 red x5, gutted-2 red through the CSRF setup | review pending | CI pending`
