### PR TITLE
feat(notifications): ntfy-native webhook delivery via ?format=ntfy

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -436,6 +436,35 @@ consumer (an ntfy topic rule, a Gotify filter, a home-automation flow) can
 route on it without parsing `message`. `disclaimer` is present on every
 payload, unconditionally.
 
+#### ntfy-native delivery (`?format=ntfy`)
+
+ntfy renders a plain-body `POST` to a topic URL **verbatim as the
+notification text**, so the JSON envelope above arrives on an ntfy topic as a
+raw JSON blob. If your webhook URL is an ntfy topic, opt that one URL into
+ntfy-native formatting by appending `format=ntfy` to it:
+
+```
+https://ntfy.example.com/my-topic?format=ntfy
+```
+
+Delivery then sends what ntfy expects natively:
+
+- `X-Title` — the reminder title (the same localized `title` as the JSON field),
+- `X-Tags` — an emoji tag per kind (`mens` 🩸 for a period reminder,
+  `sparkles` ✨ for ovulation),
+- a `text/plain` body of the localized `message`, a blank line, then the
+  `disclaimer` — the disclaimer is delivered on every notification in this
+  format too, unconditionally.
+
+Everything else about the URL passes through untouched: an access token in
+the query (`?auth=...`) or userinfo still applies (ntfy ignores the unknown
+`format` parameter), and all delivery hardening (timeouts, no redirects,
+host-only logging) is identical in both formats. URLs without `format=ntfy`
+keep the generic JSON envelope byte-for-byte, so Gotify, Apprise, and
+home-automation consumers are unaffected. Re-saving the URL in Settings (or
+`ovumcy webhook set`) is all it takes to switch a given endpoint between the
+two formats.
+
 The three text fields — `title`, `message` and `disclaimer` — are written in the
 **interface language the owner chose in settings**, all three in the same one
 (the example above is an owner on English). A pass runs without a browser, so

--- a/internal/services/webhook_delivery.go
+++ b/internal/services/webhook_delivery.go
@@ -63,6 +63,22 @@ const (
 	webhookPhaseTimeout = 5 * time.Second
 	// webhookUserAgent identifies our POSTs without revealing anything sensitive.
 	webhookUserAgent = "ovumcy-webhook/1"
+	// webhookFormatQueryParam is the URL query key that selects a delivery
+	// format for one stored webhook URL. The opt-in lives in the URL itself —
+	// already owner-controlled and encrypted at rest — so no settings column
+	// or schema change is involved in choosing a format.
+	webhookFormatQueryParam = "format"
+	// webhookFormatNtfy is the value of the format query param that selects
+	// ntfy-native plain-text delivery. ntfy renders a plain-body topic POST
+	// verbatim as the notification, so the default JSON envelope otherwise
+	// reaches the phone as a raw JSON blob.
+	webhookFormatNtfy = "ntfy"
+	// webhookNtfyTagsPeriod and webhookNtfyTagsOvulation are ntfy emoji
+	// shortcodes used as the notification tag/icon per reminder kind. They are
+	// cosmetic only: an unknown shortcode degrades to plain tag text in the
+	// ntfy client, never to a failed delivery.
+	webhookNtfyTagsPeriod    = "mens"
+	webhookNtfyTagsOvulation = "sparkles"
 )
 
 // ErrWebhookDeliveryURLScheme is returned when a decrypted URL does not use
@@ -251,7 +267,10 @@ func guardedDialContext(dial dialFunc, resolver ipResolver) dialFunc {
 	}
 }
 
-// Deliver POSTs the payload as JSON to decryptedURL under the hardened envelope.
+// Deliver POSTs the payload to decryptedURL under the hardened envelope, in
+// one of two body formats chosen by the URL itself: the default generic JSON
+// envelope, or — when the URL carries ?format=ntfy — an ntfy-native plain-text
+// body with title and tag in X-Title/X-Tags headers (see webhookFormatNtfy).
 // It returns nil only on a 2xx response. On any failure it logs a stable reason
 // key plus the destination HOST and (when available) the status code — never the
 // URL, query, userinfo, or response body — and returns an error that likewise
@@ -285,13 +304,37 @@ func (client *webhookDeliveryClient) Deliver(ctx context.Context, decryptedURL s
 		return fmt.Errorf("webhook delivery to private address refused")
 	}
 
