### PR TITLE
fix(api/overview): ovulation_exact is not personalisation, add the field that is

### DIFF
--- a/changelog.d/overview-says-when-the-luteal-phase-is-personalised.md
+++ b/changelog.d/overview-says-when-the-luteal-phase-is-personalised.md
@@ -1,0 +1,20 @@
+### Fixed
+
+- **`ovulation_exact`'s description no longer claims it is a personalisation signal.** The flag
+  reports exactly what `CalcOvulationDay` decides: whether the luteal phase fit inside the cycle
+  without the arithmetic clamp. It is `true` on the 14-day model default whenever that default
+  happens to fit a cycle, and `false` on a per-owner inferred value the cycle was too short to hold —
+  the opposite of what the wording said. It remains independent of `ovulation_confirmed` and always
+  `false` when `ovulation_date` is null; only the misleading half of the description changes.
+
+### Added
+
+- **`GET /api/v1/stats/overview` gains `luteal_phase_personalised`.** It reports whether
+  `luteal_phase` was inferred from the owner's own logs (`InferUserLutealPhase`'s refined return)
+  rather than the 14-day model constant — the signal `ovulation_exact` was wrongly described as
+  carrying. The two are independent: a personalised luteal phase can still be clamped
+  (`ovulation_exact = false`), and the 14-day default can still fit a cycle exactly
+  (`ovulation_exact = true`). `false` means the owner's logs did not yet support an inference, not
+  that a personalised value was tried and rejected. Cleared to `false` under fertility suppression,
+  alongside `ovulation_date` and `ovulation_exact`, so it never asserts personalisation about a
+  projection this tier has already withheld.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -769,6 +769,7 @@ components:
         - last_cycle_length
         - last_period_length
         - luteal_phase
+        - luteal_phase_personalised
         - last_period_start
         - next_period_start
         - ovulation_date
@@ -835,6 +836,19 @@ components:
         luteal_phase:
           type: integer
           description: Days following ovulation; per-owner when inferable, else the 14-day default.
+        luteal_phase_personalised:
+          type: boolean
+          description: >-
+            `luteal_phase` was inferred from the owner's own logs, rather than
+            the 14-day model default. This says nothing about whether the
+            resulting ovulation date avoided the arithmetic clamp (see
+            `ovulation_exact`) and nothing about whether the current cycle's
+            ovulation was confirmed by a BBT shift (see `ovulation_confirmed`)
+            — a personalised luteal phase can still be clamped, and a default
+            one can still fit exactly. `false` means the owner's logs did not
+            yet support an inference, not that a personalised value was tried
+            and found wrong. Always false when `suppression.fertility` is
+            true.
         last_period_start:
           type: [string, "null"]
           format: date
@@ -859,11 +873,15 @@ components:
         ovulation_exact:
           type: boolean
           description: >-
-            The ovulation date is anchored on a per-owner inferred luteal
-            phase rather than on the 14-day fallback. Independent of
-            `ovulation_confirmed` — a fallback-luteal cycle (`false` here) can
-            still have its ovulation confirmed by a BBT shift. Always false
-            when `ovulation_date` is null.
+            The luteal phase fit within the cycle without the arithmetic
+            clamp. This is NOT a personalisation signal and NOT an accuracy
+            claim: it is `true` on the 14-day model default whenever that
+            default fits the cycle, and `false` on a per-owner inferred value
+            the cycle was too short to hold. See `luteal_phase_personalised`
+            for whether the luteal phase came from the owner's own logs.
+            Independent of `ovulation_confirmed` — an unclamped cycle (`true`
+            here) can still have its ovulation confirmed by a BBT shift, and a
+            clamped one can too. Always false when `ovulation_date` is null.
         ovulation_confirmed:
           type: boolean
           description: >-