-	body, err := json.Marshal(payload)
-	if err != nil {
-		// codecov:ignore -- unreachable: WebhookPayload is all JSON-safe scalar
-		// fields, so json.Marshal cannot fail here. Kept as a fail-safe so a future
-		// unmarshalable field never delivers a malformed body.
-		log.Printf("webhook delivery skipped: reason=payload_marshal_failed host=%s", parsed.Hostname())
-		return fmt.Errorf("marshal webhook payload: %w", err)
+	// Delivery format is selected by the URL itself. The default is the generic
+	// JSON envelope any webhook consumer can parse. Appending ?format=ntfy to
+	// a stored ntfy topic URL opts that one URL into ntfy's native plain-text
+	// publish — title/tag headers plus a body ntfy renders as the notification
+	// text — because ntfy shows a plain-body topic POST verbatim, so the JSON
+	// envelope would reach the phone as a raw blob. The opt-in travels in the
+	// already-encrypted URL, and every other query parameter (e.g. an ntfy
+	// ?auth= token) passes through untouched: ntfy ignores the unknown
+	// `format` key, and no other consumer is affected.
+	ntfyFormat := strings.EqualFold(parsed.Query().Get(webhookFormatQueryParam), webhookFormatNtfy)
+
+	var body []byte
+	var contentType string
+	if ntfyFormat {
+		// Plain-text body: the human message, then the MANDATORY medical-safety
+		// disclaimer. The disclaimer invariant is about delivery, not JSON
+		// shape, so it rides in the body here exactly as it rides in a field
+		// of the JSON envelope.
+		body = []byte(payload.Message + "\n\n" + payload.Disclaimer)
+		contentType = "text/plain"
+	} else {
+		var marshalErr error
+		body, marshalErr = json.Marshal(payload)
+		if marshalErr != nil {
+			// codecov:ignore -- unreachable: WebhookPayload is all JSON-safe scalar
+			// fields, so json.Marshal cannot fail here. Kept as a fail-safe so a
+			// future unmarshalable field never delivers a malformed body.
+			log.Printf("webhook delivery skipped: reason=payload_marshal_failed host=%s", parsed.Hostname())
+			return fmt.Errorf("marshal webhook payload: %w", marshalErr)
+		}
+		contentType = "application/json"
 	}
 
 	requestCtx, cancel := context.WithTimeout(ctx, webhookDeliveryTimeout)
@@ -304,8 +347,23 @@ func (client *webhookDeliveryClient) Deliver(ctx context.Context, decryptedURL s
 		log.Printf("webhook delivery skipped: reason=build_request_failed host=%s", parsed.Hostname())
 		return fmt.Errorf("build webhook request: %w", err)
 	}
-	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Content-Type", contentType)
 	request.Header.Set("User-Agent", webhookUserAgent)
+	if ntfyFormat {
+		// ntfy reads the notification title and tag list from these headers.
+		// Both values come from the reminder copy/i18n catalogue or our own
+		// tag constants; headerSafeValue skips a pair only if the value ever
+		// carried control characters (which would fail the request write at
+		// the transport layer), degrading to ntfy's topic-name title rather
+		// than failing the delivery.
+		if headerSafeValue(payload.Title) {
+			request.Header.Set("X-Title", payload.Title)
+		}
+		tags := ntfyTagsForReminderType(payload.Type)
+		if headerSafeValue(tags) {
+			request.Header.Set("X-Tags", tags)
+		}
+	}
 
 	response, err := client.httpClient.Do(request)
 	if err != nil {
@@ -338,6 +396,32 @@ func (client *webhookDeliveryClient) Deliver(ctx context.Context, decryptedURL s
 		return fmt.Errorf("webhook delivery to host %q returned status %d", parsed.Hostname(), response.StatusCode)
 	}
 	return nil
+}
+
+// ntfyTagsForReminderType maps a reminder kind to an ntfy tag list. The tags
+// are ntfy emoji shortcodes rendered as the notification icon — mens (🩸) for
+// a period reminder, sparkles (✨) for ovulation — and are cosmetic only: an
+// unknown kind, or a client without the shortcode, degrades to plain tag text
+// in the notification, never a failed delivery.
+func ntfyTagsForReminderType(reminderType string) string {
+	if reminderType == DueReminderTypeOvulation {
+		return webhookNtfyTagsOvulation
+	}
+	return webhookNtfyTagsPeriod
+}
+
+// headerSafeValue reports whether value can travel in an HTTP header as-is:
+// no C0 controls and no DEL. UTF-8 text is allowed — it passes through as
+// obs-text and ntfy decodes headers as UTF-8 — so localized titles ride
+// along; only control characters (which would make the request write fail at
+// the transport layer) disqualify a value.
+func headerSafeValue(value string) bool {
+	for _, r := range value {
+		if r < 0x20 || r == 0x7f {
+			return false
+		}
+	}
+	return true
 }
 
 // isRedirectRefusal reports whether err is our zero-redirect refusal, which the

--- a/internal/services/webhook_delivery_test.go
+++ b/internal/services/webhook_delivery_test.go
@@ -827,3 +827,145 @@ func TestWebhookDeliveryURLParseFailure(t *testing.T) {
 		t.Fatalf("parse-failure log leaked URL content: %q", output)
 	}
 }