--- a/internal/api/stats_overview_dto.go
+++ b/internal/api/stats_overview_dto.go
@@ -89,32 +89,33 @@ type StatsOverviewSuppression struct {
 // Recorded history — the observed lengths, the last period start, the current
 // cycle day — is fact rather than projection and is published in every tier.
 type StatsOverviewResponse struct {
-	CurrentCycleDay         int                      `json:"current_cycle_day"`
-	CurrentPhase            string                   `json:"current_phase"`
-	CurrentFertility        string                   `json:"current_fertility"`
-	AverageCycleLength      float64                  `json:"average_cycle_length"`
-	MedianCycleLength       int                      `json:"median_cycle_length"`
-	MinCycleLength          int                      `json:"min_cycle_length"`
-	MaxCycleLength          int                      `json:"max_cycle_length"`
-	CycleLengthStdDev       float64                  `json:"cycle_length_std_dev"`
-	CompletedCycleCount     int                      `json:"completed_cycle_count"`
-	AveragePeriodLength     float64                  `json:"average_period_length"`
-	LastCycleLength         int                      `json:"last_cycle_length"`
-	LastPeriodLength        int                      `json:"last_period_length"`
-	LutealPhase             int                      `json:"luteal_phase"`
-	LutealPhasePersonalised bool                     `json:"luteal_phase_personalised"`
-	LastPeriodStart         *string                  `json:"last_period_start"`
-	NextPeriodStart         *string                  `json:"next_period_start"`
-	OvulationDate           *string                  `json:"ovulation_date"`
-	OvulationExact          bool                     `json:"ovulation_exact"`
-	OvulationConfirmed      bool                     `json:"ovulation_confirmed"`
-	OvulationImpossible     bool                     `json:"ovulation_impossible"`
-	FertilityWindowStart    *string                  `json:"fertility_window_start"`
-	FertilityWindowEnd      *string                  `json:"fertility_window_end"`
-	PregnancyPaused         bool                     `json:"pregnancy_paused"`
-	Suppression             StatsOverviewSuppression `json:"suppression"`
-	Disclaimer              string                   `json:"disclaimer"`
-	DisclaimerKey           string                   `json:"disclaimer_key"`
+	CurrentCycleDay      int                      `json:"current_cycle_day"`
+	CurrentPhase         string                   `json:"current_phase"`
+	CurrentFertility     string                   `json:"current_fertility"`
+	AverageCycleLength   float64                  `json:"average_cycle_length"`
+	MedianCycleLength    int                      `json:"median_cycle_length"`
+	MinCycleLength       int                      `json:"min_cycle_length"`
+	MaxCycleLength       int                      `json:"max_cycle_length"`
+	CycleLengthStdDev    float64                  `json:"cycle_length_std_dev"`
+	CompletedCycleCount  int                      `json:"completed_cycle_count"`
+	AveragePeriodLength  float64                  `json:"average_period_length"`
+	LastCycleLength      int                      `json:"last_cycle_length"`
+	LastPeriodLength     int                      `json:"last_period_length"`
+	LutealPhase          int                      `json:"luteal_phase"`
+	LastPeriodStart      *string                  `json:"last_period_start"`
+	NextPeriodStart      *string                  `json:"next_period_start"`
+	OvulationDate        *string                  `json:"ovulation_date"`
+	OvulationExact       bool                     `json:"ovulation_exact"`
+	OvulationConfirmed   bool                     `json:"ovulation_confirmed"`
+	OvulationImpossible  bool                     `json:"ovulation_impossible"`
+	FertilityWindowStart *string                  `json:"fertility_window_start"`
+	FertilityWindowEnd   *string                  `json:"fertility_window_end"`
+	PregnancyPaused      bool                     `json:"pregnancy_paused"`
+	Suppression          StatsOverviewSuppression `json:"suppression"`
+	Disclaimer           string                   `json:"disclaimer"`
+	DisclaimerKey        string                   `json:"disclaimer_key"`
+
+	LutealPhasePersonalised bool `json:"luteal_phase_personalised"`
 }
 
 // newStatsOverviewResponse maps the PUBLISHED stats — the copy
@@ -126,32 +127,33 @@ type StatsOverviewResponse struct {
 // with the data.
 func newStatsOverviewResponse(stats services.CycleStats, suppression services.PredictionSuppression, confirmed bool, disclaimer string) StatsOverviewResponse {
 	return StatsOverviewResponse{
-		CurrentCycleDay:         stats.CurrentCycleDay,
-		CurrentPhase:            stats.CurrentPhase,
-		CurrentFertility:        stats.CurrentFertility,
-		AverageCycleLength:      stats.AverageCycleLength,
-		MedianCycleLength:       stats.MedianCycleLength,
-		MinCycleLength:          stats.MinCycleLength,
-		MaxCycleLength:          stats.MaxCycleLength,
-		CycleLengthStdDev:       stats.CycleLengthStdDev,
-		CompletedCycleCount:     stats.CompletedCycleCount,
-		AveragePeriodLength:     stats.AveragePeriodLength,
-		LastCycleLength:         stats.LastCycleLength,
-		LastPeriodLength:        stats.LastPeriodLength,
-		LutealPhase:             stats.LutealPhase,
+		CurrentCycleDay:      stats.CurrentCycleDay,
+		CurrentPhase:         stats.CurrentPhase,
+		CurrentFertility:     stats.CurrentFertility,
+		AverageCycleLength:   stats.AverageCycleLength,
+		MedianCycleLength:    stats.MedianCycleLength,
+		MinCycleLength:       stats.MinCycleLength,
+		MaxCycleLength:       stats.MaxCycleLength,
+		CycleLengthStdDev:    stats.CycleLengthStdDev,
+		CompletedCycleCount:  stats.CompletedCycleCount,
+		AveragePeriodLength:  stats.AveragePeriodLength,
+		LastCycleLength:      stats.LastCycleLength,
+		LastPeriodLength:     stats.LastPeriodLength,
+		LutealPhase:          stats.LutealPhase,
+		LastPeriodStart:      statsOverviewDate(stats.LastPeriodStart),
+		NextPeriodStart:      statsOverviewDate(stats.NextPeriodStart),
+		OvulationDate:        statsOverviewDate(stats.OvulationDate),
+		OvulationExact:       stats.OvulationExact,
+		OvulationConfirmed:   confirmed,
+		OvulationImpossible:  stats.OvulationImpossible,
+		FertilityWindowStart: statsOverviewDate(stats.FertilityWindowStart),
+		FertilityWindowEnd:   statsOverviewDate(stats.FertilityWindowEnd),
+		PregnancyPaused:      stats.PregnancyPaused,
+		Suppression:          newStatsOverviewSuppression(suppression),
+		Disclaimer:           disclaimer,
+		DisclaimerKey:        medicalDisclaimerMessageKey,
+
 		LutealPhasePersonalised: stats.LutealPhasePersonalised,
-		LastPeriodStart:         statsOverviewDate(stats.LastPeriodStart),
-		NextPeriodStart:         statsOverviewDate(stats.NextPeriodStart),
-		OvulationDate:           statsOverviewDate(stats.OvulationDate),
-		OvulationExact:          stats.OvulationExact,
-		OvulationConfirmed:      confirmed,
-		OvulationImpossible:     stats.OvulationImpossible,
-		FertilityWindowStart:    statsOverviewDate(stats.FertilityWindowStart),
-		FertilityWindowEnd:      statsOverviewDate(stats.FertilityWindowEnd),
-		PregnancyPaused:         stats.PregnancyPaused,
-		Suppression:             newStatsOverviewSuppression(suppression),
-		Disclaimer:              disclaimer,
-		DisclaimerKey:           medicalDisclaimerMessageKey,
 	}
 }
 

--- a/internal/api/stats_overview_dto.go
+++ b/internal/api/stats_overview_dto.go
@@ -89,31 +89,32 @@ type StatsOverviewSuppression struct {
 // Recorded history — the observed lengths, the last period start, the current
 // cycle day — is fact rather than projection and is published in every tier.
 type StatsOverviewResponse struct {
-	CurrentCycleDay      int                      `json:"current_cycle_day"`
-	CurrentPhase         string                   `json:"current_phase"`
-	CurrentFertility     string                   `json:"current_fertility"`
-	AverageCycleLength   float64                  `json:"average_cycle_length"`
-	MedianCycleLength    int                      `json:"median_cycle_length"`
-	MinCycleLength       int                      `json:"min_cycle_length"`
-	MaxCycleLength       int                      `json:"max_cycle_length"`
-	CycleLengthStdDev    float64                  `json:"cycle_length_std_dev"`
-	CompletedCycleCount  int                      `json:"completed_cycle_count"`
-	AveragePeriodLength  float64                  `json:"average_period_length"`
-	LastCycleLength      int                      `json:"last_cycle_length"`
-	LastPeriodLength     int                      `json:"last_period_length"`
-	LutealPhase          int                      `json:"luteal_phase"`
-	LastPeriodStart      *string                  `json:"last_period_start"`
-	NextPeriodStart      *string                  `json:"next_period_start"`
-	OvulationDate        *string                  `json:"ovulation_date"`
-	OvulationExact       bool                     `json:"ovulation_exact"`
-	OvulationConfirmed   bool                     `json:"ovulation_confirmed"`
-	OvulationImpossible  bool                     `json:"ovulation_impossible"`
-	FertilityWindowStart *string                  `json:"fertility_window_start"`
-	FertilityWindowEnd   *string                  `json:"fertility_window_end"`
-	PregnancyPaused      bool                     `json:"pregnancy_paused"`
-	Suppression          StatsOverviewSuppression `json:"suppression"`
-	Disclaimer           string                   `json:"disclaimer"`
-	DisclaimerKey        string                   `json:"disclaimer_key"`
+	CurrentCycleDay         int                      `json:"current_cycle_day"`
+	CurrentPhase            string                   `json:"current_phase"`
+	CurrentFertility        string                   `json:"current_fertility"`
+	AverageCycleLength      float64                  `json:"average_cycle_length"`
+	MedianCycleLength       int                      `json:"median_cycle_length"`
+	MinCycleLength          int                      `json:"min_cycle_length"`
+	MaxCycleLength          int                      `json:"max_cycle_length"`
+	CycleLengthStdDev       float64                  `json:"cycle_length_std_dev"`
+	CompletedCycleCount     int                      `json:"completed_cycle_count"`
+	AveragePeriodLength     float64                  `json:"average_period_length"`
+	LastCycleLength         int                      `json:"last_cycle_length"`
+	LastPeriodLength        int                      `json:"last_period_length"`
+	LutealPhase             int                      `json:"luteal_phase"`
+	LutealPhasePersonalised bool                     `json:"luteal_phase_personalised"`
+	LastPeriodStart         *string                  `json:"last_period_start"`
+	NextPeriodStart         *string                  `json:"next_period_start"`
+	OvulationDate           *string                  `json:"ovulation_date"`
+	OvulationExact          bool                     `json:"ovulation_exact"`
+	OvulationConfirmed      bool                     `json:"ovulation_confirmed"`
+	OvulationImpossible     bool                     `json:"ovulation_impossible"`
+	FertilityWindowStart    *string                  `json:"fertility_window_start"`
+	FertilityWindowEnd      *string                  `json:"fertility_window_end"`
+	PregnancyPaused         bool                     `json:"pregnancy_paused"`
+	Suppression             StatsOverviewSuppression `json:"suppression"`
+	Disclaimer              string                   `json:"disclaimer"`
+	DisclaimerKey           string                   `json:"disclaimer_key"`
 }
 
 // newStatsOverviewResponse maps the PUBLISHED stats — the copy
@@ -125,31 +126,32 @@ type StatsOverviewResponse struct {
 // with the data.
 func newStatsOverviewResponse(stats services.CycleStats, suppression services.PredictionSuppression, confirmed bool, disclaimer string) StatsOverviewResponse {
 	return StatsOverviewResponse{
-		CurrentCycleDay:      stats.CurrentCycleDay,
-		CurrentPhase:         stats.CurrentPhase,
-		CurrentFertility:     stats.CurrentFertility,
-		AverageCycleLength:   stats.AverageCycleLength,
-		MedianCycleLength:    stats.MedianCycleLength,
-		MinCycleLength:       stats.MinCycleLength,
-		MaxCycleLength:       stats.MaxCycleLength,
-		CycleLengthStdDev:    stats.CycleLengthStdDev,
-		CompletedCycleCount:  stats.CompletedCycleCount,
-		AveragePeriodLength:  stats.AveragePeriodLength,
-		LastCycleLength:      stats.LastCycleLength,
-		LastPeriodLength:     stats.LastPeriodLength,
-		LutealPhase:          stats.LutealPhase,
-		LastPeriodStart:      statsOverviewDate(stats.LastPeriodStart),
-		NextPeriodStart:      statsOverviewDate(stats.NextPeriodStart),
-		OvulationDate:        statsOverviewDate(stats.OvulationDate),
-		OvulationExact:       stats.OvulationExact,
-		OvulationConfirmed:   confirmed,
-		OvulationImpossible:  stats.OvulationImpossible,
-		FertilityWindowStart: statsOverviewDate(stats.FertilityWindowStart),
-		FertilityWindowEnd:   statsOverviewDate(stats.FertilityWindowEnd),
-		PregnancyPaused:      stats.PregnancyPaused,
-		Suppression:          newStatsOverviewSuppression(suppression),
-		Disclaimer:           disclaimer,
-		DisclaimerKey:        medicalDisclaimerMessageKey,
+		CurrentCycleDay:         stats.CurrentCycleDay,
+		CurrentPhase:            stats.CurrentPhase,
+		CurrentFertility:        stats.CurrentFertility,
+		AverageCycleLength:      stats.AverageCycleLength,
+		MedianCycleLength:       stats.MedianCycleLength,
+		MinCycleLength:          stats.MinCycleLength,
+		MaxCycleLength:          stats.MaxCycleLength,
+		CycleLengthStdDev:       stats.CycleLengthStdDev,
+		CompletedCycleCount:     stats.CompletedCycleCount,
+		AveragePeriodLength:     stats.AveragePeriodLength,
+		LastCycleLength:         stats.LastCycleLength,
+		LastPeriodLength:        stats.LastPeriodLength,
+		LutealPhase:             stats.LutealPhase,
+		LutealPhasePersonalised: stats.LutealPhasePersonalised,
+		LastPeriodStart:         statsOverviewDate(stats.LastPeriodStart),
+		NextPeriodStart:         statsOverviewDate(stats.NextPeriodStart),
+		OvulationDate:           statsOverviewDate(stats.OvulationDate),
+		OvulationExact:          stats.OvulationExact,
+		OvulationConfirmed:      confirmed,
+		OvulationImpossible:     stats.OvulationImpossible,
+		FertilityWindowStart:    statsOverviewDate(stats.FertilityWindowStart),
+		FertilityWindowEnd:      statsOverviewDate(stats.FertilityWindowEnd),
+		PregnancyPaused:         stats.PregnancyPaused,
+		Suppression:             newStatsOverviewSuppression(suppression),
+		Disclaimer:              disclaimer,
+		DisclaimerKey:           medicalDisclaimerMessageKey,
 	}
 }
 

--- a/internal/services/cycle_baseline.go
+++ b/internal/services/cycle_baseline.go
@@ -17,15 +17,17 @@ func ApplyUserCycleBaseline(user *models.User, logs []models.DailyLog, stats Cyc
 	today := DateAtLocation(now.In(location), location)
 	latestExplicitCycleStart := latestExplicitCycleStartBeforeOrOn(logs, today, location)
 	cycleLength, periodLength, lutealPhase := resolveUserCycleLengths(user)
-	personalisedLutealPhase := false
-	if inferredLutealPhase, ok := InferUserLutealPhase(logs, location); ok {
+	inferredLutealPhase, inferred := InferUserLutealPhase(logs, location)
+	if inferred {
 		lutealPhase = inferredLutealPhase
-		personalisedLutealPhase = true
 	}
 	hasObservedCycleLengths := len(CycleLengths(logs)) >= 1
 	applyObservedBaseline(&stats, user, latestExplicitCycleStart, cycleLength, periodLength, hasObservedCycleLengths, today, location)
-	applyProjectedBaseline(&stats, cycleLength, lutealPhase, location)
-	stats.LutealPhasePersonalised = personalisedLutealPhase
+	projected := applyProjectedBaseline(&stats, cycleLength, lutealPhase, location)
+	// The inference can succeed (ObservedCycleStarts accepts unflagged period
+	// clusters) while the baseline finds no anchor to project from; then
+	// stats.LutealPhase still holds BuildCycleStats's value, not the inferred one.
+	stats.LutealPhasePersonalised = inferred && projected
 
 	stats.CurrentCycleDay = baselineCurrentCycleDay(stats.LastPeriodStart, today)
 	stats.CurrentPhase = DetectCurrentPhase(stats, logs, today, location)
@@ -70,9 +72,11 @@ func baselineLastPeriodStart(user *models.User, latestExplicitCycleStart time.Ti
 	return latestCycleStartAnchorBeforeOrOn(user, latestExplicitCycleStart, today, location)
 }
 
-func applyProjectedBaseline(stats *CycleStats, cycleLength int, lutealPhase int, location *time.Location) {
+// applyProjectedBaseline reports whether it wrote lutealPhase into stats: false
+// on the two early returns, where stats.LutealPhase is left untouched.
+func applyProjectedBaseline(stats *CycleStats, cycleLength int, lutealPhase int, location *time.Location) bool {
 	if stats.LastPeriodStart.IsZero() {
-		return
+		return false
 	}
 
 	predictionCycleLength := predictedCycleLength(stats.MedianCycleLength, stats.AverageCycleLength)
@@ -80,7 +84,7 @@ func applyProjectedBaseline(stats *CycleStats, cycleLength int, lutealPhase int,
 		predictionCycleLength = cycleLength
 	}
 	if predictionCycleLength <= 0 {
-		return
+		return false
 	}
 
 	stats.NextPeriodStart = AddCalendarDays(stats.LastPeriodStart, predictionCycleLength, location)
@@ -93,7 +97,7 @@ func applyProjectedBaseline(stats *CycleStats, cycleLength int, lutealPhase int,
 	)
 	if !window.Calculable {
 		clearPredictedCycleWindow(stats)
-		return
+		return true
 	}
 
 	stats.OvulationDate = CalendarDay(window.OvulationDate, location)
@@ -101,6 +105,7 @@ func applyProjectedBaseline(stats *CycleStats, cycleLength int, lutealPhase int,
 	stats.OvulationImpossible = false
 	stats.FertilityWindowStart = locationDateOrZero(window.FertilityWindowStart, location)
 	stats.FertilityWindowEnd = locationDateOrZero(window.FertilityWindowEnd, location)
+	return true
 }
 
 func locationDateOrZero(day time.Time, location *time.Location) time.Time {

--- a/internal/services/cycle_baseline.go
+++ b/internal/services/cycle_baseline.go
@@ -17,12 +17,15 @@ func ApplyUserCycleBaseline(user *models.User, logs []models.DailyLog, stats Cyc
 	today := DateAtLocation(now.In(location), location)
 	latestExplicitCycleStart := latestExplicitCycleStartBeforeOrOn(logs, today, location)
 	cycleLength, periodLength, lutealPhase := resolveUserCycleLengths(user)
+	personalisedLutealPhase := false
 	if inferredLutealPhase, ok := InferUserLutealPhase(logs, location); ok {
 		lutealPhase = inferredLutealPhase
+		personalisedLutealPhase = true
 	}
 	hasObservedCycleLengths := len(CycleLengths(logs)) >= 1
 	applyObservedBaseline(&stats, user, latestExplicitCycleStart, cycleLength, periodLength, hasObservedCycleLengths, today, location)
 	applyProjectedBaseline(&stats, cycleLength, lutealPhase, location)
+	stats.LutealPhasePersonalised = personalisedLutealPhase
 
 	stats.CurrentCycleDay = baselineCurrentCycleDay(stats.LastPeriodStart, today)
 	stats.CurrentPhase = DetectCurrentPhase(stats, logs, today, location)

--- a/internal/services/cycle_luteal_personalised_test.go
+++ b/internal/services/cycle_luteal_personalised_test.go
@@ -26,6 +26,23 @@ import (
 // on CycleStats at that SHA (compile failure: undefined field
 // LutealPhasePersonalised) — the same absence the fix closes.
 
+// personalisedBaselineFixture is the shared fixture of this file: an owner with
+// the 14-day setting, and logs whose ovulation signals are placed cycleLength
+// days apart from origin so InferUserLutealPhase refines a value the setting
+// does not hold. now sits five days into the logs' last (in-progress) cycle.
+func personalisedBaselineFixture(t *testing.T, cycleLength int, ovulationCycleDays []int, kind lutealSignalKind) (*models.User, []models.DailyLog, time.Time) {
+	t.Helper()
+	origin := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	logs := lutealRoundTripLogs(t, origin, cycleLength, ovulationCycleDays, kind)
+	now := origin.AddDate(0, 0, len(ovulationCycleDays)*cycleLength+5).Add(9 * time.Hour)
+	user := &models.User{
+		Role:        models.RoleOwner,
+		CycleLength: cycleLength,
+		LutealPhase: 14,
+	}
+	return user, logs, now
+}
+
 // TestOvulationExactAloneCannotTellDefaultFromPersonalisedLutealPhase pins the
 // invariant this task's fix depends on staying true: OvulationExact by itself
 // must never be read as a personalisation signal, because a default-14 cycle
@@ -60,14 +77,7 @@ func TestOvulationExactAloneCannotTellDefaultFromPersonalisedLutealPhase(t *test
 
 	// Personalised: the round-trip fixture from cycle_luteal_round_trip_test.go,
 	// which infers 13 from two observed cycles and also fits without a clamp.
-	origin := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
-	personalisedLogs := lutealRoundTripLogs(t, origin, 28, []int{15, 15}, lutealSignalBBT)
-	personalisedNow := time.Date(2026, time.March, 3, 9, 0, 0, 0, time.UTC)
-	personalisedUser := &models.User{
-		Role:        models.RoleOwner,
-		CycleLength: 28,
-		LutealPhase: 14,
-	}
+	personalisedUser, personalisedLogs, personalisedNow := personalisedBaselineFixture(t, 28, []int{15, 15}, lutealSignalBBT)
 	personalisedStats := ApplyUserCycleBaseline(personalisedUser, personalisedLogs, BuildCycleStats(personalisedLogs, personalisedNow), personalisedNow, time.UTC)
 
 	if personalisedStats.LutealPhase != 13 {
@@ -105,9 +115,7 @@ func TestLutealPhasePersonalisedTrueButClamped(t *testing.T) {
 	// own plausible window (10-20) and therefore accepted. Predicting the next
 	// 22-day cycle needs maxSupportedLutealPhase = 22-5 = 17, so CalcOvulationDay
 	// clamps 20 down to 17 and reports ovulationExact=false.
-	const cycleLength = 22
-	origin := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
-	logs := lutealRoundTripLogs(t, origin, cycleLength, []int{2, 2}, lutealSignalEggWhite)
+	user, logs, now := personalisedBaselineFixture(t, 22, []int{2, 2}, lutealSignalEggWhite)
 
 	luteal, refined := InferUserLutealPhase(logs, time.UTC)
 	if !refined {
@@ -117,12 +125,6 @@ func TestLutealPhasePersonalisedTrueButClamped(t *testing.T) {
 		t.Fatalf("fixture: inferred luteal phase = %d, want 20", luteal)
 	}
 
-	now := origin.AddDate(0, 0, 3*cycleLength).Add(9 * time.Hour)
-	user := &models.User{
-		Role:        models.RoleOwner,
-		CycleLength: cycleLength,
-		LutealPhase: 14,
-	}
 	stats := ApplyUserCycleBaseline(user, logs, BuildCycleStats(logs, now), now, time.UTC)
 
 	if !stats.LutealPhasePersonalised {
@@ -141,18 +143,11 @@ func TestLutealPhasePersonalisedTrueButClamped(t *testing.T) {
 func TestPublishedStatsClearsLutealPhasePersonalisedUnderFertilitySuppression(t *testing.T) {
 	t.Parallel()
 
-	origin := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
-	logs := lutealRoundTripLogs(t, origin, 28, []int{15, 15}, lutealSignalBBT)
-	now := time.Date(2026, time.March, 3, 9, 0, 0, 0, time.UTC)
-	user := &models.User{
-		Role:        models.RoleOwner,
-		CycleLength: 28,
-		LutealPhase: 14,
-		// Unpredictable-cycle mode is one of the PredictionsSuppressed disjuncts
-		// that FertilityProjectionSuppressed folds in; any gate that reaches
-		// suppression.FertilitySuppressed exercises the same clearing branch.
-		UnpredictableCycle: true,
-	}
+	user, logs, now := personalisedBaselineFixture(t, 28, []int{15, 15}, lutealSignalBBT)
+	// Unpredictable-cycle mode is one of the PredictionsSuppressed disjuncts
+	// that FertilityProjectionSuppressed folds in; any gate that reaches
+	// suppression.FertilitySuppressed exercises the same clearing branch.
+	user.UnpredictableCycle = true
 	stats := ApplyUserCycleBaseline(user, logs, BuildCycleStats(logs, now), now, time.UTC)
 	if !stats.LutealPhasePersonalised {
 		t.Fatal("fixture: stats.LutealPhasePersonalised = false before publishing, want true (the inference must have refined)")
@@ -164,5 +159,44 @@ func TestPublishedStatsClearsLutealPhasePersonalisedUnderFertilitySuppression(t 
 	}
 	if published.LutealPhasePersonalised {
 		t.Error("published.LutealPhasePersonalised = true under fertility suppression: it must not assert personalisation about an ovulation date this tier just withheld")
+	}
+}
+
+// TestLutealPhasePersonalisedStaysFalseWhenTheInferredValueNeverLandsOnLastPeriodStart
+// pins the gap between the two conditions the flag used to conflate.
+// InferUserLutealPhase needs only ObservedCycleStarts, which accepts a period
+// cluster with no CycleStart flag; ApplyUserCycleBaseline's projection needs an
+// anchor — a flagged start or user.LastPeriodStart — and writes the inferred
+// value into stats.LutealPhase only past that anchor. An owner who logs periods
+// without ever flagging a start therefore gets a successful inference and no
+// projection, and the flag must follow the projection, not the inference.
+//
+// Repro (6fb73c13, the PR's first commit): this test failed with
+// `stats.LutealPhasePersonalised = true` beside `stats.LutealPhase = 14`.
+func TestLutealPhasePersonalisedStaysFalseWhenTheInferredValueNeverLandsOnLastPeriodStart(t *testing.T) {
+	t.Parallel()
+
+	user, logs, now := personalisedBaselineFixture(t, 28, []int{15, 15}, lutealSignalBBT)
+	for index := range logs {
+		logs[index].CycleStart = false
+	}
+
+	luteal, refined := InferUserLutealPhase(logs, time.UTC)
+	if !refined {
+		t.Fatal("fixture: InferUserLutealPhase declined to refine from unflagged period clusters")
+	}
+	if luteal != 13 {
+		t.Fatalf("fixture: inferred luteal phase = %d, want 13", luteal)
+	}
+
+	stats := ApplyUserCycleBaseline(user, logs, BuildCycleStats(logs, now), now, time.UTC)
+	if !stats.LastPeriodStart.IsZero() {
+		t.Fatalf("fixture: stats.LastPeriodStart = %s, want zero (no flagged start and no user.LastPeriodStart to anchor on)", stats.LastPeriodStart.Format("2006-01-02"))
+	}
+	if stats.LutealPhase == luteal {
+		t.Fatalf("fixture: stats.LutealPhase = %d equals the inferred value; the test needs the projection to have been skipped", stats.LutealPhase)
+	}
+	if stats.LutealPhasePersonalised {
+		t.Errorf("stats.LutealPhasePersonalised = true while stats.LutealPhase = %d, not the inferred %d: the flag claims a value that never landed", stats.LutealPhase, luteal)
 	}
 }

--- a/internal/services/cycle_luteal_personalised_test.go
+++ b/internal/services/cycle_luteal_personalised_test.go
@@ -1,0 +1,168 @@
+package services
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ovumcy/ovumcy-web/internal/models"
+)
+
+// This file is the regression for C07: before it, CycleStats carried no field
+// that told a client whether LutealPhase came from the owner's own logs
+// (InferUserLutealPhase's refined return) or from the defaultLutealPhaseDays
+// model constant. ovulation_exact could not stand in for that signal — it
+// reports the absence of CalcOvulationDay's arithmetic clamp, which is true on
+// the 14-day default whenever that default happens to fit the cycle, and false
+// on a personalised value the cycle was too short to hold.
+//
+// Repro (base df6cbcb7, before LutealPhasePersonalised existed):
+// TestOvulationExactAloneCannotTellDefaultFromPersonalisedLutealPhase below
+// built exactly this pair — a default-14 cycle that fits and a personalised-13
+// cycle that also fits — and found both report OvulationExact=true, with no
+// other field on CycleStats distinguishing them: `go test ./internal/services/
+// -run TestOvulationExactAloneCannotTellDefaultFromPersonalisedLutealPhase -v`
+// failed at the `stats.LutealPhase != 14` / personalised-mismatch assertion
+// once LutealPhasePersonalised was referenced, because the field did not exist
+// on CycleStats at that SHA (compile failure: undefined field
+// LutealPhasePersonalised) — the same absence the fix closes.
+
+// TestOvulationExactAloneCannotTellDefaultFromPersonalisedLutealPhase pins the
+// invariant this task's fix depends on staying true: OvulationExact by itself
+// must never be read as a personalisation signal, because a default-14 cycle
+// that fits and a personalised-13 cycle that also fits report the identical
+// OvulationExact=true. LutealPhasePersonalised is the field that tells them
+// apart.
+func TestOvulationExactAloneCannotTellDefaultFromPersonalisedLutealPhase(t *testing.T) {
+	t.Parallel()
+
+	// Default: no observed cycle history, so InferUserLutealPhase has nothing to
+	// refine from and ApplyUserCycleBaseline falls back to the 14-day model
+	// constant. A 28-day cycle absorbs it without a clamp.
+	defaultLastPeriod := mustParseBaselineDay(t, "2026-02-01")
+	defaultUser := &models.User{
+		Role:            models.RoleOwner,
+		CycleLength:     28,
+		PeriodLength:    5,
+		LastPeriodStart: &defaultLastPeriod,
+	}
+	defaultLogs := []models.DailyLog{
+		{Date: defaultLastPeriod, IsPeriod: true, CycleStart: true, Flow: models.FlowMedium},
+	}
+	defaultNow := mustParseBaselineDay(t, "2026-02-10")
+	defaultStats := ApplyUserCycleBaseline(defaultUser, defaultLogs, BuildCycleStats(defaultLogs, defaultNow), defaultNow, time.UTC)
+
+	if defaultStats.LutealPhase != 14 {
+		t.Fatalf("default fixture: stats.LutealPhase = %d, want 14 (the model default)", defaultStats.LutealPhase)
+	}
+	if !defaultStats.OvulationExact {
+		t.Fatal("default fixture: stats.OvulationExact = false; the 14-day default fits a 28-day cycle without a clamp")
+	}
+
+	// Personalised: the round-trip fixture from cycle_luteal_round_trip_test.go,
+	// which infers 13 from two observed cycles and also fits without a clamp.
+	origin := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	personalisedLogs := lutealRoundTripLogs(t, origin, 28, []int{15, 15}, lutealSignalBBT)
+	personalisedNow := time.Date(2026, time.March, 3, 9, 0, 0, 0, time.UTC)
+	personalisedUser := &models.User{
+		Role:        models.RoleOwner,
+		CycleLength: 28,
+		LutealPhase: 14,
+	}
+	personalisedStats := ApplyUserCycleBaseline(personalisedUser, personalisedLogs, BuildCycleStats(personalisedLogs, personalisedNow), personalisedNow, time.UTC)
+
+	if personalisedStats.LutealPhase != 13 {
+		t.Fatalf("personalised fixture: stats.LutealPhase = %d, want 13 (the live inference)", personalisedStats.LutealPhase)
+	}
+	if !personalisedStats.OvulationExact {
+		t.Fatal("personalised fixture: stats.OvulationExact = false; the inferred 13 fits a 28-day cycle without a clamp")
+	}
+
+	// The whole point: OvulationExact agrees on both, so it cannot be the signal
+	// a client reads to tell a personalised cycle from a default one.
+	if defaultStats.OvulationExact != personalisedStats.OvulationExact {
+		t.Fatal("fixture invalid: this test needs OvulationExact identical on both sides to demonstrate it cannot distinguish them")
+	}
+
+	// LutealPhasePersonalised is the field that actually distinguishes them.
+	if defaultStats.LutealPhasePersonalised {
+		t.Error("default fixture: stats.LutealPhasePersonalised = true, want false: no observed cycle supported an inference")
+	}
+	if !personalisedStats.LutealPhasePersonalised {
+		t.Error("personalised fixture: stats.LutealPhasePersonalised = false, want true: the live inference refined a value from the owner's own logs")
+	}
+}
+
+// TestLutealPhasePersonalisedTrueButClamped is the third control the task
+// asks for: a personalised luteal phase that CalcOvulationDay had to clamp.
+// LutealPhasePersonalised and OvulationExact answer different questions, so
+// this fixture must report personalised=true, exact=false — neither field may
+// borrow the other's answer.
+func TestLutealPhasePersonalisedTrueButClamped(t *testing.T) {
+	t.Parallel()
+
+	// Egg-white ovulation on cycle day 2 (the earliest the peak-day rule
+	// admits) of a 22-day cycle infers luteal phase 20 — inside the inference's
+	// own plausible window (10-20) and therefore accepted. Predicting the next
+	// 22-day cycle needs maxSupportedLutealPhase = 22-5 = 17, so CalcOvulationDay
+	// clamps 20 down to 17 and reports ovulationExact=false.
+	const cycleLength = 22
+	origin := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	logs := lutealRoundTripLogs(t, origin, cycleLength, []int{2, 2}, lutealSignalEggWhite)
+
+	luteal, refined := InferUserLutealPhase(logs, time.UTC)
+	if !refined {
+		t.Fatal("fixture: InferUserLutealPhase declined to refine")
+	}
+	if luteal != 20 {
+		t.Fatalf("fixture: inferred luteal phase = %d, want 20", luteal)
+	}
+
+	now := origin.AddDate(0, 0, 3*cycleLength).Add(9 * time.Hour)
+	user := &models.User{
+		Role:        models.RoleOwner,
+		CycleLength: cycleLength,
+		LutealPhase: 14,
+	}
+	stats := ApplyUserCycleBaseline(user, logs, BuildCycleStats(logs, now), now, time.UTC)
+
+	if !stats.LutealPhasePersonalised {
+		t.Error("stats.LutealPhasePersonalised = false, want true: the value came from the owner's own logs")
+	}
+	if stats.OvulationExact {
+		t.Error("stats.OvulationExact = true, want false: the inferred 20-day luteal phase does not fit a 22-day cycle and CalcOvulationDay had to clamp it")
+	}
+}
+
+// TestPublishedStatsClearsLutealPhasePersonalisedUnderFertilitySuppression
+// pins the suppression contract this task asks be decided explicitly:
+// LutealPhasePersonalised must not keep asserting personalisation once the
+// fertility tier has withheld the ovulation date and window it is claimed
+// about.
+func TestPublishedStatsClearsLutealPhasePersonalisedUnderFertilitySuppression(t *testing.T) {
+	t.Parallel()
+
+	origin := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	logs := lutealRoundTripLogs(t, origin, 28, []int{15, 15}, lutealSignalBBT)
+	now := time.Date(2026, time.March, 3, 9, 0, 0, 0, time.UTC)
+	user := &models.User{
+		Role:        models.RoleOwner,
+		CycleLength: 28,
+		LutealPhase: 14,
+		// Unpredictable-cycle mode is one of the PredictionsSuppressed disjuncts
+		// that FertilityProjectionSuppressed folds in; any gate that reaches
+		// suppression.FertilitySuppressed exercises the same clearing branch.
+		UnpredictableCycle: true,
+	}
+	stats := ApplyUserCycleBaseline(user, logs, BuildCycleStats(logs, now), now, time.UTC)
+	if !stats.LutealPhasePersonalised {
+		t.Fatal("fixture: stats.LutealPhasePersonalised = false before publishing, want true (the inference must have refined)")
+	}
+
+	published, suppression := PublishedStats(user, stats, logs, DateAtLocation(now, time.UTC), time.UTC)
+	if !suppression.FertilitySuppressed {
+		t.Fatal("fixture: suppression.FertilitySuppressed = false, want true")
+	}
+	if published.LutealPhasePersonalised {
+		t.Error("published.LutealPhasePersonalised = true under fertility suppression: it must not assert personalisation about an ovulation date this tier just withheld")
+	}
+}

--- a/internal/services/cycles.go
+++ b/internal/services/cycles.go
@@ -9,37 +9,40 @@ import (
 )
 
 type CycleStats struct {
-	CurrentCycleDay     int     `json:"current_cycle_day"`
-	CurrentPhase        string  `json:"current_phase"`
-	CurrentFertility    string  `json:"current_fertility"`
-	AverageCycleLength  float64 `json:"average_cycle_length"`
-	MedianCycleLength   int     `json:"median_cycle_length"`
-	MinCycleLength      int     `json:"min_cycle_length"`
-	MaxCycleLength      int     `json:"max_cycle_length"`
-	CycleLengthStdDev   float64 `json:"cycle_length_std_dev"`
-	CompletedCycleCount int     `json:"completed_cycle_count"`
-	AveragePeriodLength float64 `json:"average_period_length"`
-	LastCycleLength     int     `json:"last_cycle_length"`
-	LastPeriodLength    int     `json:"last_period_length"`
-	LutealPhase         int     `json:"luteal_phase"`
-	// LutealPhasePersonalised reports whether LutealPhase was inferred from the
-	// owner's own logs (InferUserLutealPhase's refined return), rather than the
+	CurrentCycleDay      int       `json:"current_cycle_day"`
+	CurrentPhase         string    `json:"current_phase"`
+	CurrentFertility     string    `json:"current_fertility"`
+	AverageCycleLength   float64   `json:"average_cycle_length"`
+	MedianCycleLength    int       `json:"median_cycle_length"`
+	MinCycleLength       int       `json:"min_cycle_length"`
+	MaxCycleLength       int       `json:"max_cycle_length"`
+	CycleLengthStdDev    float64   `json:"cycle_length_std_dev"`
+	CompletedCycleCount  int       `json:"completed_cycle_count"`
+	AveragePeriodLength  float64   `json:"average_period_length"`
+	LastCycleLength      int       `json:"last_cycle_length"`
+	LastPeriodLength     int       `json:"last_period_length"`
+	LutealPhase          int       `json:"luteal_phase"`
+	LastPeriodStart      time.Time `json:"last_period_start"`
+	NextPeriodStart      time.Time `json:"next_period_start"`
+	OvulationDate        time.Time `json:"ovulation_date"`
+	OvulationExact       bool      `json:"ovulation_exact"`
+	OvulationImpossible  bool      `json:"ovulation_impossible"`
+	FertilityWindowStart time.Time `json:"fertility_window_start"`
+	FertilityWindowEnd   time.Time `json:"fertility_window_end"`
+	PregnancyPaused      bool      `json:"pregnancy_paused"`
+
+	// LutealPhasePersonalised reports whether LutealPhase holds the value
+	// InferUserLutealPhase refined from the owner's own logs, rather than the
 	// defaultLutealPhaseDays model constant. It says nothing about OvulationExact
 	// (a personalised value can still get clamped, and the 14-day default can
 	// still fit a cycle without a clamp) and nothing about ovulation_confirmed
 	// (a BBT shift confirms a day independently of where the luteal phase came
-	// from). ApplyUserCycleBaseline is the only writer; BuildCycleStats leaves it
-	// at its zero value (false) because it always seeds LutealPhase with the
-	// default.
-	LutealPhasePersonalised bool      `json:"luteal_phase_personalised"`
-	LastPeriodStart         time.Time `json:"last_period_start"`
-	NextPeriodStart         time.Time `json:"next_period_start"`
-	OvulationDate           time.Time `json:"ovulation_date"`
-	OvulationExact          bool      `json:"ovulation_exact"`
-	OvulationImpossible     bool      `json:"ovulation_impossible"`
-	FertilityWindowStart    time.Time `json:"fertility_window_start"`
-	FertilityWindowEnd      time.Time `json:"fertility_window_end"`
-	PregnancyPaused         bool      `json:"pregnancy_paused"`
+	// from). ApplyUserCycleBaseline is the only writer and sets it only when the
+	// inferred value actually landed in LutealPhase — a successful inference with
+	// no cycle anchor to project from leaves both this flag and LutealPhase as
+	// BuildCycleStats left them. BuildCycleStats never writes anything but the
+	// default (or nothing at all) into LutealPhase, so it leaves this false.
+	LutealPhasePersonalised bool `json:"luteal_phase_personalised"`
 }
 
 type detectedCycle struct {

--- a/internal/services/cycles.go
+++ b/internal/services/cycles.go
@@ -9,27 +9,37 @@ import (
 )
 
 type CycleStats struct {
-	CurrentCycleDay      int       `json:"current_cycle_day"`
-	CurrentPhase         string    `json:"current_phase"`
-	CurrentFertility     string    `json:"current_fertility"`
-	AverageCycleLength   float64   `json:"average_cycle_length"`
-	MedianCycleLength    int       `json:"median_cycle_length"`
-	MinCycleLength       int       `json:"min_cycle_length"`
-	MaxCycleLength       int       `json:"max_cycle_length"`
-	CycleLengthStdDev    float64   `json:"cycle_length_std_dev"`
-	CompletedCycleCount  int       `json:"completed_cycle_count"`
-	AveragePeriodLength  float64   `json:"average_period_length"`
-	LastCycleLength      int       `json:"last_cycle_length"`
-	LastPeriodLength     int       `json:"last_period_length"`
-	LutealPhase          int       `json:"luteal_phase"`
-	LastPeriodStart      time.Time `json:"last_period_start"`
-	NextPeriodStart      time.Time `json:"next_period_start"`
-	OvulationDate        time.Time `json:"ovulation_date"`
-	OvulationExact       bool      `json:"ovulation_exact"`
-	OvulationImpossible  bool      `json:"ovulation_impossible"`
-	FertilityWindowStart time.Time `json:"fertility_window_start"`
-	FertilityWindowEnd   time.Time `json:"fertility_window_end"`
-	PregnancyPaused      bool      `json:"pregnancy_paused"`
+	CurrentCycleDay     int     `json:"current_cycle_day"`
+	CurrentPhase        string  `json:"current_phase"`
+	CurrentFertility    string  `json:"current_fertility"`
+	AverageCycleLength  float64 `json:"average_cycle_length"`
+	MedianCycleLength   int     `json:"median_cycle_length"`
+	MinCycleLength      int     `json:"min_cycle_length"`
+	MaxCycleLength      int     `json:"max_cycle_length"`
+	CycleLengthStdDev   float64 `json:"cycle_length_std_dev"`
+	CompletedCycleCount int     `json:"completed_cycle_count"`
+	AveragePeriodLength float64 `json:"average_period_length"`
+	LastCycleLength     int     `json:"last_cycle_length"`
+	LastPeriodLength    int     `json:"last_period_length"`
+	LutealPhase         int     `json:"luteal_phase"`
+	// LutealPhasePersonalised reports whether LutealPhase was inferred from the
+	// owner's own logs (InferUserLutealPhase's refined return), rather than the
+	// defaultLutealPhaseDays model constant. It says nothing about OvulationExact
+	// (a personalised value can still get clamped, and the 14-day default can
+	// still fit a cycle without a clamp) and nothing about ovulation_confirmed
+	// (a BBT shift confirms a day independently of where the luteal phase came
+	// from). ApplyUserCycleBaseline is the only writer; BuildCycleStats leaves it
+	// at its zero value (false) because it always seeds LutealPhase with the
+	// default.
+	LutealPhasePersonalised bool      `json:"luteal_phase_personalised"`
+	LastPeriodStart         time.Time `json:"last_period_start"`
+	NextPeriodStart         time.Time `json:"next_period_start"`
+	OvulationDate           time.Time `json:"ovulation_date"`
+	OvulationExact          bool      `json:"ovulation_exact"`
+	OvulationImpossible     bool      `json:"ovulation_impossible"`
+	FertilityWindowStart    time.Time `json:"fertility_window_start"`
+	FertilityWindowEnd      time.Time `json:"fertility_window_end"`
+	PregnancyPaused         bool      `json:"pregnancy_paused"`
 }
 
 type detectedCycle struct {

--- a/internal/services/prediction_published_stats.go
+++ b/internal/services/prediction_published_stats.go
@@ -69,6 +69,13 @@ func PublishedStats(user *models.User, stats CycleStats, logs []models.DailyLog,
 	if suppression.FertilitySuppressed {
 		stats.OvulationDate = time.Time{}
 		stats.OvulationExact = false
+		// LutealPhasePersonalised describes the luteal phase this same clearing
+		// just withheld the ovulation date and window for; it must not keep
+		// asserting personalisation about a projection this tier has decided not
+		// to publish. LutealPhase itself (the RECORDED derived value, not a
+		// projection) is left standing along with the rest of the facts-only
+		// tier — only the personalisation CLAIM about it is cleared here.
+		stats.LutealPhasePersonalised = false
 		// OvulationImpossible is itself a claim derived from the fertility
 		// projection (clearPredictedCycleWindow in cycles.go sets it exactly
 		// where it also clears OvulationDate/OvulationExact/the window), so it


### PR DESCRIPTION
## Summary
- `ovulation_exact` description in `docs/openapi.yaml` claimed the date was anchored on a per-owner inferred luteal phase; it actually only means the arithmetic clamp didn't fire (true on the 14-day default too). Text corrected; the flag and its computation are unchanged.
- Added additive field `luteal_phase_personalised` (bool) to the overview: surfaces the second return of `InferUserLutealPhase`, previously dropped in `ApplyUserCycleBaseline`. `CycleStats` → `StatsOverviewResponse` DTO → `docs/openapi.yaml`.
- Under fertility suppression, `luteal_phase_personalised` is cleared to `false` alongside the rest of the projection fields — no personalisation claim survives for a date the response no longer publishes.

## Risk
Touches a public API contract (openapi, response DTO) — additive only, no field renamed/removed, no change to `OvulationExact`/`CalcOvulationDay`/`InferUserLutealPhase`/the 10–20 filter.

## Test plan
- [x] `TestOvulationExactAloneCannotTellDefaultFromPersonalisedLutealPhase` — repro: default vs. personalised cycle both report `ovulation_exact: true`
- [x] `TestLutealPhasePersonalisedTrueButClamped` — personalised luteal phase clamped by `CalcOvulationDay` (`personalised: true`, `exact: false`)
- [x] `TestPublishedStatsClearsLutealPhasePersonalisedUnderFertilitySuppression`
- [x] `TestInferredLutealPhaseRoundTripsThroughPrediction`, `TestInferredLutealPhaseReachesTheOwnerSurfacesThroughTheBaseline`, `TestLutealPhaseRoundTrip_ReferenceVectors` (regression, unchanged)
- [x] `TestStatsOverviewSpecEnumeratesExactlyTheDTOsFields` (DTO ⇄ openapi sync)
- [x] `golangci-lint run ./internal/services/... ./internal/api/...` — 0 issues
- [ ] full CI (pending)