+
+// captureDelivery is the shared recorder for the ntfy-format tests: one
+// request's method, path, headers, and body, snapshotted under the handler.
+type captureDelivery struct {
+	method string
+	path   string
+	title  string
+	tags   string
+	ctype  string
+	body   string
+}
+
+// TestWebhookDeliveryNtfyFormatSendsNativeEnvelope pins the ?format=ntfy
+// opt-in: the request must carry the title and tag as ntfy headers, a
+// text/plain body of message + blank line + disclaimer, and still POST to the
+// exact URL the owner configured (query param riding along untouched).
+func TestWebhookDeliveryNtfyFormatSendsNativeEnvelope(t *testing.T) {
+	payload := samplePayload()
+	var captured captureDelivery
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		bodyBytes, _ := io.ReadAll(request.Body)
+		captured = captureDelivery{
+			method: request.Method,
+			path:   request.URL.RequestURI(),
+			title:  request.Header.Get("X-Title"),
+			tags:   request.Header.Get("X-Tags"),
+			ctype:  request.Header.Get("Content-Type"),
+			body:   string(bodyBytes),
+		}
+		writer.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	deliverer := NewWebhookDeliverer(false)
+	if err := deliverer.Deliver(context.Background(), server.URL+"/ovumcy?auth=tok&format=ntfy", payload); err != nil {
+		t.Fatalf("ntfy-format delivery must succeed on 2xx, got %v", err)
+	}
+	if captured.method != http.MethodPost {
+		t.Fatalf("expected POST, got %s", captured.method)
+	}
+	if captured.path != "/ovumcy?auth=tok&format=ntfy" {
+		t.Fatalf("ntfy-format must keep the owner URL (params and order) untouched, got %q", captured.path)
+	}
+	if captured.title != payload.Title {
+		t.Fatalf("X-Title must carry the payload title %q, got %q", payload.Title, captured.title)
+	}
+	if captured.tags != "mens" {
+		t.Fatalf("period reminder must tag mens, got %q", captured.tags)
+	}
+	if captured.ctype != "text/plain" {
+		t.Fatalf("ntfy-format body must be text/plain, got %q", captured.ctype)
+	}
+	expectedBody := payload.Message + "\n\n" + payload.Disclaimer
+	if captured.body != expectedBody {
+		t.Fatalf("ntfy-format body must be message + blank line + disclaimer:\n want %q\n got  %q", expectedBody, captured.body)
+	}
+}
+
+// TestWebhookDeliveryNtfyFormatOvulationTag pins the ovulation-kind tag branch
+// of ntfyTagsForReminderType (and, through the table's default row, that an
+// unknown kind falls back to the period tag rather than an empty header).
+func TestWebhookDeliveryNtfyFormatOvulationTag(t *testing.T) {
+	cases := []struct {
+		name         string
+		reminderType string
+		expectedTag  string
+	}{
+		{"ovulation maps to sparkles", DueReminderTypeOvulation, "sparkles"},
+		{"period maps to mens", DueReminderTypePeriod, "mens"},
+		{"unknown kind falls back to mens", "fertility-window", "mens"},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := ntfyTagsForReminderType(testCase.reminderType); got != testCase.expectedTag {
+				t.Fatalf("ntfyTagsForReminderType(%q) = %q, want %q", testCase.reminderType, got, testCase.expectedTag)
+			}
+		})
+	}
+}
+
+// TestWebhookDeliveryUnrelatedQueryParamsKeepJSONEnvelope pins the default:
+// query parameters that are NOT format=ntfy (a token param, or an explicit
+// format=json) must leave the generic JSON envelope — and its Content-Type —
+// byte-for-byte in place, so no existing consumer changes behavior.
+func TestWebhookDeliveryUnrelatedQueryParamsKeepJSONEnvelope(t *testing.T) {
+	for _, target := range []string{
+		"/hook?auth=tok",
+		"/hook?format=json",
+		"/hook?format=ntfyish",
+	} {
+		var gotTitle, gotTags, gotCtype string
+		var gotBody []byte
+		server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			gotTitle = request.Header.Get("X-Title")
+			gotTags = request.Header.Get("X-Tags")
+			gotCtype = request.Header.Get("Content-Type")
+			gotBody, _ = io.ReadAll(request.Body)
+			writer.WriteHeader(http.StatusOK)
+		}))
+		deliverer := NewWebhookDeliverer(false)
+		if err := deliverer.Deliver(context.Background(), server.URL+target, samplePayload()); err != nil {
+			t.Fatalf("default-format delivery to %q must succeed, got %v", target, err)
+		}
+		server.Close()
+		if gotTitle != "" || gotTags != "" {
+			t.Fatalf("%q must not set ntfy headers, got title=%q tags=%q", target, gotTitle, gotTags)
+		}
+		if gotCtype != "application/json" {
+			t.Fatalf("%q must stay application/json, got %q", target, gotCtype)
+		}
+		var decoded WebhookPayload
+		if err := json.Unmarshal(gotBody, &decoded); err != nil {
+			t.Fatalf("%q body must remain the JSON envelope: %v", target, err)
+		}
+		if decoded.Disclaimer == "" {
+			t.Fatalf("%q JSON envelope lost the mandatory disclaimer", target)
+		}
+	}
+}
+
+// TestWebhookDeliveryNtfyFormatSkipsUnsafeTitleHeader pins headerSafeValue's
+// degradation: a title carrying a control character must be dropped from
+// X-Title (the request would otherwise fail to write at the transport layer)
+// while the delivery itself still succeeds with the plain-text body.
+func TestWebhookDeliveryNtfyFormatSkipsUnsafeTitleHeader(t *testing.T) {
+	payload := samplePayload()
+	payload.Title = "Broken\n title"
+	var gotTitle string
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		gotTitle = request.Header.Get("X-Title")
+		writer.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	deliverer := NewWebhookDeliverer(false)
+	if err := deliverer.Deliver(context.Background(), server.URL+"/t?format=ntfy", payload); err != nil {
+		t.Fatalf("delivery must succeed without the unsafe title header, got %v", err)
+	}
+	if gotTitle != "" {
+		t.Fatalf("unsafe title must be dropped from X-Title, got %q", gotTitle)
+	}
+}


### PR DESCRIPTION
## Summary
- ntfy renders a plain-body topic POST verbatim, so the generic JSON webhook envelope reached ntfy phones as a raw JSON blob (title/message/disclaimer fields visible as JSON).
- A stored webhook URL can now opt into ntfy-native delivery by appending `?format=ntfy`:
  - `X-Title` — the localized reminder title
  - `X-Tags` — `mens` 🩸 (period) / `sparkles` ✨ (ovulation)
  - `text/plain` body — localized message, blank line, then the mandatory disclaimer (disclaimer invariant preserved in both formats)
- The opt-in lives in the already-encrypted URL (no schema/settings change); other query params (`?auth=` tokens) pass through untouched; URLs without the param keep the JSON envelope byte-for-byte, so Gotify/Apprise/automation consumers are unaffected.
- All egress hardening (timeouts, no redirects, header/body caps, host-only logging) identical in both modes. Unsafe header values (control chars) degrade to ntfy's topic-title rather than failing delivery.
- Docs: new `?format=ntfy` section in `docs/notifications.md`.

## Test plan
- [x] `TestWebhookDeliveryNtfyFormatSendsNativeEnvelope` — X-Title/X-Tags/text-plain body, URL params untouched
- [x] `TestWebhookDeliveryNtfyFormatOvulationTag` — tag mapping incl. unknown-kind fallback
- [x] `TestWebhookDeliveryUnrelatedQueryParamsKeepJSONEnvelope` — `?auth=`, `?format=json`, `?format=ntfyish` all keep JSON
- [x] `TestWebhookDeliveryNtfyFormatSkipsUnsafeTitleHeader` — control-char title dropped, delivery succeeds
- [x] Full `go test ./cmd/... ./internal/... ./migrations/... ./scripts/... ./web/...` green locally
- [x] Live-verified the exact envelope against a self-hosted ntfy instance (title/tag/body rendered correctly)